### PR TITLE
ci: release procedure rework

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -3,7 +3,7 @@ name: Java (Bindings)
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/js-wasm.yml
+++ b/.github/workflows/js-wasm.yml
@@ -3,7 +3,7 @@ name: JS/WASM (Bindings)
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -3,7 +3,7 @@ name: Prek (linting and formatting)
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ name: Python (Bindings)
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -197,25 +197,19 @@ jobs:
         run: |
           NIGHTLY_TAG=nightly
 
-          if ! gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
-            echo "GitHub release '$NIGHTLY_TAG' does not exist or cannot be accessed."
-            echo "Create it first, then rerun this workflow."
-            exit 1
+          if gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
+            gh release delete "$NIGHTLY_TAG" --yes
           fi
-
-          for asset in $(gh release view "$NIGHTLY_TAG" --json assets --jq '.assets[].name'); do
-            gh release delete-asset "$NIGHTLY_TAG" "$asset" --yes
-          done
-
-          gh release upload "$NIGHTLY_TAG" artifacts/sysand-*
 
           git tag --force "$NIGHTLY_TAG" "$GITHUB_SHA"
           git push --force origin "refs/tags/$NIGHTLY_TAG"
 
-          gh release edit "$NIGHTLY_TAG" \
+          gh release create "$NIGHTLY_TAG" artifacts/sysand-* \
               --title "Nightly Release" \
               --prerelease \
-              --latest=false
+              --latest=false \
+              --verify-tag
+
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: Rust (Library & CLI)
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -172,7 +172,7 @@ jobs:
   nightly-release:
     name: Nightly Release
     needs: [test, build]
-    if: github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write # for actions/attest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,13 +120,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
-          - windows-latest
-          - windows-11-arm
-          - macos-15-intel # x86
-          - macos-latest # arm64
+        include:
+          - os: ubuntu-24.04
+            asset: sysand-linux-x86_64
+            ext: ""
+          - os: ubuntu-24.04-arm
+            asset: sysand-linux-arm64
+            ext: ""
+          - os: windows-latest
+            asset: sysand-windows-x86_64.exe
+            ext: .exe
+          - os: windows-11-arm
+            asset: sysand-windows-arm64.exe
+            ext: .exe
+          - os: macos-15-intel
+            asset: sysand-macos-x86_64
+            ext: ""
+          - os: macos-latest
+            asset: sysand-macos-arm64
+            ext: ""
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -137,14 +149,13 @@ jobs:
       - name: Relocate binaries
         run: |
           mkdir -p dist
-          ext=${{ (matrix.os == 'windows-latest' || matrix.os == 'windows-11-arm') && '.exe' || '' }}
-          cp target/release/sysand${ext} dist/sysand-${{ matrix.os }}${ext}
+          cp target/release/sysand${{ matrix.ext }} dist/${{ matrix.asset }}
 
       - name: Upload binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sysand-cli-${{ matrix.os }}
-          path: dist
+          name: ${{ matrix.asset }}
+          path: dist/${{ matrix.asset }}
           if-no-files-found: error
 
   ci-gate:
@@ -170,6 +181,8 @@ jobs:
       contents: write # for "gh release create"
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
@@ -180,65 +193,28 @@ jobs:
         with:
           subject-path: "artifacts/*"
 
-      - name: Rename artifacts
+      - name: Update the nightly release
         run: |
-          mv artifacts/sysand-ubuntu-24.04 artifacts/sysand-linux-x86_64
-          mv artifacts/sysand-ubuntu-24.04-arm artifacts/sysand-linux-arm64
-          mv artifacts/sysand-windows-latest.exe artifacts/sysand-windows-x86_64.exe
-          mv artifacts/sysand-windows-11-arm.exe artifacts/sysand-windows-arm64.exe
-          mv artifacts/sysand-macos-15-intel artifacts/sysand-macos-x86_64
-          mv artifacts/sysand-macos-latest artifacts/sysand-macos-arm64
+          NIGHTLY_TAG=nightly
+          shopt -s nullglob
+          assets=(artifacts/sysand-linux-* artifacts/sysand-macos-* artifacts/sysand-windows-*)
 
