### PR TITLE
feat: don't update metadata by default when building projects

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,7 +9,7 @@
 # crt-static reference: See https://rust-lang.github.io/rfcs/1721-crt-static.html
 # dumpbin verification: https://github.com/sensmetry/sysand/pull/91#issuecomment-4081523020
 #
-# Increase the stack size, since Windows default 1 MiB causes a stack
+# Increase the stack size to 8MiB, since Windows default 1 MiB causes a stack
 # overflow on almost any CLI operation
 [target.'cfg(windows)']
 rustflags = ["-Ctarget-feature=+crt-static", "-Clink-args=/STACK:8388608"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,5 +9,7 @@
 # crt-static reference: See https://rust-lang.github.io/rfcs/1721-crt-static.html
 # dumpbin verification: https://github.com/sensmetry/sysand/pull/91#issuecomment-4081523020
 #
+# Increase the stack size, since Windows default 1 MiB causes a stack
+# overflow on almost any CLI operation
 [target.'cfg(windows)']
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = ["-Ctarget-feature=+crt-static", "-Clink-args=/STACK:8388608"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,7 @@
 # dumpbin verification: https://github.com/sensmetry/sysand/pull/91#issuecomment-4081523020
 #
 # Increase the stack size to 8MiB, since Windows default 1 MiB causes a stack
-# overflow on almost any CLI operation
+# overflow on almost any CLI operation. Likely related to
+# https://github.com/clap-rs/clap/issues/5134
 [target.'cfg(windows)']
 rustflags = ["-Ctarget-feature=+crt-static", "-Clink-args=/STACK:8388608"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,6 +3670,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "foldhash",
  "indexmap",
  "serde_core",
  "serde_spanned",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,7 +3670,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
  "indexmap",
  "serde_core",
  "serde_spanned",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3968,6 +3968,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "foldhash",
  "indexmap",
  "serde_core",
  "serde_spanned",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3968,7 +3968,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
  "indexmap",
  "serde_core",
  "serde_spanned",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3968,7 +3968,6 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "foldhash 0.2.0",
  "indexmap",
  "serde_core",
  "serde_spanned",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3968,6 +3968,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "foldhash 0.2.0",
  "indexmap",
  "serde_core",
  "serde_spanned",

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -447,6 +447,12 @@ fn compression_from_java_string(
             env.throw_exception(ExceptionKind::SysandException, err.to_string());
             None
         }
+        KParBuildError::MissingIndexSymbol(path, symbol) => {
+            env.throw_exception(
+                ExceptionKind::SysandException,
+                format!("file `{path}` is missing symbol `{symbol}` found in index"),
+            );
+        }
     }
 }
 
@@ -478,7 +484,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_buildProject<'local>(
         &project,
         &output_path,
         compression,
-        true,
+        false,
         false,
     );
     match command_result {

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -422,17 +422,14 @@ fn handle_build_error(env: &mut JNIEnv<'_>, error: KParBuildError<LocalSrcError>
                 format!("Workspace read error: {}", error),
             );
         }
-        KParBuildError::PathUsage(usage) => {
-            env.throw_exception(
-                ExceptionKind::SysandException,
-                format!(
-                    "project includes a path usage `{usage}`,\n\
-        which is unlikely to be available on other computers at the same path"
-                ),
-            );
+        KParBuildError::PathUsage(_) => {
+            env.throw_exception(ExceptionKind::SysandException, error.to_string());
         }
         KParBuildError::WorkspaceMetamodelConflict { .. } => {
             env.throw_exception(ExceptionKind::SysandException, error.to_string());
+        }
+        KParBuildError::MissingIndexSymbol(_, _) => {
+            env.throw_exception(ExceptionKind::InvalidValue, error.to_string())
         }
     }
 }
@@ -446,12 +443,6 @@ fn compression_from_java_string(
         Err(err) => {
             env.throw_exception(ExceptionKind::SysandException, err.to_string());
             None
-        }
-        KParBuildError::MissingIndexSymbol(path, symbol) => {
-            env.throw_exception(
-                ExceptionKind::SysandException,
-                format!("file `{path}` is missing symbol `{symbol}` found in index"),
-            );
         }
     }
 }

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -473,17 +473,14 @@ fn handle_build_error(env: &mut JNIEnv<'_>, error: KParBuildError<LocalSrcError>
                 format!("Workspace read error: {}", error),
             );
         }
-        KParBuildError::PathUsage(usage) => {
-            env.throw_exception(
-                ExceptionKind::SysandException,
-                format!(
-                    "project includes a path usage `{usage}`,\n\
-        which is unlikely to be available on other computers at the same path"
-                ),
-            );
+        KParBuildError::PathUsage(_) => {
+            env.throw_exception(ExceptionKind::SysandException, error.to_string());
         }
         KParBuildError::WorkspaceMetamodelConflict { .. } => {
             env.throw_exception(ExceptionKind::SysandException, error.to_string());
+        }
+        KParBuildError::MissingIndexSymbol(_, _) => {
+            env.throw_exception(ExceptionKind::InvalidValue, error.to_string())
         }
     }
 }
@@ -497,12 +494,6 @@ fn compression_from_java_string(
         Err(err) => {
             env.throw_exception(ExceptionKind::SysandException, err.to_string());
             None
-        }
-        KParBuildError::MissingIndexSymbol(path, symbol) => {
-            env.throw_exception(
-                ExceptionKind::SysandException,
-                format!("file `{path}` is missing symbol `{symbol}` found in index"),
-            );
         }
     }
 }

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -498,6 +498,12 @@ fn compression_from_java_string(
             env.throw_exception(ExceptionKind::SysandException, err.to_string());
             None
         }
+        KParBuildError::MissingIndexSymbol(path, symbol) => {
+            env.throw_exception(
+                ExceptionKind::SysandException,
+                format!("file `{path}` is missing symbol `{symbol}` found in index"),
+            );
+        }
     }
 }
 
@@ -530,7 +536,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_buildProject<'local>(
         &project,
         &output_path,
         compression,
