### PR TITLE
Improve 'sysand info' command output

### DIFF
--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
@@ -92,14 +92,12 @@ public class BasicTest {
             assertExpectedProject(project);
 
             java.net.URI fileUri = tempDir.toUri();
-            com.sensmetry.sysand.model.InterchangeProject[] projects = com.sensmetry.sysand.Sysand.info(fileUri,
+            com.sensmetry.sysand.model.InterchangeProject project2 = com.sensmetry.sysand.Sysand.info(fileUri,
                     tempDir);
-            assertEquals(projects.length, 1);
-            assertExpectedProject(projects[0]);
+            assertExpectedProject(project2);
 
-            com.sensmetry.sysand.model.InterchangeProject[] projects2 = com.sensmetry.sysand.Sysand.info(fileUri);
-            assertEquals(projects2.length, 1);
-            assertExpectedProject(projects2[0]);
+            com.sensmetry.sysand.model.InterchangeProject project3 = com.sensmetry.sysand.Sysand.info(fileUri);
+            assertExpectedProject(project3);
         } catch (java.io.IOException e) {
             fail("Failed during temporary directory operations or Sysand.info: " + e.getMessage());
         } catch (com.sensmetry.sysand.exceptions.SysandException e) {
@@ -117,10 +115,9 @@ public class BasicTest {
             assertExpectedProject(project);
 
             java.net.URI fileUri = tempDir.toUri();
-            com.sensmetry.sysand.model.InterchangeProject[] projects = com.sensmetry.sysand.Sysand.info(fileUri,
+            com.sensmetry.sysand.model.InterchangeProject project2 = com.sensmetry.sysand.Sysand.info(fileUri,
                     tempDir);
-            assertEquals(projects.length, 1);
-            assertExpectedProject(projects[0]);
+            assertExpectedProject(project2);
 
             com.sensmetry.sysand.Sysand.buildProject(tempDir.resolve("sysand-test-build.kpar"), tempDir, CompressionMethod.DEFLATED);
         } catch (java.io.IOException e) {

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
@@ -90,7 +90,7 @@ public class Sysand {
      *                         relative file URIs.
      * @return The project information and metadata.
      */
-    public static native com.sensmetry.sysand.model.InterchangeProject[] info(
+    public static native com.sensmetry.sysand.model.InterchangeProject info(
             String uri,
             String relativeFileRoot,
             String indexUrl)
@@ -104,7 +104,7 @@ public class Sysand {
      *                         relative file URIs.
      * @return The project information and metadata.
      */
-    public static com.sensmetry.sysand.model.InterchangeProject[] info(
+    public static com.sensmetry.sysand.model.InterchangeProject info(
             java.net.URI uri,
             java.nio.file.Path relativeFileRoot,
             java.net.URL indexUrl)
@@ -126,7 +126,7 @@ public class Sysand {
      *                         relative file URIs.
      * @return The project information and metadata.
      */
-    public static com.sensmetry.sysand.model.InterchangeProject[] info(
+    public static com.sensmetry.sysand.model.InterchangeProject info(
             java.net.URI uri,
             java.nio.file.Path relativeFileRoot)
             throws com.sensmetry.sysand.exceptions.SysandException {
@@ -140,7 +140,7 @@ public class Sysand {
      * @param uri The URI of the project.
      * @return The project information and metadata.
      */
-    public static com.sensmetry.sysand.model.InterchangeProject[] info(java.net.URI uri)
+    public static com.sensmetry.sysand.model.InterchangeProject info(java.net.URI uri)
             throws com.sensmetry.sysand.exceptions.SysandException {
         java.nio.file.Path relativeFileRoot = java.nio.file.Paths.get(".");
         return info(uri, relativeFileRoot, null);

--- a/bindings/java/src/conversion.rs
+++ b/bindings/java/src/conversion.rs
@@ -361,35 +361,3 @@ impl ToJObject for (InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw) {
         }
     }
 }
-
-impl ToJObjectArray for Vec<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
-    fn to_jobject_array<'local>(&self, env: &mut JNIEnv<'local>) -> Option<JObjectArray<'local>> {
-        let mut array = match env.new_object_array(
-            self.len()
-                .try_into()
-                .expect("Failed to convert length to i32"),
-            INTERCHANGE_PROJECT_CLASS,
-            JObject::null(),
-        ) {
-            Ok(o) => o,
-            Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create InterchangeProject[]: {e}"));
-                return None;
-            }
-        };
-        for (i, value) in self.iter().enumerate() {
-            let index: i32 = i.try_into().expect("Failed to convert index to i32");
-            let value_object = value.to_jobject(env)?;
-            match env.set_object_array_element(&mut array, index, value_object) {
-                Ok(o) => o,
-                Err(e) => {
-                    env.throw_runtime_exception(format!(
-                        "Failed to set InterchangeProject[] element: {e}"
-                    ));
-                    return None;
-                }
-            }
-        }
-        Some(array)
-    }
-}

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -193,8 +193,11 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_infoPath<'local>(
 
     let command_result = commands::info::do_info_project(&project);
     match command_result {
-        Some(info_metadata) => info_metadata.to_jobject(&mut env).unwrap_or_default(),
-        None => JObject::default(),
+        Ok(info_metadata) => info_metadata.to_jobject(&mut env).unwrap_or_default(),
+        Err(e) => {
+            env.throw_exception(ExceptionKind::SysandException, e.to_string());
+            JObject::default()
+        }
     }
 }
 
@@ -205,15 +208,15 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
     uri: JString<'local>,
     relative_file_root: JString<'local>,
     index_url: JString<'local>,
-) -> JObjectArray<'local> {
+) -> JObject<'local> {
     let Some(uri) = env.get_str(&uri, "uri") else {
-        return JObjectArray::default();
+        return JObject::default();
     };
     let client = match create_reqwest_client() {
         Ok(c) => c,
         Err(e) => {
             env.throw_exception(ExceptionKind::SysandException, e.to_string());
-            return JObjectArray::default();
+            return JObject::default();
         }
     };
 
@@ -228,21 +231,21 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
                     ExceptionKind::IOError,
                     format!("Failed to build tokio runtime: {e}"),
                 );
-                return JObjectArray::default();
+                return JObject::default();
             }
         };
         Arc::new(r)
     };
 
     let Some(relative_file_root) = env.get_str(&relative_file_root, "relativeFileRoot") else {
-        return JObjectArray::default();
+        return JObject::default();
     };
 
     let index_base_url = if index_url.is_null() {
         None
     } else {
         let Some(index_url) = env.get_str(&index_url, "indexUrl") else {
-            return JObjectArray::default();
+            return JObject::default();
         };
         match url::Url::parse(&index_url) {
             Ok(url) => Some(url),
@@ -251,7 +254,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
                     StdlibExceptionKind::UnsupportedOperationException,
                     format!("Failed to parse index URL `{}`: {}", index_url, error),
                 );
-                return JObjectArray::default();
+                return JObject::default();
             }
         }
     };
