### PR TITLE
Update VS Code settings and setup instructions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
+        "charliermarsh.ruff",
         "davidanson.vscode-markdownlint",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "gruntfuggly.todo-tree",
+        "ms-python.mypy-type-checker",
         "ms-python.python",
         "rust-lang.rust-analyzer",
         "streetsidesoftware.code-spell-checker",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,11 @@
         "werr",
         "wrapfs"
     ],
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "[rust]": {
+        "editor.defaultFormatter": "rust-lang.rust-analyzer"
+    }
 }

--- a/bindings/py/DEVELOPMENT.md
+++ b/bindings/py/DEVELOPMENT.md
@@ -16,7 +16,8 @@ Python development as well.
 If using VS Code (or other compatible editor like e.g. Codium or Cursor) we
 recommended the official [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 extension from Microsoft. This will also install the Pylance, Python Debugger
-and Python Environments extensions.
+and Python Environments extensions. For formatting and linting we use [Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
+and typechecking is done by [Mypy](https://marketplace.visualstudio.com/items?itemName=ms-python.mypy-type-checker).
 
 If your editor is having problems finding imports even after installing all
 dependencies (see below), you can try to go into the settings of the Python


### PR DESCRIPTION
Add correct default formatters for Rust and Python to VS Code settings and update the setup instructions for Python to include Ruff and Mypy extensions to match pre-commits/CI.