-        true,
+        false,
         false,
     );
     match command_result {

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -220,7 +220,7 @@ fn do_build_py(
         None => KparCompressionMethod::default(),
     };
 
-    do_build_kpar(&project, &output_path, compression, true, false)
+    do_build_kpar(&project, &output_path, compression, false, false)
         .map(|_| ())
         .map_err(|err| match err {
             KParBuildError::ProjectRead(_) => PyRuntimeError::new_err(err.to_string()),
@@ -239,6 +239,7 @@ fn do_build_py(
             KParBuildError::WorkspaceMetamodelConflict { .. } => {
                 PyValueError::new_err(err.to_string())
             }
+            KParBuildError::MissingIndexSymbol(_, _) => PyValueError::new_err(err.to_string()),
         })
 }
 

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -225,7 +225,7 @@ fn do_build_py(
         None => KparCompressionMethod::default(),
     };
 
-    do_build_kpar(&project, &output_path, compression, true, false)
+    do_build_kpar(&project, &output_path, compression, false, false)
         .map(|_| ())
         .map_err(|err| match err {
             KParBuildError::ProjectRead(_) => PyRuntimeError::new_err(err.to_string()),
@@ -244,6 +244,7 @@ fn do_build_py(
             KParBuildError::WorkspaceMetamodelConflict { .. } => {
                 PyValueError::new_err(err.to_string())
             }
+            KParBuildError::MissingIndexSymbol(_, _) => PyValueError::new_err(err.to_string()),
         })
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ sha2 = { version = "0.10.9", default-features = false }
 sysand-macros = { path = "../macros"}
 spdx = "0.13.4"
 thiserror = { version = "2.0.18", default-features = false }
-toml = "1.0.6"
+toml = { version = "1.0.6", features = ["fast_hash"] }
 typed-path = { version = "0.12.3", default-features = false }
 walkdir = "2.5.0"
 # unicode-normalization = { version = "0.1.24", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = { version = "1.0.149", default-features = false, features = ["prese
 sysand-macros = { path = "../macros"}
 spdx = "0.13.4"
 thiserror = { version = "2.0.18", default-features = false }
-toml = "1.0.6"
+toml = { version = "1.0.6", features = ["fast_hash"] }
 typed-path = { version = "0.12.3", default-features = false }
 walkdir = "2.5.0"
 # unicode-normalization = { version = "0.1.24", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = { version = "1.0.149", default-features = false, features = ["prese
 sysand-macros = { path = "../macros"}
 spdx = "0.13.4"
 thiserror = { version = "2.0.18", default-features = false }
-toml = { version = "1.0.6" }
+toml = { version = "1.0.6", features = ["fast_hash"] }
 typed-path = { version = "0.12.3", default-features = false }
 walkdir = "2.5.0"
 # unicode-normalization = { version = "0.1.24", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = { version = "1.0.149", default-features = false, features = ["prese
 sysand-macros = { path = "../macros"}
 spdx = "0.13.4"
 thiserror = { version = "2.0.18", default-features = false }
-toml = { version = "1.0.6", features = ["fast_hash"] }
+toml = { version = "1.0.6" }
 typed-path = { version = "0.12.3", default-features = false }
 walkdir = "2.5.0"
 # unicode-normalization = { version = "0.1.24", default-features = false }

--- a/core/scripts/run_tests.sh
+++ b/core/scripts/run_tests.sh
@@ -12,5 +12,6 @@ PACKAGE_DIR=$(dirname "$SCRIPT_DIR")
 cd "$PACKAGE_DIR"
 
 cargo test --features filesystem,networking,alltests $@
-cargo test --features js $@
-cargo test --features python $@
+# Currently these features don't enable any tests
+# cargo test --features js $@
+# cargo test --features python $@

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -4,6 +4,8 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use thiserror::Error;
 
+use std::collections::HashSet;
+
 use crate::{
     env::utils::{CloneError, ErrorBound},
     include::IncludeError,
@@ -163,6 +165,8 @@ pub enum KParBuildError<ProjectReadError: ErrorBound> {
         project_metamodel: String,
         project_path: String,
     },
+    #[error("file `{0}` is missing symbol `{1}` found in index")]
+    MissingIndexSymbol(Box<str>, String),
 }
 
 impl<ProjectReadError: ErrorBound> From<FsIoError> for KParBuildError<ProjectReadError> {
@@ -242,18 +246,20 @@ pub fn default_kpar_file_name<Pr: ProjectRead>(
     ))
 }
 
+/// `update_index_checksum` controls whether to parse symbols from current
+/// file to update index and also update file checksum
 pub fn do_build_kpar<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
     compression: KparCompressionMethod,
-    canonicalise: bool,
+    update_index_checksum: bool,
     allow_path_usage: bool,
 ) -> Result<LocalKParProject, KParBuildError<Pr::Error>> {
     do_build_kpar_inner(
         project,
         path,
         compression,
-        canonicalise,
+        update_index_checksum,
         allow_path_usage,
         None,
     )
@@ -263,11 +269,14 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
     compression: KparCompressionMethod,
-    canonicalise: bool,
+    update_index_checksum: bool,
     allow_path_usage: bool,
     workspace_metamodel: Option<&str>,
 ) -> Result<LocalKParProject, KParBuildError<Pr::Error>> {
-    use crate::project::local_src::LocalSrcProject;
+    use crate::{
+        include::{do_include, extract_symbols},
+        project::local_src::LocalSrcProject,
+    };
 
     let building = "Building";
     let header = crate::style::get_style_config().header;
@@ -333,11 +342,26 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
         }
     }
 
-    if canonicalise {
-        for path in meta.validate()?.source_paths(true) {
-            use crate::include::do_include;
-
-            do_include(&mut local_project, &path, true, true, None)?;
+    let meta = meta.validate()?;
+    // Check whether index symbols are up to date
+    if update_index_checksum {
+        for p in meta.source_paths(true) {
+            do_include(&mut local_project, p, true, true, None)?
+        }
+    } else {
+        for p in meta.source_paths(true) {
+            let new_symbols = extract_symbols(&mut local_project, &p, None)?;
+            let new_symbols: HashSet<String> = new_symbols.into_iter().collect();
+            let old_symbols = meta.file_index_symbols(&p);
+            if let Some(only_in_old) = old_symbols.difference(&new_symbols).next() {
+                return Err(KParBuildError::MissingIndexSymbol(
+                    p.as_str().into(),
+                    only_in_old.clone(),
+                ));
+            }
+            for only_in_new in new_symbols.difference(&old_symbols) {
+                log::warn!("index is missing symbol `{only_in_new}` found in file `{p}`");
+            }
         }
     }
 
@@ -418,7 +442,7 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
     workspace: &Workspace,
     path: P,
     compression: KparCompressionMethod,
-    canonicalise: bool,
+    update_index_checksum: bool,
     allow_path_usage: bool,
 ) -> Result<Vec<LocalKParProject>, KParBuildError<LocalSrcError>> {
     let ws_metamodel = workspace.metamodel().map(|iri| iri.as_str());
@@ -436,7 +460,7 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
             &project,
             &output_path,
             compression,
-            canonicalise,
+            update_index_checksum,
             allow_path_usage,
             ws_metamodel,
         )?;

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -359,8 +359,8 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                 // TODO: figure out a way to only print suggestions when running the CLI
                 log::warn!(
                     "index is missing symbol `{only_in_new}` found in file `{p}`;\n\
-                    include the file again to update its exported symbols, or pass `--update-meta`\n\
-                    to do so for all files"
+                    if this is not intentional, include the file again to update its\n\
+                    exported symbols, or pass `--update-meta` to do so for all files"
                 );
             }
         }

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -356,7 +356,12 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                 ));
             }
             for only_in_new in new_symbols.difference(&old_symbols) {
-                log::warn!("index is missing symbol `{only_in_new}` found in file `{p}`");
+                // TODO: figure out a way to only print suggestions when running the CLI
+                log::warn!(
+                    "index is missing symbol `{only_in_new}` found in file `{p}`;\n\
+                    include the file again to update its exported symbols, or pass `--update-meta`\n\
+                    to do so for all files"
+                );
             }
         }
     }

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -4,9 +4,11 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use thiserror::Error;
 
+use std::collections::HashSet;
+
 use crate::{
     env::utils::{CloneError, ErrorBound},
-    include::IncludeError,
+    include::{IncludeError, do_include, extract_symbols},
     model::InterchangeProjectValidationError,
     project::{
         ProjectRead,
@@ -164,6 +166,8 @@ pub enum KParBuildError<ProjectReadError: ErrorBound> {
         project_metamodel: String,
         project_path: String,
     },
+    #[error("file `{0}` is missing symbol `{1}` found in index")]
+    MissingIndexSymbol(Box<str>, String),
 }
 
 impl<ProjectReadError: ErrorBound> From<FsIoError> for KParBuildError<ProjectReadError> {
@@ -243,18 +247,20 @@ pub fn default_kpar_file_name<Pr: ProjectRead>(
     ))
 }
 
