### PR TITLE
feat(build): bundle LICENSES into kpar

### DIFF
--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -282,14 +282,18 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
             info.version
         ),
     }
-    if let Some(l) = info.license {
-        match spdx::Expression::parse(&l) {
-            Ok(_) => (),
-            Err(e) => {
-                log::warn!("project's license `{l}` is not a valid SPDX license expression:\n{e}")
-            }
-        }
-    }
+    let license_info: Option<(&str, spdx::Expression)> =
+        info.license
+            .as_deref()
+            .and_then(|l| match spdx::Expression::parse(l) {
+                Ok(expr) => Some((l, expr)),
+                Err(e) => {
+                    log::warn!(
+                        "project's license `{l}` is not a valid SPDX license expression:\n{e}"
+                    );
+                    None
+                }
+            });
 
     if let Some(u) = info.usage.iter().find(|x| {
         // Case-insensitively match `file:` scheme
@@ -338,15 +342,31 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     }
 
     let project_root = project.project_root();
-    let readme_content = read_optional_project_file(project_root, "README.md", "readme")?;
-    let changelog_content = read_optional_project_file(project_root, "CHANGELOG.md", "changelog")?;
+    let mut extra_files: Vec<(String, String)> = Vec::new();
+
+    if let Some(content) = read_optional_project_file(project_root, "README.md", "readme")? {
+        extra_files.push(("README.md".to_string(), content));
+    }
+    if let Some(content) = read_optional_project_file(project_root, "CHANGELOG.md", "changelog")? {
+        extra_files.push(("CHANGELOG.md".to_string(), content));
+    }
+    if let Some((license_str, expression)) = license_info.as_ref() {
+        for stem in license_file_stems(expression) {
+            let relative = format!("LICENSES/{stem}.txt");
+            match read_optional_project_file(project_root, &relative, "license")? {
+                Some(content) => extra_files.push((relative, content)),
+                None => log::warn!(
+                    "license file `{relative}` referenced by project license `{license_str}` was not found"
+                ),
+            }
+        }
+    }
 
     Ok(LocalKParProject::from_project(
         &local_project,
         path,
         compression.into(),
-        readme_content.as_deref(),
-        changelog_content.as_deref(),
+        &extra_files,
     )?)
 }
 
@@ -368,6 +388,30 @@ fn read_optional_project_file(
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(FsIoError::ReadFile(file_path, e)),
     }
