### PR TITLE
feat!: rename `sysand_env` to `.sysand`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -253,10 +253,10 @@ Captures a project's resolved usages and their dependencies.
 The `sysand lock` command regenerates this file, recording each project's name,
 version, exported symbols, dependency usages, sources (local paths, index URLs,
 git repos, etc.), and a content checksum. The `sysand sync` command reads
-`sysand-lock.toml` to populate `sysand_env`, and will run `lock` first if the
+`sysand-lock.toml` to populate `.sysand`, and will run `lock` first if the
 file does not yet exist.
 
-### Local environment (`sysand_env`)
+### Local environment (`.sysand`)
 
 A local environment for use by tools like `syside`. It can be initialized by
 `sysand env`, and populated with `sysand sync`.
@@ -264,7 +264,7 @@ A local environment for use by tools like `syside`. It can be initialized by
 The local environment looks like this:
 
 ```text
-sysand_env
+.sysand
  ├──env.toml
  └──lib
     ├──package_ID1_version
@@ -279,7 +279,7 @@ sysand_env
 - `version`. Taken from `.project.json`
 - `path`. Relative path of the project's directory. For non-`editable`
   projects, this is currently `lib/package_ID_version`, and is relative to
-  `sysand_env`. For `editable` projects, path is relative to the
+  `.sysand`. For `editable` projects, path is relative to the
   workspace/project root; these projects are only listed in `env.toml`, but
   are not otherwise managed by it.
 - `identifiers`. Identifiers of the project, the first one being considered

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
@@ -46,14 +46,14 @@ public class Sysand {
     public static native String defaultEnvName();
 
     /**
-     * Create a local sysand_env environment for installing dependencies.
+     * Create a local .sysand environment for installing dependencies.
      *
      * @param path
      */
     public static native void env(String path) throws com.sensmetry.sysand.exceptions.SysandException;
 
     /**
-     * Create a local sysand_env environment for installing dependencies.
+     * Create a local .sysand environment for installing dependencies.
      *
      * @param path
      */

--- a/bindings/js/spec/browser/browser_basic.spec.js
+++ b/bindings/js/spec/browser/browser_basic.spec.js
@@ -43,11 +43,9 @@ it("can initialise a project in browser local storage", async function () {
 
 it("can initialise an empty environment in browser local storage", async function () {
   sysand.do_env_js_local_storage("sysand_storage", "/");
-  expect(window.localStorage.key(0)).toBe(
-    "sysand_storage/sysand_env/entries.txt",
-  );
+  expect(window.localStorage.key(0)).toBe("sysand_storage/.sysand/entries.txt");
   expect(window.localStorage.key(1)).toBe(null);
   expect(
-    window.localStorage.getItem("sysand_storage/sysand_env/entries.txt"),
+    window.localStorage.getItem("sysand_storage/.sysand/entries.txt"),
   ).toBe("");
 });

--- a/bindings/js/tests/basic_browser.rs
+++ b/bindings/js/tests/basic_browser.rs
@@ -92,13 +92,13 @@ mod browser_tests {
 
         assert_eq!(
             local_storage.key(0),
-            Ok(Some("sysand_storage/sysand_env/entries.txt".to_string()))
+            Ok(Some("sysand_storage/.sysand/entries.txt".to_string()))
         );
         assert_eq!(local_storage.key(1), Ok(None));
 
         assert_eq!(
             local_storage
-                .get_item("sysand_storage/sysand_env/entries.txt")
+                .get_item("sysand_storage/.sysand/entries.txt")
                 .unwrap(),
             Some("".to_string())
         );

--- a/core/src/commands/sync.rs
+++ b/core/src/commands/sync.rs
@@ -174,7 +174,7 @@ where
 
         for uri in &project.identifiers {
             if is_installed(uri, &project.checksum, env)? {
-                log::debug!("`{uri}` found in sysand_env");
+                log::debug!("`{uri}` found in .sysand");
                 continue 'main_loop;
             }
         }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -21,7 +21,7 @@ pub struct ProjectContext {
     /// Path to current directory
     #[cfg(feature = "filesystem")]
     pub current_directory: Utf8PathBuf,
-    /// Metadata of the current workspace/project `sysand_env`. `Some` if
+    /// Metadata of the current workspace/project `.sysand`. `Some` if
     /// either `current_workspace` or `current_project` is `Some` and
     /// the environment metadata file exists.
     #[cfg(feature = "filesystem")]

--- a/core/src/env/local_directory/mod.rs
+++ b/core/src/env/local_directory/mod.rs
@@ -55,6 +55,9 @@ impl LocalDirectoryEnvironment {
     /// `root_dir` can be any cwd-relative/absolute path
     pub fn read<P: AsRef<Utf8Path>>(root_dir: P) -> Result<Self, EnvMetadataError> {
         let root_dir = wrapfs::canonicalize(root_dir)?;
+
+        Self::warn_if_old_sysand_env_present(&root_dir);
+
         let metadata = load_env_metadata(root_dir.join(METADATA_PATH))?;
         Ok(Self { root_dir, metadata })
     }
@@ -62,6 +65,8 @@ impl LocalDirectoryEnvironment {
     /// `root_dir` can be any cwd-relative/absolute path. `env.toml` must not exist
     pub fn create<P: AsRef<Utf8Path>>(root_dir: P) -> Result<Self, Box<FsIoError>> {
         let root_dir = wrapfs::canonicalize(root_dir)?;
+
+        Self::warn_if_old_sysand_env_present(&root_dir);
 
         let metadata = EnvMetadata::default();
         let path = root_dir.join(METADATA_PATH);
@@ -77,6 +82,9 @@ impl LocalDirectoryEnvironment {
     /// `root_dir` can be any cwd-relative/absolute path
     pub fn try_read<P: AsRef<Utf8Path>>(root_dir: P) -> Result<Option<Self>, EnvMetadataError> {
         let root_dir = root_dir.as_ref();
+
+        Self::warn_if_old_sysand_env_present(root_dir);
+
         let meta_path = root_dir.join(METADATA_PATH);
         match fs::read_to_string(&meta_path) {
             Ok(s) => {
@@ -239,6 +247,21 @@ impl LocalDirectoryEnvironment {
         let mut path = String::from(path_iter);
         path.insert_str(0, PROJECT_PATH_PREFIX);
         path.into()
+    }
+
+    fn warn_if_old_sysand_env_present(root_dir: &Utf8Path) {
+        let parent = root_dir.parent().unwrap();
+        let path = parent.join("sysand_env");
+        match fs::metadata(&path) {
+            Ok(m) => {
+                if m.is_dir() {
+                    log::warn!(
+                        "`sysand_env` directory was found; it is no longer used by sysand and should be removed"
+                    );
+                }
+            }
+            Err(e) => log::debug!("failed to get metadata of old env at `{path}`: {e}"),
+        }
     }
 
     // /// Find a project `uri` version `version` and determine its absolute path

--- a/core/src/env/local_directory/mod.rs
+++ b/core/src/env/local_directory/mod.rs
@@ -40,10 +40,10 @@ pub mod utils;
 use utils::{TryMoveError, try_move_files};
 
 // TODO: avoid cloning, maybe use `Arc`?
-/// `sysand_env` metadata. Metadata changes have to be written to `env.toml` explicitly
+/// `.sysand` metadata. Metadata changes have to be written to `env.toml` explicitly
 #[derive(Debug, Clone)]
 pub struct LocalDirectoryEnvironment {
-    /// Path of the env, including `sysand_env` part. Must be canonical
+    /// Path of the env, including `.sysand` part. Must be canonical
     root_dir: Utf8PathBuf,
     metadata: EnvMetadata,
 }
@@ -169,10 +169,10 @@ impl LocalDirectoryEnvironment {
         }
     }
 
-    /// Parent directory of the env, i.e. the directory in which `sysand_env` resides.
+    /// Parent directory of the env, i.e. the directory in which `.sysand` resides.
     /// It is assumed to be the workspace (if present) or project root, which in turn is
     /// the root of relative paths of `editable`/`workspace` projects
-    // TODO: is it correct to assume that `sysand_env` is always at workspace/project root?
+    // TODO: is it correct to assume that `.sysand` is always at workspace/project root?
     fn parent_dir(&self) -> &Utf8Path {
         // Will fail only if env is at root, i.e. `self.root_dir == /`
         self.root_dir.parent().unwrap()

--- a/core/src/env/mod.rs
+++ b/core/src/env/mod.rs
@@ -27,7 +27,7 @@ pub mod null;
 
 pub mod utils;
 
-pub const DEFAULT_ENV_NAME: &str = "sysand_env";
+pub const DEFAULT_ENV_NAME: &str = ".sysand";
 
 /// Get path segment(s) corresponding to the given `uri`
 pub fn segment_uri_generic<S: AsRef<str>, D: Digest>(uri: S) -> std::vec::IntoIter<String>

--- a/core/tests/filesystem_env.rs
+++ b/core/tests/filesystem_env.rs
@@ -74,7 +74,7 @@ version = \"0.1\"
         }
 
         assert_eq!(
-            std::fs::File::open(cwd.path().join("sysand_env/env.toml"))?
+            std::fs::File::open(cwd.path().join(".sysand/env.toml"))?
                 .metadata()?
                 .len(),
             DEFAULT_ENV_FILE_CONTENTS.len() as u64
@@ -161,15 +161,15 @@ version = \"0.1\"
         assert!(uris.contains(&uri.to_string()));
 
         // v1 project dir is fully removed
-        let v1_dir = cwd.path().join("sysand_env/lib/sysand_test.multi_1.0.0");
+        let v1_dir = cwd.path().join(".sysand/lib/sysand_test.multi_1.0.0");
         assert!(!v1_dir.exists());
 
         // v2 project dir still has its files
-        let v2_dir = cwd.path().join("sysand_env/lib/sysand_test.multi_2.0.0");
+        let v2_dir = cwd.path().join(".sysand/lib/sysand_test.multi_2.0.0");
         assert!(!ls_dir(&v2_dir).is_empty());
 
         // Persisted to disk: re-reading gives same result
-        let env2 = LocalDirectoryEnvironment::read(cwd.path().join("sysand_env"))?;
+        let env2 = LocalDirectoryEnvironment::read(cwd.path().join(".sysand"))?;
         let versions: Vec<String> = env2.versions(uri)?.into_iter().collect::<Result<_, _>>()?;
         assert_eq!(versions, vec!["2.0.0"]);
 
@@ -233,13 +233,13 @@ version = \"0.1\"
         assert!(env.get_project(other_uri, "1.0.0").is_ok());
 
         // Both project dirs are fully removed
-        let v1_dir = cwd.path().join("sysand_env/lib/sysand_test.multi_1.0.0");
-        let v2_dir = cwd.path().join("sysand_env/lib/sysand_test.multi_2.0.0");
+        let v1_dir = cwd.path().join(".sysand/lib/sysand_test.multi_1.0.0");
+        let v2_dir = cwd.path().join(".sysand/lib/sysand_test.multi_2.0.0");
         assert!(!v1_dir.exists());
         assert!(!v2_dir.exists());
 
         // Persisted to disk: re-reading gives same result
-        let env2 = LocalDirectoryEnvironment::read(cwd.path().join("sysand_env"))?;
+        let env2 = LocalDirectoryEnvironment::read(cwd.path().join(".sysand"))?;
         let versions: Vec<String> = env2.versions(uri)?.into_iter().collect::<Result<_, _>>()?;
         assert!(versions.is_empty());
 
@@ -317,17 +317,10 @@ version = \"0.1\"
             vec!["urn:sysand_test:1"]
         );
 
-        assert_eq!(ls_dir(cwd.path()), vec!["sysand_env"]);
+        assert_eq!(ls_dir(cwd.path()), vec![".sysand"]);
+        assert_eq!(ls_dir(cwd.path().join(".sysand")), vec!["env.toml", "lib"]);
         assert_eq!(
-            ls_dir(cwd.path().join("sysand_env")),
-            vec!["env.toml", "lib"]
-        );
-        assert_eq!(
-            ls_dir(
-                cwd.path()
-                    .join("sysand_env/lib")
-                    .join("sysand_test.1_1.2.3")
-            ),
+            ls_dir(cwd.path().join(".sysand/lib").join("sysand_test.1_1.2.3")),
             vec![".meta.json", ".project.json", "SomePackage.sysml"]
         );
 

--- a/docs/src/commands/env.md
+++ b/docs/src/commands/env.md
@@ -1,6 +1,6 @@
 # `sysand env`
 
-Create a local `sysand_env` environment for installing dependencies
+Create a local `.sysand` environment for installing dependencies
 
 ## Usage
 
@@ -10,7 +10,7 @@ sysand env [OPTIONS]
 
 ## Description
 
-Creates an empty `sysand_env` environment for the current project if no existing
+Creates an empty `.sysand` environment for the current project if no existing
 environment can be found, and otherwise leaves it unchanged.
 
 Current project is determined as in [sysand print-root](root.md) and

--- a/docs/src/commands/env/install.md
+++ b/docs/src/commands/env/install.md
@@ -1,6 +1,6 @@
 # `sysand env install`
 
-Install project in `sysand_env`
+Install project in `.sysand`
 
 ## Usage
 
@@ -10,12 +10,12 @@ sysand env install [OPTIONS] <IRI> [VERSION]
 
 ## Description
 
-Installs a given project and all it's dependencies in `sysand_env` for current project.
+Installs a given project and all it's dependencies in `.sysand` for current project.
 
 Current project is determined as in [sysand print-root](../root.md) and
 if none is found uses the current directory instead.
 
-If no existing `sysand_env` is found, a new one will be created in the same way
+If no existing `.sysand` is found, a new one will be created in the same way
 as [sysand env](../env.md).
 
 ## Arguments

--- a/docs/src/commands/env/list.md
+++ b/docs/src/commands/env/list.md
@@ -1,6 +1,6 @@
 # `sysand env list`
 
-List projects installed in `sysand_env`
+List projects installed in `.sysand`
 
 ## Usage
 
@@ -10,6 +10,6 @@ sysand env list [OPTIONS]
 
 ## Description
 
-List projects installed in `sysand_env` by IRI and version.
+List projects installed in `.sysand` by IRI and version.
 
 {{#include ../partials/global_opts.md}}

--- a/docs/src/commands/env/uninstall.md
+++ b/docs/src/commands/env/uninstall.md
@@ -1,10 +1,10 @@
 # `sysand env uninstall`
 
-Uninstall project in `sysand_env`
+Uninstall project in `.sysand`
 
 ## Description
 
-Uninstalls a given project in `sysand_env`.
+Uninstalls a given project in `.sysand`.
 
 ## Usage
 

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -1,6 +1,6 @@
 # `sysand sync`
 
-Sync `sysand_env` to lockfile, creating a lockfile and `sysand_env` if needed
+Sync `.sysand` to lockfile, creating a lockfile and `.sysand` if needed
 
 ## Usage
 
@@ -11,12 +11,12 @@ sysand sync [OPTIONS]
 ## Description
 
 Installs all projects in the current projects lockfile `sysand-lock.toml` from
-the sources listed, into the local `sysand_env` environment.
+the sources listed, into the local `.sysand` environment.
 
 If a lockfile is not found, a new lockfile will be generated from the usages in
 the project information in the same way as [sysand lock](lock.md).
 
-If no existing `sysand_env` is found, a new one will be created in the same way
+If no existing `.sysand` is found, a new one will be created in the same way
 as [sysand env](env.md).
 
 Current project is determined as in [sysand print-root](root.md) and

--- a/docs/src/getting_started/tutorial.md
+++ b/docs/src/getting_started/tutorial.md
@@ -90,7 +90,7 @@ sysand add urn:kpar:sysmod
 
 This may take a few seconds to run, as Sysand needs to download the project
 (and its usages as well) into a new local environment. Once finished, a file
-`sysand-lock.toml` and a directory `sysand_env` will be created. The former
+`sysand-lock.toml` and a directory `.sysand` will be created. The former
 records the precise versions of the external projects installed, so that the
 same installation can be reproduced later. The latter directory stores the added
 project and its usages.
@@ -112,7 +112,7 @@ $ sysand sources
 warning: SysML v2/KerML standard library packages are omitted by default.
          If you want to include them, pass `--include-std` flag
 /path/to/my_project/MyProject.sysml
-/path/to/my_project/sysand_env/lib/kpar.sysmod_5.0.0-alpha.2/SYSMOD.sysml
+/path/to/my_project/.sysand/lib/kpar.sysmod_5.0.0-alpha.2/SYSMOD.sysml
 ```
 
 > [!note]