@@ -275,16 +278,20 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
         }
     };
 
-    let results = match commands::info::do_info(&uri, &combined_resolver) {
-        Ok(matches) => matches,
-        Err(InfoError::NoResolve(..)) => Vec::new(),
-        Err(e @ (InfoError::UnsupportedIri(..) | InfoError::Resolution(_))) => {
+    let info_meta = match commands::info::do_info(&uri, &combined_resolver) {
+        Ok(info_meta) => info_meta,
+        Err(
+            e @ (InfoError::NoSemanticVersionsFound(_)
+            | InfoError::NoResolve(..)
+            | InfoError::UnsupportedIri(..)
+            | InfoError::Resolution(_)),
+        ) => {
             env.throw_exception(ExceptionKind::ResolutionError, e.to_string());
-            return JObjectArray::default();
+            return JObject::default();
         }
     };
 
-    results.to_jobject_array(&mut env).unwrap_or_default()
+    info_meta.to_jobject(&mut env).unwrap_or_default()
 }
 
 #[unsafe(no_mangle)]

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -274,7 +274,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
                 ExceptionKind::ResolutionError,
                 format!("Failed to discover index endpoints: {error}"),
             );
-            return JObjectArray::default();
+            return JObject::default();
         }
     };
 

--- a/bindings/py/python/sysand/_info.py
+++ b/bindings/py/python/sysand/_info.py
@@ -14,7 +14,7 @@ from os import getcwd
 
 def info_path(
     path: str | Path = ".",
-) -> typing.Tuple[InterchangeProjectInfo, InterchangeProjectMetadata] | None:
+) -> typing.Tuple[InterchangeProjectInfo, InterchangeProjectMetadata]:
     return sysand_rs.do_info_py_path(str(path))  # type: ignore
 
 