+}
+
+/// Return the deduplicated, in-order list of SPDX identifiers (licenses plus
+/// any `WITH` exceptions) named in `expression`. Each identifier maps to a
+/// `LICENSES/<id>.txt` file under REUSE conventions; the `+` "or later"
+/// modifier does not affect the filename.
+pub(crate) fn license_file_stems(expression: &spdx::Expression) -> Vec<String> {
+    let mut stems: indexmap::IndexSet<String> = indexmap::IndexSet::new();
+    for req in expression.requirements() {
+        let license_name = match &req.req.license {
+            spdx::LicenseItem::Spdx { id, .. } => id.name.to_string(),
+            spdx::LicenseItem::Other(license_ref) => license_ref.to_string(),
+        };
+        stems.insert(license_name);
+
+        if let Some(addition) = &req.req.addition {
+            let addition_name = match addition {
+                spdx::AdditionItem::Spdx(id) => id.name.to_string(),
+                spdx::AdditionItem::Other(add_ref) => add_ref.to_string(),
+            };
+            stems.insert(addition_name);
+        }
+    }
+    stems.into_iter().collect()
 }
 
 pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(

--- a/core/src/commands/build_tests.rs
+++ b/core/src/commands/build_tests.rs
@@ -3,7 +3,7 @@
 
 use camino_tempfile::tempdir;
 
-use super::read_optional_project_file;
+use super::{license_file_stems, read_optional_project_file};
 use crate::project::utils::FsIoError;
 
 #[test]
@@ -40,4 +40,60 @@ fn surfaces_non_not_found_io_errors() {
         FsIoError::ReadFile(path, _) => assert_eq!(path, tmp.path().join("README.md")),
         other => panic!("expected FsIoError::ReadFile, got {other:?}"),
     }
+}
+
+fn stems(expr: &str) -> Vec<String> {
+    license_file_stems(&spdx::Expression::parse(expr).unwrap())
+}
+
+#[test]
+fn license_stems_single() {
+    assert_eq!(stems("MIT"), vec!["MIT".to_string()]);
+}
+
+#[test]
+fn license_stems_compound_or() {
+    assert_eq!(
+        stems("MIT OR Apache-2.0"),
+        vec!["MIT".to_string(), "Apache-2.0".to_string()]
+    );
+}
+
+#[test]
+fn license_stems_compound_and() {
+    assert_eq!(
+        stems("MIT AND BSD-2-Clause"),
+        vec!["MIT".to_string(), "BSD-2-Clause".to_string()]
+    );
+}
+
+#[test]
+fn license_stems_with_exception() {
+    assert_eq!(
+        stems("GPL-2.0-only WITH Classpath-exception-2.0"),
+        vec![
+            "GPL-2.0-only".to_string(),
+            "Classpath-exception-2.0".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn license_stems_license_ref() {
+    assert_eq!(
+        stems("LicenseRef-MyCustom"),
+        vec!["LicenseRef-MyCustom".to_string()]
+    );
+}
+
+#[test]
+fn license_stems_or_later_strips_plus() {
+    // `MIT+` shares its license file with `MIT` per REUSE conventions —
+    // the `+` does not appear in the bundled filename.
+    assert_eq!(stems("MIT+"), vec!["MIT".to_string()]);
+}
+
+#[test]
+fn license_stems_deduplicates() {
+    assert_eq!(stems("MIT AND MIT"), vec!["MIT".to_string()]);
 }

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -206,12 +206,16 @@ impl LocalKParProject {
         })
     }
 
+    /// Build a KPAR archive from `from`.
+    ///
+    /// `extra_files` are added to the archive alongside the project's source
+    /// files. Each entry is `(archive_path, content)`; `archive_path` uses `/`
+    /// as the separator and is interpreted relative to the archive root.
     pub fn from_project<Pr: ProjectRead, P: AsRef<Utf8Path>>(
         from: &Pr,
         path: P,
         compression: zip::CompressionMethod,
-        readme: Option<&str>,
-        changelog: Option<&str>,
+        extra_files: &[(String, String)],
     ) -> Result<Self, IntoKparError<Pr::Error>> {
         let file = wrapfs::File::create(&path)?;
         let mut zip = zip::ZipWriter::new(file);
@@ -250,18 +254,12 @@ impl LocalKParProject {
                 .map_err(|e| FsIoError::CopyFile(source_path.into(), path.to_path_buf(), e))?;
         }
 
-        let mut write_optional =
-            |name: &str, content: Option<&str>| -> Result<(), IntoKparError<Pr::Error>> {
-                if let Some(content) = content {
-                    zip.start_file(name, options)
-                        .map_err(|e| ZipArchiveError::Write(Utf8Path::new(name).into(), e))?;
-                    zip.write_all(content.as_bytes())
-                        .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
-                }
-                Ok(())
-            };
-        write_optional("README.md", readme)?;
-        write_optional("CHANGELOG.md", changelog)?;
+        for (archive_path, content) in extra_files {
+            zip.start_file(archive_path, options)
+                .map_err(|e| ZipArchiveError::Write(Utf8Path::new(archive_path).into(), e))?;
+            zip.write_all(content.as_bytes())
+                .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
+        }
 
         zip.finish()
             .map_err(|e| ZipArchiveError::Finish(path.as_ref().into(), e))?;

--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -22,6 +22,17 @@ If a `README.md` file exist at the project root, it is included in the
 If a `CHANGELOG.md` file exist at the project root, it is included in the
 `.kpar` archive.
 
+If the project's `license` field in `.project.json` is a valid SPDX License
+Expression, Sysand will look for matching files under the `LICENSES/`
+directory at the project root and include them in the `.kpar` archive.
+Filenames follow REUSE conventions: a license file is expected at
+`LICENSES/<id>.txt` for each license identifier in the expression, including
+each `WITH` exception identifier (e.g. `LicenseRef-MyCustom` →
+`LICENSES/LicenseRef-MyCustom.txt`; `GPL-2.0-only WITH Classpath-exception-2.0`
+expects both `LICENSES/GPL-2.0-only.txt` and
+`LICENSES/Classpath-exception-2.0.txt`). Missing files are reported as a
+warning; the build still succeeds.
+
 ## Arguments
 
 - `[PATH]`: Path for the finished KPAR or KPARs. When building a

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -527,8 +527,11 @@ fn project_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stderr(predicate::str::contains("Including readme from"));
 
-    // Verify the KPAR contains README.md with correct content
-    assert_kpar_readme(&cwd.join("test_build.kpar"), "# My Project\nHello world\n");
+    assert_kpar_file(
+        &cwd.join("test_build.kpar"),
+        "README.md",
+        "# My Project\nHello world\n",
+    );
 
     Ok(())
 }
@@ -551,8 +554,7 @@ fn project_build_without_readme() -> Result<(), Box<dyn std::error::Error>> {
     let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
     out.assert().success();
 
-    // Verify the KPAR does NOT contain README.md
-    assert_kpar_no_readme(&cwd.join("test_build.kpar"));
+    assert_kpar_missing(&cwd.join("test_build.kpar"), "README.md");
 
     Ok(())
 }
@@ -611,28 +613,10 @@ fn workspace_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
             kpar_path
         );
 
