### PR TITLE
ci: fix yaml issue making incorrect release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -190,12 +190,12 @@ jobs:
           mv artifacts/sysand-macos-latest artifacts/sysand-macos-arm64
 
       - name: Create a nightly release
-        run: >-
-          NEW_TAG=$(date +v-%Y-%m-%d-%H%M) &&
-          gh release create "$NEW_TAG"
-              --title "Nightly Release $NEW_TAG"
-              --prerelease
-              --target "$GITHUB_SHA"
+        run: |
+          NEW_TAG=$(date +v-%Y-%m-%d-%H%M)
+          gh release create "$NEW_TAG" \
+              --title "Nightly Release $NEW_TAG" \
+              --prerelease \
+              --target "$GITHUB_SHA" \
               artifacts/*
         env:
           GH_TOKEN: ${{ github.token }}
@@ -233,10 +233,10 @@ jobs:
           mv artifacts/sysand-macos-latest artifacts/sysand-macos-arm64
 
       - name: Create a release
-        run: >-
-          gh release create "$TRIGGERING_TAG"
-              --title "Release $TRIGGERING_TAG"
-              --verify-tag
+        run: |
+          gh release create "$TRIGGERING_TAG" \
+              --title "Release $TRIGGERING_TAG" \
+              --verify-tag \
               artifacts/*
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
When the YAML detail > is used, you can have multiple lines wrapped into
a single line, however, if you indent things to different levels, you do
get new lines which caused issues. This commit fixes the bug by
simplifying to use | instead of > for multiline behavior, where I
explicitly add symbols so that bash realizes it should be a command that
continues on another line.

Signed-off-by: Erik Sundell <erik.sundell+2025@sensmetry.com>

---

@andrius-puksta-sensmetry reported this to me via chat, and cleaned up the mess!!