@@ -23,7 +23,7 @@ def info(
     *,
     relative_file_root: str | Path | None = None,
     index_urls: str | typing.List[str] | None = None,
-) -> typing.List[typing.Tuple[InterchangeProjectInfo, InterchangeProjectMetadata]]:
+) -> typing.Tuple[InterchangeProjectInfo, InterchangeProjectMetadata]:
     if relative_file_root is None:
         relative_file_root = getcwd()
 

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -26,7 +26,7 @@ use sysand_core::{
     },
     exclude::do_exclude,
     include::do_include,
-    info::{InfoError, do_info, do_info_project},
+    info::{InfoError, InfoProjectError, do_info, do_info_project},
     init::InitError,
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw, InterchangeProjectUsageRaw},
     project::{
@@ -119,7 +119,7 @@ fn do_env_py_local_dir(path: String) -> PyResult<()> {
 )]
 fn do_info_py_path(
     path: String,
-) -> PyResult<Option<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)>> {
+) -> PyResult<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
     let _ = pyo3_log::try_init();
 
     let project = LocalSrcProject {
@@ -127,7 +127,15 @@ fn do_info_py_path(
         project_path: path.into(),
     };
 
-    Ok(do_info_project(&project))
+    match do_info_project(&project) {
+        Ok(info_meta) => Ok(info_meta),
+        Err(
+            e @ (InfoProjectError::MissingProject
+            | InfoProjectError::MissingInfo
+            | InfoProjectError::MissingMeta
+            | InfoProjectError::InvalidProject(..)),
+        ) => Err(PyRuntimeError::new_err(e.to_string())),
+    }
 }
 
 #[pyfunction(name = "do_info_py")]
@@ -139,11 +147,10 @@ fn do_info_py(
     uri: String,
     relative_file_root: String,
     index_urls: Option<Vec<String>>,
-) -> PyResult<Vec<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)>> {
+) -> PyResult<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
     let _ = pyo3_log::try_init();
 
     py.detach(|| {
-        let mut results = vec![];
         let client = create_reqwest_client().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
         let runtime = Arc::new(
@@ -174,14 +181,14 @@ fn do_info_py(
         .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         match do_info(&uri, &combined_resolver) {
-            Ok(matches) => results.extend(matches),
-            Err(InfoError::NoResolve(..)) => {}
-            Err(e @ (InfoError::UnsupportedIri(..) | InfoError::Resolution(_))) => {
-                return Err(PyRuntimeError::new_err(e.to_string()));
-            }
-        };
-
-        Ok(results)
+            Ok(info_meta) => Ok(info_meta),
+            Err(
+                e @ (InfoError::NoSemanticVersionsFound(_)
+                | InfoError::NoResolve(..)
+                | InfoError::UnsupportedIri(..)
+                | InfoError::Resolution(_)),
+            ) => Err(PyRuntimeError::new_err(e.to_string())),
+        }
     })
 }
 

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -85,9 +85,8 @@ def test_basic_info(caplog: pytest.LogCaptureFixture) -> None:
 
         file_uri = Path(tmpdirname).resolve().as_uri()
 
-        info_metas = sysand.info(file_uri)
-        assert len(info_metas) == 1, f"file_uri: {file_uri}"
-        assert info_metas[0] == info_meta
+        info_meta2 = sysand.info(file_uri)
+        assert info_meta2 == info_meta
 
 
 def test_http_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) -> None:
@@ -102,10 +101,7 @@ def test_http_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) -> 
         {"index": {}, "created": "0000-00-00T00:00:00.123456789Z"}
     )
 
-    info_metas = sysand.info(httpserver.url_for(""))
-
-    assert len(info_metas) == 1
-    info, meta = info_metas[0]
+    info, meta = sysand.info(httpserver.url_for(""))
 
     assert info == {
         "name": "test_http_info",
@@ -163,12 +159,9 @@ def test_index_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) ->
         {"index": {}, "created": "2026-01-01T00:00:00Z"}
     )
 