-        assert_kpar_readme(&kpar_path, expected_readme);
+        assert_kpar_file(&kpar_path, "README.md", expected_readme);
     }
 
     Ok(())
-}
-
-fn assert_kpar_readme(kpar_path: &camino::Utf8Path, expected: &str) {
-    let file = std::fs::File::open(kpar_path).unwrap();
-    let mut archive = zip::ZipArchive::new(file).unwrap();
-    let mut readme = archive.by_name("README.md").unwrap();
-    let mut content = String::new();
-    readme.read_to_string(&mut content).unwrap();
-    assert_eq!(content, expected, "README mismatch in {kpar_path}");
-}
-
-fn assert_kpar_no_readme(kpar_path: &camino::Utf8Path) {
-    let file = std::fs::File::open(kpar_path).unwrap();
-    let mut archive = zip::ZipArchive::new(file).unwrap();
-    assert!(
-        archive.by_name("README.md").is_err(),
-        "KPAR should not contain README.md: {kpar_path}"
-    );
 }
 
 /// Build a project with a CHANGELOG.md at the project root
@@ -659,9 +643,9 @@ fn project_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stderr(predicate::str::contains("Including changelog from"));
 
-    // Verify the KPAR contains CHANGELOG.md with correct content
-    assert_kpar_changelog(
+    assert_kpar_file(
         &cwd.join("test_build.kpar"),
+        "CHANGELOG.md",
         "# Changelog\n\n## 1.2.3\n- Initial release\n",
     );
 
@@ -686,8 +670,7 @@ fn project_build_without_changelog() -> Result<(), Box<dyn std::error::Error>> {
     let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
     out.assert().success();
 
-    // Verify the KPAR does NOT contain CHANGELOG.md
-    assert_kpar_no_changelog(&cwd.join("test_build.kpar"));
+    assert_kpar_missing(&cwd.join("test_build.kpar"), "CHANGELOG.md");
 
     Ok(())
 }
@@ -750,28 +733,273 @@ fn workspace_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
             kpar_path
         );
 
-        assert_kpar_changelog(&kpar_path, expected_changelog);
+        assert_kpar_file(&kpar_path, "CHANGELOG.md", expected_changelog);
     }
 
     Ok(())
 }
 
-fn assert_kpar_changelog(kpar_path: &camino::Utf8Path, expected: &str) {
-    let file = std::fs::File::open(kpar_path).unwrap();
-    let mut archive = zip::ZipArchive::new(file).unwrap();
-    let mut changelog = archive.by_name("CHANGELOG.md").unwrap();
-    let mut content = String::new();
-    changelog.read_to_string(&mut content).unwrap();
-    assert_eq!(content, expected, "CHANGELOG mismatch in {kpar_path}");
+/// Build a project with a single SPDX license — the matching
+/// `LICENSES/<id>.txt` is included in the KPAR.
+#[test]
+fn project_build_with_single_license() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "test_license",
+            "--license",
+            "MIT",
+        ],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    std::fs::create_dir(cwd.join("LICENSES"))?;
+    std::fs::write(cwd.join("LICENSES").join("MIT.txt"), b"MIT license text\n")?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Including license from"));
+
+    assert_kpar_file(
+        &cwd.join("test_build.kpar"),
+        "LICENSES/MIT.txt",
+        "MIT license text\n",
+    );
+
+    Ok(())
 }
 
