### PR TITLE
Add CLI commands for manipulating `.project.json` and `.meta.json` fields

### DIFF
--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -118,7 +118,7 @@ pub extern "system" fn Java_org_sysand_Sysand_info_1path__Ljava_lang_String_2<'l
         project_path: std::path::PathBuf::from(&path),
     };
 
-    let command_result = sysand_core::commands::info::do_info_project(project);
+    let command_result = sysand_core::commands::info::do_info_project(&project);
     match command_result {
         Some(info_metadata) => info_metadata.to_jobject(&mut env),
         None => JObject::null(),

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -95,7 +95,7 @@ fn do_info_py_path(
         project_path: Path::new(&path).to_path_buf(),
     };
 
-    Ok(do_info_project(project))
+    Ok(do_info_project(&project))
 }
 
 #[pyfunction(name = "do_info_py")]

--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -18,7 +18,7 @@ pub enum InfoError<Error: std::error::Error> {
 }
 
 pub fn do_info_project<P: ProjectRead>(
-    project: P,
+    project: &P,
 ) -> Option<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
     match project.get_project() {
         Ok((Some(info), Some(meta))) => Some((info, meta)),
@@ -59,7 +59,7 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
                 vec![];
 
             for project in resolved.into_iter() {
-                if let Some(info_meta) = do_info_project(project?) {
+                if let Some(info_meta) = do_info_project(&project?) {
                     result.push(info_meta);
                 }
             }

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -919,6 +919,8 @@ impl InfoCommand {
     }
 
     pub fn numbered(&self) -> bool {
+        // NOTE: Avoid using { .. } here, in order to not accidentally miss the introduction of
+        //       relevant flags in the future.
         match self {
             InfoCommand::Name {
                 set: _,

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -655,7 +655,11 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetDescription,
                 set.map(SetInfoVerb::SetDescription),
-                if clear { Some(ClearInfoVerb::ClearDescription) } else { None },
+                if clear {
+                    Some(ClearInfoVerb::ClearDescription)
+                } else {
+                    None
+                },
                 impossible(add),
                 impossible(remove),
             ),
@@ -679,7 +683,11 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetLicence,
                 set.map(SetInfoVerb::SetLicence),
-                if clear { Some(ClearInfoVerb::ClearLicence) } else { None },
+                if clear {
+                    Some(ClearInfoVerb::ClearLicence)
+                } else {
+                    None
+                },
                 impossible(add),
                 impossible(remove),
             ),
@@ -692,7 +700,11 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetMaintainer,
                 set.map(|x| SetInfoVerb::SetMaintainer(vec![x])),
-                if clear { Some(ClearInfoVerb::ClearMaintainer) } else { None },
+                if clear {
+                    Some(ClearInfoVerb::ClearMaintainer)
+                } else {
+                    None
+                },
                 add.map(|x| AddInfoVerb::AddMaintainer(vec![x])),
                 remove.map(RemoveInfoVerb::RemoveMaintainer),
             ),
@@ -704,7 +716,11 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetWebsite,
                 set.map(SetInfoVerb::SetWebsite),
-                if clear { Some(ClearInfoVerb::ClearWebsite) } else { None },
+                if clear {
+                    Some(ClearInfoVerb::ClearWebsite)
+                } else {
+                    None
+                },
                 impossible(add),
                 impossible(remove),
             ),
@@ -717,7 +733,11 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetTopic,
                 set.map(|x| SetInfoVerb::SetTopic(vec![x])),
-                if clear { Some(ClearInfoVerb::ClearTopic) } else { None },
+                if clear {
+                    Some(ClearInfoVerb::ClearTopic)
+                } else {
+                    None
+                },
                 add.map(|x| AddInfoVerb::AddTopic(vec![x])),
                 remove.map(RemoveInfoVerb::RemoveTopic),
             ),
@@ -767,7 +787,11 @@ impl InfoCommand {
             } => pack_meta(
                 GetMetaVerb::GetMetamodel,
                 set.map(SetMetaVerb::SetMetamodel),
-                if clear { Some(ClearMetaVerb::ClearMetamodel) } else { None },
+                if clear {
+                    Some(ClearMetaVerb::ClearMetamodel)
+                } else {
+                    None
+                },
                 impossible(add),
                 impossible(remove),
             ),
@@ -779,7 +803,11 @@ impl InfoCommand {
             } => pack_meta(
                 GetMetaVerb::GetIncludesDerived,
                 set.map(SetMetaVerb::SetIncludesDerived),
-                if clear { Some(ClearMetaVerb::ClearIncludesDerived) } else { None },
+                if clear {
+                    Some(ClearMetaVerb::ClearIncludesDerived)
+                } else {
+                    None
+                },
                 impossible(add),
                 impossible(remove),
             ),
@@ -791,7 +819,11 @@ impl InfoCommand {
             } => pack_meta(
                 GetMetaVerb::GetIncludesImplied,
                 set.map(SetMetaVerb::SetIncludesImplied),
-                if clear { Some(ClearMetaVerb::ClearIncludesImplied) } else { None },
+                if clear {
+                    Some(ClearMetaVerb::ClearIncludesImplied)
+                } else {
+                    None
+                },
                 impossible(add),
                 impossible(remove),
             ),

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -434,34 +434,6 @@ pub enum InfoCommand {
     },
 }
 