-    info_metas = sysand.info(
+    info, meta = sysand.info(
         "urn:kpar:test_index_info", index_urls=httpserver.url_for("")
     )
-
-    assert len(info_metas) == 1
-    info, meta = info_metas[0]
 
     assert info["name"] == "test_index_info"
     assert info["version"] == "1.2.3"

--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
+use semver::Version;
 use thiserror::Error;
 
 use crate::{
@@ -8,10 +9,39 @@ use crate::{
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::ProjectRead,
     resolve::{ResolutionOutcome, ResolveRead},
+    utils::format_sources,
 };
 
 #[derive(Error, Debug)]
+pub enum InfoProjectError<Error: ErrorBound> {
+    // TODO: Add URI hints to projects and use them here
+    #[error("project is missing")]
+    MissingProject,
+    #[error("project has .meta.json but not .project.json")]
+    MissingInfo,
+    #[error("project has .project.json but not .meta.json")]
+    MissingMeta,
+    #[error(transparent)]
+    InvalidProject(#[from] Error),
+}
+
+pub fn do_info_project<P: ProjectRead>(
+    project: &P,
+) -> Result<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw), InfoProjectError<P::Error>>
+{
+    match project.get_project() {
+        Ok((Some(info), Some(meta))) => Ok((info, meta)),
+        Ok((None, None)) => Err(InfoProjectError::MissingProject),
+        Ok((None, Some(_))) => Err(InfoProjectError::MissingInfo),
+        Ok((Some(_), None)) => Err(InfoProjectError::MissingMeta),
+        Err(err) => Err(InfoProjectError::InvalidProject(err)),
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum InfoError<Error: ErrorBound> {
+    #[error("none of the following found versions are valid semantic versions {}", .0.join(", "))]
+    NoSemanticVersionsFound(Vec<String>),
     #[error("failed to resolve IRI `{0}`: {1}")]
     NoResolve(Box<str>, String),
     #[error("IRI `{0}` is not supported: {1}")]
@@ -20,47 +50,10 @@ pub enum InfoError<Error: ErrorBound> {
     Resolution(#[from] Error),
 }
 
-pub fn do_info_project<P: ProjectRead>(
-    project: &P,
-) -> Option<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
-    match project.get_project() {
-        Ok((Some(info), Some(meta))) => Some((info, meta)),
-        Ok((None, None)) => {
-            // TODO: Add URI hints to projects and use them here
-            log::warn!(
-                "ignoring a missing project",
-                //uri.as_ref()
-            );
-            None
-        }
-        Ok((Some(_), None)) => {
-            log::warn!(
-                "ignoring a partial project, it has info but not metadata",
-                //uri.as_ref()
-            );
-            None
-        }
-        Ok((None, Some(_))) => {
-            log::warn!(
-                "ignoring a partial project, it has metadata but not info",
-                //uri.as_ref()
-            );
-            None
-        }
-        Err(e) => {
-            log::warn!(
-                "ignoring an invalid project: {e}",
-                //uri.as_ref()
-            );
-            None
-        }
-    }
-}
-
 pub fn do_info<S: AsRef<str>, R: ResolveRead>(
     uri: S,
     resolver: &R,
-) -> Result<Vec<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)>, InfoError<R::Error>> {
+) -> Result<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw), InfoError<R::Error>> {
     let outcome = resolver.resolve_read_raw(uri.as_ref())?;
 
     match outcome {
@@ -68,7 +61,9 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
             let mut it = resolved.into_iter().peekable();
             assert!(it.peek().is_some());
 
-            let mut result = vec![];
+            let mut best_version_info_meta: Option<(Version, _, _)> = None;
+            let mut non_semantic_versions: Vec<String> = Vec::new();
+
             for alt in it {
                 let candidate_project = match alt {
                     Ok(cp) => cp,
@@ -80,11 +75,41 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
                         continue;
                     }
                 };
-                if let Some(info_meta) = do_info_project(&candidate_project) {
-                    result.push(info_meta);
+                match do_info_project(&candidate_project) {
+                    Ok((info, meta)) => {
+                        best_version_info_meta =
+                            match (Version::parse(&info.version), &best_version_info_meta) {
+                                (Ok(cur_version), Some((best_version, _, _)))
+                                    if &cur_version > best_version =>
+                                {
+                                    Some((cur_version, info, meta))
+                                }
+                                (Ok(_), Some(_)) => best_version_info_meta,
+                                (Ok(cur_version), None) => Some((cur_version, info, meta)),
+                                (Err(_), _) => {
+                                    non_semantic_versions.push(info.version);
+                                    best_version_info_meta
+                                }
+                            }
+                    }
+                    Err(err) => {
+                        log::warn!("Ignoring a project because: {err}");
+                        log::info!("{}", format_sources(&err));
+                    }
                 };
             }
-            Ok(result)
+            match best_version_info_meta {
+                Some((_, info, meta)) => {
+                    if !non_semantic_versions.is_empty() {
+                        log::warn!(
+                            "The following versions were skipped as they are not semantic versions {}",
+                            non_semantic_versions.join(", ")
+                        );
+                    }
+                    Ok((info, meta))
+                }
+                None => Err(InfoError::NoSemanticVersionsFound(non_semantic_versions)),
+            }
         }
         ResolutionOutcome::UnsupportedIRIType(e) => {
             Err(InfoError::UnsupportedIri(uri.as_ref().into(), e))

--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -93,7 +93,7 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
                             }
                     }
                     Err(err) => {
-                        log::warn!("Ignoring a project because: {err}");
+                        log::warn!("ignoring a project because: {err}");
                         log::info!("{}", format_sources(&err));
                     }
                 };
@@ -102,7 +102,7 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
                 Some((_, info, meta)) => {
                     if !non_semantic_versions.is_empty() {
                         log::warn!(
-                            "The following versions were skipped as they are not semantic versions {}",
+                            "the following versions were skipped as they are not semantic versions {}",
                             non_semantic_versions.join(", ")
                         );
                     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod solve;
 pub mod stdlib;
 pub mod style;
 pub mod symbols;
+mod utils;
 
 #[cfg(feature = "filesystem")]
 pub mod workspace;

--- a/core/src/resolve/combined_tests.rs
+++ b/core/src/resolve/combined_tests.rs
@@ -7,7 +7,7 @@ use fluent_uri::Iri;
 use indexmap::IndexMap;
 
 use crate::{
-    info::do_info,
+    info::{InfoError, do_info},
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::memory::InMemoryProject,
     resolve::{
@@ -68,6 +68,19 @@ fn single_project_any_resolver<S: AsRef<str>>(
     })
 }
 
+fn multiple_projects_any_resolver<S: AsRef<str>>(
+    uri: S,
+    projects: Vec<InMemoryProject>,
+) -> Option<MemoryResolver<AcceptAll, InMemoryProject>> {
+    let uri = Iri::parse(uri.as_ref().to_string()).unwrap();
+    let mut projects_map = HashMap::new();
+    projects_map.insert(uri, projects);
+    Some(MemoryResolver {
+        iri_predicate: AcceptAll {},
+        projects: projects_map,
+    })
+}
+
 // fn single_project_file_resolver<S: AsRef<str>>(
 //     uri: S,
 //     project: ProjectMemoryStorage,
@@ -104,10 +117,9 @@ fn prefer_file_resolver_when_successful() {
         index_resolver: single_project_any_resolver(example_uri, project_b.clone()),
     };
 
-    let xs = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
 
-    assert_eq!(xs.len(), 1);
-    assert_eq!(xs[0].0.name, "a");
+    assert_eq!(info.name, "a");
 }
 
 #[test]
@@ -142,10 +154,9 @@ fn skip_file_resolver_if_unsupported_iri() {
         index_resolver: single_project_any_resolver(example_uri, project_b.clone()),
     };
 
-    let xs = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
 
-    assert_eq!(xs.len(), 1);
-    assert_eq!(xs[0].0.name, "b");
+    assert_eq!(info.name, "b");
 }
 
 #[test]
@@ -162,10 +173,9 @@ fn prefer_remote_over_index_if_valid_cached() {
         index_resolver: single_project_any_resolver(example_uri, project_b.clone()),
     };
 
-    let xs = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
 
-    assert_eq!(xs.len(), 1);
-    assert_eq!(xs[0].0.name, "a");
+    assert_eq!(info.name, "a");
 }
 
 #[test]
@@ -183,11 +193,9 @@ fn prefer_remote_over_index_if_valid_uncached() {
         index_resolver: single_project_any_resolver(example_uri, project_c.clone()),
     };
 
-    let xs = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
 
-    assert_eq!(xs.len(), 2);
-    assert_eq!(xs[0].0.name, "a");
-    assert_eq!(xs[1].0.name, "b");
+    assert_eq!(info.name, "b");
 }
 
 #[test]
