### PR TITLE
feat(build): bundle CHANGELOG.md into kpar

### DIFF
--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -337,30 +337,37 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
         }
     }
 
-    let readme_source_path = project.project_root().map(|p| p.join("README.md"));
-    let readme_content = if let Some(readme_path) = &readme_source_path {
-        match std::fs::read_to_string(readme_path) {
-            Ok(content) => {
-                let header = crate::style::get_style_config().header;
-                let including = "Including";
-                log::info!("{header}{including:>12}{header:#} readme from `{readme_path}`");
-                Some(content)
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
-            Err(e) => {
-                return Err(FsIoError::ReadFile(readme_path.clone(), e).into());
-            }
-        }
-    } else {
-        None
-    };
+    let project_root = project.project_root();
+    let readme_content = read_optional_project_file(project_root, "README.md", "readme")?;
+    let changelog_content = read_optional_project_file(project_root, "CHANGELOG.md", "changelog")?;
 
     Ok(LocalKParProject::from_project(
         &local_project,
         path,
         compression.into(),
         readme_content.as_deref(),
+        changelog_content.as_deref(),
     )?)
+}
+
+fn read_optional_project_file(
+    project_root: Option<&Utf8Path>,
+    file_name: &str,
+    log_label: &str,
+) -> Result<Option<String>, FsIoError> {
+    let Some(file_path) = project_root.map(|p| p.join(file_name)) else {
+        return Ok(None);
+    };
+    match std::fs::read_to_string(&file_path) {
+        Ok(content) => {
+            let header = crate::style::get_style_config().header;
+            let including = "Including";
+            log::info!("{header}{including:>12}{header:#} {log_label} from `{file_path}`");
+            Ok(Some(content))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(FsIoError::ReadFile(file_path, e)),
+    }
 }
 
 pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
@@ -393,3 +400,7 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
     }
     Ok(result)
 }
+
+#[cfg(test)]
+#[path = "./build_tests.rs"]
+mod tests;

--- a/core/src/commands/build_tests.rs
+++ b/core/src/commands/build_tests.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use camino_tempfile::tempdir;
+
+use super::read_optional_project_file;
+use crate::project::utils::FsIoError;
+
+#[test]
+fn returns_none_when_project_root_is_none() {
+    let result = read_optional_project_file(None, "README.md", "readme").unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn returns_none_when_file_does_not_exist() {
+    let tmp = tempdir().unwrap();
+    let result = read_optional_project_file(Some(tmp.path()), "README.md", "readme").unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn returns_content_when_file_exists() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("CHANGELOG.md"), b"# Changelog\n- entry\n").unwrap();
+
+    let result = read_optional_project_file(Some(tmp.path()), "CHANGELOG.md", "changelog").unwrap();
+    assert_eq!(result.as_deref(), Some("# Changelog\n- entry\n"));
+}
+
+#[test]
+fn surfaces_non_not_found_io_errors() {
+    let tmp = tempdir().unwrap();
+    // A directory at the target path makes `read_to_string` fail with a
+    // non-`NotFound` error, which the helper must propagate.
+    std::fs::create_dir(tmp.path().join("README.md")).unwrap();
+
+    let err = read_optional_project_file(Some(tmp.path()), "README.md", "readme").unwrap_err();
+    match err {
+        FsIoError::ReadFile(path, _) => assert_eq!(path, tmp.path().join("README.md")),
+        other => panic!("expected FsIoError::ReadFile, got {other:?}"),
+    }
+}

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -211,6 +211,7 @@ impl LocalKParProject {
         path: P,
         compression: zip::CompressionMethod,
         readme: Option<&str>,
+        changelog: Option<&str>,
     ) -> Result<Self, IntoKparError<Pr::Error>> {
         let file = wrapfs::File::create(&path)?;
         let mut zip = zip::ZipWriter::new(file);
@@ -249,12 +250,18 @@ impl LocalKParProject {
                 .map_err(|e| FsIoError::CopyFile(source_path.into(), path.to_path_buf(), e))?;
         }
 
-        if let Some(readme_content) = readme {
-            zip.start_file("README.md", options)
-                .map_err(|e| ZipArchiveError::Write(Utf8Path::new("README.md").into(), e))?;
-            zip.write_all(readme_content.as_bytes())
-                .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
-        }
+        let mut write_optional =
+            |name: &str, content: Option<&str>| -> Result<(), IntoKparError<Pr::Error>> {
+                if let Some(content) = content {
+                    zip.start_file(name, options)
+                        .map_err(|e| ZipArchiveError::Write(Utf8Path::new(name).into(), e))?;
+                    zip.write_all(content.as_bytes())
+                        .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
+                }
+                Ok(())
+            };
+        write_optional("README.md", readme)?;
+        write_optional("CHANGELOG.md", changelog)?;
 
         zip.finish()
             .map_err(|e| ZipArchiveError::Finish(path.as_ref().into(), e))?;

--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -19,6 +19,9 @@ if none is found uses the current directory instead.
 If a `README.md` file exist at the project root, it is included in the
 `.kpar` archive.
 
+If a `CHANGELOG.md` file exist at the project root, it is included in the
+`.kpar` archive.
+
 ## Arguments
 
 - `[PATH]`: Path for the finished KPAR or KPARs. When building a

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -635,6 +635,145 @@ fn assert_kpar_no_readme(kpar_path: &camino::Utf8Path) {
     );
 }
 