-// #[derive(Debug, Clone)]
-// pub enum InfoAction<S, C, A, R> {
-//     Get,
-//     Set(S),
-//     Clear(C),
-//     Add(A),
-//     Remove(R),
-// }
-
-// type ROMultiFieldVerb = InfoAction<Infallible, Infallible, Infallible, Infallible>;
-// type MandatorySingleFieldVerb = InfoAction<String, Infallible, Infallible, Infallible>;
-// type OptionalSingleFieldVerb = InfoAction<String, bool, Infallible, Infallible>;
-// type OptionalSingleBoolFieldVerb = InfoAction<bool, bool, Infallible, Infallible>;
-// type OptionalMultiFieldVerb = InfoAction<String, bool, String, usize>;
-
-// impl<S, C, A, R> InfoAction<S, C, A, R> {
-//     fn from_args(set: Option<S>, clear: Option<C>, add: Option<A>, remove: Option<R>) -> Self {
-//         match (set, clear, add, remove) {
-//             (None, None, None, None) => InfoAction::Get,
-//             (Some(set), None, None, None) => InfoAction::Set(set),
-//             (None, Some(clear), None, None) => InfoAction::Clear(clear),
-//             (None, None, Some(add), None) => InfoAction::Add(add),
-//             (None, None, None, Some(remove)) => InfoAction::Remove(remove),
-//             _ => panic!("internal error: invalid CLI command produced"),
-//         }
-//     }
-//}
-
 #[derive(Debug, Clone)]
 pub enum InfoCommandVerb {
     Get(GetVerb),

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::{convert::Infallible, fmt::Write};
+
+use clap::builder::StyledStr;
 use semver::VersionReq;
 
 const DEFAULT_INDEX_URL: &str = "https://beta.sysand.org";
@@ -51,25 +54,22 @@ pub enum Command {
     PrintRoot,
     /// Resolve and describe current interchange project or one at at a specified path or IRI/URL.
     Info {
-        /// Use local path instead of IRI/URI (set by default).
-        #[arg(short = 'p', long, group = "location-kind", requires = "location")]
-        path: bool,
-        /// Use IRI/URI instead of local path.
+        /// Use the project at the given path instead of the current project
+        #[arg(short = 'p', long, group = "location")]
+        path: Option<String>,
+        /// Use the project with the given IRI/URI/URL instead of the current project
         #[arg(
             short = 'i',
             long,
             visible_alias = "uri",
-            group = "location-kind",
-            requires = "location"
+            visible_alias = "url",
+            group = "location"
         )]
-        iri: bool,
-        /// Automatically detect the location kind by first trying to parse it
-        /// as an IRI/URI and then falling back to a local path.
-        #[arg(short = 'a', long, group = "location-kind", requires = "location")]
-        auto: bool,
-        /// Local path or IRI/URI of interchange project
-        #[arg(default_value = None)]
-        location: Option<String>,
+        iri: Option<String>,
+        /// Use the project with the given location, trying to parse it
+        /// as an IRI/URI/URL and otherwise falling back to a local path
+        #[arg(short = 'a', long, group = "location")]
+        auto_location: Option<String>,
         /// Do not try to normalise the IRI/URI when resolving
         #[arg(long, default_value = "false", visible_alias = "no-normalize")]
         no_normalise: bool,
@@ -81,6 +81,8 @@ pub enum Command {
         no_index: bool,
         // TODO: Add various options, such as whether to take local environment
         //       into consideration
+        #[command(subcommand)]
+        subcommand: Option<InfoCommand>,
     },
     /// Update lockfile
     Lock {
@@ -163,6 +165,745 @@ pub enum Command {
         #[arg(long, default_value = "false")]
         include_std: bool,
     },
+}
+
+#[derive(Clone, Debug)]
+struct InvalidCommand {
+    message: String,
+}
+
+fn invalid_command<S: AsRef<str>>(message: S) -> InvalidCommand {
+    InvalidCommand {
+        message: message.as_ref().to_string(),
+    }
+}
+
+impl clap::builder::TypedValueParser for InvalidCommand {
+    type Value = Infallible;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let mut err = clap::Error::new(clap::error::ErrorKind::UnknownArgument).with_cmd(cmd);
+        if let Some(arg) = arg {
+            err.insert(
+                clap::error::ContextKind::InvalidArg,
+                clap::error::ContextValue::String(arg.to_string()),
+            );
+        }
+        err.insert(
+            clap::error::ContextKind::InvalidValue,
+            clap::error::ContextValue::String(value.to_string_lossy().to_string()),
+        );
+
+        // NOTE: https://github.com/clap-rs/clap/discussions/5318
+        // Only works with StyledStrs
+        let mut styled = StyledStr::new();
+        styled.write_str(&self.message)?;
+        err.insert(
+            clap::error::ContextKind::Suggested,
+            clap::error::ContextValue::StyledStrs(vec![styled]),
+        );
+
+        Err(err)
+    }
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum InfoCommand {
+    /// Get or set the name of the project
+    #[group(required = false, multiple = false)]
+    Name {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        // Only for better error messages
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'name' cannot be unset"))]
+        clear: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'name' is not a list, did you mean to use 'sysand info name --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'name' is not a list, and cannot be unset"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or set the description of the project
+    #[group(required = false, multiple = false)]
+    Description {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        #[arg(long, default_value = None)]
+        clear: Option<bool>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'description' is not a list, did you mean to use 'sysand info description --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'description' is not a list, did you mean to use 'sysand info description --clear'?"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or set the version of the project
+    #[group(required = false, multiple = false)]
+    Version {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        // Only for better error messages
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", default_value = None, value_parser=invalid_command("'version' cannot be unset"))]
+        clear: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'version' is not a list, did you mean to use 'sysand info version --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'version' is not a list, and cannot be unset"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or set the licence of the project
+    #[command(visible_alias = "license")]
+    #[group(required = false, multiple = false)]
+    Licence {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        #[arg(long, default_value = None)]
+        clear: Option<bool>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'licence' is not a list, did you mean to use 'sysand info licence --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'licence' is not a list, did you mean to use 'sysand info licence --clear'?"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or manipulate the list of maintainers of the project
+    #[group(required = false, multiple = false)]
+    Maintainer {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        #[arg(long, default_value = None)]
+        clear: Option<bool>,
+        #[arg(long, default_value=None)]
+        add: Option<String>,
+        #[arg(long, default_value=None)]
+        remove: Option<usize>,
+        /// Prints a numbered list
+        #[arg(long, default_value = "false")]
+        numbered: bool,
+    },
+    /// Get or set the website of the project
+    #[group(required = false, multiple = false)]
+    Website {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        #[arg(long, default_value = None)]
+        clear: Option<bool>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'website' is not a list, did you mean to use 'sysand info website --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'website' is not a list, did you mean to use 'sysand info website --clear'?"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or manipulate the list of topics of the project
+    #[group(required = false, multiple = false)]
+    Topic {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        #[arg(long, default_value = None)]
+        clear: Option<bool>,
+        #[arg(long, default_value=None)]
+        add: Option<String>,
+        #[arg(long, default_value=None)]
+        remove: Option<usize>,
+        /// Prints a numbered list
+        #[arg(long, default_value = "false")]
+        numbered: bool,
+    },
+    /// Print project usages
+    #[group(required = false, multiple = false)]
+    Usage {
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'usage' cannot be set directly, please use 'sysand add' and 'sysand remove'"))]
+        set: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'usage' cannot be cleared directly, please use 'sysand remove'"))]
+        clear: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'usage' cannot be added to directly, please use 'sysand add'"))]
+        add: Option<Infallible>,
+        // Only for Infallible error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'usage' cannot be removed from directly, please use 'sysand remove'"))]
+        remove: Option<Infallible>,
+        /// Prints a numbered list
+        #[arg(long, default_value = "false")]
+        numbered: bool,
+    },
+    // Get project index
+    #[group(required = false, multiple = false)]
+    Index {
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be set directly, please use 'sysand include' and 'sysand exclude'"))]
+        set: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide = true, long, default_value = None, value_parser=invalid_command("'index' cannot be cleared directly, please use 'sysand exclude'"))]
+        clear: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be added to directly, please use 'sysand include' and 'sysand exclude'"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be removed from directly, please use 'sysand exclude'"))]
+        remove: Option<Infallible>,
+        /// Prints a numbered list
+        #[arg(long, default_value = "false")]
+        numbered: bool,
+    },
+    // Get project creation time
+    #[group(required = false, multiple = false)]
+    Created {
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be set directly, it is automatically updated"))]
+        set: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide = true, long, default_value = None, value_parser=invalid_command("'created' cannot be cleared, it is automatically updated"))]
+        clear: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be added to, it is automatically updated"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be removed from, it is automatically updated"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or set the metamodel of the project
+    #[group(required = false, multiple = false)]
+    Metamodel {
+        #[arg(long, default_value=None)]
+        set: Option<String>,
+        #[arg(long, default_value = None)]
+        clear: Option<bool>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'metamodel' is not a list, did you mean to use 'sysand info metamodel --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'metamodel' is not a list, did you mean to use 'sysand info metamodel --clear'?"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or set whether the project includes derived properties
+    #[group(required = false, multiple = false)]
+    IncludesDerived {
+        #[arg(long, num_args=0..1, default_missing_value="true", default_value=None)]
+        set: Option<bool>,
+        #[arg(long, num_args=0, default_missing_value="Some(())", default_value = None)]
+        clear: Option<bool>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_derived' is not a list, did you mean to use 'sysand info include_derived --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_derived' is not a list, did you mean to use 'sysand info include_derived --clear'?"))]
+        remove: Option<Infallible>,
+    },
+    /// Get or set whether the project includes implied properties
+    #[group(required = false, multiple = false)]
+    IncludesImplied {
+        #[arg(long, num_args=0..1, default_missing_value="true", default_value=None)]
+        set: Option<bool>,
+        #[arg(long, num_args=0, default_missing_value="true", default_value = None)]
+        clear: Option<bool>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_implied' is not a list, did you mean to use 'sysand info include_implied --set'?"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_implied' is not a list, did you mean to use 'sysand info include_implied --clear'?"))]
+        remove: Option<Infallible>,
+    },
+    // Get project checksums
+    #[group(required = false, multiple = false)]
+    Checksum {
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be set directly, please use 'sysand include' and 'sysand exclude'"))]
+        set: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide = true, long, default_value = None, value_parser=invalid_command("checksum cannot be cleared directly, please use 'sysand exclude'"))]
+        clear: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be added to directly, please use 'sysand include'"))]
+        add: Option<Infallible>,
+        // Only for better error messages
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be removed from directly, please use 'sysand exclude'"))]
+        remove: Option<Infallible>,
+        /// Prints a numbered list
+        #[arg(long, default_value = "false")]
+        numbered: bool,
+    },
+}
+
+// #[derive(Debug, Clone)]
+// pub enum InfoAction<S, C, A, R> {
+//     Get,
+//     Set(S),
+//     Clear(C),
+//     Add(A),
+//     Remove(R),
+// }
+
+// type ROMultiFieldVerb = InfoAction<Infallible, Infallible, Infallible, Infallible>;
+// type MandatorySingleFieldVerb = InfoAction<String, Infallible, Infallible, Infallible>;
+// type OptionalSingleFieldVerb = InfoAction<String, bool, Infallible, Infallible>;
+// type OptionalSingleBoolFieldVerb = InfoAction<bool, bool, Infallible, Infallible>;
+// type OptionalMultiFieldVerb = InfoAction<String, bool, String, usize>;
+
+// impl<S, C, A, R> InfoAction<S, C, A, R> {
+//     fn from_args(set: Option<S>, clear: Option<C>, add: Option<A>, remove: Option<R>) -> Self {
+//         match (set, clear, add, remove) {
+//             (None, None, None, None) => InfoAction::Get,
+//             (Some(set), None, None, None) => InfoAction::Set(set),
+//             (None, Some(clear), None, None) => InfoAction::Clear(clear),
+//             (None, None, Some(add), None) => InfoAction::Add(add),
+//             (None, None, None, Some(remove)) => InfoAction::Remove(remove),
+//             _ => panic!("internal error: invalid CLI command produced"),
+//         }
+//     }
+//}
+
+#[derive(Debug, Clone)]
+pub enum InfoCommandVerb {
+    Get(GetVerb),
+    Set(SetVerb),
+    Clear(ClearVerb),
+    Add(AddVerb),
+    Remove(RemoveVerb),
+}
+
+#[derive(Debug, Clone)]
+pub enum GetVerb {
+    GetInfoVerb(GetInfoVerb),
+    GetMetaVerb(GetMetaVerb),
+}
+
+#[derive(Debug, Clone)]
+pub enum SetVerb {
+    SetInfoVerb(SetInfoVerb),
+    SetMetaVerb(SetMetaVerb),
+}
+
+#[derive(Debug, Clone)]
+pub enum ClearVerb {
+    ClearInfoVerb(ClearInfoVerb),
+    ClearMetaVerb(ClearMetaVerb),
+}
+
+#[derive(Debug, Clone)]
+pub enum AddVerb {
+    AddInfoVerb(AddInfoVerb),
+    AddMetaVerb(AddMetaVerb),
+}
+
+#[derive(Debug, Clone)]
+pub enum RemoveVerb {
+    RemoveInfoVerb(RemoveInfoVerb),
+    RemoveMetaVerb(RemoveMetaVerb),
+}
+
+#[derive(Debug, Clone)]
+pub enum GetInfoVerb {
+    GetName,
+    GetDescription,
+    GetVersion,
+    GetLicence,
+    GetMaintainer,
+    GetWebsite,
+    GetTopic,
+    GetUsage,
+}
+
+#[derive(Debug, Clone)]
+pub enum SetInfoVerb {
+    SetName(String),
+    SetDescription(String),
+    SetVersion(String),
+    SetLicence(String),
+    SetMaintainer(Vec<String>),
+    SetWebsite(String),
+    SetTopic(Vec<String>),
+}
+
+#[derive(Debug, Clone)]
+pub enum ClearInfoVerb {
+    ClearDescription,
+    ClearLicence,
+    ClearMaintainer,
+    ClearWebsite,
+    ClearTopic,
+}
+
+#[derive(Debug, Clone)]
+pub enum AddInfoVerb {
+    AddMaintainer(Vec<String>),
+    AddTopic(Vec<String>),
+}
+
+#[derive(Debug, Clone)]
+pub enum RemoveInfoVerb {
+    RemoveMaintainer(usize),
+    RemoveTopic(usize),
+}
+
+#[derive(Debug, Clone)]
+pub enum GetMetaVerb {
+    GetIndex,
+    GetCreated,
+    GetMetamodel,
+    GetIncludesDerived,
+    GetIncludesImplied,
+    GetChecksum,
+}
+
+#[derive(Debug, Clone)]
+pub enum SetMetaVerb {
+    SetMetamodel(String),
+    SetIncludesDerived(bool),
+    SetIncludesImplied(bool),
+}
+
+#[derive(Debug, Clone)]
+pub enum ClearMetaVerb {
+    ClearMetamodel,
+    ClearIncludesDerived,
+    ClearIncludesImplied,
+}
+
+#[derive(Debug, Clone)]
+pub enum AddMetaVerb {
+    // Currently nothing
+}
+
+#[derive(Debug, Clone)]
+pub enum RemoveMetaVerb {
+    // Currently nothing
+}
+
+impl InfoCommand {
+    pub fn as_verb(self) -> InfoCommandVerb {
+        fn pack(
+            get: GetVerb,
+            set: Option<SetVerb>,
+            clear: Option<ClearVerb>,
+            add: Option<AddVerb>,
+            remove: Option<RemoveVerb>,
+        ) -> InfoCommandVerb {
+            match (set, clear, add, remove) {
+                (None, None, None, None) => InfoCommandVerb::Get(get),
+                (Some(set), None, None, None) => InfoCommandVerb::Set(set),
+                (None, Some(clear), None, None) => InfoCommandVerb::Clear(clear),
+                (None, None, Some(add), None) => InfoCommandVerb::Add(add),
+                (None, None, None, Some(remove)) => InfoCommandVerb::Remove(remove),
+                _ => panic!("internal error: invalid CLI command produced"),
+            }
+        }
+
+        fn pack_info(
+            get: GetInfoVerb,
+            set: Option<SetInfoVerb>,
+            clear: Option<ClearInfoVerb>,
+            add: Option<AddInfoVerb>,
+            remove: Option<RemoveInfoVerb>,
+        ) -> InfoCommandVerb {
+            pack(
+                GetVerb::GetInfoVerb(get),
+                set.map(SetVerb::SetInfoVerb),
+                clear.map(ClearVerb::ClearInfoVerb),
+                add.map(AddVerb::AddInfoVerb),
+                remove.map(RemoveVerb::RemoveInfoVerb),
+            )
+        }
+
+        fn pack_meta(
+            get: GetMetaVerb,
+            set: Option<SetMetaVerb>,
+            clear: Option<ClearMetaVerb>,
+            add: Option<AddMetaVerb>,
+            remove: Option<RemoveMetaVerb>,
+        ) -> InfoCommandVerb {
+            pack(
+                GetVerb::GetMetaVerb(get),
+                set.map(SetVerb::SetMetaVerb),
+                clear.map(ClearVerb::ClearMetaVerb),
+                add.map(AddVerb::AddMetaVerb),
+                remove.map(RemoveVerb::RemoveMetaVerb),
+            )
+        }
+
+        fn impossible<T>(impossible: Option<Infallible>) -> Option<T> {
+            impossible.map(|x| match x {})
+        }
+
+        match self {
+            InfoCommand::Name {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_info(
+                GetInfoVerb::GetName,
+                set.map(SetInfoVerb::SetName),
+                impossible(clear),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Description {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_info(
+                GetInfoVerb::GetDescription,
+                set.map(SetInfoVerb::SetDescription),
+                clear.map(|_| ClearInfoVerb::ClearDescription),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Version {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_info(
+                GetInfoVerb::GetVersion,
+                set.map(SetInfoVerb::SetVersion),
+                impossible(clear),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Licence {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_info(
+                GetInfoVerb::GetLicence,
+                set.map(SetInfoVerb::SetLicence),
+                clear.map(|_| ClearInfoVerb::ClearLicence),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Maintainer {
+                set,
+                clear,
+                add,
+                remove,
+                numbered: _,
+            } => pack_info(
+                GetInfoVerb::GetMaintainer,
+                set.map(|x| SetInfoVerb::SetMaintainer(vec![x])),
+                clear.map(|_| ClearInfoVerb::ClearMaintainer),
+                add.map(|x| AddInfoVerb::AddMaintainer(vec![x])),
+                remove.map(RemoveInfoVerb::RemoveMaintainer),
+            ),
+            InfoCommand::Website {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_info(
+                GetInfoVerb::GetWebsite,
+                set.map(SetInfoVerb::SetWebsite),
+                clear.map(|_| ClearInfoVerb::ClearWebsite),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Topic {
+                set,
+                clear,
+                add,
+                remove,
+                numbered: _,
+            } => pack_info(
+                GetInfoVerb::GetTopic,
+                set.map(|x| SetInfoVerb::SetTopic(vec![x])),
+                clear.map(|_| ClearInfoVerb::ClearTopic),
+                add.map(|x| AddInfoVerb::AddTopic(vec![x])),
+                remove.map(RemoveInfoVerb::RemoveTopic),
+            ),
+            InfoCommand::Usage {
+                set,
+                clear,
+                add,
+                remove,
+                numbered: _,
+            } => pack_info(
+                GetInfoVerb::GetUsage,
+                impossible(set),
+                impossible(clear),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Index {
+                set,
+                clear,
+                add,
+                remove,
+                numbered: _,
+            } => pack_meta(
+                GetMetaVerb::GetIndex,
+                impossible(set),
+                impossible(clear),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Created {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_meta(
+                GetMetaVerb::GetCreated,
+                impossible(set),
+                impossible(clear),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Metamodel {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_meta(
+                GetMetaVerb::GetMetamodel,
+                set.map(SetMetaVerb::SetMetamodel),
+                clear.map(|_| ClearMetaVerb::ClearMetamodel),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::IncludesDerived {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_meta(
+                GetMetaVerb::GetIncludesDerived,
+                set.map(SetMetaVerb::SetIncludesDerived),
+                clear.map(|_| ClearMetaVerb::ClearIncludesDerived),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::IncludesImplied {
+                set,
+                clear,
+                add,
+                remove,
+            } => pack_meta(
+                GetMetaVerb::GetIncludesImplied,
+                set.map(SetMetaVerb::SetIncludesImplied),
+                clear.map(|_| ClearMetaVerb::ClearIncludesImplied),
+                impossible(add),
+                impossible(remove),
+            ),
+            InfoCommand::Checksum {
+                set,
+                clear,
+                add,
+                remove,
+                numbered: _,
+            } => pack_meta(
+                GetMetaVerb::GetChecksum,
+                impossible(set),
+                impossible(clear),
+                impossible(add),
+                impossible(remove),
+            ),
+        }
+    }
+
+    pub fn numbered(&self) -> bool {
+        match self {
+            InfoCommand::Name {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::Description {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::Version {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::Licence {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::Maintainer {
+                numbered,
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => *numbered,
+            InfoCommand::Website {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::Topic {
+                numbered,
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => *numbered,
+            InfoCommand::Usage {
+                numbered,
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => *numbered,
+            InfoCommand::Index {
+                numbered,
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => *numbered,
+            InfoCommand::Created {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::Metamodel {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::IncludesDerived {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::IncludesImplied {
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => false,
+            InfoCommand::Checksum {
+                numbered,
+                set: _,
+                clear: _,
+                add: _,
+                remove: _,
+            } => *numbered,
+        }
+    }
 }
 
 #[derive(clap::Subcommand, Debug, Clone)]

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -235,7 +235,7 @@ pub enum InfoCommand {
         #[arg(long, default_value=None)]
         set: Option<String>,
         #[arg(long, default_value = None)]
-        clear: Option<bool>,
+        clear: bool,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'description' is not a list, did you mean to use 'sysand info description --set'?"))]
         add: Option<Infallible>,
@@ -265,7 +265,7 @@ pub enum InfoCommand {
         #[arg(long, default_value=None)]
         set: Option<String>,
         #[arg(long, default_value = None)]
-        clear: Option<bool>,
+        clear: bool,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'licence' is not a list, did you mean to use 'sysand info licence --set'?"))]
         add: Option<Infallible>,
@@ -279,7 +279,7 @@ pub enum InfoCommand {
         #[arg(long, default_value=None)]
         set: Option<String>,
         #[arg(long, default_value = None)]
-        clear: Option<bool>,
+        clear: bool,
         #[arg(long, default_value=None)]
         add: Option<String>,
         #[arg(long, default_value=None)]
@@ -294,7 +294,7 @@ pub enum InfoCommand {
         #[arg(long, default_value=None)]
         set: Option<String>,
         #[arg(long, default_value = None)]
-        clear: Option<bool>,
+        clear: bool,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'website' is not a list, did you mean to use 'sysand info website --set'?"))]
         add: Option<Infallible>,
@@ -308,7 +308,7 @@ pub enum InfoCommand {
         #[arg(long, default_value=None)]
         set: Option<String>,
         #[arg(long, default_value = None)]
-        clear: Option<bool>,
+        clear: bool,
         #[arg(long, default_value=None)]
         add: Option<String>,
         #[arg(long, default_value=None)]
@@ -336,14 +336,14 @@ pub enum InfoCommand {
         #[arg(long, default_value = "false")]
         numbered: bool,
     },
-    // Get project index
+    /// Get project index
     #[group(required = false, multiple = false)]
     Index {
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be set directly, please use 'sysand include' and 'sysand exclude'"))]
         set: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide = true, long, default_value = None, value_parser=invalid_command("'index' cannot be cleared directly, please use 'sysand exclude'"))]
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'index' cannot be cleared directly, please use 'sysand exclude'"))]
         clear: Option<Infallible>,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be added to directly, please use 'sysand include' and 'sysand exclude'"))]
@@ -355,14 +355,14 @@ pub enum InfoCommand {
         #[arg(long, default_value = "false")]
         numbered: bool,
     },
-    // Get project creation time
+    /// Get project metadata manifest creation time
     #[group(required = false, multiple = false)]
     Created {
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be set directly, it is automatically updated"))]
         set: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide = true, long, default_value = None, value_parser=invalid_command("'created' cannot be cleared, it is automatically updated"))]
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'created' cannot be cleared, it is automatically updated"))]
         clear: Option<Infallible>,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be added to, it is automatically updated"))]
@@ -376,8 +376,8 @@ pub enum InfoCommand {
     Metamodel {
         #[arg(long, default_value=None)]
         set: Option<String>,
-        #[arg(long, default_value = None)]
-        clear: Option<bool>,
+        #[arg(long, num_args=0, default_missing_value="true", default_value = None)]
+        clear: bool,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'metamodel' is not a list, did you mean to use 'sysand info metamodel --set'?"))]
         add: Option<Infallible>,
@@ -388,10 +388,10 @@ pub enum InfoCommand {
     /// Get or set whether the project includes derived properties
     #[group(required = false, multiple = false)]
     IncludesDerived {
-        #[arg(long, num_args=0..1, default_missing_value="true", default_value=None)]
+        #[arg(long, num_args=1, default_value=None)]
         set: Option<bool>,
-        #[arg(long, num_args=0, default_missing_value="Some(())", default_value = None)]
-        clear: Option<bool>,
+        #[arg(long, default_value = None)]
+        clear: bool,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_derived' is not a list, did you mean to use 'sysand info include_derived --set'?"))]
         add: Option<Infallible>,
@@ -402,10 +402,10 @@ pub enum InfoCommand {
     /// Get or set whether the project includes implied properties
     #[group(required = false, multiple = false)]
     IncludesImplied {
-        #[arg(long, num_args=0..1, default_missing_value="true", default_value=None)]
+        #[arg(long, num_args=1, default_value=None)]
         set: Option<bool>,
-        #[arg(long, num_args=0, default_missing_value="true", default_value = None)]
-        clear: Option<bool>,
+        #[arg(long, default_value = None)]
+        clear: bool,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_implied' is not a list, did you mean to use 'sysand info include_implied --set'?"))]
         add: Option<Infallible>,
@@ -413,14 +413,14 @@ pub enum InfoCommand {
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_implied' is not a list, did you mean to use 'sysand info include_implied --clear'?"))]
         remove: Option<Infallible>,
     },
-    // Get project checksums
+    /// Get project source file checksums
     #[group(required = false, multiple = false)]
     Checksum {
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be set directly, please use 'sysand include' and 'sysand exclude'"))]
         set: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide = true, long, default_value = None, value_parser=invalid_command("checksum cannot be cleared directly, please use 'sysand exclude'"))]
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("checksum cannot be cleared directly, please use 'sysand exclude'"))]
         clear: Option<Infallible>,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be added to directly, please use 'sysand include'"))]
@@ -655,7 +655,7 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetDescription,
                 set.map(SetInfoVerb::SetDescription),
-                clear.map(|_| ClearInfoVerb::ClearDescription),
+                if clear { Some(ClearInfoVerb::ClearDescription) } else { None },
                 impossible(add),
                 impossible(remove),
             ),
@@ -679,7 +679,7 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetLicence,
                 set.map(SetInfoVerb::SetLicence),
-                clear.map(|_| ClearInfoVerb::ClearLicence),
+                if clear { Some(ClearInfoVerb::ClearLicence) } else { None },
                 impossible(add),
                 impossible(remove),
             ),
@@ -692,7 +692,7 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetMaintainer,
                 set.map(|x| SetInfoVerb::SetMaintainer(vec![x])),
-                clear.map(|_| ClearInfoVerb::ClearMaintainer),
+                if clear { Some(ClearInfoVerb::ClearMaintainer) } else { None },
                 add.map(|x| AddInfoVerb::AddMaintainer(vec![x])),
                 remove.map(RemoveInfoVerb::RemoveMaintainer),
             ),
@@ -704,7 +704,7 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetWebsite,
                 set.map(SetInfoVerb::SetWebsite),
-                clear.map(|_| ClearInfoVerb::ClearWebsite),
+                if clear { Some(ClearInfoVerb::ClearWebsite) } else { None },
                 impossible(add),
                 impossible(remove),
             ),
@@ -717,7 +717,7 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetTopic,
                 set.map(|x| SetInfoVerb::SetTopic(vec![x])),
-                clear.map(|_| ClearInfoVerb::ClearTopic),
+                if clear { Some(ClearInfoVerb::ClearTopic) } else { None },
                 add.map(|x| AddInfoVerb::AddTopic(vec![x])),
                 remove.map(RemoveInfoVerb::RemoveTopic),
             ),
@@ -767,7 +767,7 @@ impl InfoCommand {
             } => pack_meta(
                 GetMetaVerb::GetMetamodel,
                 set.map(SetMetaVerb::SetMetamodel),
-                clear.map(|_| ClearMetaVerb::ClearMetamodel),
+                if clear { Some(ClearMetaVerb::ClearMetamodel) } else { None },
                 impossible(add),
                 impossible(remove),
             ),
@@ -779,7 +779,7 @@ impl InfoCommand {
             } => pack_meta(
                 GetMetaVerb::GetIncludesDerived,
                 set.map(SetMetaVerb::SetIncludesDerived),
-                clear.map(|_| ClearMetaVerb::ClearIncludesDerived),
+                if clear { Some(ClearMetaVerb::ClearIncludesDerived) } else { None },
                 impossible(add),
                 impossible(remove),
             ),
@@ -791,7 +791,7 @@ impl InfoCommand {
             } => pack_meta(
                 GetMetaVerb::GetIncludesImplied,
                 set.map(SetMetaVerb::SetIncludesImplied),
-                clear.map(|_| ClearMetaVerb::ClearIncludesImplied),
+                if clear { Some(ClearMetaVerb::ClearIncludesImplied) } else { None },
                 impossible(add),
                 impossible(remove),
             ),

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -220,13 +220,16 @@ pub enum InfoCommand {
         #[arg(long, default_value=None)]
         set: Option<String>,
         // Only for better error messages
-        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'name' cannot be unset"))]
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=
+            invalid_command("'name' cannot be unset"))]
         clear: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'name' is not a list, did you mean to use 'sysand info name --set'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=
+            invalid_command("'name' is not a list, consider using 'sysand info name --set'?"))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'name' is not a list, and cannot be unset"))]
+        #[arg(hide=true, long, default_value=None, value_parser=
+            invalid_command("'name' is not a list, and cannot be unset"))]
         remove: Option<Infallible>,
     },
     /// Get or set the description of the project
@@ -237,10 +240,14 @@ pub enum InfoCommand {
         #[arg(long, default_value = None)]
         clear: bool,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'description' is not a list, did you mean to use 'sysand info description --set'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'description' is not a list, consider using 'sysand info description --set'?"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'description' is not a list, did you mean to use 'sysand info description --clear'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'description' is not a list, consider using 'sysand info description --clear'?"
+        ))]
         remove: Option<Infallible>,
     },
     /// Get or set the version of the project
@@ -249,13 +256,24 @@ pub enum InfoCommand {
         #[arg(long, default_value=None)]
         set: Option<String>,
         // Only for better error messages
-        #[arg(hide = true, long, num_args=0, default_missing_value="None", default_value = None, value_parser=invalid_command("'version' cannot be unset"))]
+        #[arg(
+            hide = true,
+            long,
+            num_args=0,
+            default_missing_value="None",
+            default_value = None,
+            value_parser=invalid_command("'version' cannot be unset")
+        )]
         clear: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'version' is not a list, did you mean to use 'sysand info version --set'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'version' is not a list, consider using 'sysand info version --set'?"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'version' is not a list, and cannot be unset"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'version' is not a list, and cannot be unset"
+        ))]
         remove: Option<Infallible>,
     },
     /// Get or set the licence of the project
@@ -267,10 +285,14 @@ pub enum InfoCommand {
         #[arg(long, default_value = None)]
         clear: bool,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'licence' is not a list, did you mean to use 'sysand info licence --set'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'licence' is not a list, consider using 'sysand info licence --set'?"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'licence' is not a list, did you mean to use 'sysand info licence --clear'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'licence' is not a list, consider using 'sysand info licence --clear'?"
+        ))]
         remove: Option<Infallible>,
     },
     /// Get or manipulate the list of maintainers of the project
@@ -296,10 +318,14 @@ pub enum InfoCommand {
         #[arg(long, default_value = None)]
         clear: bool,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'website' is not a list, did you mean to use 'sysand info website --set'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'website' is not a list, consider using 'sysand info website --set'?"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'website' is not a list, did you mean to use 'sysand info website --clear'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'website' is not a list, consider using 'sysand info website --clear'?"
+        ))]
         remove: Option<Infallible>,
     },
     /// Get or manipulate the list of topics of the project
@@ -321,16 +347,30 @@ pub enum InfoCommand {
     #[group(required = false, multiple = false)]
     Usage {
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'usage' cannot be set directly, please use 'sysand add' and 'sysand remove'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'usage' cannot be set directly, please use 'sysand add' and 'sysand remove'"
+        ))]
         set: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'usage' cannot be cleared directly, please use 'sysand remove'"))]
+        #[arg(
+            hide = true,
+            long,
+            num_args=0,
+            default_missing_value="None",
+            value_parser=invalid_command(
+              "'usage' cannot be cleared directly, please use 'sysand remove'"
+            )
+        )]
         clear: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'usage' cannot be added to directly, please use 'sysand add'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'usage' cannot be added to directly, please use 'sysand add'"
+        ))]
         add: Option<Infallible>,
         // Only for Infallible error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'usage' cannot be removed from directly, please use 'sysand remove'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'usage' cannot be removed from directly, please use 'sysand remove'"
+        ))]
         remove: Option<Infallible>,
         /// Prints a numbered list
         #[arg(long, default_value = "false")]
@@ -340,16 +380,30 @@ pub enum InfoCommand {
     #[group(required = false, multiple = false)]
     Index {
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be set directly, please use 'sysand include' and 'sysand exclude'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'index' cannot be set directly, please use 'sysand include' and 'sysand exclude'"
+        ))]
         set: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'index' cannot be cleared directly, please use 'sysand exclude'"))]
+        #[arg(
+            hide = true,
+            long,
+            num_args=0,
+            default_missing_value="None",
+            value_parser=invalid_command(
+              "'index' cannot be cleared directly, please use 'sysand exclude'"
+            )
+        )]
         clear: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be added to directly, please use 'sysand include' and 'sysand exclude'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'index' cannot be added to directly, please use 'sysand include' and 'sysand exclude'"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'index' cannot be removed from directly, please use 'sysand exclude'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'index' cannot be removed from directly, please use 'sysand exclude'"
+        ))]
         remove: Option<Infallible>,
         /// Prints a numbered list
         #[arg(long, default_value = "false")]