-      - name: Create a nightly release
-        run: |
-          NEW_TAG=$(date +v-%Y-%m-%d-%H%M)
-          gh release create "$NEW_TAG" \
-              --title "Nightly Release $NEW_TAG" \
+          gh release view "$NIGHTLY_TAG" >/dev/null
+
+          # Remove stale assets so the floating nightly release mirrors this run.
+          while read -r asset; do
+              gh release delete-asset "$NIGHTLY_TAG" "$asset" --yes
+          done < <(gh release view "$NIGHTLY_TAG" --json assets --jq '.assets[].name')
+
+          gh release upload "$NIGHTLY_TAG" "${assets[@]}"
+
+          git tag --force "$NIGHTLY_TAG" "$GITHUB_SHA"
+          git push --force origin "refs/tags/$NIGHTLY_TAG"
+
+          gh release edit "$NIGHTLY_TAG" \
+              --title "Nightly Release" \
               --prerelease \
-              --target "$GITHUB_SHA" \
-              artifacts/*
+              --latest=false
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-
-  release:
-    name: Release
-    needs: [test, build]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write # for actions/attest
-      attestations: write # for actions/attest
-      artifact-metadata: write # for actions/attest
-      contents: write # for "gh release create"
-
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Generate artifact attestation
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        with:
-          subject-path: "artifacts/*"
-
-      - name: Rename artifacts
-        run: |
-          mv artifacts/sysand-ubuntu-24.04 artifacts/sysand-linux-x86_64
-          mv artifacts/sysand-ubuntu-24.04-arm artifacts/sysand-linux-arm64
-          mv artifacts/sysand-windows-latest.exe artifacts/sysand-windows-x86_64.exe
-          mv artifacts/sysand-windows-11-arm.exe artifacts/sysand-windows-arm64.exe
-          mv artifacts/sysand-macos-15-intel artifacts/sysand-macos-x86_64
-          mv artifacts/sysand-macos-latest artifacts/sysand-macos-arm64
-
-      - name: Create a release
-        run: |
-          gh release create "$TRIGGERING_TAG" \
-              --title "Release $TRIGGERING_TAG" \
-              --verify-tag \
-              artifacts/*
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TRIGGERING_TAG: ${{ github.ref_name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -196,17 +196,18 @@ jobs:
       - name: Update the nightly release
         run: |
           NIGHTLY_TAG=nightly
-          shopt -s nullglob
-          assets=(artifacts/sysand-linux-* artifacts/sysand-macos-* artifacts/sysand-windows-*)
 
-          gh release view "$NIGHTLY_TAG" >/dev/null
+          if ! gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
+            echo "GitHub release '$NIGHTLY_TAG' does not exist or cannot be accessed."
+            echo "Create it first, then rerun this workflow."
+            exit 1
+          fi
 
-          # Remove stale assets so the floating nightly release mirrors this run.
-          while read -r asset; do
-              gh release delete-asset "$NIGHTLY_TAG" "$asset" --yes
-          done < <(gh release view "$NIGHTLY_TAG" --json assets --jq '.assets[].name')
+          for asset in $(gh release view "$NIGHTLY_TAG" --json assets --jq '.assets[].name'); do
+            gh release delete-asset "$NIGHTLY_TAG" "$asset" --yes
+          done
 
-          gh release upload "$NIGHTLY_TAG" "${assets[@]}"
+          gh release upload "$NIGHTLY_TAG" artifacts/sysand-*
 
           git tag --force "$NIGHTLY_TAG" "$GITHUB_SHA"
           git push --force origin "refs/tags/$NIGHTLY_TAG"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+# Releasing Sysand
+
+The release procedure is coordinated with the
+[sysand-signing GitLab project][sysand-signing]. That project is the source of
+truth for signing, packaging, and publishing GitHub Release assets.
+
+At a high level, a Sysand version release starts in this repository:
+
+1. Prepare a pull request that updates the version number and any generated
+   lockfiles that must change with it.
+2. Get the release pull request reviewed and merged to `main`.
+3. Wait for the `main` CI pipelines to recreate the `nightly` GitHub Release.
+   The `nightly` release contains the raw CLI binaries used as signing inputs.
+4. Continue with the release instructions in the
+   [sysand-signing GitLab project][sysand-signing]. The signing pipeline is
+   responsible for creating the final `v*` release tag.
+
+The final version release has several publication paths:
+
+- CLI binaries are built by this repository's `Rust (Library & CLI)` workflow
+  on `main`, attached to the `nightly` GitHub Release as raw signing inputs,
+  then signed, packaged, and published to the public GitHub Release by
+  `sysand-signing`.
+- Python packages are built and published to PyPI by this repository's
+  `Python (Bindings)` workflow when `sysand-signing` creates the final `v*`
+  release tag.
+- Java artifacts are built and deployed to Maven Central by this repository's
+  `Java (Bindings)` workflow when `sysand-signing` creates the final `v*`
+  release tag.
+- Documentation is deployed by this repository's mdBook workflow when the final
+  non-prerelease GitHub Release is published.
+
+[sysand-signing]: https://gitlab.com/sensmetry/internal2/tech/syside/sysand/sysand-signing

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ truth for signing, packaging, and publishing GitHub Release assets.
 At a high level, a Sysand version release starts in this repository:
 
 1. Prepare a pull request that updates the version number and any generated
-   lockfiles that must change with it.
+   lockfiles that must change with it ([example](https://github.com/sensmetry/sysand/pull/310)).
 2. Get the release pull request reviewed and merged to `main`.
 3. Wait for the `main` CI pipelines to recreate the `nightly` GitHub Release.
    The `nightly` release contains the raw CLI binaries used as signing inputs.

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -59,19 +59,23 @@ or from [latest GitHub release][gh_rel].
   </tr>
   <tr>
     <td><strong>x86_x64</strong></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-x86_64.exe"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-x86_64"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-x86_64"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-x86_64.zip"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-x86_64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-x86_64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
   </tr>
   <tr>
     <td><strong>ARM64</strong></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-arm64.exe"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-arm64"><button><i class="fas fa-download"></i> Download</button></a></td>
-    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-arm64"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-windows-arm64.zip"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-macos-arm64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
+    <td><a href="https://github.com/sensmetry/sysand/releases/latest/download/sysand-linux-arm64.tar.xz"><button><i class="fas fa-download"></i> Download</button></a></td>
   </tr>
 </table>
 <!-- markdownlint-enable MD033 MD013 -->
-After downloading the appropriate file, installation depends on your platform:
+
+The download is an archive (`.zip` on Windows, `.tar.xz` on macOS and
+Linux) containing a single `sysand` executable (`sysand.exe` on
+Windows). After downloading, extract the archive and follow the steps
+for your platform:
 
 - [Windows (both x86_64 and ARM64)](#windows)
 - [macOS (both Intel and ARM64 (a.k.a. Apple Silicon))](#macos)
@@ -81,13 +85,14 @@ It is recommended to then [verify the installation](#verify-the-installation).
 
 ### Windows
 
-The downloaded binary can either be installed manually or by running
-a few PowerShell commands.
+The downloaded `.zip` archive contains `sysand.exe`. It can either be
+installed manually or by running a few PowerShell commands.
 
 #### Manual installation
 
-1. Move the downloaded `.exe` file to `%LOCALAPPDATA%\Programs\Sysand\sysand.exe`
-2. Add to `PATH` via Environment Variables:
+1. Right-click the downloaded `.zip` file and choose "Extract All..."
+2. Move the extracted `sysand.exe` to `%LOCALAPPDATA%\Programs\Sysand\sysand.exe`
+3. Add to `PATH` via Environment Variables:
    1. Open "Environment Variables" (search in Start menu)
    2. Under "User variables", select "Path" and click "Edit"
    3. Click "New" and add `%LOCALAPPDATA%\Programs\Sysand`
@@ -101,15 +106,17 @@ a few PowerShell commands.
 ```powershell
 # For x86_64 systems
 
-# Create directory and move to it
+# Create directory and extract the archive into it
 mkdir "$env:LOCALAPPDATA\Programs\Sysand" -Force
-mv sysand-windows-x86_64.exe "$env:LOCALAPPDATA\Programs\Sysand\sysand.exe"
+Expand-Archive -Path sysand-windows-x86_64.zip `
+  -DestinationPath "$env:LOCALAPPDATA\Programs\Sysand" -Force
 
 # For ARM64 systems
 
-# Create directory and move to it
+# Create directory and extract the archive into it
 mkdir "$env:LOCALAPPDATA\Programs\Sysand" -Force
-mv sysand-windows-arm64.exe "$env:LOCALAPPDATA\Programs\Sysand\sysand.exe"
+Expand-Archive -Path sysand-windows-arm64.zip `
+  -DestinationPath "$env:LOCALAPPDATA\Programs\Sysand" -Force
 ```
 
 3. Add folder to `PATH`:
@@ -131,17 +138,17 @@ if ($currentPath -notlike "*$newPath*") {
 #### System installation (requires `sudo`)
 
 1. Open Terminal
-2. Make the binary executable and move to a folder in `PATH` by running the
-   following commands:
+2. Extract the archive and move the `sysand` binary to a folder in
+   `PATH` by running the following commands:
 
 ```sh
 # For Intel Macs
-chmod +x ~/Downloads/sysand-macos-x86_64
-sudo mv ~/Downloads/sysand-macos-x86_64 /usr/local/bin/sysand
+tar -xJf ~/Downloads/sysand-macos-x86_64.tar.xz -C ~/Downloads
+sudo mv ~/Downloads/sysand /usr/local/bin/sysand
 
 # For Apple Silicon Macs
-chmod +x ~/Downloads/sysand-macos-arm64
-sudo mv ~/Downloads/sysand-macos-arm64 /usr/local/bin/sysand
+tar -xJf ~/Downloads/sysand-macos-arm64.tar.xz -C ~/Downloads
+sudo mv ~/Downloads/sysand /usr/local/bin/sysand
 ```
 
 #### Alternative: user installation (no `sudo` required)
@@ -169,17 +176,17 @@ source ~/.zshrc
 #### System installation (requires `sudo`)
 
 1. Open a terminal
-2. Make the binary executable and move to a folder in `PATH` by running the
-   following commands:
+2. Extract the archive and move the `sysand` binary to a folder in
+   `PATH` by running the following commands:
 
 ```sh
 # For x86_64 systems
-chmod +x sysand-linux-x86_64
-sudo mv sysand-linux-x86_64 /usr/local/bin/sysand
+tar -xJf sysand-linux-x86_64.tar.xz
+sudo mv sysand /usr/local/bin/sysand
 
 # For ARM64 systems
-chmod +x sysand-linux-arm64
-sudo mv sysand-linux-arm64 /usr/local/bin/sysand
+tar -xJf sysand-linux-arm64.tar.xz
+sudo mv sysand /usr/local/bin/sysand
 ```
 
 #### Alternative: user installation (no `sudo` required)
@@ -213,9 +220,12 @@ You should see an output similar to: `sysand X.Y.Z`
 
 ## Download development version
 
-Latest development version of Sysand can be downloaded from
-[GitHub releases][gh_rel_all] by choosing the latest release by date
-(which is usually labelled starting with "Nightly Release").
+Latest development version of Sysand can be downloaded from the
+[`nightly` GitHub release][gh_rel_nightly].
+
+> [!warning]
+> Nightly assets are raw signing inputs for release automation. They are not
+> packaged like the official release downloads above.
 
 ## Compiling from source code
 
@@ -229,4 +239,4 @@ cargo install sysand --git=https://github.com/sensmetry/sysand.git
 ```
 
 [gh_rel]: https://github.com/sensmetry/sysand/releases/latest
-[gh_rel_all]: https://github.com/sensmetry/sysand/releases/
+[gh_rel_nightly]: https://github.com/sensmetry/sysand/releases/tag/nightly

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -224,8 +224,8 @@ Latest development version of Sysand can be downloaded from the
 [`nightly` GitHub release][gh_rel_nightly].
 
 > [!warning]
-> Nightly assets are raw signing inputs for release automation. They are not
-> packaged like the official release downloads above.
+> Nightly assets are not signed and so may be prevented from running by
+> antivirus software.
 
 ## Compiling from source code
 


### PR DESCRIPTION
This PR makes us get a single moving `nightly` tag and single nightly GitHub Release, which together with [a GitLab MR](https://gitlab.com/sensmetry/internal2/tech/syside/sysand/sysand-signing/-/merge_requests/2) should help us promote it to stable releases. This was requested by @andrius-puksta-sensmetry but I don't think there is an issue about it.

Also, with this, we start providing archives of the binaries instead of the binaries directly, and that fixes #83.

Our release artifacts will be archives with an associated executable marked binary:
- `sysand-linux-arm64.tar.xz` - `sysand`
- `sysand-linux-x86_64.tar.xz` - `sysand`
- `sysand-macos-arm64.tar.xz` - `sysand`
- `sysand-macos-x86_64.tar.xz` - `sysand`
- `sysand-windows-arm64.zip` - `sysand.exe`
- `sysand-windows-x86_64.zip` - `sysand.exe`

---

I've tested this at [consideratio/sysand](https://github.com/consideRatio/sysand/actions) together with [the GitLab MR](https://gitlab.com/sensmetry/internal2/tech/syside/sysand/sysand-signing/-/merge_requests/2), but not the `sign` command, only `download`, `package`, `publish`.