### PR TITLE
ci: group 0.1.x bumps into the 1.x.y group bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,14 +1,26 @@
+// Renovate creates automated PRs to update various kinds of dependencies.
+//
+// config ref: https://docs.renovatebot.com/configuration-options/
+//
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:best-practices", "schedule:earlyMondays"],
   packageRules: [
+    // Group bumps of all non-major dependencies by using two rules, one for
+    // situations like 1.2.3, and one for situations like 0.1.2.
     {
       groupName: "all non-major dependencies",
-      groupSlug: "all-minor-patch",
+      groupSlug: "all-non-major",
       matchPackageNames: ["*"],
+      matchCurrentVersion: "/^[1-9]/",
       matchUpdateTypes: ["minor", "patch"],
-      // Only upgrade deps with version >=1
-      matchCurrentVersion: "!/^0/",
+    },
+    {
+      groupName: "all non-major dependencies",
+      groupSlug: "all-non-major",
+      matchCurrentVersion: "/^0\\.[1-9]/",
+      matchPackageNames: ["*"],
+      matchUpdateTypes: ["patch"],
     },
     // pyo3 packages have interdependencies on each other
     {


### PR DESCRIPTION
We recently got two PRs like 0.1.x that I figured should have been grouped with 1.x.y like bumps.

- https://github.com/sensmetry/sysand/pull/187
- https://github.com/sensmetry/sysand/pull/188