@@ -359,16 +413,30 @@ pub enum InfoCommand {
     #[group(required = false, multiple = false)]
     Created {
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be set directly, it is automatically updated"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'created' cannot be set directly, it is automatically updated"
+        ))]
         set: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("'created' cannot be cleared, it is automatically updated"))]
+        #[arg(
+            hide = true,
+            long,
+            num_args=0,
+            default_missing_value="None",
+            value_parser=invalid_command(
+              "'created' cannot be cleared, it is automatically updated"
+            )
+        )]
         clear: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be added to, it is automatically updated"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'created' cannot be added to, it is automatically updated"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'created' cannot be removed from, it is automatically updated"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'created' cannot be removed from, it is automatically updated"
+        ))]
         remove: Option<Infallible>,
     },
     /// Get or set the metamodel of the project
@@ -379,10 +447,14 @@ pub enum InfoCommand {
         #[arg(long, num_args=0, default_missing_value="true", default_value = None)]
         clear: bool,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'metamodel' is not a list, did you mean to use 'sysand info metamodel --set'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'metamodel' is not a list, consider using 'sysand info metamodel --set'?"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'metamodel' is not a list, did you mean to use 'sysand info metamodel --clear'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'metamodel' is not a list, consider using 'sysand info metamodel --clear'?"
+        ))]
         remove: Option<Infallible>,
     },
     /// Get or set whether the project includes derived properties