@@ -204,11 +212,9 @@ fn skip_remote_if_unsupported_uncached() {
         index_resolver: single_project_any_resolver(example_uri, project_a.clone()),
     };
 
-    let xs = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
 
-    assert_eq!(xs.len(), 2);
-    assert_eq!(xs[0].0.name, "a");
-    assert_eq!(xs[1].0.name, "b");
+    assert_eq!(info.name, "b");
 }
 
 #[test]
@@ -224,10 +230,9 @@ fn skip_remote_if_unsupported_cached() {
         index_resolver: single_project_any_resolver(example_uri, project_a.clone()),
     };
 
-    let xs = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
 
-    assert_eq!(xs.len(), 1);
-    assert_eq!(xs[0].0.name, "a");
+    assert_eq!(info.name, "a");
 }
 
 #[test]
@@ -243,10 +248,9 @@ fn skip_remote_if_unresolved_cached() {
         index_resolver: single_project_any_resolver(example_uri, project_a.clone()),
     };
 
-    let xs = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
 
-    assert_eq!(xs.len(), 1);
-    assert_eq!(xs[0].0.name, "a");
+    assert_eq!(info.name, "a");
 }
 
 #[test]
@@ -283,4 +287,53 @@ fn unresolved_iri_test() {
     else {
         panic!()
     };
+}
+
+#[test]
+fn skip_non_semantic_versions_test() {
+    let example_uri = "http://example.com";
+
+    let project_a = minimal_project("a", "1.2.3");
+    let project_b = minimal_project("b", "3.2.1.H");
+
+    let resolver = CombinedResolver {
+        file_resolver: multiple_projects_any_resolver(
+            example_uri,
+            vec![project_a.clone(), project_b.clone()],
+        ),
+        remote_resolver: empty_any_resolver(),
+        local_resolver: empty_any_resolver(),
+        index_resolver: empty_any_resolver(),
+    };
+
+    let (info, _) = do_info(example_uri, &resolver).unwrap();
+
+    assert_eq!(info.name, "a");
+}
+
+#[test]
+fn no_semantic_versions_error_test() {
+    let example_uri = "http://example.com";
+
+    let project_a = minimal_project("a", "1.23");
+    let project_b = minimal_project("b", "3.2.1.H");
+
+    let resolver = CombinedResolver {
+        file_resolver: multiple_projects_any_resolver(
+            example_uri,
+            vec![project_a.clone(), project_b.clone()],
+        ),
+        remote_resolver: empty_any_resolver(),
+        local_resolver: empty_any_resolver(),
+        index_resolver: empty_any_resolver(),
+    };
+
+    let info_meta = do_info(example_uri, &resolver);
+
+    // Would like to use assert_matches, but that's not yet stable, see
+    // https://github.com/rust-lang/rust/issues/82775
+    assert!(matches!(
+        info_meta,
+        Err(InfoError::NoSemanticVersionsFound(_))
+    ));
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use std::error::Error;
+use std::{error::Error, fmt::Write as _};
 
 pub fn format_sources(mut error: &dyn Error) -> String {
     let mut message = error.to_string();

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 pub fn format_sources(mut error: &dyn Error) -> String {
     let mut message = error.to_string();
     while let Some(source) = error.source() {
-        message += &format!("  caused by: {source}\n");
+        writeln!(&mut message, "  caused by: {source}").unwrap();
         error = source;
     }
     message

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -3,7 +3,7 @@
 
 use std::{error::Error, fmt::Write as _};
 
-pub fn format_sources(mut error: &dyn Error) -> String {
+pub(crate) fn format_sources(mut error: &dyn Error) -> String {
     let mut message = error.to_string();
     while let Some(source) = error.source() {
         writeln!(&mut message, "  caused by: {source}").unwrap();

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use std::error::Error;
+
+pub fn format_sources(mut error: &dyn Error) -> String {
+    let mut message = error.to_string();
+    while let Some(source) = error.source() {
+        message += &format!("  caused by: {source}\n");
+        error = source;
+    }
+    message
+}

--- a/core/tests/filesystem_env.rs
+++ b/core/tests/filesystem_env.rs
@@ -190,10 +190,9 @@ mod filesystem_tests {
             env: directory_environment,
         };
 
-        let resolved_projects = do_info("urn::sysand_test::1", &resolver)?;
+        let resolved_project = do_info("urn::sysand_test::1", &resolver)?;
 
-        assert_eq!(resolved_projects.len(), 1);
-        assert_eq!(resolved_projects[0], (info, meta));
+        assert_eq!(resolved_project, (info, meta));
 
         Ok(())
     }

--- a/core/tests/memory_env.rs
+++ b/core/tests/memory_env.rs
@@ -103,10 +103,9 @@ fn env_manual_install() -> Result<(), Box<dyn std::error::Error>> {
         )]),
     };
 
-    let resolved_projects = do_info("urn:sysand_test:1", &resolver)?;
+    let resolved_project = do_info("urn:sysand_test:1", &resolver)?;
 
-    assert_eq!(resolved_projects.len(), 1);
-    assert_eq!(resolved_projects[0], (info, meta));
+    assert_eq!(resolved_project, (info, meta));
 
     Ok(())
 }

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -40,7 +40,7 @@ pub fn pprint_interchange_project(
 ) {
     let header = style::get_style_config().header;
     println!("{header}Name:{header:#} {}", info.name);
-    if let Some(ref publisher) = info.publisher {
+    if let Some(publisher) = &info.publisher {
         println!("{header}Publisher:{header:#} {}", publisher);
     }
     if let Some(ref description) = info.description {

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -20,6 +20,7 @@ use sysand_core::{
         file::FileResolverProject, memory::MemoryResolver, priority::PriorityResolver,
         standard::standard_resolver,
     },
+    style,
 };
 
 use anstream::{print, println};
@@ -34,43 +35,60 @@ use sysand_core::{
 use url::Url;
 
 pub fn pprint_interchange_project(
-    info: InterchangeProjectInfoRaw,
+    info: &InterchangeProjectInfoRaw,
     excluded_iris: &HashSet<String>,
 ) {
-    println!("Name: {}", info.name);
-    if let Some(publisher) = info.publisher {
-        println!("Publisher: {}", publisher);
+    let header = style::get_style_config().header;
+    println!("{header}Name:{header:#} {}", info.name);
+    if let Some(ref publisher) = info.publisher {
+        println!("{header}Publisher:{header:#} {}", publisher);
     }
-    if let Some(description) = info.description {
-        println!("Description: {}", description);
+    if let Some(ref description) = info.description {
+        println!("{header}Description:{header:#} {}", description);
     }
-    println!("Version: {}", info.version);
-    if let Some(license) = info.license {
-        println!("License: {}", license);
+    println!("{header}Version:{header:#} {}", info.version);
+    if let Some(ref license) = info.license {
+        println!("{header}License:{header:#} {}", license);
     }
-    if let Some(website) = info.website {
-        println!("Website: {}", website);
+    if let Some(ref website) = info.website {
+        println!("{header}Website:{header:#} {}", website);
     }
     if !info.maintainer.is_empty() {
-        println!("Maintainer(s): {}", info.maintainer.join(", "));
+        println!(
+            "{header}Maintainer(s):{header:#} {}",
+            info.maintainer.join(", ")
+        );
     }
     if !info.topic.is_empty() {
-        println!("Topics: {}", info.topic.join(", "));
+        println!("{header}Topics:{header:#} {}", info.topic.join(", "));
     }
 
     if info.usage.is_empty() {
         println!("No usages.");
     } else {
-        println!("Usages:");
-        for usage in info.usage {
-            if excluded_iris.contains(&usage.resource) {
-                continue;
+        let has_ignored_usages = info
+            .usage
+            .iter()
+            .any(|u| excluded_iris.contains(&u.resource));
+        let usages_to_print: Vec<_> = info
+            .usage
+            .iter()
+            .filter(|u| !excluded_iris.contains(&u.resource))
+            .collect();
+        if has_ignored_usages && usages_to_print.is_empty() {
+            println!("All usages are ignored");
+        } else {
+            println!("{header}Usages:{header:#}");
+            for usage in usages_to_print.iter() {
+                print!("    {}", usage.resource);
+                if let Some(ref v) = usage.version_constraint {
+                    println!(" ({})", v);
+                } else {
+                    println!();
+                }
             }
-            print!("    {}", usage.resource);
-            if let Some(v) = usage.version_constraint {
-                println!(" ({})", v);
-            } else {
-                println!();
+            if has_ignored_usages {
+                println!("Some usages are ignored");
             }
         }
     }
@@ -96,14 +114,16 @@ pub fn command_info_path<P: AsRef<Utf8Path>>(
     excluded_iris: &HashSet<String>,
 ) -> Result<()> {
     let project = interpret_project_path(&path)?;
-
     match do_info_project(&project) {
-        Some((info, _)) => {
-            pprint_interchange_project(info, excluded_iris);
+        Ok((info, _)) => {
+            pprint_interchange_project(&info, excluded_iris);
 
             Ok(())
         }
-        None => bail!(CliError::NoResolve(path.as_ref().to_string())),
+        Err(err) => bail!(CliError::InvalidProject {
+            iri: path.as_ref().to_string(),
+            source: err
+        }),
     }
 }
 
@@ -144,10 +164,8 @@ pub fn command_info_uri<Policy: HTTPAuthentication>(
         )?,
     );
 
-    for (info, _) in do_info(&uri, &combined_resolver)? {
-        pprint_interchange_project(info, excluded_iris);
-    }
-
+    let (info, _) = do_info(&uri, &combined_resolver)?;
+    pprint_interchange_project(&info, excluded_iris);
     Ok(())
 }
 
@@ -225,28 +243,16 @@ pub fn command_info_verb_uri<Policy: HTTPAuthentication>(
                 )?,
             );
 
-            let mut found = false;
-
             match get_verb {
                 crate::cli::GetVerb::GetInfoVerb(get_info_verb) => {
-                    for (info, _meta) in do_info(&uri, &combined_resolver)? {
-                        found = true;
-
-                        apply_get_info(&get_info_verb, info, numbered)?;
-                    }
+                    let (info, _meta) = do_info(&uri, &combined_resolver)?;
+                    apply_get_info(&get_info_verb, info, numbered)?;
                 }
                 crate::cli::GetVerb::GetMetaVerb(get_meta_verb) => {
-                    for (_info, meta) in do_info(&uri, &combined_resolver)? {
-                        found = true;
-
-                        apply_get_meta(&get_meta_verb, meta, numbered)?;
-                    }
+                    let (_info, meta) = do_info(&uri, &combined_resolver)?;
+                    apply_get_meta(&get_meta_verb, meta, numbered)?;
                 }
             }
-
-            if !found {
-                bail!("unable to find a valid project at `{}`", uri.as_str());
-            };
         }
         InfoCommandVerb::Set(_) => bail!("`set` cannot be used with remote projects"),
         InfoCommandVerb::Clear(_) => bail!("`clear` cannot be used with remote projects"),

--- a/sysand/src/error.rs
+++ b/sysand/src/error.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
+use sysand_core::{info::InfoProjectError, resolve::file::FileResolverProjectError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -9,6 +10,12 @@ pub enum CliError {
     InvalidDirectory(String),
     #[error("unable to find project with IRI `{0}`")]
     NoResolve(String),
+    #[error("invalid project with IRI `{iri}`")]
+    InvalidProject {
+        iri: String,
+        #[source]
+        source: InfoProjectError<FileResolverProjectError>,
+    },
     #[error("invalid IRI `{0}`: {1}")]
     InvalidIri(String, fluent_uri::ParseError),
     #[error("unable to find interchange project `{0}`")]

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     sync::Arc,
 };
 
-use anstream::{eprint, eprintln};
+use anstream::eprintln;
 use anyhow::{Result, anyhow, bail};
 use fluent_uri::Iri;
 
@@ -87,9 +87,12 @@ where
         Ok(args) => {
             if let Err(err) = run_cli(args) {
                 let style = style::ERROR;
-                eprint!("{style}error{style:#}: ");
-                for cause in err.chain() {
-                    eprintln!("{}", cause);
+                eprintln!("{style}error{style:#}: {err}");
+                let mut causes = err.chain();
+                // The first cause is the error itself which is printed already
+                _ = causes.next();
+                for cause in causes {
+                    eprintln!("{style}  caused by:{style:#} {cause}");
                 }
                 let note_style = style::GOOD;
                 if log::max_level() < log::Level::Debug {


### PR DESCRIPTION
Resolves #208.

Changes:
* Make sysand info return only the info of the highest package version
* Make sysand path info command in the bindings consider missing info or meta an error
* Improve the sysand info printing - colorize output and be more explicit about skipped standard library usages