@@ -122,9 +122,9 @@ warning: SysML v2/KerML standard library packages are omitted by default.
 > requested with `--include-std` for a given command
 
 > [!tip]
-> `sysand-lock.toml` is sufficient to reproduce `sysand_env` on any computer;
+> `sysand-lock.toml` is sufficient to reproduce `.sysand` on any computer;
 > therefore, we recommend checking in `sysand-lock.toml` into your version
-> control system and adding `sysand_env` to `.gitignore` (or equivalent).
+> control system and adding `.sysand` to `.gitignore` (or equivalent).
 
 ## List installed dependencies
 

--- a/docs/src/hosting_index.md
+++ b/docs/src/hosting_index.md
@@ -16,7 +16,7 @@ Sysand project index. The guide describes three ways to run the index:
 
 > [!warning]
 > Sysand is in active development. The structure of indexes and
-> `sysand_env` folders **can and will change** with future updates of Sysand. As
+> `.sysand` folders **can and will change** with future updates of Sysand. As
 > long as Sysand is on version 0.x.y, we cannot guarantee backwards
 > compatibility between different Sysand versions and indexes created using
 > different Sysand versions.
@@ -29,10 +29,10 @@ production hosting as well. Get in touch with your IT administrator to get this
 running on your company's infrastructure.
 
 The easiest way to host a project index from which to install packages is to