@@ -393,10 +465,23 @@ pub enum InfoCommand {
         #[arg(long, default_value = None)]
         clear: bool,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_derived' is not a list, did you mean to use 'sysand info include_derived --set'?"))]
+        #[arg(
+            hide=true,
+            long,
+            default_value=None,
+            value_parser=invalid_command(
+            "'include_derived' is not a list, consider using 'sysand info include_derived --set'?"
+            )
+        )]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_derived' is not a list, did you mean to use 'sysand info include_derived --clear'?"))]
+        #[arg(hide=true,
+          long,
+          default_value=None,
+          value_parser=invalid_command(
+          "'include_derived' is not a list, consider using 'sysand info include_derived --clear'?"
+          )
+        )]
         remove: Option<Infallible>,
     },
     /// Get or set whether the project includes implied properties
@@ -407,26 +492,44 @@ pub enum InfoCommand {
         #[arg(long, default_value = None)]
         clear: bool,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_implied' is not a list, did you mean to use 'sysand info include_implied --set'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'include_implied' is not a list, consider using 'sysand info include_implied --set'?"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("'include_implied' is not a list, did you mean to use 'sysand info include_implied --clear'?"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "'include_implied' is not a list, consider using 'sysand info include_implied --clear'?"
+        ))]
         remove: Option<Infallible>,
     },
     /// Get project source file checksums
     #[group(required = false, multiple = false)]
     Checksum {
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be set directly, please use 'sysand include' and 'sysand exclude'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "checksum cannot be set directly, please use 'sysand include' and 'sysand exclude'"
+        ))]
         set: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=invalid_command("checksum cannot be cleared directly, please use 'sysand exclude'"))]
