### PR TITLE
prek: add reuse annotate hook, and fix SPDX headers

### DIFF
--- a/.github/scripts/run-pytest.sh
+++ b/.github/scripts/run-pytest.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 # This script expects to be executed in CI from the root of the repository.
 # Usage: .github/scripts/run-pytest.sh

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
 
   ci-gate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,21 @@ repos:
               \.lock
           )
 
+  # Autoformat: Ensure SPDX license and copyright headers
+  - repo: local
+    hooks:
+      - id: reuse-annotate
+        name: reuse annotate
+        language: system
+        entry: uv tool run reuse annotate
+        args:
+          - --license=MIT OR Apache-2.0
+          - --copyright=Sysand contributors <opensource@sensmetry.com>
+          - --copyright-prefix=spdx-symbol
+          - --template=compact
+          - --skip-existing
+        types_or: [rust, python, java, groovy, shell, xml, javascript]
+
   # Autoformat: rust
   - repo: local
     hooks:

--- a/.reuse/templates/compact.jinja2
+++ b/.reuse/templates/compact.jinja2
@@ -1,0 +1,6 @@
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}

--- a/bindings/java/java-deploy-test/pom.xml
+++ b/bindings/java/java-deploy-test/pom.xml
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-
 SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/bindings/java/java-deploy-test/src/test/java/com/sensmetry/sysand/DeployedTest.java
+++ b/bindings/java/java-deploy-test/src/test/java/com/sensmetry/sysand/DeployedTest.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand;
 

--- a/bindings/java/java-test/pom.xml
+++ b/bindings/java/java-test/pom.xml
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-
 SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand;
 

