### PR TITLE
feat: add panic hook that asks users to report bugs

### DIFF
--- a/sysand/src/main.rs
+++ b/sysand/src/main.rs
@@ -1,12 +1,16 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::panic;
+
 use anstream::{eprint, eprintln};
 use clap::Parser;
 
 use sysand::{cli::Args, run_cli};
 
 fn main() {
+    set_panic_hook();
+
     match Args::try_parse() {
         Ok(args) => {
             if let Err(err) = run_cli(args) {
@@ -23,4 +27,23 @@ fn main() {
             std::process::exit(err.exit_code())
         }
     }
+}
+
+fn set_panic_hook() {
+    // TODO: use `panic::update_hook()` once it's stable
+    //       also set bactrace style once it's stable, but take
+    //       into account the current level
+    let default_hook = panic::take_hook();
+    // panic::set_backtrace_style(panic::BacktraceStyle::Short);
+    panic::set_hook(Box::new(move |panic_info| {
+        std::eprintln!(
+            "Sysand crashed. This is a bug. We would appreciate a bug report at either\n\
+            Sysand's issue tracker: https://github.com/sensmetry/sysand/issues\n\
+            or Sensmetry forum: https://forum.sensmetry.com/c/sysand/24\n\
+            or via email: sysand@sensmetry.com\n\
+            \n\
+            Below are details of the crash. It would be helpful to include them in the bug report."
+        );
+        default_hook(panic_info);
+    }));
 }


### PR DESCRIPTION
Example panic output:
```plain
Sysand crashed. This is a bug. We would appreciate a bug report at either
Sysand's issue tracker: https://github.com/sensmetry/sysand/issues
or Sensmetry forum: https://forum.sensmetry.com/c/sysand/24
or via email: sysand@sensmetry.com

Below are details of the crash. It would be helpful to include them in the bug report.

thread 'main' (33563587) panicked at sysand/src/main.rs:14:5:
explicit panic
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It would be nice to always print a short backtrace, but the API for this in std is unstable and `env::set_var()` is unsafe, so currently this is not done.