+        #[arg(
+            hide = true,
+            long,
+            num_args=0,
+            default_missing_value="None",
+            value_parser=invalid_command(
+              "checksum cannot be cleared directly, please use 'sysand exclude'"
+            )
+        )]
         clear: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be added to directly, please use 'sysand include'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "checksum cannot be added to directly, please use 'sysand include'"
+        ))]
         add: Option<Infallible>,
         // Only for better error messages
-        #[arg(hide=true, long, default_value=None, value_parser=invalid_command("checksum cannot be removed from directly, please use 'sysand exclude'"))]
+        #[arg(hide=true, long, default_value=None, value_parser=invalid_command(
+          "checksum cannot be removed from directly, please use 'sysand exclude'"
+        ))]
         remove: Option<Infallible>,
         /// Prints a numbered list
         #[arg(long, default_value = "false")]

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -1,7 +1,18 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use crate::CliError;
-use sysand_core::resolve::standard::standard_resolver;
+use crate::{
+    CliError,
+    cli::{
+        AddInfoVerb, AddMetaVerb, AddVerb, ClearInfoVerb, ClearMetaVerb, ClearVerb, GetInfoVerb,
+        GetMetaVerb, InfoCommandVerb, RemoveInfoVerb, RemoveMetaVerb, RemoveVerb, SetInfoVerb,
+        SetMetaVerb, SetVerb,
+    },
+};
+use sysand_core::{
+    model::{InterchangeProjectChecksum, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
+    project::{ProjectMut, ProjectRead},
+    resolve::{file::FileResolverProject, standard::standard_resolver},
+};
 
 use anyhow::{Result, bail};
 use fluent_uri::Iri;
@@ -9,7 +20,6 @@ use reqwest::blocking::Client;
 use std::{env::current_dir, path::Path};
 use sysand_core::{
     info::{do_info, do_info_project},
-    model::InterchangeProjectInfoRaw,
     project::{local_kpar::LocalKParProject, local_src::LocalSrcProject},
 };
 
@@ -46,13 +56,11 @@ pub fn pprint_interchange_project(info: InterchangeProjectInfoRaw) {
     }
 }
 