+/// Build a project with a CHANGELOG.md at the project root
+#[test]
+fn project_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "test_changelog"],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    std::fs::write(
+        cwd.join("CHANGELOG.md"),
+        b"# Changelog\n\n## 1.2.3\n- Initial release\n",
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Including changelog from"));
+
+    // Verify the KPAR contains CHANGELOG.md with correct content
+    assert_kpar_changelog(
+        &cwd.join("test_build.kpar"),
+        "# Changelog\n\n## 1.2.3\n- Initial release\n",
+    );
+
+    Ok(())
+}
+
+/// Build a project without any CHANGELOG file — should succeed
+#[test]
+fn project_build_without_changelog() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "test_no_changelog"],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert().success();
+
+    // Verify the KPAR does NOT contain CHANGELOG.md
+    assert_kpar_no_changelog(&cwd.join("test_build.kpar"));
+
+    Ok(())
+}
+
+/// Build workspace with per-project CHANGELOGs
+#[test]
+fn workspace_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd) = new_temp_cwd()?;
+    let project1_cwd = cwd.join("project1");
+    let project2_cwd = cwd.join("project2");
+
+    std::fs::write(
+        cwd.join(".workspace.json"),
+        br#"{"projects": [
+            {"path": "project1", "iris": ["urn:kpar:project1"]},
+            {"path": "project2", "iris": ["urn:kpar:project2"]}
+            ]}"#,
+    )?;
+
+    for (project_cwd, changelog_content) in [
+        (&project1_cwd, "# Project 1 Changelog\n"),
+        (&project2_cwd, "# Project 2 Changelog\n"),
+    ] {
+        std::fs::create_dir(project_cwd)?;
+        let project_name = project_cwd.file_name().unwrap();
+        let out = run_sysand_in(
+            project_cwd,
+            ["init", "--version", "1.2.3", "--name", project_name],
+            None,
+        )?;
+        out.assert().success();
+
+        std::fs::write(project_cwd.join("test.sysml"), b"package P;\n")?;
+        let out = run_sysand_in(
+            project_cwd,
+            ["include", "--no-index-symbols", "test.sysml"],
+            None,
+        )?;
+        out.assert().success();
+
+        std::fs::write(
+            project_cwd.join("CHANGELOG.md"),
+            changelog_content.as_bytes(),
+        )?;
+    }
+
+    let out = run_sysand_in(&cwd, ["build"], None)?;
+    out.assert().success();
+
+    for (project_name, expected_changelog) in [
+        ("project1", "# Project 1 Changelog\n"),
+        ("project2", "# Project 2 Changelog\n"),
+    ] {
+        let kpar_path = cwd
+            .join("output")
+            .join(format!("{}-1.2.3.kpar", project_name));
+        assert!(
+            kpar_path.is_file(),
+            "kpar file does not exist: {}",
+            kpar_path
+        );
+
+        assert_kpar_changelog(&kpar_path, expected_changelog);
+    }
+
+    Ok(())
+}
+
+fn assert_kpar_changelog(kpar_path: &camino::Utf8Path, expected: &str) {
+    let file = std::fs::File::open(kpar_path).unwrap();
+    let mut archive = zip::ZipArchive::new(file).unwrap();
+    let mut changelog = archive.by_name("CHANGELOG.md").unwrap();
+    let mut content = String::new();
+    changelog.read_to_string(&mut content).unwrap();
+    assert_eq!(content, expected, "CHANGELOG mismatch in {kpar_path}");
+}
+
+fn assert_kpar_no_changelog(kpar_path: &camino::Utf8Path) {
+    let file = std::fs::File::open(kpar_path).unwrap();
+    let mut archive = zip::ZipArchive::new(file).unwrap();
+    assert!(
+        archive.by_name("CHANGELOG.md").is_err(),
+        "KPAR should not contain CHANGELOG.md: {kpar_path}"
+    );
+}
+
 fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) =
         run_sysand(["init", "--version", "1.2.3", "--name", "test_build"], None)?;


### PR DESCRIPTION
This PR mirrors the previously-implemented README.md building, but for CHANGELOG.md files.

For now, it looks only for a specifically named file without user configuration. We can handle that (together with README config) in a future PR.

The PR also prepares for upcoming LICENSE bundling by setting up helper `read_optional_project_file` and `write_optional` functions.  