### PR TITLE
fix(core): solve incorrect sources for remote kpar projects

### DIFF
--- a/core/src/resolve/reqwest_http.rs
+++ b/core/src/resolve/reqwest_http.rs
@@ -130,7 +130,7 @@ impl ProjectReadAsync for HTTPProjectAsync {
         match self {
             HTTPProjectAsync::HTTPSrcProject(proj) => proj.sources_async().await,
             //HTTPProjectAsync::HTTPKParProjectRanged(proj) => proj.sources(),
-            HTTPProjectAsync::HTTPKParProjectDownloaded(proj) => proj.inner.sources(),
+            HTTPProjectAsync::HTTPKParProjectDownloaded(proj) => proj.sources_async().await,
         }
     }
 }


### PR DESCRIPTION
Due to a typo there is currently a (severe) bug where the `source` of a remote kpar archive is misidentified as as a (temporary) local archive. 