--- a/bindings/java/java/pom.xml
+++ b/bindings/java/java/pom.xml
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-
 SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/NativeLoader.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/NativeLoader.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/IOError.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/IOError.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidSPDXLicense.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidSPDXLicense.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidSemanticVersion.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidSemanticVersion.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidValue.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidValue.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidWorkspace.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/InvalidWorkspace.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/PathError.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/PathError.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/ProjectAlreadyExists.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/ProjectAlreadyExists.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/ResolutionError.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/ResolutionError.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/SerializationError.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/SerializationError.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/SysandException.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/exceptions/SysandException.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.exceptions;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/CompressionMethod.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/CompressionMethod.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 package com.sensmetry.sysand.model;
 
 public enum CompressionMethod {

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProject.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProject.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.model;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectChecksum.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectChecksum.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.model;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectInfo.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectInfo.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.model;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectMetadata.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectMetadata.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.model;
 

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsage.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsage.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.model;
 

--- a/bindings/java/plugin/pom.xml
+++ b/bindings/java/plugin/pom.xml
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-
 SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/bindings/java/plugin/src/it/empty-project/pom.xml
+++ b/bindings/java/plugin/src/it/empty-project/pom.xml
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-
 SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/bindings/java/plugin/src/it/workspace-metamodel/pom.xml
+++ b/bindings/java/plugin/src/it/workspace-metamodel/pom.xml
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-
 SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/bindings/java/plugin/src/it/workspace-metamodel/verify.groovy
+++ b/bindings/java/plugin/src/it/workspace-metamodel/verify.groovy
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 import java.util.zip.ZipFile
 import groovy.json.JsonSlurper

--- a/bindings/java/plugin/src/it/workspace/pom.xml
+++ b/bindings/java/plugin/src/it/workspace/pom.xml
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-
 SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/bindings/java/plugin/src/main/java/org/sysand/maven/SysandBuildKParMojo.java
+++ b/bindings/java/plugin/src/main/java/org/sysand/maven/SysandBuildKParMojo.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package org.sysand.maven;
 

--- a/bindings/java/plugin/src/main/java/org/sysand/maven/SysandInfoPathMojo.java
+++ b/bindings/java/plugin/src/main/java/org/sysand/maven/SysandInfoPathMojo.java
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 package com.sensmetry.sysand.maven;
 

--- a/bindings/java/scripts/java-builder.py
+++ b/bindings/java/scripts/java-builder.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 #
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 import argparse
 import json

--- a/bindings/java/scripts/run_tests.sh
+++ b/bindings/java/scripts/run_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 # Assumes that Java, Maven, and Python are installed.
 
 set -eu

--- a/bindings/java/src/conversion.rs
+++ b/bindings/java/src/conversion.rs
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use crate::exceptions::JniExt;
 use indexmap::IndexMap;

--- a/bindings/java/src/exceptions.rs
+++ b/bindings/java/src/exceptions.rs
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::fmt;
 

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -1,6 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-//
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::sync::Arc;
 

--- a/bindings/js/eslint.config.cjs
+++ b/bindings/js/eslint.config.cjs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 const js = require("@eslint/js");
 const globals = require("globals");
 

--- a/bindings/js/scripts/run_tests.sh
+++ b/bindings/js/scripts/run_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 set -eu
 
 # Compute the root directory based on the location of this script.

--- a/bindings/js/spec/browser/browser_basic.spec.js
+++ b/bindings/js/spec/browser/browser_basic.spec.js
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 //NON-working
 //import * as sysand from "sysand";
 //const sysand = await import("sysand");;

--- a/bindings/js/spec/support/jasmine-browser.mjs
+++ b/bindings/js/spec/support/jasmine-browser.mjs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 export default {
   srcDir: "browser_test_dist",
   srcFiles: [

--- a/bindings/js/src/env/local_storage.rs
+++ b/bindings/js/src/env/local_storage.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use sha2::{Digest, Sha256};
 use sysand_core::env::{PutProjectError, ReadEnvironment, WriteEnvironment};

--- a/bindings/js/src/env/mod.rs
+++ b/bindings/js/src/env/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(feature = "browser")]
 pub mod local_storage;

--- a/bindings/js/src/io/local_storage.rs
+++ b/bindings/js/src/io/local_storage.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::io::{Cursor, Read};
 use sysand_core::context::ProjectContext;

--- a/bindings/js/src/io/mod.rs
+++ b/bindings/js/src/io/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(feature = "browser")]
 pub mod local_storage;

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use wasm_bindgen::prelude::*;
 

--- a/bindings/js/src/local_storage_utils.rs
+++ b/bindings/js/src/local_storage_utils.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::io::Read;
 

--- a/bindings/js/tests/basic_browser.rs
+++ b/bindings/js/tests/basic_browser.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(feature = "browser")]
 mod browser_tests {

--- a/bindings/js/webpack-browser-test.config.cjs
+++ b/bindings/js/webpack-browser-test.config.cjs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 const path = require("path");
 //const HtmlWebpackPlugin = require('html-webpack-plugin');
 //const webpack = require('webpack');

--- a/bindings/js/webpack-browser.config.cjs
+++ b/bindings/js/webpack-browser.config.cjs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 const path = require("path");
 //const HtmlWebpackPlugin = require('html-webpack-plugin');
 //const webpack = require('webpack');

--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from ._model import (
     InterchangeProjectUsage,

--- a/bindings/py/python/sysand/__main__.py
+++ b/bindings/py/python/sysand/__main__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 import sys
 

--- a/bindings/py/python/sysand/_add.py
+++ b/bindings/py/python/sysand/_add.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/_build.py
+++ b/bindings/py/python/sysand/_build.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 from __future__ import annotations
 
 from sysand._model import CompressionMethod

--- a/bindings/py/python/sysand/_exclude.py
+++ b/bindings/py/python/sysand/_exclude.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/_include.py
+++ b/bindings/py/python/sysand/_include.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/_info.py
+++ b/bindings/py/python/sysand/_info.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/_init.py
+++ b/bindings/py/python/sysand/_init.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from enum import Enum, auto
 import typing

--- a/bindings/py/python/sysand/_remove.py
+++ b/bindings/py/python/sysand/_remove.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/_sources.py
+++ b/bindings/py/python/sysand/_sources.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 from typing import List

--- a/bindings/py/python/sysand/env/__init__.py
+++ b/bindings/py/python/sysand/env/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/env/_install.py
+++ b/bindings/py/python/sysand/env/_install.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 

--- a/bindings/py/python/sysand/env/_sources.py
+++ b/bindings/py/python/sysand/env/_sources.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
-#
 # SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 from typing import List

--- a/bindings/py/scripts/run_tests.sh
+++ b/bindings/py/scripts/run_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 set -eu
 
 # Compute the root directory based on the location of this script.

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{collections::HashMap, process::ExitCode, sync::Arc};
 

--- a/bindings/py/tests/basic.rs
+++ b/bindings/py/tests/basic.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use predicates::prelude::*;
 use pyo3::prelude::*;

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 import logging
 import tempfile
 from pathlib import Path

--- a/core/scripts/run_tests.sh
+++ b/core/scripts/run_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 set -eu
 
 # Compute the root directory based on the location of this script.

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 //! This module includes utilities for creating and using authentication policies for requests.
 

--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 use thiserror::Error;
 
 use crate::{

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use camino::{Utf8Path, Utf8PathBuf};
 use thiserror::Error;
 

--- a/core/src/commands/env/install.rs
+++ b/core/src/commands/env/install.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use thiserror::Error;
 

--- a/core/src/commands/env/list.rs
+++ b/core/src/commands/env/list.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use crate::env::ReadEnvironment;
 

--- a/core/src/commands/env/mod.rs
+++ b/core/src/commands/env/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(feature = "filesystem")]
 use crate::{

--- a/core/src/commands/env/uninstall.rs
+++ b/core/src/commands/env/uninstall.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use crate::env::WriteEnvironment;
 

--- a/core/src/commands/exclude.rs
+++ b/core/src/commands/exclude.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use thiserror::Error;
 use typed_path::Utf8UnixPath;

--- a/core/src/commands/include.rs
+++ b/core/src/commands/include.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use thiserror::Error;
 use typed_path::Utf8UnixPath;

--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use thiserror::Error;
 

--- a/core/src/commands/init.rs
+++ b/core/src/commands/init.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(feature = "filesystem")]
 use camino::Utf8PathBuf;

--- a/core/src/commands/lock.rs
+++ b/core/src/commands/lock.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use fluent_uri::Iri;
 use std::{

--- a/core/src/commands/mod.rs
+++ b/core/src/commands/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 pub mod add;
 #[cfg(feature = "filesystem")]

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::sync::Arc;
 

--- a/core/src/commands/remove.rs
+++ b/core/src/commands/remove.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use thiserror::Error;
 

--- a/core/src/commands/root.rs
+++ b/core/src/commands/root.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use camino::{Utf8Path, Utf8PathBuf};
 

--- a/core/src/commands/sources.rs
+++ b/core/src/commands/sources.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{collections::HashMap, fmt::Debug};
 

--- a/core/src/commands/sync.rs
+++ b/core/src/commands/sync.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::collections::HashMap;
 

--- a/core/src/config/local_fs.rs
+++ b/core/src/config/local_fs.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{fs, io::ErrorKind, str::FromStr};
 

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 #[cfg(feature = "filesystem")]
 use camino::Utf8PathBuf;
 

--- a/core/src/discover.rs
+++ b/core/src/discover.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use camino::{Utf8Path, Utf8PathBuf};
 

--- a/core/src/env/local_directory/metadata.rs
+++ b/core/src/env/local_directory/metadata.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{fmt::Display, str::FromStr};
 

--- a/core/src/env/local_directory/mod.rs
+++ b/core/src/env/local_directory/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::io::{self, BufRead, BufReader, Write};
 

--- a/core/src/env/local_directory/utils.rs
+++ b/core/src/env/local_directory/utils.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     fs,

--- a/core/src/env/memory.rs
+++ b/core/src/env/memory.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use crate::{
     env::{PutProjectError, ReadEnvironment, WriteEnvironment},

--- a/core/src/env/mod.rs
+++ b/core/src/env/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{fmt::Debug, marker::Unpin, sync::Arc};
 

--- a/core/src/env/null.rs
+++ b/core/src/env/null.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use std::{
     fmt::Debug,
     iter::{Empty, empty},

--- a/core/src/env/reqwest_http.rs
+++ b/core/src/env/reqwest_http.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     io,

--- a/core/src/env/utils.rs
+++ b/core/src/env/utils.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use crate::{
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 #![allow(refining_impl_trait)]
 

--- a/core/src/lock.rs
+++ b/core/src/lock.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     cmp::Ordering,

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{clone::Clone, collections::HashSet, fmt::Display, hash::Hash};
 

--- a/core/src/project/any.rs
+++ b/core/src/project/any.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{result::Result, sync::Arc};
 

--- a/core/src/project/cached.rs
+++ b/core/src/project/cached.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use crate::{
     context::ProjectContext,

--- a/core/src/project/editable.rs
+++ b/core/src/project/editable.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use camino::Utf8PathBuf;
 

--- a/core/src/project/gix_git_download.rs
+++ b/core/src/project/gix_git_download.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use std::num::NonZero;
 
 use camino::Utf8PathBuf;

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::io::Write as _;
 

--- a/core/src/project/local_src.rs
+++ b/core/src/project/local_src.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     collections::HashSet,

--- a/core/src/project/memory.rs
+++ b/core/src/project/memory.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     collections::{HashMap, hash_map::Entry},

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use camino::Utf8Path;
 use futures::io::{AsyncBufReadExt as _, AsyncRead};

--- a/core/src/project/null.rs
+++ b/core/src/project/null.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     convert::Infallible,

--- a/core/src/project/reference.rs
+++ b/core/src/project/reference.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::sync::Arc;
 

--- a/core/src/project/reqwest_kpar_download.rs
+++ b/core/src/project/reqwest_kpar_download.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     io::{self, Write as _},

--- a/core/src/project/reqwest_src.rs
+++ b/core/src/project/reqwest_src.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 //! This module implements accessing interchanged projects stored remotely over HTTP.
 

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::io::{self, Read};
 

--- a/core/src/resolve/combined.rs
+++ b/core/src/resolve/combined.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{fmt::Debug, iter::Peekable};
 

--- a/core/src/resolve/env.rs
+++ b/core/src/resolve/env.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 // Resolve IRIs in an environment
 use crate::{

--- a/core/src/resolve/file.rs
+++ b/core/src/resolve/file.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 // Resolver for file:// URLs
 

--- a/core/src/resolve/gix_git.rs
+++ b/core/src/resolve/gix_git.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use fluent_uri::component::Scheme;
 use thiserror::Error;
 

--- a/core/src/resolve/memory.rs
+++ b/core/src/resolve/memory.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{collections::HashMap, convert::Infallible};
 

--- a/core/src/resolve/mod.rs
+++ b/core/src/resolve/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{fmt::Debug, sync::Arc};
 

--- a/core/src/resolve/net_utils.rs
+++ b/core/src/resolve/net_utils.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use std::{error::Error, fmt::Display};
 

--- a/core/src/resolve/null.rs
+++ b/core/src/resolve/null.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::convert::Infallible;
 

--- a/core/src/resolve/priority.rs
+++ b/core/src/resolve/priority.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use std::{
     fmt::{self, Debug},
     io::{self, Read},

--- a/core/src/resolve/remote.rs
+++ b/core/src/resolve/remote.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use std::io::{self, Read};
 
 use thiserror::Error;

--- a/core/src/resolve/reqwest_http.rs
+++ b/core/src/resolve/reqwest_http.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{convert::Infallible, io, pin::Pin, sync::Arc};
 

--- a/core/src/resolve/sequential.rs
+++ b/core/src/resolve/sequential.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use crate::resolve::{ResolutionOutcome, ResolveRead, ResolveReadAsync};
 use futures::StreamExt as _;
 use std::iter::Flatten;

--- a/core/src/resolve/standard.rs
+++ b/core/src/resolve/standard.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{fmt, result::Result, sync::Arc};
 

--- a/core/src/solve/mod.rs
+++ b/core/src/solve/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 pub mod pubgrub;

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use fluent_uri::Iri;
 use pubgrub::{DefaultStringReporter, DependencyProvider, Reporter, VersionSet};

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use std::collections::HashMap;
 
 use crate::project::memory::InMemoryProject;

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::sync::OnceLock;
 

--- a/core/src/symbols/lex.rs
+++ b/core/src/symbols/lex.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use logos::{Lexer, Logos};
 use thiserror::Error;

--- a/core/src/symbols/mod.rs
+++ b/core/src/symbols/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 //! Module for extracting symbols from KerML or SysML v2 files.
 //!

--- a/core/src/workspace.rs
+++ b/core/src/workspace.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use camino::{Utf8Path, Utf8PathBuf};
 use fluent_uri::Iri;
 

--- a/core/tests/filesystem_env.rs
+++ b/core/tests/filesystem_env.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(feature = "filesystem")]
 mod filesystem_tests {

--- a/core/tests/memory_env.rs
+++ b/core/tests/memory_env.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     collections::HashMap,

--- a/core/tests/memory_init.rs
+++ b/core/tests/memory_init.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use semver::Version;
 use sysand_core::{commands::init::do_init, init::do_init_memory, model::InterchangeProjectInfo};

--- a/core/tests/project_derive.rs
+++ b/core/tests/project_derive.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     collections::HashMap,

--- a/core/tests/project_no_derive.rs
+++ b/core/tests/project_no_derive.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::io::Read;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use itertools::Itertools;
 use proc_macro::TokenStream;

--- a/scripts/add_header.sh
+++ b/scripts/add_header.sh
@@ -1,1 +1,0 @@
-uv tool run reuse annotate --license 'MIT OR Apache-2.0' --copyright 'SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>' $@

--- a/scripts/py_path.sh
+++ b/scripts/py_path.sh
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 # Workaround to make pyo3 embedded Python detect venv python libs.
 # See https://github.com/PyO3/pyo3/issues/1741
 OS="$(uname -s)"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 set -eu
 
 # Compute the root directory based on the location of this script.

--- a/sysand/scripts/run_tests.sh
+++ b/sysand/scripts/run_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 set -eu
 
 # Compute the root directory based on the location of this script.

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
     convert::Infallible,

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{collections::HashMap, path::Path, sync::Arc};
 

--- a/sysand/src/commands/build.rs
+++ b/sysand/src/commands/build.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use anyhow::{Result, bail};
 use camino::Utf8Path;

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
 use anyhow::{Result, anyhow, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use fluent_uri::Iri;

--- a/sysand/src/commands/env.rs
+++ b/sysand/src/commands/env.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 

--- a/sysand/src/commands/exclude.rs
+++ b/sysand/src/commands/exclude.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use anyhow::Result;
 use sysand_core::{context::ProjectContext, exclude::do_exclude};

--- a/sysand/src/commands/include.rs
+++ b/sysand/src/commands/include.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use anyhow::{Result, bail};
 use camino::Utf8PathBuf;

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 use crate::{
     CliError,
     cli::{

--- a/sysand/src/commands/init.rs
+++ b/sysand/src/commands/init.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use crate::CliError;
 use anyhow::Result;

--- a/sysand/src/commands/lock.rs
+++ b/sysand/src/commands/lock.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/sysand/src/commands/mod.rs
+++ b/sysand/src/commands/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 pub mod add;
 pub mod build;

--- a/sysand/src/commands/print_root.rs
+++ b/sysand/src/commands/print_root.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use anyhow::{Result, anyhow};
 

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::sync::Arc;
 

--- a/sysand/src/commands/remove.rs
+++ b/sysand/src/commands/remove.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use anyhow::Result;
 use camino::Utf8PathBuf;

--- a/sysand/src/commands/sources.rs
+++ b/sysand/src/commands/sources.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::collections::HashMap;
 

--- a/sysand/src/commands/sync.rs
+++ b/sysand/src/commands/sync.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/sysand/src/env_vars.rs
+++ b/sysand/src/env_vars.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 /// Corresponds to the `--index` command line argument. Can consist of a single or
 /// multiple (comma separated) list of URLs as additional indexes to use when

--- a/sysand/src/error.rs
+++ b/sysand/src/error.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use thiserror::Error;
 

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(not(feature = "std"))]
 compile_error!("`std` feature is currently required to build `sysand`");

--- a/sysand/src/logger.rs
+++ b/sysand/src/logger.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use env_logger::{Builder, Target, fmt::Formatter};
 use log::{LevelFilter, Record, SetLoggerError};

--- a/sysand/src/main.rs
+++ b/sysand/src/main.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{env, process::ExitCode};
 

--- a/sysand/src/style.rs
+++ b/sysand/src/style.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use clap::builder::styling::{AnsiColor, Effects, Style, Styles};
 

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;

--- a/sysand/tests/cli_base.rs
+++ b/sysand/tests/cli_base.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
 use clap::ValueEnum;

--- a/sysand/tests/cli_clone.rs
+++ b/sysand/tests/cli_clone.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::path::Path;
 

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::path::Path;
 

--- a/sysand/tests/cli_include_exclude.rs
+++ b/sysand/tests/cli_include_exclude.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::io::Write;
 

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 #[cfg(feature = "alltests")]
 use std::process::Command;

--- a/sysand/tests/cli_init.rs
+++ b/sysand/tests/cli_init.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::path::Path;
 

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
 use camino::{Utf8Path, Utf8PathBuf};

--- a/sysand/tests/cli_source.rs
+++ b/sysand/tests/cli_source.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::fs::canonicalize;
 

--- a/sysand/tests/cli_sync.rs
+++ b/sysand/tests/cli_sync.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
 use indexmap::IndexMap;

--- a/sysand/tests/common/mod.rs
+++ b/sysand/tests/common/mod.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::Utf8TempDir;

--- a/sysand/tests/discover.rs
+++ b/sysand/tests/discover.rs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 // SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;


### PR DESCRIPTION
This is the most suitable fix for #283 that I could come up with - we wouldn't have to think about the SPDX headers ourselves, because they are added automatically by prek when needed.

We get an initial copyright year set when a new file is created, and we don't update it over time etc. This seems to be fine based on AI ramblings, but I have no good idea about the impact of updating a copyright year etc.