### PR TITLE
feat: add experimental workspace support for building kpars

### DIFF
--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -175,6 +175,8 @@ fn do_build_py(output_path: String, project_path: Option<String>) -> PyResult<()
             KParBuildError::MissingMeta => PyValueError::new_err(err.to_string()),
             KParBuildError::Zip(_) => PyIOError::new_err(err.to_string()),
             KParBuildError::Serialize(..) => PyValueError::new_err(err.to_string()),
+            KParBuildError::WorkspaceRead(_) => PyRuntimeError::new_err(err.to_string()),
+            KParBuildError::InternalError(_) => PyRuntimeError::new_err(err.to_string()),
         })
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,9 @@ pub mod style;
 pub mod symbols;
 
 #[cfg(feature = "filesystem")]
+pub mod workspace;
+
+#[cfg(feature = "filesystem")]
 pub mod discover;
 
 #[cfg(not(feature = "std"))]

--- a/core/src/workspace.rs
+++ b/core/src/workspace.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+
+#[cfg(feature = "python")]
+use pyo3::{FromPyObject, IntoPyObject};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::project::utils::{FsIoError, wrapfs};
+
+#[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceProjectInfoG<Iri> {
+    pub path: String,
+    pub iris: Vec<Iri>,
+}
+
+#[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceInfoG<Iri> {
+    pub projects: Vec<WorkspaceProjectInfoG<Iri>>,
+}
+
+pub type WorkspaceInfoRaw = WorkspaceInfoG<String>;
+pub type WorkspaceProjectInfoRaw = WorkspaceProjectInfoG<String>;
+
+#[derive(Error, Debug)]
+pub enum WorkspaceReadError {
+    #[error(transparent)]
+    Io(#[from] Box<FsIoError>),
+    #[error("failed to deserialize '.workspace.json': {0}")]
+    Deserialize(#[from] WorkspaceDeserializationError),
+}
+
+#[derive(Debug, Error)]
+#[error("workspace deserialization error: {msg}: {err}")]
+pub struct WorkspaceDeserializationError {
+    msg: &'static str,
+    err: serde_json::Error,
+}
+
+impl WorkspaceDeserializationError {
+    pub fn new(msg: &'static str, err: serde_json::Error) -> Self {
+        Self { msg, err }
+    }
+}
+
+pub struct Workspace {
+    pub workspace_path: PathBuf,
+}
+
+impl Workspace {
+    pub fn root_path(&self) -> PathBuf {
+        self.workspace_path.clone()
+    }
+
+    pub fn info_path(&self) -> PathBuf {
+        self.workspace_path.join(".workspace.json")
+    }
+
+    pub fn get_info(&self) -> Result<Option<WorkspaceInfoRaw>, WorkspaceReadError> {
+        let info_json_path = self.info_path();
+
+        let info_json = if info_json_path.exists() {
+            Some(
+                serde_json::from_reader(wrapfs::File::open(&info_json_path)?).map_err(|e| {
+                    WorkspaceDeserializationError::new("failed to deserialize '.workspace.json'", e)
+                })?,
+            )
+        } else {
+            None
+        };
+
+        Ok(info_json)
+    }
+
+    pub fn get_projects(&self) -> Result<Option<Vec<WorkspaceProjectInfoRaw>>, WorkspaceReadError> {
+        let info = self.get_info()?;
+        Ok(info.map(|info| info.projects))
+    }
+}

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -85,11 +85,16 @@ pub enum Command {
         #[arg(num_args = 1..)]
         paths: Vec<String>,
     },
-    /// Build a KerML Project Archive (KPAR)
+    /// Build a KerML Project Archive (KPAR). If executed in a workspace outside
+    /// of a project, builds all projects in the workspace.
     Build {
-        /// Path giving where to put the finished KPAR.
-        /// Defaults to `output/<project name>.kpar` or
-        /// `output/project.kpar` if no name is found
+        /// Path giving where to put the finished KPAR or KPARs. When building a
+        /// workspace, it is a path to the folder to write the KPARs to
+        /// (default: `<current-workspace>/output`). When building a single
+        /// project, it is a path to the KPAR file to write (default
+        /// `<current-workspace>/output/<project name>-<version>.kpar` or
+        /// `<current-project>/output/<project name>-<version>.kpar` depending
+        /// on whether the current project belongs to a workspace or not).
         path: Option<PathBuf>,
     },
     /// Create or update lockfile

--- a/sysand/src/commands/build.rs
+++ b/sysand/src/commands/build.rs
@@ -4,10 +4,28 @@
 use std::path::Path;
 
 use anyhow::Result;
-use sysand_core::{build::do_build_kpar, project::local_src::LocalSrcProject};
+use sysand_core::{
+    build::{do_build_kpar, do_build_workspace_kpars},
+    project::local_src::LocalSrcProject,
+    workspace::Workspace,
+};
 
-pub fn command_build<P: AsRef<Path>>(path: P, current_project: LocalSrcProject) -> Result<()> {
+pub fn command_build_for_project<P: AsRef<Path>>(
+    path: P,
+    current_project: LocalSrcProject,
+) -> Result<()> {
     do_build_kpar(&current_project, &path, true)?;
+
+    Ok(())
+}
+
+pub fn command_build_for_workspace<P: AsRef<Path>>(path: P, workspace: Workspace) -> Result<()> {
+    log::warn!(
+        "Workspaces are an experimental feature and their behavior may change even with minor \
+        releases. For the status of this feature, see \
+        https://github.com/sensmetry/sysand/issues/101."
+    );
+    do_build_workspace_kpars(&workspace, &path, true)?;
 
     Ok(())
 }

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -15,7 +15,7 @@ mod common;
 pub use common::*;
 
 #[test]
-fn test_build() -> Result<(), Box<dyn std::error::Error>> {
+fn test_project_build() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) =
         run_sysand(["init", "--version", "1.2.3", "--name", "test_build"], None)?;
 
@@ -68,6 +68,95 @@ fn test_build() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(meta.index.len(), 1);
     assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+
+    Ok(())
+}
+
+#[test]
+fn test_workspace_build() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd) = new_temp_cwd()?;
+    let project_group_cwd = cwd.join("subgroup");
+    std::fs::create_dir(&project_group_cwd)?;
+    let project1_cwd = project_group_cwd.join("project1");
+    let project2_cwd = project_group_cwd.join("project2");
+    let project3_cwd = cwd.join("project3");
+
+    // Create .workspace.json file
+    {
+        let workspace_path = cwd.join(".workspace.json");
+        let mut workspace_file = std::fs::File::create(workspace_path)?;
+        workspace_file.write_all(
+            br#"{"projects": [
+            {"path": "subgroup/project1", "iris": ["urn:kpar:project1"]},
+            {"path": "subgroup/project2", "iris": ["urn:kpar:project2"]},
+            {"path": "project3", "iris": ["urn:kpar:project3"]}
+            ]}"#,
+        )?;
+    }
+
+    for project_cwd in [&project1_cwd, &project2_cwd, &project3_cwd] {
+        std::fs::create_dir(project_cwd)?;
+        let project_name = project_cwd.file_name().unwrap().to_string_lossy();
+        let out = run_sysand_in(
+            project_cwd,
+            ["init", "--version", "1.2.3", "--name", &project_name],
+            None,
+        )?;
+        out.assert().success();
+        {
+            let mut sysml_file = std::fs::File::create(project_cwd.join("test.sysml"))?;
+            sysml_file.write_all(b"package P;\n")?;
+        }
+        let out = run_sysand_in(
+            project_cwd,
+            ["include", "--no-index-symbols", "test.sysml"],
+            None,
+        )?;
+        out.assert().success();
+    }
+
+    let out = run_sysand_in(&cwd, ["build"], None)?;
+    out.assert().success();
+
+    for project_name in ["project1", "project2", "project3"] {
+        println!("W9: {}", project_name);
+        let kpar_path = cwd
+            .join("output")
+            .join(format!("{}-1.2.3.kpar", project_name));
+        assert!(
+            kpar_path.is_file(),
+            "kpar file does not exist: {}",
+            kpar_path.display()
+        );
+
+        let out = run_sysand_in(&cwd, ["info", "--path", &kpar_path.to_string_lossy()], None)?;
+
+        out.assert()
+            .success()
+            .stdout(predicate::str::contains(format!("Name: {}", project_name)))
+            .stdout(predicate::str::contains("Version: 1.2.3"));
+
+        let kpar_project = LocalKParProject::new_guess_root(kpar_path)?;
+
+        let (Some(_), Some(meta)) = kpar_project.get_project()? else {
+            panic!("failed to get built project info/meta");
+        };
+
+        // Ensure things get canonicalised during build
+
+        assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
+            &InterchangeProjectChecksum {
+                value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8"
+                    .to_string(),
+                algorithm: "SHA256".to_string(),
+            }
+        );
+
+        assert_eq!(meta.index.len(), 1);
+        assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Add experimental support for building kpars to make it easier to discuss the design at Reference Implementation WG. The design is not final and likely to change as mentioned in the warning printed each time the command is used.

Related issue: https://github.com/sensmetry/sysand/issues/101