### PR TITLE
feat: warn about non-semver version and non-spdx license when building a kpar

### DIFF
--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -121,21 +121,31 @@ pub fn do_build_kpar<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     path: P,
     canonicalise: bool,
 ) -> Result<LocalKParProject, KParBuildError<Pr::Error>> {
-    use crate::{model::InterchangeProjectMetadataRaw, project::local_src::LocalSrcProject};
+    use crate::project::local_src::LocalSrcProject;
 
     let building = "Building";
     let header = crate::style::get_style_config().header;
     log::info!("{header}{building:>12}{header:#} kpar `{}`", path.as_ref());
 
-    let (_tmp, mut local_project) = LocalSrcProject::temporary_from_project(project)?;
+    let (_tmp, mut local_project, info, meta) = LocalSrcProject::temporary_from_project(project)?;
+    match semver::Version::parse(&info.version) {
+        Ok(_) => (),
+        Err(e) => log::warn!(
+            "project's version `{}` is not a valid SemVer version: {e}",
+            info.version
+        ),
+    }
+    if let Some(l) = info.license {
+        match spdx::Expression::parse(&l) {
+            Ok(_) => (),
+            Err(e) => {
+                log::warn!("project's license `{l}` is not a valid SPDX license expression:\n{e}")
+            }
+        }
+    }
 
     if canonicalise {
-        for path in local_project
-            .get_meta()?
-            .unwrap_or_else(InterchangeProjectMetadataRaw::generate_blank)
-            .validate()?
-            .source_paths(true)
-        {
+        for path in meta.validate()?.source_paths(true) {
             use crate::include::do_include;
 
             do_include(&mut local_project, &path, true, true, None)?;

--- a/core/src/project/local_src.rs
+++ b/core/src/project/local_src.rs
@@ -201,17 +201,26 @@ impl LocalSrcProject {
         Ok(result)
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn temporary_from_project<Pr: ProjectRead>(
         project: &Pr,
-    ) -> Result<(camino_tempfile::Utf8TempDir, Self), CloneError<Pr::Error, LocalSrcError>> {
+    ) -> Result<
+        (
+            camino_tempfile::Utf8TempDir,
+            Self,
+            InterchangeProjectInfoRaw,
+            InterchangeProjectMetadataRaw,
+        ),
+        CloneError<Pr::Error, LocalSrcError>,
+    > {
         let tmp = camino_tempfile::tempdir().map_err(FsIoError::MkTempDir)?;
         let mut tmp_project = Self {
             project_path: wrapfs::canonicalize(tmp.path())?,
         };
 
-        clone_project(project, &mut tmp_project, true)?;
+        let (info, meta) = clone_project(project, &mut tmp_project, true)?;
 
-        Ok((tmp, tmp_project))
+        Ok((tmp, tmp_project, info, meta))
     }
 
     // pub fn source_paths(&self) -> &str {


### PR DESCRIPTION
Final part of #127, forgot to include it there.