### PR TITLE
maint: provide compressed GitHub release assets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,13 +120,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
-          - windows-latest
-          - windows-11-arm
-          - macos-15-intel # x86
-          - macos-latest # arm64
+        include:
+          - os: ubuntu-24.04
+            asset: sysand-linux-x86_64
+            ext: tar.xz
+          - os: ubuntu-24.04-arm
+            asset: sysand-linux-arm64
+            ext: tar.xz
+          - os: windows-latest
+            asset: sysand-windows-x86_64
+            ext: zip
+          - os: windows-11-arm
+            asset: sysand-windows-arm64
+            ext: zip
+          - os: macos-15-intel
+            asset: sysand-macos-x86_64
+            ext: tar.xz
+          - os: macos-latest
+            asset: sysand-macos-arm64
+            ext: tar.xz
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -134,17 +146,27 @@ jobs:
       - name: cargo build ...
         run: cargo build --locked --bin sysand --release
 
-      - name: Relocate binaries
+      - name: Package binary (unix)
+        if: runner.os != 'Windows'
         run: |
-          mkdir -p dist
-          ext=${{ (matrix.os == 'windows-latest' || matrix.os == 'windows-11-arm') && '.exe' || '' }}
-          cp target/release/sysand${ext} dist/sysand-${{ matrix.os }}${ext}
+          mkdir -p dist stage
+          cp target/release/sysand stage/sysand
+          chmod +x stage/sysand
+          tar -C stage -cJf "dist/${{ matrix.asset }}.tar.xz" sysand
+
+      - name: Package binary (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist, stage | Out-Null
+          Copy-Item target/release/sysand.exe stage/sysand.exe
+          Compress-Archive -Path stage\sysand.exe -DestinationPath "dist\${{ matrix.asset }}.zip" -Force
 
       - name: Upload binaries
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: sysand-cli-${{ matrix.os }}
-          path: dist
+          name: ${{ matrix.asset }}
+          path: dist/${{ matrix.asset }}.${{ matrix.ext }}
           if-no-files-found: error
 
   ci-gate:
@@ -180,15 +202,6 @@ jobs:
         with:
           subject-path: "artifacts/*"
 
-      - name: Rename artifacts
-        run: |
-          mv artifacts/sysand-ubuntu-24.04 artifacts/sysand-linux-x86_64
-          mv artifacts/sysand-ubuntu-24.04-arm artifacts/sysand-linux-arm64
-          mv artifacts/sysand-windows-latest.exe artifacts/sysand-windows-x86_64.exe
-          mv artifacts/sysand-windows-11-arm.exe artifacts/sysand-windows-arm64.exe
-          mv artifacts/sysand-macos-15-intel artifacts/sysand-macos-x86_64
-          mv artifacts/sysand-macos-latest artifacts/sysand-macos-arm64
-
       - name: Create a nightly release
         run: |
           NEW_TAG=$(date +v-%Y-%m-%d-%H%M)
@@ -196,7 +209,7 @@ jobs:
               --title "Nightly Release $NEW_TAG" \
               --prerelease \
               --target "$GITHUB_SHA" \
-              artifacts/*
+              artifacts/sysand-*.tar.xz artifacts/sysand-*.zip
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -223,21 +236,12 @@ jobs:
         with:
           subject-path: "artifacts/*"
 
-      - name: Rename artifacts
-        run: |
-          mv artifacts/sysand-ubuntu-24.04 artifacts/sysand-linux-x86_64
-          mv artifacts/sysand-ubuntu-24.04-arm artifacts/sysand-linux-arm64
-          mv artifacts/sysand-windows-latest.exe artifacts/sysand-windows-x86_64.exe
-          mv artifacts/sysand-windows-11-arm.exe artifacts/sysand-windows-arm64.exe
-          mv artifacts/sysand-macos-15-intel artifacts/sysand-macos-x86_64
-          mv artifacts/sysand-macos-latest artifacts/sysand-macos-arm64
-
       - name: Create a release
         run: |
           gh release create "$TRIGGERING_TAG" \
               --title "Release $TRIGGERING_TAG" \
               --verify-tag \
-              artifacts/*
+              artifacts/sysand-*.tar.xz artifacts/sysand-*.zip
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -149,18 +149,15 @@ jobs:
       - name: Package binary (unix)
         if: runner.os != 'Windows'
         run: |
-          mkdir -p dist stage
-          cp target/release/sysand stage/sysand
-          chmod +x stage/sysand
-          tar -C stage -cJf "dist/${{ matrix.asset }}.tar.xz" sysand
+          mkdir dist
+          tar -cJf "dist/${{ matrix.asset }}.tar.xz" -C target/release sysand
 
       - name: Package binary (windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path dist, stage | Out-Null
-          Copy-Item target/release/sysand.exe stage/sysand.exe
-          Compress-Archive -Path stage\sysand.exe -DestinationPath "dist\${{ matrix.asset }}.zip" -Force
+          mkdir dist
+          Compress-Archive -DestinationPath "dist\${{ matrix.asset }}.zip" -Path target\release\sysand.exe
 
       - name: Upload binaries
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -59,19 +59,23 @@ or from [latest GitHub release][gh_rel].
   </tr>
   <tr>
     <td><strong>x86_x64</strong></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-x86_64.exe"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-x86_64"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-x86_64"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-x86_64.zip"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-x86_64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-x86_64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
   </tr>
   <tr>
     <td><strong>ARM64</strong></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-arm64.exe"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-arm64"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-arm64"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-arm64.zip"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-arm64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-arm64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
   </tr>
 </table>
 <!-- markdownlint-enable MD033 MD013 -->
-After downloading the appropriate file, installation depends on your platform:
+
+The download is an archive (`.zip` on Windows, `.tar.xz` on macOS and
+Linux) containing a single `sysand` executable (`sysand.exe` on
+Windows). After downloading, extract the archive and follow the steps
+for your platform:
 
 - [Windows (both x86_64 and ARM64)](#windows)
 - [macOS (both Intel and ARM64 (a.k.a. Apple Silicon))](#macos)
@@ -81,13 +85,14 @@ It is recommended to then [verify the installation](#verify-the-installation).
 
 ### Windows
 
-The downloaded binary can either be installed manually or by running
-a few PowerShell commands.
+The downloaded `.zip` archive contains `sysand.exe`. It can either be
+installed manually or by running a few PowerShell commands.
 
 #### Manual installation
 
-1. Move the downloaded `.exe` file to `%LOCALAPPDATA%\Programs\Sysand\sysand.exe`
-2. Add to `PATH` via Environment Variables:
+1. Right-click the downloaded `.zip` file and choose "Extract All..."
+2. Move the extracted `sysand.exe` to `%LOCALAPPDATA%\Programs\Sysand\sysand.exe`
+3. Add to `PATH` via Environment Variables:
    1. Open "Environment Variables" (search in Start menu)
    2. Under "User variables", select "Path" and click "Edit"
    3. Click "New" and add `%LOCALAPPDATA%\Programs\Sysand`
@@ -101,15 +106,17 @@ a few PowerShell commands.
 ```powershell
 # For x86_64 systems
 
-# Create directory and move to it
+# Create directory and extract the archive into it
 mkdir "$env:LOCALAPPDATA\Programs\Sysand" -Force
-mv sysand-windows-x86_64.exe "$env:LOCALAPPDATA\Programs\Sysand\sysand.exe"
+Expand-Archive -Path sysand-windows-x86_64.zip `
+  -DestinationPath "$env:LOCALAPPDATA\Programs\Sysand" -Force
 
 # For ARM64 systems
 
-# Create directory and move to it
+# Create directory and extract the archive into it
 mkdir "$env:LOCALAPPDATA\Programs\Sysand" -Force
-mv sysand-windows-arm64.exe "$env:LOCALAPPDATA\Programs\Sysand\sysand.exe"
+Expand-Archive -Path sysand-windows-arm64.zip `
+  -DestinationPath "$env:LOCALAPPDATA\Programs\Sysand" -Force
 ```
 
 3. Add folder to `PATH`:
@@ -131,17 +138,17 @@ if ($currentPath -notlike "*$newPath*") {
 #### System installation (requires `sudo`)
 
 1. Open Terminal
-2. Make the binary executable and move to a folder in `PATH` by running the
-   following commands:
+2. Extract the archive and move the `sysand` binary to a folder in
+   `PATH` by running the following commands:
 
 ```sh
 # For Intel Macs
-chmod +x ~/Downloads/sysand-macos-x86_64
-sudo mv ~/Downloads/sysand-macos-x86_64 /usr/local/bin/sysand
+tar -xJf ~/Downloads/sysand-macos-x86_64.tar.xz -C ~/Downloads
+sudo mv ~/Downloads/sysand /usr/local/bin/sysand
 
 # For Apple Silicon Macs
-chmod +x ~/Downloads/sysand-macos-arm64
-sudo mv ~/Downloads/sysand-macos-arm64 /usr/local/bin/sysand
+tar -xJf ~/Downloads/sysand-macos-arm64.tar.xz -C ~/Downloads
+sudo mv ~/Downloads/sysand /usr/local/bin/sysand
 ```
 
 #### Alternative: user installation (no `sudo` required)
@@ -169,17 +176,17 @@ source ~/.zshrc
 #### System installation (requires `sudo`)
 
 1. Open a terminal
-2. Make the binary executable and move to a folder in `PATH` by running the
-   following commands:
+2. Extract the archive and move the `sysand` binary to a folder in
+   `PATH` by running the following commands:
 
 ```sh
 # For x86_64 systems
-chmod +x sysand-linux-x86_64
-sudo mv sysand-linux-x86_64 /usr/local/bin/sysand
+tar -xJf sysand-linux-x86_64.tar.xz
+sudo mv sysand /usr/local/bin/sysand
 
 # For ARM64 systems
-chmod +x sysand-linux-arm64
-sudo mv sysand-linux-arm64 /usr/local/bin/sysand
+tar -xJf sysand-linux-arm64.tar.xz
+sudo mv sysand /usr/local/bin/sysand
 ```
 
 #### Alternative: user installation (no `sudo` required)


### PR DESCRIPTION
- fixes #83

Mainly implemented by claude code, except my review fix commit. It was done with the following prompt, where the command /plan-review is a skill I've asked claude code to develop in order to have it self-review something as a staff software engineer, attached below for reference.

```
/plan-review
Currently, the GitHub release assets we upload are uncompressed. We want to compress the mac/linux ones with      
.tar.xz and name the files to indicate platform and os, while the compressed binary should always be named sysand.               
                                                                                                                                 
So in practice, I want an executable sysand binary on mac/linux extracted, and an sysand.exe on windows.                         
                                                                                                                                 
sysand-linux-arm64.tar.xz - sysand                                                                                               
sysand-linux-x86_64.tar.xz - sysand                                                                                              
sysand-macos-arm64.tar.xz - sysand                                                                                               
sysand-macos-x86_64.tar.xz - sysand                                                                                              
sysand-windows-arm64.zip - sysand.exe                                                                                            
sysand-windows-x86_64.zip - sysand.exe
```

<details><summary>~/.claude/skills/plan-review/SKILL.md</summary>

```markdown
---
name: plan-review
description: Plan a task, have it scrutinized by a staff engineer reviewer, iterate once, then present the final plan. Use when the user wants a reviewed/vetted implementation plan.
disable-model-invocation: true
argument-hint: [task description]
---

## Reviewed Plan Workflow

You are executing a structured plan-review workflow for the following task:

$ARGUMENTS

### Step 1: Draft the Plan

Enter plan mode. Explore the codebase as needed, then write a detailed implementation plan to `tasks/todo.md`. The plan should include:

- Clear problem statement
- Proposed approach with rationale
- Files to create/modify
- Step-by-step implementation checklist
- Edge cases and risks considered

### Step 2: Staff Engineer Review

Once the plan is drafted, spawn a subagent to act as a **senior staff software engineer reviewer**. Use subagent_type `general-purpose` with a prompt like:

> You are a staff software engineer reviewing an implementation plan. Read `tasks/todo.md` and the relevant codebase context. Critique the plan on:
>
> 1. **Correctness**: Will this actually solve the problem? Any logical gaps?
> 2. **Simplicity**: Is this the simplest approach? Any over-engineering?
> 3. **Risk**: What could go wrong? Missing edge cases? Migration risks?
> 4. **Maintainability**: Will this be easy to understand and modify later?
> 5. **Completeness**: Are there missing steps, tests, or documentation updates?
> 6. **Alternatives**: Is there a better approach the author didn't consider?
>
> Be direct and specific. Flag concrete issues, not vague concerns. Suggest specific improvements where possible. Read the CLAUDE.md for project conventions.

### Step 3: Iterate on the Plan

Review the staff engineer's feedback. Update `tasks/todo.md` to address valid concerns. If you disagree with a point, note your reasoning.

### Step 4: Present to User

Exit plan mode and present the final plan to the user with:

- A concise summary of the approach
- Key changes made after the staff review
- Any open questions or trade-offs that need the user's input

```

</details>