+/// `update_index_checksum` controls whether to parse symbols from current
+/// file to update index and also update file checksum
 pub fn do_build_kpar<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
     compression: KparCompressionMethod,
-    canonicalise: bool,
+    update_index_checksum: bool,
     allow_path_usage: bool,
 ) -> Result<LocalKParProjectRaw, KParBuildError<Pr::Error>> {
     do_build_kpar_inner(
         project,
         path,
         compression,
-        canonicalise,
+        update_index_checksum,
         allow_path_usage,
         None,
     )
@@ -264,12 +270,10 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
     compression: KparCompressionMethod,
-    canonicalise: bool,
+    update_index_checksum: bool,
     allow_path_usage: bool,
     workspace_metamodel: Option<&str>,
 ) -> Result<LocalKParProjectRaw, KParBuildError<Pr::Error>> {
-    use crate::project::local_src::LocalSrcProject;
-
     let building = "Building";
     let header = crate::style::get_style_config().header;
     log::info!("{header}{building:>12}{header:#} kpar `{}`", path.as_ref());
@@ -334,11 +338,26 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
         }
     }
 
-    if canonicalise {
-        for path in meta.validate()?.source_paths(true) {
-            use crate::include::do_include;
-
-            do_include(&mut local_project, &path, true, true, None)?;
+    let meta = meta.validate()?;
+    // Check whether index symbols are up to date
+    if update_index_checksum {
+        for p in meta.source_paths(true) {
+            do_include(&mut local_project, p, true, true, None)?
+        }
+    } else {
+        for p in meta.source_paths(true) {
+            let new_symbols = extract_symbols(&mut local_project, &p, None)?;
+            let new_symbols: HashSet<String> = new_symbols.into_iter().collect();
+            let old_symbols = meta.file_index_symbols(&p);
+            if let Some(only_in_old) = old_symbols.difference(&new_symbols).next() {
+                return Err(KParBuildError::MissingIndexSymbol(
+                    p.as_str().into(),
+                    only_in_old.clone(),
+                ));
+            }
+            for only_in_new in new_symbols.difference(&old_symbols) {
+                log::warn!("index is missing symbol `{only_in_new}` found in file `{p}`");
+            }
         }
     }
 
@@ -395,7 +414,7 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
     workspace: &Workspace,
     path: P,
     compression: KparCompressionMethod,
-    canonicalise: bool,
+    update_index_checksum: bool,
     allow_path_usage: bool,
 ) -> Result<Vec<LocalKParProjectRaw>, KParBuildError<LocalSrcError>> {
     let ws_metamodel = workspace.metamodel().map(|iri| iri.as_str());
@@ -414,7 +433,7 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
             &project,
             &output_path,
             compression,
-            canonicalise,
+            update_index_checksum,
             allow_path_usage,
             ws_metamodel,
         )?;

--- a/core/src/commands/include.rs
+++ b/core/src/commands/include.rs
@@ -51,29 +51,29 @@ pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
     log::info!("{header}{including:>12}{header:#} file `{}`", path.as_ref());
 
     if index_symbols {
-        match force_format.or_else(|| Language::guess_from_path(&path)) {
-            Some(Language::SysML) => {
-                let new_symbols = crate::symbols::top_level_sysml(
-                    project.read_source(&path).map_err(IncludeError::Project)?,
-                )
-                .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e))?;
-
-                project.merge_index(new_symbols.into_iter().map(|x| (x, path.as_ref())), true)?;
-            }
-            Some(Language::KerML) => {
-                let new_symbols = crate::symbols::top_level_kerml(
-                    project.read_source(&path).map_err(IncludeError::Project)?,
-                )
-                .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e))?;
-
-                project.merge_index(new_symbols.into_iter().map(|x| (x, path.as_ref())), true)?;
-            }
-            _ => {
-                return Err(IncludeError::UnknownFormat(path.as_ref().as_str().into()));
-            }
-        }
+        let new_symbols = extract_symbols(project, &path, force_format)?;
+        project.merge_index(new_symbols.into_iter().map(|x| (x, path.as_ref())), true)?;
     }
 
     project.include_source(&path, compute_checksum, true)?;
     Ok(())
+}
+
+/// Extract top level symbols from file at `path` belonging to `project`
+pub fn extract_symbols<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
+    project: &mut Pr,
+    path: &P,
+    force_format: Option<Language>,
+) -> Result<Vec<String>, IncludeError<Pr::Error>> {
+    match force_format.or_else(|| Language::guess_from_path(path)) {
+        Some(Language::SysML) => crate::symbols::top_level_sysml(
+            project.read_source(path).map_err(IncludeError::Project)?,
+        )
+        .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
+        Some(Language::KerML) => crate::symbols::top_level_kerml(
+            project.read_source(path).map_err(IncludeError::Project)?,
+        )
+        .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
+        _ => Err(IncludeError::UnknownFormat(path.as_ref().as_str().into())),
+    }
 }

--- a/core/src/commands/include.rs
+++ b/core/src/commands/include.rs
@@ -52,29 +52,29 @@ pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
     log::info!("{header}{including:>12}{header:#} file `{}`", path.as_ref());
 
     if index_symbols {
-        match force_format.or_else(|| Language::guess_from_path(&path)) {
-            Some(Language::SysML) => {
-                let new_symbols = crate::symbols::top_level_sysml(
-                    project.read_source(&path).map_err(IncludeError::Project)?,
-                )
-                .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e))?;
-
-                project.replace_index_for_file(new_symbols.into_iter(), &path, true)?;
-            }
-            Some(Language::KerML) => {
-                let new_symbols = crate::symbols::top_level_kerml(
-                    project.read_source(&path).map_err(IncludeError::Project)?,
-                )
-                .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e))?;
-
-                project.replace_index_for_file(new_symbols.into_iter(), &path, true)?;
-            }
-            _ => {
-                return Err(IncludeError::UnknownFormat(path.as_ref().as_str().into()));
-            }
-        }
+        let new_symbols = extract_symbols(project, &path, force_format)?;
+        project.replace_index_for_file(new_symbols.into_iter(), &path, true)?;
     }
 
     project.include_source(&path, compute_checksum, true)?;
     Ok(())
+}
+
+/// Extract top level symbols from file at `path` belonging to `project`
+pub fn extract_symbols<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
+    project: &mut Pr,
+    path: &P,
+    force_format: Option<Language>,
+) -> Result<Vec<String>, IncludeError<Pr::Error>> {
+    match force_format.or_else(|| Language::guess_from_path(path)) {
+        Some(Language::SysML) => crate::symbols::top_level_sysml(
+            project.read_source(path).map_err(IncludeError::Project)?,
+        )
+        .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
+        Some(Language::KerML) => crate::symbols::top_level_kerml(
+            project.read_source(path).map_err(IncludeError::Project)?,
+        )
+        .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
+        _ => Err(IncludeError::UnknownFormat(path.as_ref().as_str().into())),
+    }
 }

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -502,6 +502,22 @@ pub enum InterchangeProjectValidationError {
     },
 }
 
