### PR TITLE
Make Java build Python script executable

### DIFF
--- a/bindings/java/scripts/java-builder.py
+++ b/bindings/java/scripts/java-builder.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+# 
 # SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 #
 # SPDX-License-Identifier: MIT OR Apache-2.0


### PR DESCRIPTION
This allows running it directly: `./java-builder.py`.