-pub fn command_info_path<P: AsRef<Path>>(path: P) -> Result<()> {
-    let project = if path.as_ref().is_file() {
-        sysand_core::resolve::file::FileResolverProject::LocalKParProject(
-            LocalKParProject::new_guess_root(path.as_ref())?,
-        )
+fn interpret_project_path<P: AsRef<Path>>(path: P) -> Result<FileResolverProject> {
+    Ok(if path.as_ref().is_file() {
+        FileResolverProject::LocalKParProject(LocalKParProject::new_guess_root(path.as_ref())?)
     } else if path.as_ref().is_dir() {
-        sysand_core::resolve::file::FileResolverProject::LocalSrcProject(LocalSrcProject {
+        FileResolverProject::LocalSrcProject(LocalSrcProject {
             project_path: path.as_ref().to_path_buf(),
         })
     } else {
@@ -60,9 +68,13 @@ pub fn command_info_path<P: AsRef<Path>>(path: P) -> Result<()> {
             "Unable to find interchange project at {}",
             path.as_ref().display()
         )));
-    };
+    })
+}
 
-    match do_info_project(project) {
+pub fn command_info_path<P: AsRef<Path>>(path: P) -> Result<()> {
+    let project = interpret_project_path(&path)?;
+
+    match do_info_project(&project) {
         Some((info, _)) => {
             pprint_interchange_project(info);
 
@@ -119,4 +131,528 @@ pub fn command_info_uri<S: AsRef<str>>(
     }
 
     Ok(())
+}
+
+fn print_output(output: Option<Vec<String>>, numbered: bool) {
+    if let Some(lines) = output {
+        if numbered {
+            for (line_number, line) in lines.iter().enumerate() {
+                println!("{}: {}", line_number + 1, line);
+            }
+        } else {
+            for line in lines {
+                println!("{}", line);
+            }
+        }
+    }
+}
+
+pub fn command_info_verb_path<P: AsRef<Path>>(
+    path: P,
+    verb: InfoCommandVerb,
+    numbered: bool,
+) -> Result<()> {
+    let project = interpret_project_path(&path)?;
+
+    match project {
+        FileResolverProject::LocalSrcProject(mut local_src_project) => match verb {
+            InfoCommandVerb::Get(get_verb) => apply_get(&get_verb, &local_src_project, numbered),
+            InfoCommandVerb::Set(set_verb) => apply_set(&set_verb, &mut local_src_project),
+            InfoCommandVerb::Clear(clear_verb) => apply_clear(&clear_verb, &mut local_src_project),
+            InfoCommandVerb::Add(add_verb) => apply_add(&add_verb, &mut local_src_project),
+            InfoCommandVerb::Remove(remove_verb) => {
+                apply_remove(&remove_verb, &mut local_src_project)
+            }
+        },
+        FileResolverProject::LocalKParProject(local_kpar_project) => match verb {
+            InfoCommandVerb::Get(get_verb) => apply_get(&get_verb, &local_kpar_project, numbered),
+            InfoCommandVerb::Set(_) => bail!("'set' cannot be used with kpar archives"),
+            InfoCommandVerb::Clear(_) => bail!("'clear' cannot be used with kpar archives"),
+            InfoCommandVerb::Add(_) => bail!("'add' cannot be used with kpar archives"),
+            InfoCommandVerb::Remove(_) => bail!("'remove' cannot be used with kpar archives"),
+        },
+    }
+}
+
+pub fn command_info_verb_uri<S: AsRef<str>>(
+    uri: Iri<String>,
+    verb: InfoCommandVerb,
+    numbered: bool,
+    client: Client,
+    index_base_urls: Option<Vec<S>>,
+) -> Result<()> {
+    match verb {
+        InfoCommandVerb::Get(get_verb) => {
+            let cwd = current_dir().ok();
+
+            let local_env_path =
+                std::path::Path::new(".").join(sysand_core::env::local_directory::DEFAULT_ENV_NAME);
+
+            let combined_resolver = standard_resolver(
+                cwd,
+                if local_env_path.is_dir() {
+                    Some(local_env_path)
+                } else {
+                    None
+                },
+                Some(client),
+                index_base_urls
+                    .map(|xs| xs.iter().map(|x| url::Url::parse(x.as_ref())).collect())
+                    .transpose()?,
+            );
+
+            let mut found = false;
+
+            match get_verb {
+                crate::cli::GetVerb::GetInfoVerb(get_info_verb) => {
+                    for (info, _meta) in do_info(&uri, &combined_resolver)? {
+                        found = true;
+
+                        apply_get_info(&get_info_verb, info, numbered)?;
+                    }
+                }
+                crate::cli::GetVerb::GetMetaVerb(get_meta_verb) => {
+                    for (_info, meta) in do_info(&uri, &combined_resolver)? {
+                        found = true;
+
+                        apply_get_meta(&get_meta_verb, meta, numbered)?;
+                    }
+                }
+            }
+
+            if !found {
+                bail!("unable to find a valid project at {}", uri.as_str());
+            };
+        }
+        InfoCommandVerb::Set(_) => bail!("'set' cannot be used with remote projects"),
+        InfoCommandVerb::Clear(_) => bail!("'clear' cannot be used with remote projects"),
+        InfoCommandVerb::Add(_) => bail!("'add' cannot be used with remote projects"),
+        InfoCommandVerb::Remove(_) => bail!("'remove' cannot be used with remote projects"),
+    }
+
+    Ok(())
+}
+
+pub fn command_info_current_project(
+    mut current_project: LocalSrcProject,
+    verb: InfoCommandVerb,
+    numbered: bool,
+) -> Result<()> {
+    match verb {
+        InfoCommandVerb::Get(get_verb) => apply_get(&get_verb, &current_project, numbered),
+        InfoCommandVerb::Set(set_verb) => apply_set(&set_verb, &mut current_project),
+        InfoCommandVerb::Clear(clear_verb) => apply_clear(&clear_verb, &mut current_project),
+        InfoCommandVerb::Add(add_verb) => apply_add(&add_verb, &mut current_project),
+        InfoCommandVerb::Remove(remove_verb) => apply_remove(&remove_verb, &mut current_project),
+    }
+}
+
+fn get_info_or_bail<Project: ProjectRead>(project: &Project) -> Result<InterchangeProjectInfoRaw> {
+    match project.get_info() {
+        Ok(Some(info)) => Ok(info),
+        Ok(None) => bail!("project does not appear to have a valid .project.json"),
+        Err(err) => {
+            bail!("failed to read .project.json: {}", err.to_string())
+        }
+    }
+}
+
+fn get_meta_or_bail<Project: ProjectRead>(
+    project: &Project,
+) -> Result<InterchangeProjectMetadataRaw> {
+    match project.get_meta() {
+        Ok(Some(meta)) => Ok(meta),
+        Ok(None) => bail!("project does not appear to have a valid .meta.json"),
+        Err(err) => {
+            bail!("failed to read .project.json: {}", err.to_string())
+        }
+    }
+}
+
+fn set_info_or_bail<Project: ProjectMut>(
+    project: &mut Project,
+    info: &InterchangeProjectInfoRaw,
+) -> Result<()> {
+    if let Err(err) = project.put_info(info, true) {
+        bail!("failed to write .project.json: {}", err.to_string());
+    }
+
+    Ok(())
+}
+
+fn set_meta_or_bail<Project: ProjectMut>(
+    project: &mut Project,
+    meta: &InterchangeProjectMetadataRaw,
+) -> Result<()> {
+    if let Err(err) = project.put_meta(meta, true) {
+        bail!("failed to write .meta.json: {}", err.to_string());
+    }
+
+    Ok(())
+}
+
+fn apply_get<Project: ProjectRead>(
+    get_verb: &crate::cli::GetVerb,
+    project: &Project,
+    numbered: bool,
+) -> Result<()> {
+    match get_verb {
+        crate::cli::GetVerb::GetInfoVerb(get_info_verb) => {
+            apply_get_info(get_info_verb, get_info_or_bail(project)?, numbered)
+        }
+        crate::cli::GetVerb::GetMetaVerb(get_meta_verb) => {
+            apply_get_meta(get_meta_verb, get_meta_or_bail(project)?, numbered)
+        }
+    }
+}
+
+fn apply_get_info(
+    get_info_verb: &GetInfoVerb,
+    info: InterchangeProjectInfoRaw,
+    numbered: bool,
+) -> Result<()> {
+    match get_info_verb {
+        GetInfoVerb::GetName => print_output(Some(vec![info.name]), numbered),
+        GetInfoVerb::GetDescription => print_output(info.description.map(|x| vec![x]), numbered),
+        GetInfoVerb::GetVersion => print_output(Some(vec![info.version]), numbered),
+        GetInfoVerb::GetLicence => print_output(info.license.map(|x| vec![x]), numbered),
+        GetInfoVerb::GetMaintainer => print_output(Some(info.maintainer), numbered),
+        GetInfoVerb::GetWebsite => print_output(info.website.map(|x| vec![x]), numbered),
+        GetInfoVerb::GetTopic => print_output(Some(info.topic), numbered),
+        GetInfoVerb::GetUsage => print_output(
+            Some(
+                info.usage
+                    .into_iter()
+                    .map(|usage| {
+                        if let Some(version_constraint) = usage.version_constraint {
+                            format!("{} ({})", usage.resource, version_constraint)
+                        } else {
+                            usage.resource.clone()
+                        }
+                    })
+                    .collect(),
+            ),
+            numbered,
+        ),
+    }
+
+    Ok(())
+}
+
+fn apply_get_meta(
+    get_meta_verb: &GetMetaVerb,
+    meta: InterchangeProjectMetadataRaw,
+    numbered: bool,
+) -> Result<()> {
+    match get_meta_verb {
+        GetMetaVerb::GetIndex => print_output(
+            Some(
+                meta.index
+                    .into_iter()
+                    .map(|(symbol, path)| format!("{} in {}", symbol, path))
+                    .collect(),
+            ),
+            numbered,
+        ),
+        GetMetaVerb::GetCreated => print_output(Some(vec![meta.created]), numbered),
+        GetMetaVerb::GetMetamodel => print_output(meta.metamodel.map(|x| vec![x]), numbered),
+        GetMetaVerb::GetIncludesDerived => print_output(
+            meta.includes_derived.map(|x| vec![format!("{}", x)]),
+            numbered,
+        ),
+        GetMetaVerb::GetIncludesImplied => print_output(
+            meta.includes_implied.map(|x| vec![format!("{}", x)]),
+            numbered,
+        ),
+        GetMetaVerb::GetChecksum => print_output(
+            meta.checksum.map(|xs| {
+                xs.into_iter()
+                    .map(|(path, InterchangeProjectChecksum { value, algorithm })| {
+                        format!("{}({}) = {}", algorithm, path, value)
+                    })
+                    .collect()
+            }),
+            numbered,
+        ),
+    }
+
+    Ok(())
+}
+
+fn apply_set<Project: ProjectRead + ProjectMut>(
+    set_verb: &SetVerb,
+    project: &mut Project,
+) -> Result<()> {
+    match set_verb {
+        crate::cli::SetVerb::SetInfoVerb(set_info_verb) => {
+            let new_info = set_info(set_info_verb, get_info_or_bail(project)?)?;
+
+            set_info_or_bail(project, &new_info)
+        }
+        crate::cli::SetVerb::SetMetaVerb(set_meta_verb) => {
+            let new_meta = set_meta(set_meta_verb, get_meta_or_bail(project)?)?;
+
+            set_meta_or_bail(project, &new_meta)
+        }
+    }
+}
+
+fn set_info(
+    set_info_verb: &SetInfoVerb,
+    info: InterchangeProjectInfoRaw,
+) -> Result<InterchangeProjectInfoRaw> {
+    let mut result = info.clone();
+
+    match set_info_verb {
+        SetInfoVerb::SetName(value) => {
+            result.name = value.clone();
+        }
+        SetInfoVerb::SetDescription(value) => {
+            result.description = Some(value.clone());
+        }
+        SetInfoVerb::SetVersion(value) => {
+            result.version = value.clone();
+        }
+        SetInfoVerb::SetLicence(value) => {
+            result.license = Some(value.clone());
+        }
+        SetInfoVerb::SetMaintainer(value) => {
+            result.maintainer = value.clone();
+        }
+        SetInfoVerb::SetWebsite(value) => {
+            result.website = Some(value.clone());
+        }
+        SetInfoVerb::SetTopic(value) => {
+            result.topic = value.clone();
+        }
+    }
+
+    Ok(result)
+}
+
+fn set_meta(
+    set_meta_verb: &SetMetaVerb,
+    meta: InterchangeProjectMetadataRaw,
+) -> Result<InterchangeProjectMetadataRaw> {
+    let mut result = meta.clone();
+
+    match set_meta_verb {
+        SetMetaVerb::SetMetamodel(value) => {
+            result.metamodel = Some(value.clone());
+        }
+        SetMetaVerb::SetIncludesDerived(value) => {
+            result.includes_derived = Some(*value);
+        }
+        SetMetaVerb::SetIncludesImplied(value) => {
+            result.includes_implied = Some(*value);
+        }
+    }
+
+    Ok(result)
+}
+
+fn apply_clear<Project: ProjectRead + ProjectMut>(
+    clear_verb: &ClearVerb,
+    project: &mut Project,
+) -> Result<()> {
+    match clear_verb {
+        crate::cli::ClearVerb::ClearInfoVerb(clear_info_verb) => {
+            let new_info = clear_info(clear_info_verb, get_info_or_bail(project)?)?;
+
+            set_info_or_bail(project, &new_info)
+        }
+        crate::cli::ClearVerb::ClearMetaVerb(clear_meta_verb) => {
+            let new_meta = clear_meta(clear_meta_verb, get_meta_or_bail(project)?)?;
+
+            set_meta_or_bail(project, &new_meta)
+        }
+    }
+}
+
+fn clear_info(
+    clear_info_verb: &ClearInfoVerb,
+    info: InterchangeProjectInfoRaw,
+) -> Result<InterchangeProjectInfoRaw> {
+    let mut result = info.clone();
+
+    match clear_info_verb {
+        ClearInfoVerb::ClearDescription => {
+            result.description = None;
+        }
+        ClearInfoVerb::ClearLicence => {
+            result.license = None;
+        }
+        ClearInfoVerb::ClearMaintainer => {
+            result.maintainer = vec![];
+        }
+        ClearInfoVerb::ClearWebsite => {
+            result.website = None;
+        }
+        ClearInfoVerb::ClearTopic => {
+            result.topic = vec![];
+        }
+    }
+
+    Ok(result)
+}
+
+fn clear_meta(
+    clear_meta_verb: &ClearMetaVerb,
+    meta: InterchangeProjectMetadataRaw,
+) -> Result<InterchangeProjectMetadataRaw> {
+    let mut result = meta.clone();
+
+    match clear_meta_verb {
+        ClearMetaVerb::ClearMetamodel => {
+            result.metamodel = None;
+        }
+        ClearMetaVerb::ClearIncludesDerived => {
+            result.includes_derived = None;
+        }
+        ClearMetaVerb::ClearIncludesImplied => {
+            result.includes_implied = None;
+        }
+    }
+
+    Ok(result)
+}
+
+fn apply_add<Project: ProjectRead + ProjectMut>(
+    add_verb: &AddVerb,
+    project: &mut Project,
+) -> Result<()> {
+    match add_verb {
+        crate::cli::AddVerb::AddInfoVerb(add_info_verb) => {
+            let new_info = add_info(add_info_verb, get_info_or_bail(project)?)?;
+
+            set_info_or_bail(project, &new_info)
+        }
+        crate::cli::AddVerb::AddMetaVerb(add_meta_verb) => {
+            let new_meta = add_meta(add_meta_verb, get_meta_or_bail(project)?)?;
+
+            set_meta_or_bail(project, &new_meta)
+        }
+    }
+}
+
+fn add_info(
+    add_info_verb: &AddInfoVerb,
+    info: InterchangeProjectInfoRaw,
+) -> Result<InterchangeProjectInfoRaw> {
+    let mut result = info.clone();
+
+    match add_info_verb {
+        AddInfoVerb::AddMaintainer(items) => {
+            result.maintainer.extend(items.iter().cloned());
+        }
+        AddInfoVerb::AddTopic(items) => {
+            result.topic.extend(items.iter().cloned());
+        }
+    }
+
+    Ok(result)
+}
+
+fn add_meta(
+    add_meta_verb: &AddMetaVerb,
+    _meta: InterchangeProjectMetadataRaw,
+) -> Result<InterchangeProjectMetadataRaw> {
+    match *add_meta_verb {}
+}
+
+fn apply_remove<Project: ProjectRead + ProjectMut>(
+    remove_verb: &RemoveVerb,
+    project: &mut Project,
+) -> Result<()> {
+    match remove_verb {
+        crate::cli::RemoveVerb::RemoveInfoVerb(remove_info_verb) => {
+            let new_info = remove_info(remove_info_verb, get_info_or_bail(project)?)?;
+
+            set_info_or_bail(project, &new_info)
+        }
+        crate::cli::RemoveVerb::RemoveMetaVerb(remove_meta_verb) => {
+            let new_meta = remove_meta(remove_meta_verb, get_meta_or_bail(project)?)?;
+
+            set_meta_or_bail(project, &new_meta)
+        }
+    }
+}
+
+fn remove_info(
+    remove_info_verb: &RemoveInfoVerb,
+    info: InterchangeProjectInfoRaw,
+) -> Result<InterchangeProjectInfoRaw> {
+    let mut result = info.clone();
+
+    enum RemoveFailure {
+        ZeroIndex,
+        EmptyFailure(usize),
+        //SingularFailure,
+        PluralFailure(usize, usize),
+    }
+
+    fn remove(idx: usize, xs: &mut Vec<String>) -> std::result::Result<(), RemoveFailure> {
+        if idx == 0 {
+            Err(RemoveFailure::ZeroIndex)
+        } else if idx > xs.len() {
+            if xs.is_empty() {
+                Err(RemoveFailure::EmptyFailure(idx))
+            }
+            /* else if xs.len() == 1 {
+                Err(RemoveFailure::SingularFailure)
+            } */
+            else {
+                Err(RemoveFailure::PluralFailure(idx, xs.len()))
+            }
+        } else {
+            xs.remove(idx - 1);
+            Ok(())
+        }
+    }
+
+    match remove_info_verb {
+        RemoveInfoVerb::RemoveMaintainer(idx) => {
+            if let Err(err) = remove(*idx, &mut result.maintainer) {
+                match err {
+                    RemoveFailure::ZeroIndex => {
+                        bail!("0 is an invalid index, maintainers are indexed from 1")
+                    }
+                    RemoveFailure::EmptyFailure(idx) => {
+                        bail!("trying to remove maintainer {}, but project has none", idx)
+                    }
+                    RemoveFailure::PluralFailure(idx, len) => bail!(
+                        "trying to remove maintainer {}, but project has only {}",
+                        idx,
+                        len
+                    ),
+                }
+            }
+        }
+        RemoveInfoVerb::RemoveTopic(idx) => {
+            if let Err(err) = remove(*idx, &mut result.topic) {
+                match err {
+                    RemoveFailure::ZeroIndex => {
+                        bail!("0 is an invalid index, topics are indexed from 1")
+                    }
+                    RemoveFailure::EmptyFailure(idx) => {
+                        bail!("trying to remove topic {}, but project has none", idx)
+                    }
+                    RemoveFailure::PluralFailure(idx, len) => bail!(
+                        "trying to remove topic {}, but project has only {}",
+                        idx,
+                        len
+                    ),
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn remove_meta(
+    remove_meta_verb: &RemoveMetaVerb,
+    _meta: InterchangeProjectMetadataRaw,
+) -> Result<InterchangeProjectMetadataRaw> {
+    match *remove_meta_verb {}
 }

--- a/sysand/src/main.rs
+++ b/sysand/src/main.rs
@@ -18,6 +18,7 @@ fn main() {
         }
         Err(err) => {
             err.print().expect("Failed to write Clap error");
+            std::process::exit(err.exit_code())
         }
     }
 }

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -602,7 +602,6 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
                 out.assert().success();
                 get_field(field, Some("".to_string()))?;
             } else {
-                //out.assert().failure();
                 out.assert()
                     .stderr(predicates::str::contains("unexpected argument"));
                 get_field(field, Some(before))?;
@@ -622,8 +621,8 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
             expected_output.push('\n');
             get_field(field, Some(expected_output))?;
         } else {
-            //out.assert().failure();
             out.assert()
+                .failure()
                 .stderr(predicates::str::contains("unexpected argument"));
             get_field(field, Some(before))?;
         }
@@ -643,8 +642,8 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
             expected_output.push('\n');
             get_field(field, Some(expected_output))?;
         } else {
-            //out.assert().failure();
             out.assert()
+                .failure()
                 .stderr(predicates::str::contains("unexpected argument"));
             get_field(field, Some(before))?;
         }
@@ -669,8 +668,8 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
             }
             get_field(field, Some(expected_output))?;
         } else {
-            //out.assert().failure();
             out.assert()
+                .failure()
                 .stderr(predicates::str::contains("unexpected argument"));
             get_field(field, Some(before))?;
         }

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -581,7 +581,9 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
 
     let project_path = &cwd.join("info_detailed_verbs");
 
-    let get_field = |field: &'static str, expected: Option<String>| -> Result<String, Box<dyn std::error::Error>> {
+    let get_field = |field: &'static str,
+                     expected: Option<String>|
+     -> Result<String, Box<dyn std::error::Error>> {
         let out = run_sysand_in(project_path, ["info", field], None)?;
         let stdout = out.stdout.clone();
         if let Some(expected) = expected {
@@ -591,22 +593,27 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Check that a field does/does not get cleared
-    let try_clear = |field: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
-        let before = get_field(field, None)?;
+    let try_clear =
+        |field: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+            let before = get_field(field, None)?;
 
-        let out = run_sysand_in(project_path, ["info", field, "--clear"], None)?;
-        if expected {
-            out.assert().success();
-            get_field(field, Some("".to_string()))?;
-        } else {
-            //out.assert().failure();
-            out.assert().stderr(predicates::str::contains("unexpected argument"));
-            get_field(field, Some(before))?;
-        }
-        Ok(())
-    };
+            let out = run_sysand_in(project_path, ["info", field, "--clear"], None)?;
+            if expected {
+                out.assert().success();
+                get_field(field, Some("".to_string()))?;
+            } else {
+                //out.assert().failure();
+                out.assert()
+                    .stderr(predicates::str::contains("unexpected argument"));
+                get_field(field, Some(before))?;
+            }
+            Ok(())
+        };
 
-    let try_set = |field: &'static str, value: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+    let try_set = |field: &'static str,
+                   value: &'static str,
+                   expected: bool|
+     -> Result<(), Box<dyn std::error::Error>> {
         let before = get_field(field, None)?;
         let out = run_sysand_in(project_path, ["info", field, "--set", value], None)?;
         if expected {
@@ -616,13 +623,17 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
             get_field(field, Some(expected_output))?;
         } else {
             //out.assert().failure();
-            out.assert().stderr(predicates::str::contains("unexpected argument"));
+            out.assert()
+                .stderr(predicates::str::contains("unexpected argument"));
             get_field(field, Some(before))?;
         }
         Ok(())
     };
 
-    let try_add = |field: &'static str, value: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+    let try_add = |field: &'static str,
+                   value: &'static str,
+                   expected: bool|
+     -> Result<(), Box<dyn std::error::Error>> {
         let before = get_field(field, None)?;
         let out = run_sysand_in(project_path, ["info", field, "--add", value], None)?;
         if expected {
@@ -633,13 +644,17 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
             get_field(field, Some(expected_output))?;
         } else {
             //out.assert().failure();
-            out.assert().stderr(predicates::str::contains("unexpected argument"));
+            out.assert()
+                .stderr(predicates::str::contains("unexpected argument"));
             get_field(field, Some(before))?;
         }
         Ok(())
     };
 
-    let try_remove = |field: &'static str, index: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+    let try_remove = |field: &'static str,
+                      index: &'static str,
+                      expected: bool|
+     -> Result<(), Box<dyn std::error::Error>> {
         let before = get_field(field, None)?;
         let out = run_sysand_in(project_path, ["info", field, "--remove", index], None)?;
         if expected {
@@ -655,7 +670,8 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
             get_field(field, Some(expected_output))?;
         } else {
             //out.assert().failure();
-            out.assert().stderr(predicates::str::contains("unexpected argument"));
+            out.assert()
+                .stderr(predicates::str::contains("unexpected argument"));
             get_field(field, Some(before))?;
         }
         Ok(())

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -741,18 +741,5 @@ fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
     try_add("checksum", "checksum_1", false)?;
     try_remove("checksum", "1", false)?;
 
-    // description
-    // licence
-    // maintainer
-    // website
-    // topic
-    // usage
-    // index
-    // created
-    // metamodel
-    // includes-derive
-    // includes-implie
-    // checksum
-
     Ok(())
 }

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -38,7 +38,7 @@ fn info_basic(use_iri: bool, use_auto: bool) -> Result<(), Box<dyn std::error::E
 
     fn add_iri_args<'a>(args: &mut Vec<&'a str>, use_auto: bool, path: &'a str) {
         if use_auto {
-            args.push("--auto");
+            args.push("--auto-location");
         } else {
             args.push("--iri");
         }
@@ -47,7 +47,9 @@ fn info_basic(use_iri: bool, use_auto: bool) -> Result<(), Box<dyn std::error::E
 
     fn add_path_args<'a>(args: &mut Vec<&'a str>, use_auto: bool, path: &'a str) {
         if use_auto {
-            args.push("--auto");
+            args.push("--auto-location");
+        } else {
+            args.push("--path")
         }
         args.push(path);
     }

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -573,3 +573,186 @@ fn info_multi_index_url() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn info_detailed_verbs() -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp, cwd, out) = run_sysand(["new", "info_detailed_verbs", "--version", "1.2.3"], None)?;
+    out.assert().success();
+
+    let project_path = &cwd.join("info_detailed_verbs");
+
+    let get_field = |field: &'static str, expected: Option<String>| -> Result<String, Box<dyn std::error::Error>> {
+        let out = run_sysand_in(project_path, ["info", field], None)?;
+        let stdout = out.stdout.clone();
+        if let Some(expected) = expected {
+            out.assert().success().stdout(expected);
+        }
+        Ok(String::from_utf8(stdout)?)
+    };
+
+    // Check that a field does/does not get cleared
+    let try_clear = |field: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+        let before = get_field(field, None)?;
+
+        let out = run_sysand_in(project_path, ["info", field, "--clear"], None)?;
+        if expected {
+            out.assert().success();
+            get_field(field, Some("".to_string()))?;
+        } else {
+            //out.assert().failure();
+            out.assert().stderr(predicates::str::contains("unexpected argument"));
+            get_field(field, Some(before))?;
+        }
+        Ok(())
+    };
+
+    let try_set = |field: &'static str, value: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+        let before = get_field(field, None)?;
+        let out = run_sysand_in(project_path, ["info", field, "--set", value], None)?;
+        if expected {
+            out.assert().success();
+            let mut expected_output = value.to_string();
+            expected_output.push('\n');
+            get_field(field, Some(expected_output))?;
+        } else {
+            //out.assert().failure();
+            out.assert().stderr(predicates::str::contains("unexpected argument"));
+            get_field(field, Some(before))?;
+        }
+        Ok(())
+    };
+
+    let try_add = |field: &'static str, value: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+        let before = get_field(field, None)?;
+        let out = run_sysand_in(project_path, ["info", field, "--add", value], None)?;
+        if expected {
+            out.assert().success();
+            let mut expected_output = before;
+            expected_output.push_str(value);
+            expected_output.push('\n');
+            get_field(field, Some(expected_output))?;
+        } else {
+            //out.assert().failure();
+            out.assert().stderr(predicates::str::contains("unexpected argument"));
+            get_field(field, Some(before))?;
+        }
+        Ok(())
+    };
+
+    let try_remove = |field: &'static str, index: &'static str, expected: bool| -> Result<(), Box<dyn std::error::Error>> {
+        let before = get_field(field, None)?;
+        let out = run_sysand_in(project_path, ["info", field, "--remove", index], None)?;
+        if expected {
+            out.assert().success();
+            let skipped = index.parse::<usize>()? - 1;
+            let mut expected_output = "".to_string();
+            for (i, line) in before.lines().enumerate() {
+                if i != skipped {
+                    expected_output.push_str(line);
+                    expected_output.push('\n');
+                }
+            }
+            get_field(field, Some(expected_output))?;
+        } else {
+            //out.assert().failure();
+            out.assert().stderr(predicates::str::contains("unexpected argument"));
+            get_field(field, Some(before))?;
+        }
+        Ok(())
+    };
+
+    get_field("name", Some("info_detailed_verbs\n".to_string()))?;
+    try_set("name", "info_detailed_verbs_alt", true)?;
+    try_clear("name", false)?;
+    try_add("name", "name_1", false)?;
+    try_remove("name", "1", false)?;
+    get_field("version", Some("1.2.3\n".to_string()))?;
+    try_set("version", "3.2.1", true)?;
+    try_clear("version", false)?;
+    try_add("version", "version_1", false)?;
+    try_remove("version", "1", false)?;
+    get_field("description", Some("".to_string()))?;
+    try_set("description", "description", true)?;
+    try_clear("description", true)?;
+    try_add("description", "description_1", false)?;
+    try_remove("description", "1", false)?;
+    get_field("licence", Some("".to_string()))?;
+    try_set("licence", "BSD4", true)?;
+    try_clear("licence", true)?;
+    try_add("licence", "licence_1", false)?;
+    try_remove("licence", "1", false)?;
+    get_field("license", Some("".to_string()))?;
+    try_set("license", "BSD4", true)?;
+    try_clear("license", true)?;
+    try_add("license", "license_1", false)?;
+    try_remove("license", "1", false)?;
+    get_field("maintainer", Some("".to_string()))?;
+    try_set("maintainer", "maintainer", true)?;
+    try_clear("maintainer", true)?;
+    try_add("maintainer", "maintainer_1", true)?;
+    try_add("maintainer", "maintainer_2", true)?;
+    try_add("maintainer", "maintainer_3", true)?;
+    try_remove("maintainer", "2", true)?;
+    get_field("website", Some("".to_string()))?;
+    try_set("website", "www.example.com", true)?;
+    try_clear("website", true)?;
+    try_add("website", "website_1", false)?;
+    try_remove("website", "1", false)?;
+    get_field("topic", Some("".to_string()))?;
+    try_set("topic", "example", true)?;
+    try_clear("topic", true)?;
+    try_add("topic", "topic_1", true)?;
+    try_add("topic", "topic_2", true)?;
+    try_add("topic", "topic_3", true)?;
+    try_remove("topic", "2", true)?;
+    get_field("usage", Some("".to_string()))?;
+    try_set("usage", "usage", false)?;
+    try_clear("usage", false)?;
+    try_add("usage", "usage_1", false)?;
+    try_remove("usage", "1", false)?;
+    get_field("index", Some("".to_string()))?;
+    try_set("index", "index", false)?;
+    try_clear("index", false)?;
+    try_add("index", "index_1", false)?;
+    try_remove("index", "1", false)?;
+    // get_field("created", Some("".to_string()))?;
+    try_set("created", "created", false)?;
+    try_clear("created", false)?;
+    try_add("created", "created_1", false)?;
+    try_remove("created", "1", false)?;
+    get_field("metamodel", Some("".to_string()))?;
+    try_set("metamodel", "metamodel", true)?;
+    try_clear("metamodel", true)?;
+    try_add("metamodel", "metamodel_1", false)?;
+    try_remove("metamodel", "1", false)?;
+    get_field("includes-derived", Some("".to_string()))?;
+    try_set("includes-derived", "true", true)?;
+    try_clear("includes-derived", true)?;
+    try_add("includes-derived", "includes_1", false)?;
+    try_remove("includes-derived", "1", false)?;
+    get_field("includes-implied", Some("".to_string()))?;
+    try_set("includes-implied", "false", true)?;
+    try_clear("includes-implied", true)?;
+    try_add("includes-implied", "includes_1", false)?;
+    try_remove("includes-implied", "1", false)?;
+    get_field("checksum", Some("".to_string()))?;
+    try_set("checksum", "checksum", false)?;
+    try_clear("checksum", false)?;
+    try_add("checksum", "checksum_1", false)?;
+    try_remove("checksum", "1", false)?;
+
+    // description
+    // licence
+    // maintainer
+    // website
+    // topic
+    // usage
+    // index
+    // created
+    // metamodel
+    // includes-derive
+    // includes-implie
+    // checksum
+
+    Ok(())
+}

