### PR TITLE
docs: make navigation sections not expanded

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,3 +9,7 @@ create-missing = false
 
 [output.html]
 git-repository-url = "https://github.com/sensmetry/sysand"
+
+[output.html.fold]
+enable = true
+level = 0


### PR DESCRIPTION
## We get this

<img width="398" height="435" alt="image" src="https://github.com/user-attachments/assets/1d1e5c55-f02c-42a8-a061-98c6808b51b6" />

## Instead of this

<img width="379" height="906" alt="image" src="https://github.com/user-attachments/assets/a4394862-6313-43de-bd36-f8cd799fc72a" />
