### PR TITLE
fix(ci): disable failing job

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -70,9 +70,11 @@ jobs:
           - runner: windows-latest
             target: x64
             rust_target: x86_64-pc-windows-msvc
-          - runner: windows-11-arm
-            target: arm64 # not aarch64 because expected by setup-python
-            rust_target: aarch64-pc-windows-msvc
+            # arm64 fails in setup-python, see
+            # https://github.com/actions/partner-runner-images/issues/154
+          # - runner: windows-11-arm
+          #   target: arm64 # not aarch64 because expected by setup-python
+          #   rust_target: aarch64-pc-windows-msvc
         # It is sufficient to build wheels for the lowest supported Python
         # version, but we need to build wheels for each supported free-threaded
         # version.

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -427,12 +427,7 @@ impl StandardHTTPAuthentication {
 
         // `GlobMap` stores keys and values in parallel vectors; consume `self` so we
         // can move bearer tokens into a publish-only map without cloning secrets.
-        for (key, sequence_auth) in self
-            .restricted
-            .keys
-            .into_iter()
-            .zip(self.restricted.values.into_iter())
-        {
+        for (key, sequence_auth) in self.restricted.keys.into_iter().zip(self.restricted.values) {
             if let StandardInnerAuthentication::BearerAuth(inner) = sequence_auth.lower {
                 partial.add(key, inner);
             }

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -541,7 +541,7 @@ pub trait ProjectReadAsync {
                 });
 
                 let collected_checksums: Result<Vec<(String, InterchangeProjectChecksumRaw)>, _> =
-                    futures::future::join_all(future_checksums.into_iter())
+                    futures::future::join_all(future_checksums)
                         .await
                         .into_iter()
                         .collect();

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -338,8 +338,6 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
         }
     }
 
-    // TODO: replace this with `from(deps)` when https://github.com/pubgrub-rs/pubgrub/pull/423
-    // is merged and released
     let constraints = DependencyConstraints::from_iter(deps);
     Ok(pubgrub::Dependencies::Available(constraints))
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,6 @@
 # - Check latest stable version: rustup check
 #
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -190,13 +190,9 @@ pub fn command_add<Policy: HTTPAuthentication>(
     if !no_lock {
         let info_path = current_project.info_path();
         let info_backup = wrapfs::read_to_string(&info_path)?;
-        match do_add(&mut current_project, &usage_raw) {
-            Ok(added) => {
-                if !added {
-                    return Ok(());
-                }
-            }
-            Err(e) => return Err(e.into()),
+        let added = do_add(&mut current_project, &usage_raw)?;
+        if !added {
+            return Ok(());
         }
 
         let alias_iris = if let Some(w) = &ctx.current_workspace {


### PR DESCRIPTION
Disable python 3.14t on Windows 11 arm64, since it always fails (see https://github.com/actions/runner-images/issues/14058)