-fn assert_kpar_no_changelog(kpar_path: &camino::Utf8Path) {
+/// Build a project with a compound SPDX expression — both license files
+/// are included.
+#[test]
+fn project_build_with_compound_license() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "test_compound_license",
+            "--license",
+            "MIT OR Apache-2.0",
+        ],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    std::fs::create_dir(cwd.join("LICENSES"))?;
+    std::fs::write(cwd.join("LICENSES").join("MIT.txt"), b"MIT body\n")?;
+    std::fs::write(
+        cwd.join("LICENSES").join("Apache-2.0.txt"),
+        b"Apache body\n",
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert().success();
+
+    assert_kpar_file(
+        &cwd.join("test_build.kpar"),
+        "LICENSES/MIT.txt",
+        "MIT body\n",
+    );
+    assert_kpar_file(
+        &cwd.join("test_build.kpar"),
+        "LICENSES/Apache-2.0.txt",
+        "Apache body\n",
+    );
+
+    Ok(())
+}
+
+/// Build a project with a `WITH` exception — both the license and the
+/// exception file are included.
+#[test]
+fn project_build_with_license_exception() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "test_license_with",
+            "--license",
+            "GPL-2.0-only WITH Classpath-exception-2.0",
+        ],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    std::fs::create_dir(cwd.join("LICENSES"))?;
+    std::fs::write(cwd.join("LICENSES").join("GPL-2.0-only.txt"), b"GPL body\n")?;
+    std::fs::write(
+        cwd.join("LICENSES").join("Classpath-exception-2.0.txt"),
+        b"Classpath exception body\n",
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert().success();
+
+    assert_kpar_file(
+        &cwd.join("test_build.kpar"),
+        "LICENSES/GPL-2.0-only.txt",
+        "GPL body\n",
+    );
+    assert_kpar_file(
+        &cwd.join("test_build.kpar"),
+        "LICENSES/Classpath-exception-2.0.txt",
+        "Classpath exception body\n",
+    );
+
+    Ok(())
+}
+
+/// Build a project with a custom `LicenseRef-` identifier — the matching
+/// file is bundled verbatim.
+#[test]
+fn project_build_with_license_ref() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "test_license_ref",
+            "--license",
+            "LicenseRef-MyCustom",
+        ],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    std::fs::create_dir(cwd.join("LICENSES"))?;
+    std::fs::write(
+        cwd.join("LICENSES").join("LicenseRef-MyCustom.txt"),
+        b"Custom license body\n",
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert().success();
+
+    assert_kpar_file(
+        &cwd.join("test_build.kpar"),
+        "LICENSES/LicenseRef-MyCustom.txt",
+        "Custom license body\n",
+    );
+
+    Ok(())
+}
+
+/// Build a project that declares a license but ships no matching file —
+/// the build succeeds and warns about the missing license file.
+#[test]
+fn project_build_with_license_file_missing() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "test_missing_license",
+            "--license",
+            "MIT",
+        ],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("LICENSES/MIT.txt"));
+
+    assert_kpar_missing(&cwd.join("test_build.kpar"), "LICENSES/MIT.txt");
+
+    Ok(())
+}
+
+/// Build a project without any license — no LICENSES/* entries are added.
+#[test]
+fn project_build_without_license() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "test_no_license"],
+        None,
+    )?;
+
+    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "--no-index-symbols", "test.sysml"], None)?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    out.assert().success();
+
+    assert_kpar_no_licenses_dir(&cwd.join("test_build.kpar"));
+
+    Ok(())
+}
+
+fn assert_kpar_file(kpar_path: &camino::Utf8Path, archive_path: &str, expected: &str) {
+    let file = std::fs::File::open(kpar_path).unwrap();
+    let mut archive = zip::ZipArchive::new(file).unwrap();
+    let mut entry = archive
+        .by_name(archive_path)
+        .unwrap_or_else(|_| panic!("expected {archive_path} in {kpar_path}"));
+    let mut content = String::new();
+    entry.read_to_string(&mut content).unwrap();
+    assert_eq!(content, expected, "{archive_path} mismatch in {kpar_path}");
+}
+
+fn assert_kpar_missing(kpar_path: &camino::Utf8Path, archive_path: &str) {
     let file = std::fs::File::open(kpar_path).unwrap();
     let mut archive = zip::ZipArchive::new(file).unwrap();
     assert!(
-        archive.by_name("CHANGELOG.md").is_err(),
-        "KPAR should not contain CHANGELOG.md: {kpar_path}"
+        archive.by_name(archive_path).is_err(),
+        "KPAR should not contain {archive_path}: {kpar_path}"
     );
+}
+
+fn assert_kpar_no_licenses_dir(kpar_path: &camino::Utf8Path) {
+    let file = std::fs::File::open(kpar_path).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    for name in archive.file_names() {
+        assert!(
+            !name.starts_with("LICENSES/"),
+            "KPAR should not contain any LICENSES/ entries but found {name}: {kpar_path}"
+        );
+    }
 }
 
 fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
This PR mirrors the previously-implemented README.md and CHANGELOG.md bundling.

For now, it looks for license files in a pre-defined top-level `LICENSES/` folder. In it, it tries to look for `.txt` license files named after the license expression in the `.project.json` file:

- `"license": "MIT",` looks for `LICENSES/MIT.txt`
- `"license": "LicenseRef-MyCustom",` looks for `LICENSES/LicenseRef-MyCustom.txt`
- `"license": "MIT OR Apache-2.0",` looks for both `LICENSES/MIT.txt` and `LICENSES/Apache-2.0.txt`

We can handle custom license folders (together with README/CHANGELOG config) in a future PR.