### PR TITLE
Simple temporary work-around for skipping standard library installation

### DIFF
--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -40,7 +40,13 @@ pub enum Command {
         command: Option<EnvCommand>,
     },
     /// Sync env to lockfile
-    Sync,
+    Sync {
+        /// Includes the KerML/SysML standard libraries when installing.
+        /// By default these are excluded because they are typically
+        /// shipped with your language implementation.
+        #[arg(long, default_value = "false")]
+        include_std: bool,
+    },
     /// Prints the root directory of the current project
     PrintRoot,
     /// Resolve and describe current interchange project or one at at a specified path or IRI/URL.
@@ -103,6 +109,11 @@ pub enum Command {
         /// Do not use any index when resolving this usage
         #[arg(long, default_value = "false", conflicts_with = "use_index")]
         no_index: bool,
+        /// Allows installation of the KerML/SysML standard libraries. By default
+        /// these are excluded, as they are typically shipped with your language
+        /// implementation.
+        #[arg(long, default_value = "false")]
+        include_std: bool,
     },
     /// Remove usage from project information
     Remove {

--- a/sysand/src/commands/sync.rs
+++ b/sysand/src/commands/sync.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use anyhow::Result;
 use url::ParseError;
@@ -20,6 +20,7 @@ pub fn command_sync(
     project_root: PathBuf,
     env: &mut LocalDirectoryEnvironment,
     client: reqwest::blocking::Client,
+    exclude_iris: &HashSet<String>,
 ) -> Result<()> {
     let lockfile: Lock = toml::from_str(&std::fs::read_to_string(
         project_root.join(DEFAULT_LOCKFILE_NAME),
@@ -50,6 +51,7 @@ pub fn command_sync(
                 )
             },
         ),
+        exclude_iris,
     )?;
     Ok(())
 }


### PR DESCRIPTION
Default to not installing any of the known IRIs of the KerML/SysML Beta1 standard libraries. Adds a flag `--include-std` to override this behaviour. The standard library is still treated normally when solving for dependencies, but is excluded during actual installation.

I've only done manual testing for this functionality, as it is only a short term temporary work-around until https://github.com/sensmetry/sysand/issues/13 is treated properly.