### PR TITLE
docs: add unreferenced dependencies section

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,3 +28,4 @@
 - [Publishing a package to Sysand Index](publishing.md)
 - [Configuration](config.md)
   - [Indexes](config/indexes.md)
+  - [Dependencies](config/dependencies.md)


### PR DESCRIPTION
This section was not referenced, so not seen in the docs. Should it be?

<img width="901" height="756" alt="image" src="https://github.com/user-attachments/assets/33f05ff8-a34c-4964-b351-1723e0def71a" />

<img width="880" height="1470" alt="image" src="https://github.com/user-attachments/assets/d8b4d09f-503c-48e1-b733-e6dee218736a" />