--- a/sysand/tests/common/mod.rs
+++ b/sysand/tests/common/mod.rs
@@ -26,7 +26,7 @@ pub fn sysand_cmd_in<'a, I: IntoIterator<Item = &'a str>>(
 ) -> Result<Command, Box<dyn std::error::Error>> {
     let args = [
         args.into_iter().map(|s| s.to_string()).collect(),
-        cfg.map(|config| vec!["--config".to_string(), config.to_string()])
+        cfg.map(|config| vec!["--config-file".to_string(), config.to_string()])
             .unwrap_or(vec!["--no-config".to_string()]),
     ]
     .concat();


### PR DESCRIPTION
Adds subcommands under `sysand info` for getting and manipulating specific fields. Specifically:

```
sysand info [field] [--set X|--clear|--add X|--remove IDX]
```

Unless `--set`, `--clear`, `--add`, `--remove` is present, the value it fetched. 

- `--set X` overwrites the current value to be `X` (or a singleton list containing `X`)
- `--clear` clears the current value (None or empty list)
- `--add X` pushes `X` to the end of a list field (singleton list if field currently empty)
- `--remove IDX` removes the element at index `IDX` (counting from 1)

Tries to add helpful error messages such as:
```
 $ sysand info name --clear
error: unexpected argument '--clear' found

  tip: 'name' cannot be unset

For more information, try '--help'.
```

```
$ sysand info version --add 1.2.3
error: unexpected argument '--add <ADD>' found

  tip: 'version' is not a list, did you mean to use 'sysand info version --set'?

For more information, try '--help'.
```

```
$ sysand info usage --add 1.2.3
error: unexpected argument '--add <ADD>' found

  tip: 'usage' cannot be added to directly, please use 'sysand add'

For more information, try '--help'.
```