### PR TITLE
fix(tests): faulty test case `sources_without_std`

### DIFF
--- a/sysand/tests/cli_source.rs
+++ b/sysand/tests/cli_source.rs
@@ -174,7 +174,7 @@ fn sources_without_std() -> Result<(), Box<dyn std::error::Error>> {
 
     let out = run_sysand_in(&path, ["sources"], None)?;
     out.assert().success().stdout(predicates::str::is_match(
-        "^.*src\\.sysml\n.*src_dep\\.sysml\n$",
+        r"^.*?src\.sysml\n.*?src_dep\.sysml\n$",
     )?);
 
     Ok(())


### PR DESCRIPTION
One of the tests for the `sysand sources` command didn't actually check if standard libraries where filtered out properly, and as such missed the fact that code for adding old standard library hadn't been removed when support was dropped.

This PR both removes the old code and makes the test stricter to catch similar mishaps in the future.