### PR TITLE
Fix absolute path to current project in lockfile

### DIFF
--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 
@@ -46,7 +46,7 @@ pub fn command_add(
     if !no_lock {
         let index_base_urls = if no_index { None } else { Some(use_index) };
         crate::commands::lock::command_lock(
-            &project_root,
+            PathBuf::from("."),
             client.clone(),
             index_base_urls,
             &provided_iris,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -6,7 +6,7 @@ compile_error!("`std` feature is currently required to build `sysand`");
 
 use std::{
     collections::{HashMap, HashSet},
-    path::Path,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -182,9 +182,9 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 HashMap::default()
             };
 
-            if let Some(path) = project_root {
+            if project_root.is_some() {
                 crate::commands::lock::command_lock(
-                    path,
+                    PathBuf::from("."),
                     client,
                     index_base_urls,
                     &provided_iris,
@@ -221,7 +221,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             if !lockfile.is_file() {
                 let index_base_urls = if no_index { None } else { Some(use_index) };
                 command_lock(
-                    &project_root,
+                    PathBuf::from("."),
                     client.clone(),
                     index_base_urls,
                     &provided_iris,

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use assert_cmd::prelude::*;
 use mockito::{Server, ServerGuard};
@@ -47,7 +47,7 @@ fn lock_trivial() -> Result<(), Box<dyn std::error::Error>> {
         panic!();
     };
 
-    assert_eq!(cwd.canonicalize()?, Path::new(editable).canonicalize()?);
+    assert_eq!(PathBuf::from("."), PathBuf::from(editable));
 
     Ok(())
 }


### PR DESCRIPTION
Fixes the lockfiles path to current project from an absolute path to being simply `"."`.