### PR TITLE
chore: add vs code setup to developer guide

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,12 @@
 {
     "recommendations": [
-        "rust-lang.rust-analyzer",
-        "tamasfe.even-better-toml",
-        "streetsidesoftware.code-spell-checker",
         "davidanson.vscode-markdownlint",
-        "gruntfuggly.todo-tree"
+        "gruntfuggly.todo-tree",
+        "ms-python.python",
+        "rust-lang.rust-analyzer",
+        "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml",
+        "usernamehw.errorlens",
+        "vadimcn.vscode-lldb"
     ]
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,23 +28,46 @@ Directory structure:
 
 ## Setup
 
-Development is done on Linux (including WSL) or macOS. For Sysand core and CLI
-development, you need to [install Rust](https://rust-lang.org/tools/install/)
-specified in `rust-version` field of [Cargo.toml](Cargo.toml) or later
-and [uv](https://docs.astral.sh/uv/). It is also recommended to use
-[`rust-analyzer`](https://github.com/rust-lang/rust-analyzer). It has an
-[extension for VS Code](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
-and many other code editors can use it via
-[LSP](https://microsoft.github.io/language-server-protocol/).
-Other useful VS Code extensions can be found in
-[`.vscode/extensions.json`](.vscode/extensions.json).
-
-Get the repository:
+To get the repository you need [Git](https://git-scm.com/) installed on your
+system and then run:
 
 ```sh
 git clone git@github.com:sensmetry/sysand.git
 cd sysand
 ```
+
+Development is done on Linux (including WSL), macOS or Windows. For Sysand core
+and CLI development, you need to [install Rust](https://rust-lang.org/tools/install/)
+specified in `rust-version` field of [Cargo.toml](Cargo.toml). It is also
+recommended to use [`rust-analyzer`](https://github.com/rust-lang/rust-analyzer)
+which is supported by many different editors.
+
+### VS Code
+
+If using [VS Code](https://code.visualstudio.com/) (or other compatible editor
+like e.g. [VSCodium](https://vscodium.com/) or [Cursor](https://cursor.com/download))
+we recommended the following extensions for developing in Rust:
+
+- [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+  for Rust language support.
+- [Error Lens](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens)
+  for improved highlighting of errors.
+- [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
+  for debugging.
+- [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)
+  for `Cargo.toml` etc.
+
+For rust-analyzer we can also recommend going into the settings and choosing
+to activate the `Test Explorer` option to easily run tests in the editor.
+
+Additionally you may be interested in using [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree)
+for tracking `TODO` and `FIXME` comments. You may also want to go into the
+REGEX setting and add `|todo!\(` to the end of the default regex to also catch
+invocations of Rust's `todo!` macros.
+
+All the extensions and more can be found in
+[`.vscode/extensions.json`](.vscode/extensions.json) and these should show up
+as recommended at the bottom of the extensions tab.
 
 ## Installing Sysand CLI
 

--- a/bindings/py/DEVELOPMENT.md
+++ b/bindings/py/DEVELOPMENT.md
@@ -1,11 +1,28 @@
 # Python bindings
 
-## Building and running tests
+## Setup
 
 Requirements:
 
 - Rust version given in `rust-version` in [Cargo.toml](../../Cargo.toml) or later
-- uv
+- [uv](https://docs.astral.sh/uv/)
+
+The main part of the python bindings are written in Rust but some of the
+tests are written in Python so it can be a good idea configure your editor for
+Python development as well.
+
+### VS Code
+
+If using VS Code (or other compatible editor like e.g. Codium or Cursor) we
+recommended the official [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+extension from Microsoft. This will also install the Pylance, Python Debugger
+and Python Environments extensions.
+
+If your editor is having problems finding imports even after installing all
+dependencies (see below), you can try to go into the settings of the Python
+extension and check the `Use Environments Extension` option.
+
+## Building and running tests
 
 First, set up a Python venv:
 


### PR DESCRIPTION
Update developer guides with a sections on VS Code setup for Rust and Python.