### PR TITLE
Customize Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
       "groupSlug": "all-pyo3",
       "matchDatasources": ["crate"],
       "matchPackageNames": ["pyo3*"]
+    },
+    {
+      "matchPackageNames": ["org.sysand:sysand"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
- Group all non-major and non-0.x updates together in one PR. This will reduce PR spam and not cause problems with cross dependencies between packages.
- Group all `pyo3` packages together, as they are `0.x` and thus not affected by first rule
- Run Renovate weekly on Monday mornings
- Ignore `org.sysand:sysand` package (Java tests depend on it), because it is local