### PR TITLE
ci: switch pypi-publish job to regular ubuntu-24.04

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -333,7 +333,7 @@ jobs:
     environment: pypi-publish
     needs: [lint, linux, macos, windows, sdist]
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write # for actions/attest and pypa/gh-action-pypi-publish
       attestations: write # for actions/attest and pypa/gh-action-pypi-publish


### PR DESCRIPTION
Signed-off-by: Erik Sundell <erik.sundell+2025@sensmetry.com>
