### PR TITLE
Make publisher optional in bindings and core

### DIFF
--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
@@ -15,7 +15,7 @@ public class Sysand {
      * already exist.
      *
      * @param name    The name of the project.
-     * @param publisher  The publisher of the project.
+     * @param publisher  The publisher of the project. If {@code null}, default value will be used.
      * @param version The version of the project in SemVer 2.0.0 format.
      * @param license The license of the project given as an SPDX license identifier. May be {@code null}.
      * @param path    The path to the directory in which to initialize the project.
@@ -28,7 +28,7 @@ public class Sysand {
      * already exist.
      *
      * @param name    The name of the project.
-     * @param publisher  The publisher of the project.
+     * @param publisher  The publisher of the project. If {@code null}, default value will be used.
      * @param version The version of the project in SemVer 2.0.0 format.
      * @param license The license of the project given as an SPDX license identifier. May be {@code null}.
      * @param path    The path to the directory in which to initialize the project.

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use camino::Utf8PathBuf;
 use jni::{
     JNIEnv,
+    errors::Error,
     objects::{JClass, JObject, JObjectArray, JString},
 };
 use sysand_core::{
@@ -45,8 +46,16 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_init<'local>(
     let Some(name) = env.get_str(&name, "name") else {
         return;
     };
-    let Some(publisher) = env.get_str(&publisher, "publisher") else {
-        return;
+    // If `publisher` is `null`, no publisher is specified
+    let publisher: Option<String> = match env.get_string(&publisher) {
+        Ok(s) => Some(s.into()),
+        Err(e) => match e {
+            Error::NullPtr(_) => None,
+            _ => {
+                env.throw_runtime_exception(format!("failed to get argument `publisher`: {}", e));
+                return;
+            }
+        },
     };
     let Some(version) = env.get_str(&version, "version") else {
         return;
@@ -59,7 +68,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_init<'local>(
     let license: Option<String> = match env.get_string(&license) {
         Ok(s) => Some(s.into()),
         Err(e) => match e {
-            jni::errors::Error::NullPtr(_) => None,
+            Error::NullPtr(_) => None,
             _ => {
                 env.throw_runtime_exception(format!("failed to get argument `license`: {}", e));
                 return;

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -34,7 +34,7 @@ pub fn clear_local_storage(prefix: &str) -> Result<(), JsValue> {
 #[wasm_bindgen(js_name = do_init_js_local_storage)]
 pub fn do_init_js_local_storage(
     name: String,
-    publisher: String,
+    publisher: Option<String>,
     version: String,
     prefix: &str,
     root_path: &str,

--- a/bindings/js/tests/basic_browser.rs
+++ b/bindings/js/tests/basic_browser.rs
@@ -23,7 +23,7 @@ mod browser_tests {
     fn test_basic_init() -> Result<(), Box<dyn Error>> {
         do_init_js_local_storage(
             "test_basic_init".to_string(),
-            String::from("a"),
+            Some(String::from("a")),
             "1.2.3".to_string(),
             "sysand_storage",
             "/",

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -54,7 +54,7 @@ fn run_cli(args: Vec<String>) -> PyResult<bool> {
 )]
 fn do_init_py_local_file(
     name: String,
-    publisher: String,
+    publisher: Option<String>,
     version: String,
     path: String,
     license: Option<String>,

--- a/core/src/commands/init.rs
+++ b/core/src/commands/init.rs
@@ -17,6 +17,8 @@ use crate::project::local_src::{LocalSrcError, LocalSrcProject};
 
 use thiserror::Error;
 
+const DEFAULT_PUBLISHER: &str = "untitled";
+
 #[derive(Error, Debug)]
 pub enum InitError<ProjectError: ErrorBound> {
     #[error("failed to parse `{0}` as a Semantic Version: {1}")]
@@ -29,7 +31,7 @@ pub enum InitError<ProjectError: ErrorBound> {
 
 pub fn do_init_ext<P: ProjectMut>(
     name: String,
-    publisher: String,
+    publisher: Option<String>,
     version: String,
     no_semver: bool,
     license: Option<String>,
@@ -48,6 +50,7 @@ pub fn do_init_ext<P: ProjectMut>(
     } else {
         None
     };
+    let publisher = publisher.unwrap_or_else(|| String::from(DEFAULT_PUBLISHER));
 
     let creating = "Creating";
     let header = crate::style::get_style_config().header;
@@ -82,7 +85,7 @@ pub fn do_init_ext<P: ProjectMut>(
 
 pub fn do_init<P: ProjectMut>(
     name: String,
-    publisher: String,
+    publisher: Option<String>,
     version: String,
     license: Option<String>,
     storage: &mut P,
@@ -92,7 +95,7 @@ pub fn do_init<P: ProjectMut>(
 
 pub fn do_init_memory<N: AsRef<str>, P: AsRef<str>, V: AsRef<str>>(
     name: N,
-    publisher: P,
+    publisher: Option<P>,
     version: V,
     license: Option<String>,
 ) -> Result<InMemoryProject, InitError<crate::project::memory::InMemoryError>> {
@@ -100,7 +103,7 @@ pub fn do_init_memory<N: AsRef<str>, P: AsRef<str>, V: AsRef<str>>(
 
     do_init(
         name.as_ref().to_owned(),
-        publisher.as_ref().to_owned(),
+        publisher.map(|p| String::from(p.as_ref())),
         version.as_ref().to_owned(),
         license,
         &mut storage,
@@ -112,7 +115,7 @@ pub fn do_init_memory<N: AsRef<str>, P: AsRef<str>, V: AsRef<str>>(
 #[cfg(feature = "filesystem")]
 pub fn do_init_local_file(
     name: String,
-    publisher: String,
+    publisher: Option<String>,
     version: String,
     license: Option<String>,
     path: Utf8PathBuf,

--- a/core/src/env/memory.rs
+++ b/core/src/env/memory.rs
@@ -73,8 +73,8 @@ pub enum TryFromError<Project: ProjectRead> {
 /// # use sysand_core::env::memory::MemoryStorageEnvironment;
 /// # use sysand_core::env::ReadEnvironment;
 /// # use sysand_core::project::memory::InMemoryProject;
-/// let project1 = do_init_memory("First", "a", "0.0.1", None).unwrap();
-/// let project2 = do_init_memory("First", "a", "0.1.0", None).unwrap();
+/// let project1 = do_init_memory("First", Some("a"), "0.0.1", None).unwrap();
+/// let project2 = do_init_memory("First", None::<&str>, "0.1.0", None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::try_from([
 ///     ("urn:kpar:first".into(), project1.clone()),
 ///     ("urn:kpar:first".into(), project2.clone()),
@@ -120,8 +120,8 @@ impl<Project: ProjectRead + Clone, const N: usize> TryFrom<[(String, Project); N
 /// # use sysand_core::env::memory::MemoryStorageEnvironment;
 /// # use sysand_core::env::ReadEnvironment;
 /// # use sysand_core::project::memory::InMemoryProject;
-/// let project1 = do_init_memory("First", "a", "0.0.1", None).unwrap();
-/// let project2 = do_init_memory("First", "a", "0.1.0", None).unwrap();
+/// let project1 = do_init_memory("First", Some("a"), "0.0.1", None).unwrap();
+/// let project2 = do_init_memory("First", None::<&str>, "0.1.0", None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::try_from(vec![
 ///     ("urn:kpar:first".into(), project1.clone()),
 ///     ("urn:kpar:first".into(), project2.clone()),
@@ -177,8 +177,8 @@ impl<Project: ProjectRead + Clone> FromIterator<(String, String, Project)>
 /// # use sysand_core::project::memory::InMemoryProject;
 /// let version1 = "0.0.1".to_string();
 /// let version2 = "0.1.0".to_string();
-/// let project1 = do_init_memory("First", "a", &version1, None).unwrap();
-/// let project2 = do_init_memory("First", "a", &version2, None).unwrap();
+/// let project1 = do_init_memory("First", Some("a"), &version1, None).unwrap();
+/// let project2 = do_init_memory("First", None::<&str>, &version2, None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::from([
 ///     ("urn:kpar:first".into(), version1.clone(), project1.clone()),
 ///     ("urn:kpar:first".into(), version2.clone(), project2.clone()),
@@ -219,8 +219,8 @@ impl<Project: ProjectRead + Clone, const N: usize> From<[(String, String, Projec
 /// # use sysand_core::project::memory::InMemoryProject;
 /// let version1 = "0.0.1".to_string();
 /// let version2 = "0.1.0".to_string();
-/// let project1 = do_init_memory("First", "a", &version1, None).unwrap();
-/// let project2 = do_init_memory("First", "a", &version2, None).unwrap();
+/// let project1 = do_init_memory("First", Some("a"), &version1, None).unwrap();
+/// let project2 = do_init_memory("First", None::<&str>, &version2, None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::from(vec![
 ///     ("urn:kpar:first".into(), version1.clone(), project1.clone()),
 ///     ("urn:kpar:first".into(), version2.clone(), project2.clone()),
@@ -372,8 +372,8 @@ mod test {
         let uri1 = "urn:kpar:first".to_string();
         let uri2 = "urn:kpar:second".to_string();
         let version = "0.0.1".to_string();
-        let project1 = do_init_memory("First", "a", &version, None).unwrap();
-        let project2 = do_init_memory("Second", "a", &version, None).unwrap();
+        let project1 = do_init_memory("First", Some("a"), &version, None).unwrap();
+        let project2 = do_init_memory("Second", None::<&str>, &version, None).unwrap();
         let mut env = MemoryStorageEnvironment::<InMemoryProject>::new();
 
         env.put_project(&uri1, &version, |p| {
@@ -417,7 +417,7 @@ mod test {
     fn read_environment() {
         let iri = "urn:kpar:first".to_string();
         let version = "0.0.1".to_string();
-        let project = do_init_memory("First", "a", &version, None).unwrap();
+        let project = do_init_memory("First", Some("a"), &version, None).unwrap();
         let env = MemoryStorageEnvironment {
             projects: HashMap::from([(
                 iri.clone(),
@@ -451,9 +451,9 @@ mod test {
         let version1 = "0.0.1".to_string();
         let version2 = "0.1.0".to_string();
         let version3 = "0.0.1".to_string();
-        let project1 = do_init_memory("First 0.0.1", "a", &version1, None).unwrap();
-        let project2 = do_init_memory("First 0.1.0", "a", &version2, None).unwrap();
-        let project3 = do_init_memory("Second", "a", &version3, None).unwrap();
+        let project1 = do_init_memory("First 0.0.1", Some("a"), &version1, None).unwrap();
+        let project2 = do_init_memory("First 0.1.0", None::<&str>, &version2, None).unwrap();
+        let project3 = do_init_memory("Second", Some("a"), &version3, None).unwrap();
         let env = MemoryStorageEnvironment::<InMemoryProject>::from([
             ("urn:kpar:first".into(), version1.clone(), project1.clone()),
             ("urn:kpar:first".into(), version2.clone(), project2.clone()),
@@ -478,9 +478,9 @@ mod test {
 
     #[test]
     fn try_from() {
-        let project1 = do_init_memory("First 0.0.1", "a", "0.0.1", None).unwrap();
-        let project2 = do_init_memory("First 0.1.0", "a", "0.1.0", None).unwrap();
-        let project3 = do_init_memory("Second", "a", "0.0.1", None).unwrap();
+        let project1 = do_init_memory("First 0.0.1", Some("a"), "0.0.1", None).unwrap();
+        let project2 = do_init_memory("First 0.1.0", Some("a"), "0.1.0", None).unwrap();
+        let project3 = do_init_memory("Second", Some("a"), "0.0.1", None).unwrap();
         let env = MemoryStorageEnvironment::<InMemoryProject>::try_from([
             ("urn:kpar:first".into(), project1.clone()),
             ("urn:kpar:first".into(), project2.clone()),

--- a/core/tests/memory_init.rs
+++ b/core/tests/memory_init.rs
@@ -8,14 +8,18 @@ use sysand_core::{commands::init::do_init, init::do_init_memory, model::Intercha
 /// and .meta.json files in the current working directory. (Non-interactive use)
 #[test]
 fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
-    let memory_storage =
-        do_init_memory("init_basic", "a", "1.2.3", Some("Apache-2.0".to_string()))?;
+    let memory_storage = do_init_memory(
+        "init_basic",
+        None::<&str>,
+        "1.2.3",
+        Some("Apache-2.0".to_string()),
+    )?;
 
     assert_eq!(
         memory_storage.info.unwrap(),
         InterchangeProjectInfo {
             name: "init_basic".to_string(),
-            publisher: Some(String::from("a")),
+            publisher: Some("untitled".to_owned()),
             description: None,
             version: Version::parse("1.2.3").unwrap(),
             license: Some("Apache-2.0".to_string()),
@@ -58,7 +62,7 @@ fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
 fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
     let mut memory_storage = do_init_memory(
         "init_fail_on_double_init",
-        "a",
+        Some("a"),
         "1.2.3",
         Some("Apache-2.0 OR MIT".to_string()),
     )?;
@@ -68,7 +72,7 @@ fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
 
     let second_result = do_init(
         "init_fail_on_double_init".to_string(),
-        "a".to_owned(),
+        Some("a".to_owned()),
         "1.2.3".to_string(),
         Some("Apache-2.0 OR MIT".to_string()),
         &mut memory_storage,

--- a/sysand/src/commands/init.rs
+++ b/sysand/src/commands/init.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use sysand_core::project::utils::wrapfs;
 
-const DEFAULT_PUBLISHER: &str = "untitled";
 const DEFAULT_VERSION: &str = "0.0.1";
 
 pub fn command_init(
@@ -31,7 +30,6 @@ pub fn command_init(
         Some(n) => n,
         None => default_name_from_path(&path)?,
     };
-    let publisher = publisher.unwrap_or_else(|| DEFAULT_PUBLISHER.to_owned());
 
     sysand_core::init::do_init_ext(
         name,


### PR DESCRIPTION
In #212 I made `publisher` a required field for all bindings. Now realized that it was probably not such a good idea, so making it optional for now. If not provided, default `untitled` will be stored in `.project.json`.