### PR TITLE
Add support for multiple indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "sysand"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-core"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-js"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-py"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "predicates",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["sysand", "core", "bindings/py", "bindings/js", "bindings/java"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 publish = false
 authors = ["Sensmetry <opensource@sensmetry.com>"]

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -170,7 +170,7 @@ pub extern "system" fn Java_org_sysand_Sysand_info<'local>(
         Some(std::path::PathBuf::from(&relative_file_root)),
         None,
         Some(client),
-        index_base_url,
+        index_base_url.map(|x| vec![x]),
     );
 
     let results = match sysand_core::commands::info::do_info(&uri, &combined_resolver) {

--- a/bindings/py/python/sysand/_info.py
+++ b/bindings/py/python/sysand/_info.py
@@ -23,12 +23,15 @@ def info(
     uri: str,
     *,
     relative_file_root: str | Path | None = None,
-    index_url: str | None = None,
+    index_urls: str | typing.List[str] | None = None,
 ) -> typing.List[typing.Tuple[InterchangeProjectInfo, InterchangeProjectMetadata]]:
     if relative_file_root is None:
         relative_file_root = getcwd()
 
-    return sysand_rs.do_info_py(uri, relative_file_root, index_url)  # type: ignore
+    if isinstance(index_urls, str):
+        index_urls = [index_urls]
+
+    return sysand_rs.do_info_py(uri, relative_file_root, index_urls)  # type: ignore
 
 
 __all__ = [

--- a/bindings/py/scripts/run_chores.sh
+++ b/bindings/py/scripts/run_chores.sh
@@ -10,6 +10,6 @@ cd $PACKAGE_DIR
 
 cargo fmt
 cargo clippy --all-targets -- --deny warnings
-uv run ruff format python tests
-uv run ruff check python
-uv run mypy --strict python
+uv tool run ruff format python tests
+uv tool run ruff check python
+uv tool run mypy --strict python

--- a/bindings/py/scripts/run_tests.sh
+++ b/bindings/py/scripts/run_tests.sh
@@ -14,4 +14,4 @@ maturin develop
 
 cargo test --no-default-features
 
-pytest
+uv run --with=pytest pytest

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -99,13 +99,13 @@ fn do_info_py_path(
 
 #[pyfunction(name = "do_info_py")]
 #[pyo3(
-    signature = (uri, relative_file_root, index_url),
+    signature = (uri, relative_file_root, index_urls),
 )]
 fn do_info_py(
     py: Python,
     uri: String,
     relative_file_root: String,
-    index_url: Option<String>,
+    index_urls: Option<Vec<String>>,
 ) -> PyResult<Vec<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)>> {
     py.allow_threads(|| {
         let mut results = vec![];
@@ -113,8 +113,13 @@ fn do_info_py(
             .build()
             .expect("internal HTTP error");
 
-        let index_url = index_url
-            .map(|url_str| url::Url::parse(&url_str))
+        let index_url = index_urls
+            .map(|url_strs| {
+                url_strs
+                    .iter()
+                    .map(|url_str| url::Url::parse(url_str))
+                    .collect()
+            })
             .transpose()
             .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?;
 

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -142,7 +142,7 @@ def test_index_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) ->
     ).respond_with_json({"index": {}, "created": "0000-00-00T00:00:00.123456789Z"})
 
     info_metas = sysand.info(
-        "urn:kpar:test_index_info", index_url=httpserver.url_for("")
+        "urn:kpar:test_index_info", index_urls=httpserver.url_for("")
     )
 
     assert len(info_metas) == 1

--- a/core/src/resolve/mod.rs
+++ b/core/src/resolve/mod.rs
@@ -14,6 +14,7 @@ pub mod null;
 pub mod remote;
 #[cfg(all(feature = "filesystem", feature = "networking"))]
 pub mod reqwest_http;
+pub mod sequential;
 #[cfg(all(feature = "filesystem", feature = "networking"))]
 pub mod standard;
 

--- a/core/src/resolve/sequential.rs
+++ b/core/src/resolve/sequential.rs
@@ -1,0 +1,174 @@
+use std::iter::Flatten;
+
+use crate::resolve::ResolveRead;
+
+/// Takes a sequence of similar resolvers, and tries them in sequence.
+/// First resolves all versions in the first environment, then all
+/// in the second, ...
+#[derive(Debug)]
+pub struct SequentialResolve<R: ResolveRead> {
+    inner: Vec<R>,
+}
+
+impl<R: ResolveRead> SequentialResolve<R> {
+    pub fn new<I: IntoIterator<Item = R>>(resolvers: I) -> Self {
+        SequentialResolve {
+            inner: resolvers.into_iter().collect(),
+        }
+    }
+}
+
+impl<R: ResolveRead> ResolveRead for SequentialResolve<R> {
+    type Error = R::Error;
+
+    type ProjectStorage = R::ProjectStorage;
+
+    type ResolvedStorages = Flatten<std::vec::IntoIter<<R as ResolveRead>::ResolvedStorages>>;
+
+    fn resolve_read(
+        &self,
+        uri: &fluent_uri::Iri<String>,
+    ) -> Result<super::ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
+        let mut iters = vec![];
+        let mut any_supported = false;
+        let mut msgs = vec![];
+
+        for resolver in &self.inner {
+            match resolver.resolve_read(uri)? {
+                crate::resolve::ResolutionOutcome::Resolved(storages) => {
+                    any_supported = true;
+                    iters.push(storages)
+                }
+                crate::resolve::ResolutionOutcome::UnsupportedIRIType(msg) => {
+                    msgs.push(msg);
+                }
+                crate::resolve::ResolutionOutcome::Unresolvable(msg) => {
+                    any_supported = true;
+                    msgs.push(msg);
+                }
+            }
+        }
+
+        if !iters.is_empty() {
+            Ok(crate::resolve::ResolutionOutcome::Resolved(
+                iters.into_iter().flatten(),
+            ))
+        } else if any_supported {
+            Ok(crate::resolve::ResolutionOutcome::Unresolvable(format!(
+                "Unresolvable: {:?}",
+                msgs
+            )))
+        } else {
+            Ok(crate::resolve::ResolutionOutcome::UnsupportedIRIType(
+                format!("Unsupported IRI: {:?}", msgs),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use indexmap::IndexMap;
+
+    use crate::{
+        model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
+        project::{ProjectRead, memory::InMemoryProject},
+        resolve::{
+            ResolutionOutcome, ResolveRead,
+            memory::{AcceptAll, MemoryResolver},
+            sequential::SequentialResolve,
+        },
+    };
+
+    fn mock_project<S: AsRef<str>, T: AsRef<str>, V: AsRef<str>>(
+        uri: S,
+        name: T,
+        version: V,
+    ) -> (fluent_uri::Iri<String>, InMemoryProject) {
+        (
+            fluent_uri::Iri::parse(uri.as_ref().to_string()).unwrap(),
+            InMemoryProject {
+                info: Some(InterchangeProjectInfoRaw {
+                    name: name.as_ref().to_string(),
+                    description: None,
+                    version: version.as_ref().to_string(),
+                    license: None,
+                    maintainer: vec![],
+                    website: None,
+                    topic: vec![],
+                    usage: vec![],
+                }),
+                meta: Some(InterchangeProjectMetadataRaw {
+                    index: IndexMap::default(),
+                    created: chrono::Utc::now().to_rfc3339(),
+                    metamodel: None,
+                    includes_derived: None,
+                    includes_implied: None,
+                    checksum: Some(IndexMap::default()),
+                }),
+                files: HashMap::default(),
+                nominal_sources: vec![],
+            },
+        )
+    }
+
+    fn mock_resolver<I: IntoIterator<Item = (fluent_uri::Iri<String>, InMemoryProject)>>(
+        projects: I,
+    ) -> MemoryResolver<AcceptAll, InMemoryProject> {
+        MemoryResolver {
+            iri_predicate: AcceptAll {},
+            projects: HashMap::from_iter(projects),
+        }
+    }
+
+    fn expect_to_resolve<R: ResolveRead, S: AsRef<str>>(
+        resolver: &R,
+        uri: S,
+    ) -> Vec<R::ProjectStorage> {
+        let resolved = resolver.resolve_read_raw(uri).unwrap();
+
+        let foo_projects: Result<Vec<_>, _> =
+            if let ResolutionOutcome::Resolved(foo_projects) = resolved {
+                foo_projects.into_iter().collect()
+            } else {
+                panic!("expected foo to resolve")
+            };
+
+        foo_projects.unwrap()
+    }
+
+    #[test]
+    fn test_resolution_preference() -> Result<(), Box<dyn std::error::Error>> {
+        let resolver_1 = mock_resolver([
+            mock_project("urn::kpar::foo", "foo", "1.2.3"),
+            mock_project("urn::kpar::bar", "bar", "1.2.3"),
+        ]);
+
+        let resolver_2 = mock_resolver([
+            mock_project("urn::kpar::bar", "bar", "3.2.1"),
+            mock_project("urn::kpar::baz", "baz", "3.2.1"),
+        ]);
+
+        let resolver = SequentialResolve::new([resolver_1, resolver_2]);
+
+        let foos = expect_to_resolve(&resolver, "urn::kpar::foo");
+
+        assert_eq!(foos.len(), 1);
+        assert_eq!(foos[0].version().unwrap(), Some("1.2.3".to_string()));
+
+        let bars = expect_to_resolve(&resolver, "urn::kpar::bar");
+
+        assert_eq!(bars.len(), 2);
+        assert_eq!(bars[0].version().unwrap(), Some("1.2.3".to_string()));
+        assert_eq!(bars[1].version().unwrap(), Some("3.2.1".to_string()));
+
+        let bazs = expect_to_resolve(&resolver, "urn::kpar::baz");
+
+        assert_eq!(bazs.len(), 1);
+        assert_eq!(bazs[0].version().unwrap(), Some("3.2.1".to_string()));
+
+        Ok(())
+    }
+}

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -40,7 +40,13 @@ pub enum Command {
         command: Option<EnvCommand>,
     },
     /// Sync env to lockfile
-    Sync,
+    Sync {
+        /// Includes the KerML/SysML standard libraries when installing.
+        /// By default these are excluded because they are typically
+        /// shipped with your language implementation.
+        #[arg(long, default_value = "false")]
+        include_std: bool,
+    },
     /// Prints the root directory of the current project
     PrintRoot,
     /// Resolve and describe current interchange project or one at at a specified path or IRI/URL.
@@ -67,9 +73,9 @@ pub enum Command {
         /// Do not try to normalise the IRI/URI when resolving
         #[arg(long, default_value = "false", visible_alias = "no-normalize")]
         no_normalise: bool,
-        /// Use an index when resolving this usage
-        #[arg(long, default_value = Some(DEFAULT_INDEX_URL))]
-        use_index: Option<String>,
+        /// Use this index when resolving this usage
+        #[arg(long, default_values = vec![DEFAULT_INDEX_URL], num_args=0..)]
+        use_index: Vec<String>,
         /// Do not use any index when resolving this usage
         #[arg(long, default_value = "false", conflicts_with = "use_index")]
         no_index: bool,
@@ -78,9 +84,9 @@ pub enum Command {
     },
     /// Update lockfile
     Lock {
-        /// Use an index when updating the lockfile
-        #[arg(long, default_value = Some(DEFAULT_INDEX_URL))]
-        use_index: Option<String>,
+        /// Use this index when resolving this usage
+        #[arg(long, default_values = vec![DEFAULT_INDEX_URL], num_args=0..)]
+        use_index: Vec<String>,
         /// Do not use any index when updating the lockfile
         #[arg(long, default_value = "false", conflicts_with = "use_index")]
         no_index: bool,
@@ -98,11 +104,16 @@ pub enum Command {
         #[arg(long, default_value = "false")]
         no_sync: bool,
         /// Use an index when resolving this usage
-        #[arg(long, default_value = Some(DEFAULT_INDEX_URL))]
-        use_index: Option<String>,
+        #[arg(long, default_values = vec![DEFAULT_INDEX_URL], num_args=0..)]
+        use_index: Vec<String>,
         /// Do not use any index when resolving this usage
         #[arg(long, default_value = "false", conflicts_with = "use_index")]
         no_index: bool,
+        /// Allows installation of the KerML/SysML standard libraries. By default
+        /// these are excluded, as they are typically shipped with your language
+        /// implementation.
+        #[arg(long, default_value = "false")]
+        include_std: bool,
     },
     /// Remove usage from project information
     Remove {

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -79,7 +79,7 @@ pub fn command_info_uri<S: AsRef<str>>(
     uri: Iri<String>,
     _normalise: bool,
     client: Client,
-    index_base_url: Option<S>,
+    index_base_urls: Option<Vec<S>>,
 ) -> Result<()> {
     let cwd = current_dir().ok();
 
@@ -94,8 +94,8 @@ pub fn command_info_uri<S: AsRef<str>>(
             None
         },
         Some(client),
-        index_base_url
-            .map(|x| url::Url::parse(x.as_ref()))
+        index_base_urls
+            .map(|xs| xs.iter().map(|x| url::Url::parse(x.as_ref())).collect())
             .transpose()?,
     );
 

--- a/sysand/src/commands/lock.rs
+++ b/sysand/src/commands/lock.rs
@@ -13,7 +13,7 @@ use sysand_core::resolve::standard::{StandardResolver, standard_resolver};
 pub fn command_lock<P: AsRef<Path>, S: AsRef<str>>(
     path: P,
     client: Client,
-    index_base_url: Option<S>,
+    index_base_urls: Option<Vec<S>>,
 ) -> Result<()> {
     let cwd = current_dir().ok();
 
@@ -28,8 +28,8 @@ pub fn command_lock<P: AsRef<Path>, S: AsRef<str>>(
             None
         },
         Some(client),
-        index_base_url
-            .map(|x| url::Url::parse(x.as_ref()))
+        index_base_urls
+            .map(|xs| xs.iter().map(|x| url::Url::parse(x.as_ref())).collect())
             .transpose()?,
     );
 

--- a/sysand/src/commands/sync.rs
+++ b/sysand/src/commands/sync.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use anyhow::Result;
 use url::ParseError;
@@ -20,6 +20,7 @@ pub fn command_sync(
     project_root: PathBuf,
     env: &mut LocalDirectoryEnvironment,
     client: reqwest::blocking::Client,
+    exclude_iris: &HashSet<String>,
 ) -> Result<()> {
     let lockfile: Lock = toml::from_str(&std::fs::read_to_string(
         project_root.join(DEFAULT_LOCKFILE_NAME),
@@ -50,6 +51,7 @@ pub fn command_sync(
                 )
             },
         ),
+        exclude_iris,
     )?;
     Ok(())
 }

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -123,19 +123,18 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             }) => command_sources_env(iri, version, !no_deps, current_environment),
         },
         cli::Command::Lock {
-            mut use_index,
+            use_index,
             no_index,
         } => {
-            if no_index {
-                use_index = None;
-            }
+            let index_base_urls = if no_index { None } else { Some(use_index) };
+
             if let Some(path) = project_root {
-                crate::commands::lock::command_lock(path, client, use_index)
+                crate::commands::lock::command_lock(path, client, index_base_urls)
             } else {
                 bail!("Not inside a project")
             }
         }
-        cli::Command::Sync => {
+        cli::Command::Sync { include_std } => {
             let mut local_environment = match current_environment {
                 Some(env) => env,
                 None => command_env(
@@ -146,10 +145,16 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 )?,
             };
 
+            let exclude_iris = if !include_std {
+                known_std_libs()
+            } else {
+                std::collections::HashSet::default()
+            };
             command_sync(
                 project_root.unwrap_or(std::env::current_dir()?),
                 &mut local_environment,
                 client,
+                &exclude_iris,
             )
         }
         cli::Command::PrintRoot => command_print_root(std::env::current_dir()?),
@@ -159,12 +164,11 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             auto,
             location,
             no_normalise,
-            mut use_index,
+            use_index,
             no_index,
         } => {
-            if no_index {
-                use_index = None;
-            }
+            let index_base_urls = if no_index { None } else { Some(use_index) };
+
             match location {
                 Some(actual_location) => {
                     if iri {
@@ -176,7 +180,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                             uri,
                             !no_normalise,
                             client,
-                            use_index,
+                            index_base_urls,
                         )
                     } else if auto {
                         debug_assert!(!path);
@@ -185,7 +189,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                                 uri,
                                 !no_normalise,
                                 client,
-                                use_index,
+                                index_base_urls,
                             )
                         } else {
                             command_info_path(std::path::Path::new(&actual_location))
@@ -205,17 +209,17 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             versions_constraint,
             no_lock,
             no_sync,
-            mut use_index,
+            use_index,
             no_index,
+            include_std,
         } => {
-            if no_index {
-                use_index = None;
-            }
+            let index_base_urls = if no_index { None } else { Some(use_index) };
+
             command_add(iri, versions_constraint, current_project)?;
 
             if !no_lock {
                 if let Some(path) = &project_root {
-                    crate::commands::lock::command_lock(path, client.clone(), use_index)?;
+                    crate::commands::lock::command_lock(path, client.clone(), index_base_urls)?;
                 } else {
                     bail!("Not inside a project")
                 }
@@ -232,10 +236,16 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                         )?,
                     };
 
+                    let exclude_iris = if !include_std {
+                        known_std_libs()
+                    } else {
+                        std::collections::HashSet::default()
+                    };
                     command_sync(
                         project_root.unwrap_or(std::env::current_dir()?),
                         &mut local_environment,
                         client,
+                        &exclude_iris,
                     )?;
                 }
             }
@@ -270,6 +280,35 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             command_sources_project(!no_deps, current_project, current_environment)
         }
     }
+}
+
+// TODO: These should not be hard-coded, this is just a stop-gap solution
+fn known_std_libs() -> std::collections::HashSet<String> {
+    std::collections::HashSet::from([
+        "urn:kpar:quantities-and-units-library".to_string(),
+        "urn:kpar:function-library".to_string(),
+        "urn:kpar:systems-library".to_string(),
+        "urn:kpar:cause-and-effect-library".to_string(),
+        "urn:kpar:requirement-derivation-library".to_string(),
+        "urn:kpar:metadata-library".to_string(),
+        "urn:kpar:geometry-library".to_string(),
+        "urn:kpar:analysis-library".to_string(),
+        "urn:kpar:data-type-library".to_string(),
+        "urn:kpar:semantic-library".to_string(),
+        //
+        "https://www.omg.org/spec/SysML/20230201/Quantities-and-Units-Domain-Library.kpar"
+            .to_string(),
+        "https://www.omg.org/spec/KerML/20230201/Function-Library.kpar".to_string(),
+        "https://www.omg.org/spec/SysML/20230201/Systems-Library.kpar".to_string(),
+        "https://www.omg.org/spec/SysML/20230201/Cause-and-Effect-Domain-Library.kpar".to_string(),
+        "https://www.omg.org/spec/SysML/20230201/Requirement-Derivation-Domain-Library.kpar"
+            .to_string(),
+        "https://www.omg.org/spec/SysML/20230201/Metadata-Domain-Library.kpar".to_string(),
+        "https://www.omg.org/spec/SysML/20230201/Geometry-Domain-Library.kpar".to_string(),
+        "https://www.omg.org/spec/SysML/20230201/Analysis-Domain-Library.kpar".to_string(),
+        "https://www.omg.org/spec/KerML/20230201/Data-Type-Library.kpar".to_string(),
+        "https://www.omg.org/spec/KerML/20230201/Semantic-Library.kpar".to_string(),
+    ])
 }
 
 pub fn get_env(project_root: &std::path::Path) -> Option<LocalDirectoryEnvironment> {

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -365,7 +365,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn std::error::Error>> {
     let versions_mock = server
         .mock(
             "GET",
-            "/dac306141e1d854f462500d5b3fc829bf61237cf782849e27e904e43e37da4d9/versions.txt",
+            "/e837859ce90bb1917c2698a6d62caa5786f67662fd1e35eb320f6e9da96939fe/versions.txt",
         )
         .with_status(200)
         .with_header("content-type", "text/plain")
@@ -374,7 +374,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn std::error::Error>> {
         .create();
 
     let project_mock_head = server
-        .mock("HEAD", "/dac306141e1d854f462500d5b3fc829bf61237cf782849e27e904e43e37da4d9/1.2.3.kpar/.project.json")
+        .mock("HEAD", "/e837859ce90bb1917c2698a6d62caa5786f67662fd1e35eb320f6e9da96939fe/1.2.3.kpar/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_index_url","version":"1.2.3","usage":[]}"#)
@@ -382,7 +382,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn std::error::Error>> {
         .create();
 
     let project_mock = server
-        .mock("GET", "/dac306141e1d854f462500d5b3fc829bf61237cf782849e27e904e43e37da4d9/1.2.3.kpar/.project.json")
+        .mock("GET", "/e837859ce90bb1917c2698a6d62caa5786f67662fd1e35eb320f6e9da96939fe/1.2.3.kpar/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_index_url","version":"1.2.3","usage":[]}"#)
@@ -390,7 +390,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn std::error::Error>> {
         .create();
 
     let meta_mock = server
-        .mock("GET", "/dac306141e1d854f462500d5b3fc829bf61237cf782849e27e904e43e37da4d9/1.2.3.kpar/.meta.json")
+        .mock("GET", "/e837859ce90bb1917c2698a6d62caa5786f67662fd1e35eb320f6e9da96939fe/1.2.3.kpar/.meta.json")
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
@@ -401,7 +401,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn std::error::Error>> {
         &vec![
             "info",
             "--iri",
-            "urn::kpar::info_basic_index_url",
+            "urn:kpar:info_basic_index_url",
             "--use-index",
             &server.url(),
         ],
@@ -422,7 +422,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn std::error::Error>> {
         &vec![
             "info",
             "--iri",
-            "urn::kpar::other",
+            "urn:kpar:other",
             "--use-index",
             &server.url(),
         ],
@@ -430,7 +430,146 @@ fn info_basic_index_url() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     out.assert().failure().stderr(predicate::str::contains(
-        "Unable to find interchange project at urn::kpar::other",
+        "Unable to find interchange project at urn:kpar:other",
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn info_multi_index_url() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = mockito::Server::new();
+    let mut server_alt = mockito::Server::new();
+
+    let versions_mock = server
+        .mock(
+            "GET",
+            "/f38ace6666fe279c9e856b2a25b14bf0a03b8c23ff1db524acf1afd78f66b042/versions.txt",
+        )
+        .with_status(200)
+        .with_header("content-type", "text/plain")
+        .with_body("1.2.3\n")
+        .expect_at_most(1)
+        .create();
+
+    let project_mock_head = server
+        .mock("HEAD", "/f38ace6666fe279c9e856b2a25b14bf0a03b8c23ff1db524acf1afd78f66b042/1.2.3.kpar/.project.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"info_multi_index_url","version":"1.2.3","usage":[]}"#)
+        .expect_at_most(1)
+        .create();
+
+    let project_mock = server
+        .mock("GET", "/f38ace6666fe279c9e856b2a25b14bf0a03b8c23ff1db524acf1afd78f66b042/1.2.3.kpar/.project.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"info_multi_index_url","version":"1.2.3","usage":[]}"#)
+        .expect_at_most(2) // TODO: Reduce this to 1 after caching
+        .create();
+
+    let meta_mock = server
+        .mock("GET", "/f38ace6666fe279c9e856b2a25b14bf0a03b8c23ff1db524acf1afd78f66b042/1.2.3.kpar/.meta.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
+        .expect_at_most(2) // TODO: Reduce this to 1 after caching
+        .create();
+
+    let versions_alt_mock = server_alt
+        .mock(
+            "GET",
+            "/f0f4203b967855590901dc5c90f525d732015ca10598e333815cc30600874565/versions.txt",
+        )
+        .with_status(200)
+        .with_header("content-type", "text/plain")
+        .with_body("1.2.3\n")
+        .expect_at_most(1)
+        .create();
+
+    let project_alt_mock_head = server_alt
+        .mock("HEAD", "/f0f4203b967855590901dc5c90f525d732015ca10598e333815cc30600874565/1.2.3.kpar/.project.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"info_multi_index_url_alt","version":"1.2.3","usage":[]}"#)
+        .expect_at_most(1)
+        .create();
+
+    let project_alt_mock = server_alt
+        .mock("GET", "/f0f4203b967855590901dc5c90f525d732015ca10598e333815cc30600874565/1.2.3.kpar/.project.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"info_multi_index_url_alt","version":"1.2.3","usage":[]}"#)
+        .expect_at_most(2) // TODO: Reduce this to 1 after caching
+        .create();
+
+    let meta_alt_mock = server_alt
+        .mock("GET", "/f0f4203b967855590901dc5c90f525d732015ca10598e333815cc30600874565/1.2.3.kpar/.meta.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
+        .expect_at_most(2) // TODO: Reduce this to 1 after caching
+        .create();
+
+    let (_, _, out) = run_sysand(
+        &vec![
+            "info",
+            "--iri",
+            "urn:kpar:info_multi_index_url",
+            "--use-index",
+            &server.url(),
+            "--use-index",
+            &server_alt.url(),
+        ],
+        None,
+    )?;
+
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("Name: info_multi_index_url"))
+        .stdout(predicate::str::contains("Version: 1.2.3"));
+
+    let (_, _, out) = run_sysand(
+        &vec![
+            "info",
+            "--iri",
+            "urn:kpar:info_multi_index_url_alt",
+            "--use-index",
+            &server.url(),
+            "--use-index",
+            &server_alt.url(),
+        ],
+        None,
+    )?;
+
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("Name: info_multi_index_url_alt"))
+        .stdout(predicate::str::contains("Version: 1.2.3"));
+
+    versions_mock.assert();
+    project_mock_head.assert();
+    project_mock.assert();
+    meta_mock.assert();
+
+    versions_alt_mock.assert();
+    project_alt_mock_head.assert();
+    project_alt_mock.assert();
+    meta_alt_mock.assert();
+
+    let (_, _, out) = run_sysand(
+        &vec![
+            "info",
+            "--iri",
+            "urn:kpar:other",
+            "--use-index",
+            &server.url(),
+        ],
+        None,
+    )?;
+
+    out.assert().failure().stderr(predicate::str::contains(
+        "Unable to find interchange project at urn:kpar:other",
     ));
 
     Ok(())


### PR DESCRIPTION
Introduces `SequentialResolver` for running multiple resolvers (of the same type) in sequence, and uses this from the CLI and Python bindings to allow multiple indices. 