### PR TITLE
Use non-deprecated method

### DIFF
--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -108,7 +108,7 @@ fn do_info_py(
     relative_file_root: String,
     index_urls: Option<Vec<String>>,
 ) -> PyResult<Vec<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)>> {
-    py.allow_threads(|| {
+    py.detach(|| {
         let mut results = vec![];
         let client = reqwest::blocking::ClientBuilder::new()
             .build()


### PR DESCRIPTION
CI failed because of this.

`allow_threads()` was renamed to `detach()` and old name deprecated