### PR TITLE
Add workflow to build and deploy Sysand Users Guide to GitHub Pages.

### DIFF
--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -1,0 +1,39 @@
+name: Deploy Sysand Users Guide to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+      - name: Build mdBook
+        run: mdbook build docs
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./docs/book
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Intended to automatically build and deploy on non-nightly releases but can be triggered manually for urgent fixes.