### PR TITLE
Add more metadata to Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ rust-version = "1.85"
 publish = false
 authors = ["Sensmetry <opensource@sensmetry.com>"]
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/sensmetry/sysand"
+description = "A package manager for SysML v2 and KerML"

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -6,6 +6,8 @@ rust-version.workspace = true
 publish.workspace = true
 authors.workspace = true
 license.workspace = true
+description.workspace = true
+repository.workspace = true
 
 [lib]
 name = "sysand"

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -6,6 +6,8 @@ rust-version.workspace = true
 publish.workspace = true
 authors.workspace = true
 license.workspace = true
+description.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/bindings/py/Cargo.toml
+++ b/bindings/py/Cargo.toml
@@ -6,6 +6,8 @@ rust-version.workspace = true
 publish.workspace = true
 authors.workspace = true
 license.workspace = true
+description.workspace = true
+repository.workspace = true
 
 [features]
 default = ["extension-module", "abi3"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,8 @@ rust-version.workspace = true
 publish.workspace = true
 authors.workspace = true
 license.workspace = true
+description.workspace = true
+repository.workspace = true
 
 [features]
 default = ["std"]

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -6,6 +6,8 @@ rust-version.workspace = true
 publish.workspace = true
 authors.workspace = true
 license.workspace = true
+description.workspace = true
+repository.workspace = true
 
 [features]
 default = ["std"]


### PR DESCRIPTION
It is considered a good practice to explicitly indicate MSRV (min supported Rust version) using [`rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) field. Benefits:

- Cargo produces nice error messages on older toolchains instead of unhelpfully failing due to a random unsupported feature or API.
- Cargo selects dependency versions that are compatible with the declared `rust-version` (i. e. do not require newer Rust)
- Clippy has a lint [`incompatible-msrv`](https://rust-lang.github.io/rust-clippy/stable/index.html#incompatible_msrv) which checks that no APIs from newer Rust versions are called