+impl InterchangeProjectMetadata {
+    /// Get symbols recorded in `index` for file at `path`
+    pub fn file_index_symbols<P: AsRef<str>>(&self, path: P) -> HashSet<String> {
+        self.index
+            .iter()
+            .filter_map(|(k, v)| {
+                if v == path.as_ref() {
+                    Some(k.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
 impl Default for InterchangeProjectMetadataRaw {
     fn default() -> Self {
         InterchangeProjectMetadataRaw {

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -505,6 +505,22 @@ pub enum InterchangeProjectValidationError {
     },
 }
 
+impl InterchangeProjectMetadata {
+    /// Get symbols recorded in `index` for file at `path`
+    pub fn file_index_symbols<P: AsRef<str>>(&self, path: P) -> HashSet<String> {
+        self.index
+            .iter()
+            .filter_map(|(k, v)| {
+                if v == path.as_ref() {
+                    Some(k.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
 impl Default for InterchangeProjectMetadataRaw {
     fn default() -> Self {
         InterchangeProjectMetadataRaw {

--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -1,7 +1,7 @@
 # `sysand build`
 
-Build a KerML Project Archive (KPAR). If executed in a workspace outside of a
-project, builds all projects in the workspace.
+Build a KerML Project Archive (KPAR). If executed in a workspace
+outside of a project, builds all projects in the workspace.
 
 ## Usage
 
@@ -13,8 +13,8 @@ sysand build [OPTIONS] [PATH]
 
 Creates a KPAR file from the current project.
 
-Current project is determined as in [sysand print-root](root.md) and
-if none is found uses the current directory instead.
+Current project is determined as in [`sysand print-root`](root.md) and
+if none is found, defaults to current directory.
 
 If a `README.md` file exist at the project root, it is included in the
 `.kpar` archive.
@@ -56,5 +56,9 @@ warning; the build still succeeds.
   Warning: using this makes the project not portable between different
   computers, as `file://` URL always contains an absolute path.
   For multiple related projects, consider using a workspace instead
+
+- `-u`, `--update-meta`: Update project metadata before building. This
+  includes updating project symbol index and adding/updating source
+  file checksums.
 
 {{#include ./partials/global_opts.md}}

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -32,7 +32,7 @@ env_logger = "0.11.9"
 log = { version = "0.4.29", default-features = false }
 sysand-core = { path = "../core", features = ["std", "filesystem", "networking"] }
 thiserror = "2.0.18"
-toml = { version = "1.0.6", default-features = false }
+toml = { version = "1.0.6", default-features = false, features = ["fast_hash"] }
 semver = "1.0.27"
 serde_json = { version = "1.0.149", default-features = false }
 spdx = "0.13.4"

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -32,7 +32,7 @@ env_logger = "0.11.9"
 log = { version = "0.4.29", default-features = false }
 sysand-core = { path = "../core", features = ["std", "filesystem", "networking"] }
 thiserror = "2.0.18"
-toml = { version = "1.0.6", default-features = false, features = ["fast_hash"] }
+toml = { version = "1.0.6", default-features = false }
 semver = "1.0.27"
 serde_json = { version = "1.0.149", default-features = false }
 spdx = "0.13.4"

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -32,7 +32,7 @@ env_logger = "0.11.9"
 log = { version = "0.4.29", default-features = false }
 sysand-core = { path = "../core", features = ["std", "filesystem", "networking"] }
 thiserror = "2.0.18"
-toml = { version = "1.0.6", default-features = false }
+toml = { version = "1.0.6", features = ["fast_hash"] }
 semver = "1.0.27"
 serde_json = { version = "1.0.149", default-features = false }
 spdx = "0.13.4"

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -182,8 +182,9 @@ pub enum Command {
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         allow_path_usage: bool,
         // TODO: add tests
-        /// Update project metadata before building. This includes updating
-        /// project symbol index and adding/updating source file checksums
+        /// Update project metadata to be included in the build artifacts. This
+        /// includes updating project symbol index and adding/updating source file
+        /// checksums. Original project(s) will not be affected
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         update_meta: bool,
     },

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -181,6 +181,11 @@ pub enum Command {
         /// For multiple related projects, consider using a workspace instead
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         allow_path_usage: bool,
+        // TODO: add tests
+        /// Update project metadata before building. This includes updating
+        /// project symbol index and adding/updating source file checksums
+        #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
+        update_meta: bool,
     },
     /// Publish a KPAR to a sysand package index
     Publish {

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -184,8 +184,9 @@ pub enum Command {
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         allow_path_usage: bool,
         // TODO: add tests
-        /// Update project metadata before building. This includes updating
-        /// project symbol index and adding/updating source file checksums
+        /// Update project metadata to be included in the build artifacts. This
+        /// includes updating project symbol index and adding/updating source file
+        /// checksums. Original project(s) will not be affected
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         update_meta: bool,
     },

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -183,12 +183,12 @@ pub enum Command {
         /// For multiple related projects, consider using a workspace instead
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         allow_path_usage: bool,
-        // TODO: add tests
-        /// Update project metadata to be included in the build artifacts. This
-        /// includes updating project symbol index and adding/updating source file
-        /// checksums. Original project(s) will not be affected
-        #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
-        update_meta: bool,
+        // // TODO: add tests
+        // /// Update project metadata to be included in the build artifacts. This
+        // /// includes updating project symbol index and adding/updating source file
+        // /// checksums. Original project(s) will not be affected
+        // #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
+        // update_meta: bool,
     },
     /// Publish a KPAR to a sysand package index
     Publish {

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -183,6 +183,11 @@ pub enum Command {
         /// For multiple related projects, consider using a workspace instead
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         allow_path_usage: bool,
+        // TODO: add tests
+        /// Update project metadata before building. This includes updating
+        /// project symbol index and adding/updating source file checksums
+        #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
+        update_meta: bool,
     },
     /// Publish a KPAR to a sysand package index
     Publish {

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -183,12 +183,11 @@ pub enum Command {
         /// For multiple related projects, consider using a workspace instead
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         allow_path_usage: bool,
-        // // TODO: add tests
-        // /// Update project metadata to be included in the build artifacts. This
-        // /// includes updating project symbol index and adding/updating source file
-        // /// checksums. Original project(s) will not be affected
-        // #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
-        // update_meta: bool,
+        /// Update project metadata to be included in the build artifacts. This
+        /// includes updating project symbol index and adding/updating source file
+        /// checksums. Original project(s) will not be affected
+        #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
+        update_meta: bool,
     },
     /// Publish a KPAR to a sysand package index
     Publish {

--- a/sysand/src/commands/build.rs
+++ b/sysand/src/commands/build.rs
@@ -13,9 +13,16 @@ pub fn command_build_for_project<P: AsRef<Utf8Path>>(
     path: P,
     compression: KparCompressionMethod,
     current_project: LocalSrcProject,
+    update_index_checksum: bool,
     allow_path_usage: bool,
 ) -> Result<()> {
-    match do_build_kpar(&current_project, &path, compression, true, allow_path_usage) {
+    match do_build_kpar(
+        &current_project,
+        &path,
+        compression,
+        update_index_checksum,
+        allow_path_usage,
+    ) {
         Ok(_) => Ok(()),
         Err(err) => match err {
             KParBuildError::PathUsage(_) => bail!(
@@ -31,6 +38,7 @@ pub fn command_build_for_workspace<P: AsRef<Utf8Path>>(
     path: P,
     compression: KparCompressionMethod,
     workspace: Workspace,
+    update_index_checksum: bool,
     allow_path_usage: bool,
 ) -> Result<()> {
     log::warn!(
@@ -39,7 +47,13 @@ pub fn command_build_for_workspace<P: AsRef<Utf8Path>>(
         releases. For the status of this feature, see\n\
         https://github.com/sensmetry/sysand/issues/101."
     );
-    do_build_workspace_kpars(&workspace, &path, compression, true, allow_path_usage)?;
+    do_build_workspace_kpars(
+        &workspace,
+        &path,
+        compression,
+        update_index_checksum,
+        allow_path_usage,
+    )?;
 
     Ok(())
 }

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -636,6 +636,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         Command::Build {
             path,
             compression,
+            update_meta,
             allow_path_usage,
         } => {
             if let Some(current_project) = ctx.current_project {
@@ -659,6 +660,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     path,
                     compression.into(),
                     current_project,
+                    update_meta,
                     allow_path_usage,
                 )
             } else {
@@ -677,6 +679,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     output_dir,
                     compression.into(),
                     current_workspace,
+                    update_meta,
                     allow_path_usage,
                 )
             }

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -667,7 +667,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         Command::Build {
             path,
             compression,
-            update_meta,
+            // update_meta,
             allow_path_usage,
         } => {
             if let Some(current_project) = ctx.current_project {
@@ -691,7 +691,8 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     path,
                     compression.into(),
                     current_project,
-                    update_meta,
+                    true,
+                    // update_meta,
                     allow_path_usage,
                 )
             } else {
@@ -710,7 +711,8 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     output_dir,
                     compression.into(),
                     current_workspace,
-                    update_meta,
+                    true,
+                    // update_meta,
                     allow_path_usage,
                 )
             }

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -667,6 +667,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         Command::Build {
             path,
             compression,
+            update_meta,
             allow_path_usage,
         } => {
             if let Some(current_project) = ctx.current_project {
@@ -690,6 +691,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     path,
                     compression.into(),
                     current_project,
+                    update_meta,
                     allow_path_usage,
                 )
             } else {
@@ -708,6 +710,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     output_dir,
                     compression.into(),
                     current_workspace,
+                    update_meta,
                     allow_path_usage,
                 )
             }

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -667,7 +667,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         Command::Build {
             path,
             compression,
-            // update_meta,
+            update_meta,
             allow_path_usage,
         } => {
             if let Some(current_project) = ctx.current_project {
@@ -691,8 +691,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     path,
                     compression.into(),
                     current_project,
-                    true,
-                    // update_meta,
+                    update_meta,
                     allow_path_usage,
                 )
             } else {
@@ -711,8 +710,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     output_dir,
                     compression.into(),
                     current_workspace,
-                    true,
-                    // update_meta,
+                    update_meta,
                     allow_path_usage,
                 )
             }

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -519,7 +519,6 @@ fn add_and_remove_as_local_kpar() -> Result<(), Box<dyn std::error::Error>> {
         ["init", "--version", "1.2.3", "--name", "add_and_remove"],
         None,
     )?;
-    dbg!("hello");
 
     out.assert().success();
 

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -519,6 +519,7 @@ fn add_and_remove_as_local_kpar() -> Result<(), Box<dyn std::error::Error>> {
         ["init", "--version", "1.2.3", "--name", "add_and_remove"],
         None,
     )?;
+    dbg!("hello");
 
     out.assert().success();
 

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -2,12 +2,20 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
+use camino::Utf8PathBuf;
 use clap::ValueEnum;
 use predicates::prelude::*;
-use std::io::{Read, Write};
+use serde_json::json;
+use std::{
+    fs,
+    io::{Read, Write},
+};
 use sysand::cli::KparCompressionMethodCli;
 use sysand_core::{
-    model::{InterchangeProjectChecksumRaw, KerMlChecksumAlg},
+    model::{
+        InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw,
+        KerMlChecksumAlg,
+    },
     project::{ProjectRead, local_kpar::LocalKParProject},
 };
 
@@ -27,6 +35,10 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
     let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
 
     out.assert().success();
+    let orig_info_path = cwd.join(".project.json");
+    let orig_meta_path = cwd.join(".meta.json");
+    let orig_info_contents = fs::read_to_string(&orig_info_path)?;
+    let orig_meta_contents = fs::read_to_string(&orig_meta_path)?;
 
     let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
 
@@ -45,12 +57,31 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
 
     let kpar_project = LocalKParProject::new_guess_root(cwd.join("test_build.kpar"))?;
 
-    let (Some(_), Some(meta)) = kpar_project.get_project()? else {
+    let (Some(info), Some(meta)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta");
     };
 
-    // Ensure things get canonicalised during build
+    // Ensure the build artifact matches original project
+    let original_meta: InterchangeProjectMetadataRaw = serde_json::from_str(&orig_meta_contents)?;
+    let original_info: InterchangeProjectInfoRaw = serde_json::from_str(&orig_info_contents)?;
+    assert_eq!(original_info, info);
+    assert_eq!(original_meta, meta);
 
+    // Ensure no changes were made to the original project
+    let new_info_contents = fs::read_to_string(&orig_info_path)?;
+    let new_meta_contents = fs::read_to_string(&orig_meta_path)?;
+    assert_eq!(orig_info_contents, new_info_contents);
+    assert_eq!(orig_meta_contents, new_meta_contents);
+
+    // Now canonicalize meta during build
+    let out = run_sysand_in(&cwd, ["build", "--update-meta", "./test_build2.kpar"], None)?;
+    out.assert().success();
+    let kpar_project = LocalKParProject::new_guess_root(cwd.join("test_build2.kpar"))?;
+
+    let (Some(_), Some(meta)) = kpar_project.get_project()? else {
+        panic!("failed to get built project info/meta");
+    };
+    // File hash should be updated
     assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
     assert_eq!(
         meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
@@ -62,6 +93,12 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(meta.index.len(), 1);
     assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+
+    // Ensure no changes were made to the original project
+    let new_info_contents = fs::read_to_string(&orig_info_path)?;
+    let new_meta_contents = fs::read_to_string(&orig_meta_path)?;
+    assert_eq!(orig_info_contents, new_info_contents);
+    assert_eq!(orig_meta_contents, new_meta_contents);
 
     Ok(())
 }
@@ -123,11 +160,36 @@ fn project_build_path_usage() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+struct WProject {
+    name: String,
+    info_path: Utf8PathBuf,
+    meta_path: Utf8PathBuf,
+    orig_info_contents: String,
+    orig_meta_contents: String,
+}
+impl WProject {
+    fn new(cwd: Utf8PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
+        let name = cwd.file_name().unwrap().to_owned();
+        let info_path = cwd.join(".project.json");
+        let meta_path = cwd.join(".meta.json");
+        let orig_info_contents = fs::read_to_string(&info_path)?;
+        let orig_meta_contents = fs::read_to_string(&meta_path)?;
+        Ok(Self {
+            name,
+            info_path,
+            meta_path,
+            orig_info_contents,
+            orig_meta_contents,
+        })
+    }
+}
+
 #[test]
 fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd) = new_temp_cwd()?;
     let project_group_cwd = cwd.join("subgroup");
     std::fs::create_dir(&project_group_cwd)?;
+
     let project1_cwd = project_group_cwd.join("project1");
     let project2_cwd = project_group_cwd.join("project2");
     let project3_cwd = cwd.join("project3");
@@ -135,19 +197,25 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
     // Create .workspace.json file
     std::fs::write(
         cwd.join(".workspace.json"),
-        br#"{"projects": [
-            {"path": "subgroup/project1", "iris": ["urn:kpar:project1"]},
-            {"path": "subgroup/project2", "iris": ["urn:kpar:project2"]},
-            {"path": "project3", "iris": ["urn:kpar:project3"]}
-            ]}"#,
+        json!({"projects": [
+        {"path": "subgroup/project1", "iris": ["urn:kpar:project1"]},
+        {"path": "subgroup/project2", "iris": ["urn:kpar:project2"]},
+        {"path": "project3", "iris": ["urn:kpar:project3"]}
+        ]})
+        .to_string(),
     )?;
 
     for project_cwd in [&project1_cwd, &project2_cwd, &project3_cwd] {
         std::fs::create_dir(project_cwd)?;
-        let project_name = project_cwd.file_name().unwrap();
         let out = run_sysand_in(
             project_cwd,
-            ["init", "--version", "1.2.3", "--name", project_name],
+            [
+                "init",
+                "--version",
+                "1.2.3",
+                "--name",
+                project_cwd.file_name().unwrap(),
+            ],
             None,
         )?;
         out.assert().success();
@@ -161,14 +229,20 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
         out.assert().success();
     }
 
+    let projects = [
+        WProject::new(project1_cwd)?,
+        WProject::new(project2_cwd)?,
+        WProject::new(project3_cwd)?,
+    ];
+
     let out = run_sysand_in(&cwd, ["build"], None)?;
     out.assert().success();
 
-    for project_name in ["project1", "project2", "project3"] {
-        println!("W9: {}", project_name);
+    for project in &projects {
+        println!("W9: {}", project.name);
         let kpar_path = cwd
             .join("output")
-            .join(format!("{}-1.2.3.kpar", project_name));
+            .join(format!("{}-1.2.3.kpar", project.name));
         assert!(
             kpar_path.is_file(),
             "kpar file does not exist: {}",
@@ -179,7 +253,76 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
 
         out.assert()
             .success()
-            .stdout(predicate::str::contains(format!("Name: {}", project_name)))
+            .stdout(predicate::str::contains(format!("Name: {}", project.name)))
+            .stdout(predicate::str::contains("Version: 1.2.3"));
+
+        let kpar_project = LocalKParProject::new_guess_root(kpar_path)?;
+
+        let (Some(info), Some(meta)) = kpar_project.get_project()? else {
+            panic!("failed to get built project info/meta");
+        };
+
+        // Ensure the build artifact matches original project
+        let original_meta: InterchangeProjectMetadataRaw =
+            serde_json::from_str(&project.orig_meta_contents)?;
+        let original_info: InterchangeProjectInfoRaw =
+            serde_json::from_str(&project.orig_info_contents)?;
+        assert_eq!(original_info, info);
+        assert_eq!(original_meta, meta);
+
+        // Ensure no changes were made to the original project
+        let new_info_contents = fs::read_to_string(&project.info_path)?;
+        let new_meta_contents = fs::read_to_string(&project.meta_path)?;
+        assert_eq!(project.orig_info_contents, new_info_contents);
+        assert_eq!(project.orig_meta_contents, new_meta_contents);
+
+        // out.assert()
+        //     .success()
+        //     .stdout(predicate::str::contains(format!("Name: {}", project.name)))
+        //     .stdout(predicate::str::contains("Version: 1.2.3"));
+
+        // let kpar_project = LocalKParProject::new_guess_root(kpar_path)?;
+
+        // let (Some(_), Some(meta)) = kpar_project.get_project()? else {
+        //     panic!("failed to get built project info/meta");
+        // };
+
+        // // Ensure things get canonicalised during build
+
+        // assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
+        // assert_eq!(
+        //     meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
+        //     &InterchangeProjectChecksumRaw {
+        //         value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8"
+        //             .to_string(),
+        //         algorithm: KerMlChecksumAlg::Sha256.into(),
+        //     }
+        // );
+
+        // assert_eq!(meta.index.len(), 1);
+        // assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+    }
+
+    // Now canonicalize meta during build. Previous artifacts should be overwritten
+    let out = run_sysand_in(&cwd, ["build", "--update-meta"], None)?;
+    out.assert().success();
+
+    for project in &projects {
+        println!("W9: {}", project.name);
+        let kpar_path = cwd
+            .join("output")
+            .join(format!("{}-1.2.3.kpar", project.name));
+        assert!(
+            kpar_path.is_file(),
+            "kpar file does not exist: {}",
+            kpar_path
+        );
+
+        let out = run_sysand_in(&cwd, ["info", "--path", kpar_path.as_str()], None)?;
+
+        out.assert()
+            .success()
+            .stdout(predicate::str::contains(format!("Name: {}", project.name)))
             .stdout(predicate::str::contains("Version: 1.2.3"));
 
         let kpar_project = LocalKParProject::new_guess_root(kpar_path)?;
@@ -188,20 +331,25 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
             panic!("failed to get built project info/meta");
         };
 
-        // Ensure things get canonicalised during build
-
+        // File hash should be updated
         assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
         assert_eq!(
             meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
             &InterchangeProjectChecksumRaw {
                 value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8"
                     .to_string(),
-                algorithm: KerMlChecksumAlg::Sha256.into(),
+                algorithm: KerMlChecksumAlg::Sha256.into()
             }
         );
 
         assert_eq!(meta.index.len(), 1);
         assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+
+        // Ensure no changes were made to the original project
+        let new_info_contents = fs::read_to_string(&project.info_path)?;
+        let new_meta_contents = fs::read_to_string(&project.meta_path)?;
+        assert_eq!(project.orig_info_contents, new_info_contents);
+        assert_eq!(project.orig_meta_contents, new_meta_contents);
     }
 
     Ok(())
@@ -1049,8 +1197,7 @@ fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::erro
     assert_eq!(info.version, "1.2.3");
 
     assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
-    assert_eq!(meta.index.len(), 1);
-    assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+    assert_eq!(meta.index.len(), 0);
     let mut src = String::new();
     kpar_project
         .read_source("test.sysml")?

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -103,6 +103,87 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn project_build_errors_when_index_symbol_is_missing_from_file()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "test_build_missing_index_symbol",
+        ],
+        None,
+    )?;
+    out.assert().success();
+
+    std::fs::write(cwd.join("test.sysml"), b"package Present;\n")?;
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "include",
+            "--compute-checksum",
+            "--no-index-symbols",
+            "test.sysml",
+        ],
+        None,
+    )?;
+    out.assert().success();
+
+    let meta_path = cwd.join(".meta.json");
+    let mut meta: serde_json::Value = serde_json::from_str(&fs::read_to_string(&meta_path)?)?;
+    meta["index"] = json!({
+        "Missing": "test.sysml"
+    });
+    std::fs::write(&meta_path, serde_json::to_string_pretty(&meta)?)?;
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert().failure().stderr(predicate::str::contains(
+        "file `test.sysml` is missing symbol `Missing` found in index",
+    ));
+    assert!(!cwd.join("test_build.kpar").exists());
+
+    Ok(())
+}
+
+#[test]
+fn project_build_warns_when_file_symbol_is_missing_from_index()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "test_build_missing_index_entry",
+        ],
+        None,
+    )?;
+    out.assert().success();
+
+    std::fs::write(cwd.join("test.sysml"), b"package Present;\n")?;
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "include",
+            "--compute-checksum",
+            "--no-index-symbols",
+            "test.sysml",
+        ],
+        None,
+    )?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert().success().stderr(predicate::str::contains(
+        "index is missing symbol `Present` found in file `test.sysml`",
+    ));
+    assert!(cwd.join("test_build.kpar").exists());
+
+    Ok(())
+}
+
 /// Build a project that has a path (`file:`) usage
 #[test]
 fn project_build_path_usage() -> Result<(), Box<dyn std::error::Error>> {

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -2,16 +2,21 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use assert_cmd::prelude::*;
+use camino::Utf8PathBuf;
 use clap::ValueEnum;
 use predicates::prelude::*;
-use std::io::{Read, Write};
+use serde_json::json;
+use std::{
+    fs,
+    io::{Read, Write},
+};
 use sysand::cli::KparCompressionMethodCli;
 use sysand_core::{
-    model::{InterchangeProjectChecksumRaw, KerMlChecksumAlg},
-    project::{
-        ProjectRead,
-        local_kpar::{KparInnerPath, LocalKParProject},
+    model::{
+        InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw,
+        KerMlChecksumAlg,
     },
+    project::{ProjectRead, local_kpar::LocalKParProjectRaw},
 };
 
 // pub due to https://github.com/rust-lang/rust/issues/46379
@@ -30,6 +35,10 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
     let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
 
     out.assert().success();
+    let orig_info_path = cwd.join(".project.json");
+    let orig_meta_path = cwd.join(".meta.json");
+    let orig_info_contents = fs::read_to_string(&orig_info_path)?;
+    let orig_meta_contents = fs::read_to_string(&orig_meta_path)?;
 
     let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
 
@@ -46,19 +55,33 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
         .stdout(predicate::str::contains("Name: test_build"))
         .stdout(predicate::str::contains("Version: 1.2.3"));
 
-    let kpar_project = LocalKParProject::new(
-        cwd.join("test_build.kpar"),
-        KparInnerPath::Guess,
-        None,
-        None,
-    );
+    let kpar_project = LocalKParProjectRaw::new_guess_root(cwd.join("test_build.kpar"))?;
+
+    let (Some(info), Some(meta)) = kpar_project.get_project()? else {
+        panic!("failed to get built project info/meta");
+    };
+
+    // Ensure the build artifact matches original project
+    let original_meta: InterchangeProjectMetadataRaw = serde_json::from_str(&orig_meta_contents)?;
+    let original_info: InterchangeProjectInfoRaw = serde_json::from_str(&orig_info_contents)?;
+    assert_eq!(original_info, info);
+    assert_eq!(original_meta, meta);
+
+    // Ensure no changes were made to the original project
+    let new_info_contents = fs::read_to_string(&orig_info_path)?;
+    let new_meta_contents = fs::read_to_string(&orig_meta_path)?;
+    assert_eq!(orig_info_contents, new_info_contents);
+    assert_eq!(orig_meta_contents, new_meta_contents);
+
+    // Now canonicalize meta during build
+    let out = run_sysand_in(&cwd, ["build", "--update-meta", "./test_build2.kpar"], None)?;
+    out.assert().success();
+    let kpar_project = LocalKParProjectRaw::new_guess_root(cwd.join("test_build2.kpar"))?;
 
     let (Some(_), Some(meta)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta");
     };
-
-    // Ensure things get canonicalised during build
-
+    // File hash should be updated
     assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
     assert_eq!(
         meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
@@ -70,6 +93,12 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(meta.index.len(), 1);
     assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+
+    // Ensure no changes were made to the original project
+    let new_info_contents = fs::read_to_string(&orig_info_path)?;
+    let new_meta_contents = fs::read_to_string(&orig_meta_path)?;
+    assert_eq!(orig_info_contents, new_info_contents);
+    assert_eq!(orig_meta_contents, new_meta_contents);
 
     Ok(())
 }
@@ -122,12 +151,7 @@ fn project_build_path_usage() -> Result<(), Box<dyn std::error::Error>> {
         .stdout(predicate::str::contains("Version: 1.2.3"))
         .stdout(predicate::str::contains(file_url_from_path(&cwd2)));
 
-    let kpar_project = LocalKParProject::new(
-        cwd1.join("test_build.kpar"),
-        KparInnerPath::Guess,
-        None,
-        None,
-    );
+    let kpar_project = LocalKParProjectRaw::new_guess_root(cwd1.join("test_build.kpar"))?;
 
     let (Some(_), Some(_)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta");
@@ -136,11 +160,36 @@ fn project_build_path_usage() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+struct WProject {
+    name: String,
+    info_path: Utf8PathBuf,
+    meta_path: Utf8PathBuf,
+    orig_info_contents: String,
+    orig_meta_contents: String,
+}
+impl WProject {
+    fn new(cwd: Utf8PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
+        let name = cwd.file_name().unwrap().to_owned();
+        let info_path = cwd.join(".project.json");
+        let meta_path = cwd.join(".meta.json");
+        let orig_info_contents = fs::read_to_string(&info_path)?;
+        let orig_meta_contents = fs::read_to_string(&meta_path)?;
+        Ok(Self {
+            name,
+            info_path,
+            meta_path,
+            orig_info_contents,
+            orig_meta_contents,
+        })
+    }
+}
+
 #[test]
 fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd) = new_temp_cwd()?;
     let project_group_cwd = cwd.join("subgroup");
     std::fs::create_dir(&project_group_cwd)?;
+
     let project1_cwd = project_group_cwd.join("project1");
     let project2_cwd = project_group_cwd.join("project2");
     let project3_cwd = cwd.join("project3");
@@ -148,19 +197,25 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
     // Create .workspace.json file
     std::fs::write(
         cwd.join(".workspace.json"),
-        br#"{"projects": [
-            {"path": "subgroup/project1", "iris": ["urn:kpar:project1"]},
-            {"path": "subgroup/project2", "iris": ["urn:kpar:project2"]},
-            {"path": "project3", "iris": ["urn:kpar:project3"]}
-            ]}"#,
+        json!({"projects": [
+        {"path": "subgroup/project1", "iris": ["urn:kpar:project1"]},
+        {"path": "subgroup/project2", "iris": ["urn:kpar:project2"]},
+        {"path": "project3", "iris": ["urn:kpar:project3"]}
+        ]})
+        .to_string(),
     )?;
 
     for project_cwd in [&project1_cwd, &project2_cwd, &project3_cwd] {
         std::fs::create_dir(project_cwd)?;
-        let project_name = project_cwd.file_name().unwrap();
         let out = run_sysand_in(
             project_cwd,
-            ["init", "--version", "1.2.3", "--name", project_name],
+            [
+                "init",
+                "--version",
+                "1.2.3",
+                "--name",
+                project_cwd.file_name().unwrap(),
+            ],
             None,
         )?;
         out.assert().success();
@@ -174,13 +229,19 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
         out.assert().success();
     }
 
+    let projects = [
+        WProject::new(project1_cwd)?,
+        WProject::new(project2_cwd)?,
+        WProject::new(project3_cwd)?,
+    ];
+
     let out = run_sysand_in(&cwd, ["build"], None)?;
     out.assert().success();
 
-    for project_name in ["project1", "project2", "project3"] {
+    for project in &projects {
         let kpar_path = cwd
             .join("output")
-            .join(format!("{}-1.2.3.kpar", project_name));
+            .join(format!("{}-1.2.3.kpar", project.name));
         assert!(
             kpar_path.is_file(),
             "kpar file does not exist: {}",
@@ -191,29 +252,103 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
 
         out.assert()
             .success()
-            .stdout(predicate::str::contains(format!("Name: {}", project_name)))
+            .stdout(predicate::str::contains(format!("Name: {}", project.name)))
             .stdout(predicate::str::contains("Version: 1.2.3"));
 
-        let kpar_project = LocalKParProject::new(kpar_path, KparInnerPath::Guess, None, None);
+        let kpar_project = LocalKParProjectRaw::new_guess_root(kpar_path)?;
+
+        let (Some(info), Some(meta)) = kpar_project.get_project()? else {
+            panic!("failed to get built project info/meta");
+        };
+
+        // Ensure the build artifact matches original project
+        let original_meta: InterchangeProjectMetadataRaw =
+            serde_json::from_str(&project.orig_meta_contents)?;
+        let original_info: InterchangeProjectInfoRaw =
+            serde_json::from_str(&project.orig_info_contents)?;
+        assert_eq!(original_info, info);
+        assert_eq!(original_meta, meta);
+
+        // Ensure no changes were made to the original project
+        let new_info_contents = fs::read_to_string(&project.info_path)?;
+        let new_meta_contents = fs::read_to_string(&project.meta_path)?;
+        assert_eq!(project.orig_info_contents, new_info_contents);
+        assert_eq!(project.orig_meta_contents, new_meta_contents);
+
+        // out.assert()
+        //     .success()
+        //     .stdout(predicate::str::contains(format!("Name: {}", project.name)))
+        //     .stdout(predicate::str::contains("Version: 1.2.3"));
+
+        // let kpar_project = LocalKParProject::new_guess_root(kpar_path)?;
+
+        // let (Some(_), Some(meta)) = kpar_project.get_project()? else {
+        //     panic!("failed to get built project info/meta");
+        // };
+
+        // // Ensure things get canonicalised during build
+
+        // assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
+        // assert_eq!(
+        //     meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
+        //     &InterchangeProjectChecksumRaw {
+        //         value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8"
+        //             .to_string(),
+        //         algorithm: KerMlChecksumAlg::Sha256.into(),
+        //     }
+        // );
+
+        // assert_eq!(meta.index.len(), 1);
+        // assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+    }
+
+    // Now canonicalize meta during build. Previous artifacts should be overwritten
+    let out = run_sysand_in(&cwd, ["build", "--update-meta"], None)?;
+    out.assert().success();
+
+    for project in &projects {
+        println!("W9: {}", project.name);
+        let kpar_path = cwd
+            .join("output")
+            .join(format!("{}-1.2.3.kpar", project.name));
+        assert!(
+            kpar_path.is_file(),
+            "kpar file does not exist: {}",
+            kpar_path
+        );
+
+        let out = run_sysand_in(&cwd, ["info", "--path", kpar_path.as_str()], None)?;
+
+        out.assert()
+            .success()
+            .stdout(predicate::str::contains(format!("Name: {}", project.name)))
+            .stdout(predicate::str::contains("Version: 1.2.3"));
+
+        let kpar_project = LocalKParProjectRaw::new_guess_root(kpar_path)?;
 
         let (Some(_), Some(meta)) = kpar_project.get_project()? else {
             panic!("failed to get built project info/meta");
         };
 
-        // Ensure things get canonicalised during build
-
+        // File hash should be updated
         assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
         assert_eq!(
             meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
             &InterchangeProjectChecksumRaw {
                 value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8"
                     .to_string(),
-                algorithm: KerMlChecksumAlg::Sha256.into(),
+                algorithm: KerMlChecksumAlg::Sha256.into()
             }
         );
 
         assert_eq!(meta.index.len(), 1);
         assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+
+        // Ensure no changes were made to the original project
+        let new_info_contents = fs::read_to_string(&project.info_path)?;
+        let new_meta_contents = fs::read_to_string(&project.meta_path)?;
+        assert_eq!(project.orig_info_contents, new_info_contents);
+        assert_eq!(project.orig_meta_contents, new_meta_contents);
     }
 
     Ok(())
@@ -263,7 +398,7 @@ fn workspace_build_with_metamodel() -> Result<(), Box<dyn std::error::Error>> {
         kpar_path
     );
 
-    let kpar_project = LocalKParProject::new(kpar_path, KparInnerPath::Guess, None, None);
+    let kpar_project = LocalKParProjectRaw::new_guess_root(kpar_path)?;
     let (Some(_), Some(meta)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta");
     };
@@ -321,7 +456,7 @@ fn workspace_build_with_unknown_metamodel() -> Result<(), Box<dyn std::error::Er
         kpar_path
     );
 
-    let kpar_project = LocalKParProject::new(kpar_path, KparInnerPath::Guess, None, None);
+    let kpar_project = LocalKParProjectRaw::new_guess_root(kpar_path)?;
     let (Some(_), Some(meta)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta");
     };
@@ -475,7 +610,7 @@ fn workspace_build_metamodel_idempotent() -> Result<(), Box<dyn std::error::Erro
     let kpar_path = cwd.join("output").join("project1-1.0.0.kpar");
     assert!(kpar_path.is_file());
 
-    let kpar_project = LocalKParProject::new(&kpar_path, KparInnerPath::Guess, None, None);
+    let kpar_project = LocalKParProjectRaw::new_guess_root(&kpar_path)?;
     let (Some(_), Some(meta)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta");
     };
@@ -488,7 +623,7 @@ fn workspace_build_metamodel_idempotent() -> Result<(), Box<dyn std::error::Erro
     let out = run_sysand_in(&cwd, ["build"], None)?;
     out.assert().success();
 
-    let kpar_project = LocalKParProject::new(&kpar_path, KparInnerPath::Guess, None, None);
+    let kpar_project = LocalKParProjectRaw::new_guess_root(&kpar_path)?;
     let (Some(_), Some(meta)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta on second build");
     };
@@ -1051,12 +1186,7 @@ fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::erro
         .stdout(predicate::str::contains("Name: test_build"))
         .stdout(predicate::str::contains("Version: 1.2.3"));
 
-    let kpar_project = LocalKParProject::new(
-        cwd.join("test_build.kpar"),
-        KparInnerPath::Guess,
-        None,
-        None,
-    );
+    let kpar_project = LocalKParProjectRaw::new_guess_root(cwd.join("test_build.kpar"))?;
 
     let (Some(info), Some(meta)) = kpar_project.get_project()? else {
         panic!("failed to get built project info/meta");
@@ -1066,8 +1196,7 @@ fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::erro
     assert_eq!(info.version, "1.2.3");
 
     assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
-    assert_eq!(meta.index.len(), 1);
-    assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+    assert_eq!(meta.index.len(), 0);
     let mut src = String::new();
     kpar_project
         .read_source("test.sysml")?

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -274,32 +274,6 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
         let new_meta_contents = fs::read_to_string(&project.meta_path)?;
         assert_eq!(project.orig_info_contents, new_info_contents);
         assert_eq!(project.orig_meta_contents, new_meta_contents);
-
-        // out.assert()
-        //     .success()
-        //     .stdout(predicate::str::contains(format!("Name: {}", project.name)))
-        //     .stdout(predicate::str::contains("Version: 1.2.3"));
-
-        // let kpar_project = LocalKParProject::new_guess_root(kpar_path)?;
-
-        // let (Some(_), Some(meta)) = kpar_project.get_project()? else {
-        //     panic!("failed to get built project info/meta");
-        // };
-
-        // // Ensure things get canonicalised during build
-
-        // assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
-        // assert_eq!(
-        //     meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
-        //     &InterchangeProjectChecksumRaw {
-        //         value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8"
-        //             .to_string(),
-        //         algorithm: KerMlChecksumAlg::Sha256.into(),
-        //     }
-        // );
-
-        // assert_eq!(meta.index.len(), 1);
-        // assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
     }
 
     // Now canonicalize meta during build. Previous artifacts should be overwritten


### PR DESCRIPTION
[Internal ref](https://gitlab.com/sensmetry/internal2/tech/syside/sysand/client/-/work_items/77)

- Don't update index symbols and file checksums by default when building a kpar.
- Add CLI option `--update-meta` that re-indexes and re-hashes all files mentioned in either `meta.index` or `meta.checksum`
- Increase stack size on Windows to prevent stack overflows (likely related to [clap issue](https://github.com/clap-rs/clap/issues/5134))