-expose a `sysand_env` over HTTP, since indexes and `sysand_env` share the same
+expose a `.sysand` over HTTP, since indexes and `.sysand` share the same
 structure that is understood by Sysand.
 
-### Create `sysand_env`
+### Create `.sysand`
 
 First, use the Sysand CLI to create a Sysand environment:
 
@@ -40,7 +40,7 @@ First, use the Sysand CLI to create a Sysand environment:
 sysand env
 ```
 
-This will create a `sysand_env/` folder in your current directory.
+This will create a `.sysand/` folder in your current directory.
 
 ### Add Packages to the Environment
 
@@ -81,11 +81,11 @@ to quickly start a simple HTTP server that will make the package index accessibl
 over the network. To do this, run:
 
 ```sh
-python3 -m http.server -d sysand_env 8080
+python3 -m http.server -d .sysand 8080
 ```
 
 This command executes the `http.server` module on port `8080`, and tells the
-module to expose the contents of the `sysand_env` folder to the network.
+module to expose the contents of the `.sysand` folder to the network.
 
 > [!important]
 > Python's built-in `http.server` module is **not** intended for production use.

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -201,12 +201,12 @@ pub enum Command {
         #[command(flatten)]
         resolution_opts: ResolutionOptions,
     },
-    /// Create a local `sysand_env` directory for installing dependencies
+    /// Create a local `.sysand` directory for installing dependencies
     Env {
         #[command(subcommand)]
         command: Option<EnvCommand>,
     },
-    /// Sync `sysand_env` to lockfile, creating a lockfile and `sysand_env` if needed
+    /// Sync `.sysand` to lockfile, creating a lockfile and `.sysand` if needed
     Sync {
         #[command(flatten)]
         resolution_opts: ResolutionOptions,
@@ -249,8 +249,8 @@ pub enum Command {
         subcommand: Option<InfoCommand>,
     },
     /// List source files for the current project and (optionally)
-    /// its dependencies available in `sysand_env`. Requires that
-    /// `sysand_env` is up to date, so it's recommended to run
+    /// its dependencies available in `.sysand`. Requires that
+    /// `.sysand` is up to date, so it's recommended to run
     /// `sysand sync` prior to this
     #[clap(verbatim_doc_comment)]
     Sources {
@@ -1334,7 +1334,7 @@ impl InfoCommand {
 
 #[derive(clap::Subcommand, Debug, Clone)]
 pub enum EnvCommand {
-    /// Install project in `sysand_env`
+    /// Install project in `.sysand`
     Install {
         /// IRI identifying the project to be installed
         iri: fluent_uri::Iri<String>,
@@ -1351,14 +1351,14 @@ pub enum EnvCommand {
         #[command(flatten)]
         resolution_opts: ResolutionOptions,
     },
-    /// Uninstall project in `sysand_env`
+    /// Uninstall project in `.sysand`
     Uninstall {
         /// IRI identifying the project to be uninstalled
         iri: fluent_uri::Iri<String>,
         /// Version to be uninstalled
         version: Option<String>,
     },
-    /// List projects installed in `sysand_env`
+    /// List projects installed in `.sysand`
     List,
     /// List source files for an installed project and
     /// (optionally) its dependencies

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -736,7 +736,7 @@ fn iri_or_path_to_iri(
     })
 }
 
-/// Read `root/sysand_env/` metadata
+/// Read `root/.sysand/` metadata
 pub fn get_env(root: impl AsRef<Utf8Path>) -> Result<Option<LocalDirectoryEnvironment>> {
     let environment_path = root.as_ref().join(DEFAULT_ENV_NAME);
     LocalDirectoryEnvironment::try_read(environment_path).map_err(anyhow::Error::from)

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -14,7 +14,7 @@ mod common;
 pub use common::*;
 
 /// sysand env should create an empty local environment in
-/// ./sysand_env, containing only `env.toml` file without any projects
+/// ./.sysand, containing only `env.toml` file without any projects
 #[test]
 fn env_init_empty_env() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(["env"], None)?;

--- a/sysand/tests/cli_source.rs
+++ b/sysand/tests/cli_source.rs
@@ -60,7 +60,7 @@ fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
 
     let expected_path = path.join("src.sysml");
     let dep_expected_path = path
-        .join("sysand_env/lib")
+        .join(".sysand/lib")
         .join("kpar.list_sources_dep_1.2.3")
         .join("dep_src.sysml");
     let combined_path = [&expected_path, &dep_expected_path];


### PR DESCRIPTION
Via `sed -i 's/sysand_env/.sysand/' <all files>`.

The only remaining `sysand_env` occurences are in the changelog.