### PR TITLE
feat: support sysand add/remove PURL shorthand

### DIFF
--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -10,7 +10,7 @@ use pyo3::{
 };
 use semver::{Version, VersionReq};
 use sysand_core::{
-    add::do_add,
+    add::do_add_guess,
     auth::Unauthenticated,
     build::{KParBuildError, KparCompressionMethod, do_build_kpar},
     commands::{
@@ -28,14 +28,14 @@ use sysand_core::{
     include::do_include,
     info::{InfoError, InfoProjectError, do_info, do_info_project},
     init::InitError,
-    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw, InterchangeProjectUsageRaw},
+    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::{
         ProjectRead as _,
         local_kpar::LocalKParProject,
         local_src::{LocalSrcError, LocalSrcProject},
         utils::wrapfs,
     },
-    remove::do_remove,
+    remove::do_remove_guess,
     resolve::{net_utils::create_reqwest_client, standard::standard_resolver},
     sources::{do_sources_local_src_project_no_deps, find_project_dependencies},
     stdlib::known_std_libs,
@@ -436,13 +436,7 @@ fn do_add_py(path: String, iri: String, version: Option<String>) -> PyResult<()>
     };
 
     // TODO: do dependency resolution and locking?
-    match do_add(
-        &mut project,
-        &InterchangeProjectUsageRaw {
-            resource: iri,
-            version_constraint: version,
-        },
-    ) {
+    match do_add_guess(&mut project, iri, version) {
         Ok(_added) => Ok(()),
         Err(e) => Err(PyRuntimeError::new_err(e.to_string())),
     }
@@ -460,7 +454,7 @@ fn do_remove_py(path: String, iri: String) -> PyResult<()> {
         project_path: path.into(),
     };
 
-    do_remove(&mut project, iri).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    do_remove_guess(&mut project, iri).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
     Ok(())
 }

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -53,6 +53,31 @@ def test_basic_env() -> None:
         )
 
 
+def test_add_accepts_sysand_shorthand() -> None:
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        sysand.init("test_add_accepts_sysand_shorthand", "a", "1.2.3", tmpdirname)
+
+        sysand.add(tmpdirname, "acme-labs/my.project")
+
+        assert (
+            (Path(tmpdirname) / ".project.json").read_text()
+            == '{\n  "name": "test_add_accepts_sysand_shorthand",\n  "publisher": "a",\n  "version": "1.2.3",\n  "usage": [\n    {\n      "resource": "pkg:sysand/acme-labs/my.project"\n    }\n  ]\n}\n'
+        )
+
+
+def test_remove_accepts_sysand_shorthand() -> None:
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        sysand.init("test_remove_accepts_sysand_shorthand", "a", "1.2.3", tmpdirname)
+
+        sysand.add(tmpdirname, "acme-labs/my.project")
+        sysand.remove(tmpdirname, "acme-labs/my.project")
+
+        assert (
+            (Path(tmpdirname) / ".project.json").read_text()
+            == '{\n  "name": "test_remove_accepts_sysand_shorthand",\n  "publisher": "a",\n  "version": "1.2.3",\n  "usage": []\n}\n'
+        )
+
+
 def test_basic_info(caplog: pytest.LogCaptureFixture) -> None:
     level = logging.DEBUG
     logging.basicConfig(level=level)

--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -7,6 +7,7 @@ use crate::{
         InterchangeProjectUsageG, InterchangeProjectUsageRaw, InterchangeProjectValidationError,
     },
     project::ProjectMut,
+    purl::{PKG_SYSAND_PREFIX, SysandPurlError, parse_sysand_purl},
 };
 
 const SP: char = ' ';
@@ -21,12 +22,42 @@ pub enum AddError<ProjectError> {
     MissingInfo(&'static str),
 }
 
+pub fn expand_sysand_purl_shorthand(
+    resource: &str,
+) -> Result<String, InterchangeProjectValidationError> {
+    let mut parts = resource.split('/');
+    let publisher = parts.next();
+    let name = parts.next();
+    let has_exactly_two_segments = publisher.is_some() && name.is_some() && parts.next().is_none();
+
+    // IRI always starts with `scheme:`, so differentiate from it by absence of `:`
+    if !resource.contains(':') && has_exactly_two_segments {
+        let purl = format!("{PKG_SYSAND_PREFIX}{resource}");
+        match parse_sysand_purl(&purl) {
+            Ok(Some(_)) => Ok(purl),
+            Err(source @ SysandPurlError::NotNormalized { .. }) => {
+                Err(InterchangeProjectValidationError::MalformedSysandPurl {
+                    iri: resource.to_owned(),
+                    source,
+                })
+            }
+            Ok(None) | Err(_) => Ok(resource.to_owned()),
+        }
+    } else {
+        Ok(resource.to_owned())
+    }
+}
+
 /// Ok(true) => usage added to project info
 /// Ok(false) => usage already present in project info
 pub fn do_add<P: ProjectMut>(
     project: &mut P,
     usage_raw: &InterchangeProjectUsageRaw,
 ) -> Result<bool, AddError<P::Error>> {
+    let usage_raw = InterchangeProjectUsageRaw {
+        resource: expand_sysand_purl_shorthand(&usage_raw.resource)?,
+        version_constraint: usage_raw.version_constraint.clone(),
+    };
     let usage: InterchangeProjectUsageG<String, String> = usage_raw.validate()?.into();
 
     let adding = "Adding";
@@ -109,3 +140,7 @@ pub fn do_add<P: ProjectMut>(
         ))
     }
 }
+
+#[cfg(test)]
+#[path = "./add_tests.rs"]
+mod tests;

--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -22,9 +22,11 @@ pub enum AddError<ProjectError> {
     MissingInfo(&'static str),
 }
 
-pub fn expand_sysand_purl_shorthand(
-    resource: &str,
-) -> Result<String, InterchangeProjectValidationError> {
+/// If `resource` is of shape `publisher/name`, and both satisfy Sysand PURL
+/// rules, return `Ok(Some(pkg:sysand/publisher/name))`. Otherwise, if it's of shape
+/// `string1/string2` and does not contain `:`, return error. If none of these,
+/// return `Ok(None)`, which indicates that it's likely something else
+pub fn expand_sysand_purl_shorthand(resource: &str) -> Result<Option<String>, SysandPurlError> {
     let mut parts = resource.split('/');
     let publisher = parts.next();
     let name = parts.next();
@@ -34,18 +36,38 @@ pub fn expand_sysand_purl_shorthand(
     if !resource.contains(':') && has_exactly_two_segments {
         let purl = format!("{PKG_SYSAND_PREFIX}{resource}");
         match parse_sysand_purl(&purl) {
-            Ok(Some(_)) => Ok(purl),
-            Err(source @ SysandPurlError::NotNormalized { .. }) => {
-                Err(InterchangeProjectValidationError::MalformedSysandPurl {
-                    iri: resource.to_owned(),
-                    source,
-                })
-            }
-            Ok(None) | Err(_) => Ok(resource.to_owned()),
+            Ok(Some(_)) => Ok(Some(purl)),
+            Err(SysandPurlError::WrongShape { .. }) | Ok(None) => unreachable!(),
+            Err(source) => Err(source),
         }
     } else {
-        Ok(resource.to_owned())
+        Ok(None)
     }
+}
+
+/// Like `do_add`, but try to guess how `resource` should be interpreted.
+/// Currently it can be either an IRI or `publisher/name` PURL shorthand
+pub fn do_add_guess<P: ProjectMut>(
+    project: &mut P,
+    resource: String,
+    version_constraint: Option<String>,
+) -> Result<bool, AddError<P::Error>> {
+    let usage_raw = InterchangeProjectUsageRaw {
+        resource: match expand_sysand_purl_shorthand(&resource) {
+            Ok(Some(purl)) => purl,
+            Ok(None) => resource,
+            Err(source) => {
+                return Err(AddError::Validation(
+                    InterchangeProjectValidationError::MalformedSysandPurl {
+                        iri: resource,
+                        source,
+                    },
+                ));
+            }
+        },
+        version_constraint,
+    };
+    do_add(project, &usage_raw)
 }
 
 /// Ok(true) => usage added to project info
@@ -54,10 +76,6 @@ pub fn do_add<P: ProjectMut>(
     project: &mut P,
     usage_raw: &InterchangeProjectUsageRaw,
 ) -> Result<bool, AddError<P::Error>> {
-    let usage_raw = InterchangeProjectUsageRaw {
-        resource: expand_sysand_purl_shorthand(&usage_raw.resource)?,
-        version_constraint: usage_raw.version_constraint.clone(),
-    };
     let usage: InterchangeProjectUsageG<String, String> = usage_raw.validate()?.into();
 
     let adding = "Adding";

--- a/core/src/commands/add_tests.rs
+++ b/core/src/commands/add_tests.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use crate::{
+    add::{do_add, expand_sysand_purl_shorthand},
+    model::{InterchangeProjectInfoRaw, InterchangeProjectUsageRaw},
+    project::memory::InMemoryProject,
+};
+
+fn project() -> InMemoryProject {
+    InMemoryProject {
+        info: Some(InterchangeProjectInfoRaw {
+            name: "main".to_owned(),
+            publisher: Some("publisher".to_owned()),
+            description: None,
+            version: "1.2.3".to_owned(),
+            license: None,
+            maintainer: vec![],
+            topic: vec![],
+            usage: vec![],
+            website: None,
+        }),
+        ..InMemoryProject::default()
+    }
+}
+
+#[test]
+fn purl_shorthand_expansion_keeps_two_segment_non_purl_resource() {
+    assert_eq!(
+        expand_sysand_purl_shorthand("ab/proj0").unwrap(),
+        "ab/proj0"
+    );
+}
+
+#[test]
+fn purl_shorthand_expansion_keeps_iri_resource() {
+    assert_eq!(
+        expand_sysand_purl_shorthand("https://example.com/acme-labs/my.project").unwrap(),
+        "https://example.com/acme-labs/my.project"
+    );
+}
+
+#[test]
+fn add_accepts_normalized_sysand_shorthand() {
+    let mut project = project();
+
+    do_add(
+        &mut project,
+        &InterchangeProjectUsageRaw {
+            resource: "acme-labs/my.project".to_owned(),
+            version_constraint: Some("1.2.3".to_owned()),
+        },
+    )
+    .unwrap();
+
+    let info = project.info.unwrap();
+    assert_eq!(info.usage.len(), 1);
+    assert_eq!(info.usage[0].resource, "pkg:sysand/acme-labs/my.project");
+    assert_eq!(info.usage[0].version_constraint.as_deref(), Some("^1.2.3"));
+}
+
+#[test]
+fn add_keeps_iri_resource() {
+    let mut project = project();
+
+    do_add(
+        &mut project,
+        &InterchangeProjectUsageRaw {
+            resource: "https://example.com/acme-labs/my.project".to_owned(),
+            version_constraint: None,
+        },
+    )
+    .unwrap();
+
+    let info = project.info.unwrap();
+    assert_eq!(info.usage.len(), 1);
+    assert_eq!(
+        info.usage[0].resource,
+        "https://example.com/acme-labs/my.project"
+    );
+}
+
+#[test]
+fn add_rejects_non_normalized_sysand_shorthand() {
+    let mut project = project();
+
+    let err = do_add(
+        &mut project,
+        &InterchangeProjectUsageRaw {
+            resource: "Acme Labs/My.Project".to_owned(),
+            version_constraint: None,
+        },
+    )
+    .unwrap_err();
+
+    let err = err.to_string();
+    assert!(err.contains("`Acme Labs/My.Project`"), "{err}");
+    assert!(err.contains("`pkg:sysand/acme-labs/my.project`"), "{err}");
+    assert!(project.info.unwrap().usage.is_empty());
+}

--- a/core/src/commands/add_tests.rs
+++ b/core/src/commands/add_tests.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use crate::{
-    add::{do_add, expand_sysand_purl_shorthand},
-    model::{InterchangeProjectInfoRaw, InterchangeProjectUsageRaw},
+    add::{do_add_guess, expand_sysand_purl_shorthand},
+    model::InterchangeProjectInfoRaw,
     project::memory::InMemoryProject,
 };
 
@@ -26,17 +26,17 @@ fn project() -> InMemoryProject {
 
 #[test]
 fn purl_shorthand_expansion_keeps_two_segment_non_purl_resource() {
-    assert_eq!(
-        expand_sysand_purl_shorthand("ab/proj0").unwrap(),
-        "ab/proj0"
-    );
+    assert!(matches!(
+        expand_sysand_purl_shorthand("ab/proj0"),
+        Err(crate::purl::SysandPurlError::InvalidPublisher { .. })
+    ));
 }
 
 #[test]
 fn purl_shorthand_expansion_keeps_iri_resource() {
     assert_eq!(
         expand_sysand_purl_shorthand("https://example.com/acme-labs/my.project").unwrap(),
-        "https://example.com/acme-labs/my.project"
+        None
     );
 }
 
@@ -44,12 +44,10 @@ fn purl_shorthand_expansion_keeps_iri_resource() {
 fn add_accepts_normalized_sysand_shorthand() {
     let mut project = project();
 
-    do_add(
+    do_add_guess(
         &mut project,
-        &InterchangeProjectUsageRaw {
-            resource: "acme-labs/my.project".to_owned(),
-            version_constraint: Some("1.2.3".to_owned()),
-        },
+        "acme-labs/my.project".to_owned(),
+        Some("1.2.3".to_owned()),
     )
     .unwrap();
 
@@ -63,12 +61,10 @@ fn add_accepts_normalized_sysand_shorthand() {
 fn add_keeps_iri_resource() {
     let mut project = project();
 
-    do_add(
+    do_add_guess(
         &mut project,
-        &InterchangeProjectUsageRaw {
-            resource: "https://example.com/acme-labs/my.project".to_owned(),
-            version_constraint: None,
-        },
+        "https://example.com/acme-labs/my.project".to_owned(),
+        None,
     )
     .unwrap();
 
@@ -84,14 +80,7 @@ fn add_keeps_iri_resource() {
 fn add_rejects_non_normalized_sysand_shorthand() {
     let mut project = project();
 
-    let err = do_add(
-        &mut project,
-        &InterchangeProjectUsageRaw {
-            resource: "Acme Labs/My.Project".to_owned(),
-            version_constraint: None,
-        },
-    )
-    .unwrap_err();
+    let err = do_add_guess(&mut project, "Acme Labs/My.Project".to_owned(), None).unwrap_err();
 
     let err = err.to_string();
     assert!(err.contains("`Acme Labs/My.Project`"), "{err}");

--- a/core/src/commands/remove.rs
+++ b/core/src/commands/remove.rs
@@ -21,11 +21,31 @@ pub enum RemoveError<ProjectError> {
     MissingInfo(Box<str>),
 }
 
-pub fn do_remove<P: ProjectMut, S: AsRef<str>>(
+/// Like `do_remove`, but try to guess how `resource` should be interpreted.
+/// Currently it can be either an IRI or `publisher/name` PURL shorthand
+pub fn do_remove_guess<P: ProjectMut>(
     project: &mut P,
-    iri: S,
+    resource: String,
 ) -> Result<Vec<InterchangeProjectUsageRaw>, RemoveError<P::Error>> {
-    let iri = expand_sysand_purl_shorthand(iri.as_ref())?;
+    let iri = match expand_sysand_purl_shorthand(&resource) {
+        Ok(Some(purl)) => purl,
+        Ok(None) => resource,
+        Err(source) => {
+            return Err(RemoveError::Validation(
+                InterchangeProjectValidationError::MalformedSysandPurl {
+                    iri: resource,
+                    source,
+                },
+            ));
+        }
+    };
+    do_remove(project, iri)
+}
+
+pub fn do_remove<P: ProjectMut>(
+    project: &mut P,
+    iri: String,
+) -> Result<Vec<InterchangeProjectUsageRaw>, RemoveError<P::Error>> {
     let removing = "Removing";
     let header = crate::style::get_style_config().header;
     log::info!("{header}{removing:>12}{header:#} `{}` from usages", iri);

--- a/core/src/commands/remove.rs
+++ b/core/src/commands/remove.rs
@@ -3,12 +3,18 @@
 
 use thiserror::Error;
 
-use crate::{model::InterchangeProjectUsageRaw, project::ProjectMut};
+use crate::{
+    add::expand_sysand_purl_shorthand,
+    model::{InterchangeProjectUsageRaw, InterchangeProjectValidationError},
+    project::ProjectMut,
+};
 
 #[derive(Error, Debug)]
 pub enum RemoveError<ProjectError> {
     #[error(transparent)]
     Project(ProjectError),
+    #[error(transparent)]
+    Validation(#[from] InterchangeProjectValidationError),
     #[error("could not find usage for `{0}`")]
     UsageNotFound(Box<str>),
     #[error("could not find project information for `{0}`")]
@@ -19,18 +25,16 @@ pub fn do_remove<P: ProjectMut, S: AsRef<str>>(
     project: &mut P,
     iri: S,
 ) -> Result<Vec<InterchangeProjectUsageRaw>, RemoveError<P::Error>> {
+    let iri = expand_sysand_purl_shorthand(iri.as_ref())?;
     let removing = "Removing";
     let header = crate::style::get_style_config().header;
-    log::info!(
-        "{header}{removing:>12}{header:#} `{}` from usages",
-        iri.as_ref()
-    );
+    log::info!("{header}{removing:>12}{header:#} `{}` from usages", iri);
 
     if let Some(mut info) = project.get_info().map_err(RemoveError::Project)? {
-        let popped = info.pop_usage(&iri.as_ref().to_string());
+        let popped = info.pop_usage(&iri);
 
         if popped.is_empty() {
-            Err(RemoveError::UsageNotFound(iri.as_ref().into()))
+            Err(RemoveError::UsageNotFound(iri.into_boxed_str()))
         } else {
             project
                 .put_info(&info, true)
@@ -38,6 +42,10 @@ pub fn do_remove<P: ProjectMut, S: AsRef<str>>(
             Ok(popped)
         }
     } else {
-        Err(RemoveError::MissingInfo(iri.as_ref().into()))
+        Err(RemoveError::MissingInfo(iri.into_boxed_str()))
     }
 }
+
+#[cfg(test)]
+#[path = "./remove_tests.rs"]
+mod tests;

--- a/core/src/commands/remove_tests.rs
+++ b/core/src/commands/remove_tests.rs
@@ -4,7 +4,7 @@
 use crate::{
     model::{InterchangeProjectInfoRaw, InterchangeProjectUsageRaw},
     project::memory::InMemoryProject,
-    remove::do_remove,
+    remove::do_remove_guess,
 };
 
 fn project_with_usage(resource: &str) -> InMemoryProject {
@@ -35,7 +35,7 @@ fn project() -> InMemoryProject {
 fn remove_accepts_normalized_sysand_shorthand() {
     let mut project = project();
 
-    let removed = do_remove(&mut project, "acme-labs/my.project").unwrap();
+    let removed = do_remove_guess(&mut project, "acme-labs/my.project".to_owned()).unwrap();
 
     assert_eq!(removed.len(), 1);
     assert_eq!(removed[0].resource, "pkg:sysand/acme-labs/my.project");
@@ -46,7 +46,11 @@ fn remove_accepts_normalized_sysand_shorthand() {
 fn remove_keeps_iri_resource() {
     let mut project = project_with_usage("https://example.com/acme-labs/my.project");
 
-    let removed = do_remove(&mut project, "https://example.com/acme-labs/my.project").unwrap();
+    let removed = do_remove_guess(
+        &mut project,
+        "https://example.com/acme-labs/my.project".to_owned(),
+    )
+    .unwrap();
 
     assert_eq!(removed.len(), 1);
     assert_eq!(
@@ -60,7 +64,7 @@ fn remove_keeps_iri_resource() {
 fn remove_rejects_non_normalized_sysand_shorthand() {
     let mut project = project();
 
-    let err = do_remove(&mut project, "Acme Labs/My.Project").unwrap_err();
+    let err = do_remove_guess(&mut project, "Acme Labs/My.Project".to_owned()).unwrap_err();
 
     let err = err.to_string();
     assert!(err.contains("`Acme Labs/My.Project`"), "{err}");

--- a/core/src/commands/remove_tests.rs
+++ b/core/src/commands/remove_tests.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use crate::{
+    model::{InterchangeProjectInfoRaw, InterchangeProjectUsageRaw},
+    project::memory::InMemoryProject,
+    remove::do_remove,
+};
+
+fn project_with_usage(resource: &str) -> InMemoryProject {
+    InMemoryProject {
+        info: Some(InterchangeProjectInfoRaw {
+            name: "main".to_owned(),
+            publisher: Some("publisher".to_owned()),
+            description: None,
+            version: "1.2.3".to_owned(),
+            license: None,
+            maintainer: vec![],
+            topic: vec![],
+            usage: vec![InterchangeProjectUsageRaw {
+                resource: resource.to_owned(),
+                version_constraint: None,
+            }],
+            website: None,
+        }),
+        ..InMemoryProject::default()
+    }
+}
+
+fn project() -> InMemoryProject {
+    project_with_usage("pkg:sysand/acme-labs/my.project")
+}
+
+#[test]
+fn remove_accepts_normalized_sysand_shorthand() {
+    let mut project = project();
+
+    let removed = do_remove(&mut project, "acme-labs/my.project").unwrap();
+
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0].resource, "pkg:sysand/acme-labs/my.project");
+    assert!(project.info.unwrap().usage.is_empty());
+}
+
+#[test]
+fn remove_keeps_iri_resource() {
+    let mut project = project_with_usage("https://example.com/acme-labs/my.project");
+
+    let removed = do_remove(&mut project, "https://example.com/acme-labs/my.project").unwrap();
+
+    assert_eq!(removed.len(), 1);
+    assert_eq!(
+        removed[0].resource,
+        "https://example.com/acme-labs/my.project"
+    );
+    assert!(project.info.unwrap().usage.is_empty());
+}
+
+#[test]
+fn remove_rejects_non_normalized_sysand_shorthand() {
+    let mut project = project();
+
+    let err = do_remove(&mut project, "Acme Labs/My.Project").unwrap_err();
+
+    let err = err.to_string();
+    assert!(err.contains("`Acme Labs/My.Project`"), "{err}");
+    assert!(err.contains("`pkg:sysand/acme-labs/my.project`"), "{err}");
+    assert_eq!(project.info.unwrap().usage.len(), 1);
+}

--- a/core/src/purl.rs
+++ b/core/src/purl.rs
@@ -172,7 +172,9 @@ pub fn parse_sysand_purl(iri: &str) -> Result<Option<(&str, &str)>, SysandPurlEr
         });
     };
 
-    if !is_valid_purl_name(name) || !is_valid_purl_publisher(publisher) {
+    let invalid_publisher = !is_valid_purl_publisher(publisher);
+    let invalid_name = !is_valid_purl_name(name);
+    if invalid_publisher || invalid_name {
         if is_valid_unnormalized_name(name) && is_valid_unnormalized_publisher(publisher) {
             return Err(SysandPurlError::NotNormalized {
                 purl: iri.to_owned(),
@@ -181,7 +183,7 @@ pub fn parse_sysand_purl(iri: &str) -> Result<Option<(&str, &str)>, SysandPurlEr
             });
         }
 
-        if !is_valid_purl_publisher(publisher) {
+        if invalid_publisher {
             return Err(SysandPurlError::InvalidPublisher {
                 purl: iri.to_owned(),
                 publisher: (*publisher).to_owned(),

--- a/docs/src/commands/add.md
+++ b/docs/src/commands/add.md
@@ -5,7 +5,7 @@ Add usage to project information.
 ## Usage
 
 ```sh
-sysand add [OPTIONS] <IRI|--path <PATH>> [VERSION_CONSTRAINT]
+sysand add [OPTIONS] <IRI|PUBLISHER/NAME|--path <PATH>> [VERSION_CONSTRAINT]
 ```
 
 ## Description
@@ -30,7 +30,8 @@ so future syncing will not take this into account.
 
 ## Arguments
 
-- `<IRI>`: IRI/URI/URL identifying the project to be used. See
+- `<IRI|PUBLISHER/NAME>`: IRI/URI/URL identifying the project to be used, or
+  `<publisher>/<name>` shorthand for `pkg:sysand/<publisher>/<name>`. See
   [`usage` field](../metadata.md#usage) for details.
 - `[VERSION_CONSTRAINT]`: A constraint on the allowable versions of a used
   project. Assumes that the project uses Semantic Versioning. See

--- a/docs/src/commands/remove.md
+++ b/docs/src/commands/remove.md
@@ -7,7 +7,7 @@ Will also remove project source overrides from configuration file if available.
 ## Usage
 
 ```sh
-sysand remove [OPTIONS] <IRI>
+sysand remove [OPTIONS] <IRI|PUBLISHER/NAME>
 ```
 
 ## Description
@@ -18,6 +18,7 @@ environment (creating one if not already present).
 
 ## Arguments
 
-- `<IRI>`: IRI identifying the project usage to be removed
+- `<IRI|PUBLISHER/NAME>`: IRI identifying the project usage to be removed, or
+  `<publisher>/<name>` shorthand for `pkg:sysand/<publisher>/<name>`
 
 {{#include ./partials/global_opts.md}}

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -11,7 +11,10 @@ use camino::Utf8PathBuf;
 use clap::{ValueEnum, builder::StyledStr, crate_authors};
 use fluent_uri::Iri;
 use semver::VersionReq;
-use sysand_core::build::KparCompressionMethod;
+use sysand_core::{
+    add::expand_sysand_purl_shorthand, build::KparCompressionMethod,
+    model::InterchangeProjectValidationError, purl::SysandPurlError,
+};
 use url::Url;
 
 use crate::env_vars;
@@ -269,9 +272,11 @@ pub enum Command {
 #[derive(clap::Args, Debug, Clone)]
 #[group(required = true, multiple = false)]
 pub struct AddProjectLocatorArgs {
-    /// IRI/URI/URL identifying the project to be used
-    #[clap(default_value = None, value_parser = parse_iri_suggest_path)]
-    pub iri: Option<fluent_uri::Iri<String>>,
+    /// IRI/URI/URL identifying the project to be used, or
+    /// <publisher>/<name> shorthand for pkg:sysand/<publisher>/<name>.
+    /// Paths must use --path.
+    #[clap(default_value = None, value_parser = parse_usage_locator_suggest_path)]
+    pub iri: Option<String>,
     /// Path to the project to be added. Since every usage is identified
     /// by an IRI, `file://` URL will be used to refer to the project.
     /// Warning: using this makes the project not portable between different
@@ -289,9 +294,11 @@ pub struct AddProjectLocatorArgs {
 #[derive(clap::Args, Debug, Clone)]
 #[group(required = true, multiple = false)]
 pub struct RemoveProjectLocatorArgs {
-    /// IRI identifying the project usage to be removed
-    #[clap(default_value = None, value_parser = parse_iri_suggest_path)]
-    pub iri: Option<fluent_uri::Iri<String>>,
+    /// IRI identifying the project usage to be removed, or
+    /// <publisher>/<name> shorthand for pkg:sysand/<publisher>/<name>.
+    /// Paths must use --path.
+    #[clap(default_value = None, value_parser = parse_usage_locator_suggest_path)]
+    pub iri: Option<String>,
     /// Path to the project to be removed from usages. Since every usage is
     /// identified by an IRI, the path will be transformed into a `file://` URL
     #[arg(
@@ -1719,9 +1726,29 @@ impl ValueEnum for MetamodelVersion {
     }
 }
 
-fn parse_iri_suggest_path(s: &str) -> Result<Iri<String>, String> {
-    use crate::style::USAGE;
-    Iri::parse(s.to_owned()).map_err(|(err, _val)| {
-        format!("{err}\n{USAGE}hint:{USAGE:#} if you wanted to use a path, use `--path` instead")
-    })
+fn parse_usage_locator_suggest_path(s: &str) -> Result<String, String> {
+    match Iri::parse(s.to_owned()) {
+        Ok(_) => Ok(s.to_owned()),
+        Err((err, _val)) => {
+            if is_sysand_purl_shorthand_input(s) {
+                Ok(s.to_owned())
+            } else {
+                use crate::style::USAGE;
+                Err(format!(
+                    "{err}\n{USAGE}hint:{USAGE:#} if you wanted to use a path, use `--path` instead"
+                ))
+            }
+        }
+    }
+}
+
+fn is_sysand_purl_shorthand_input(s: &str) -> bool {
+    match expand_sysand_purl_shorthand(s) {
+        Ok(expanded) => expanded != s,
+        Err(InterchangeProjectValidationError::MalformedSysandPurl {
+            source: SysandPurlError::NotNormalized { .. },
+            ..
+        }) => true,
+        Err(_) => false,
+    }
 }

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -11,10 +11,7 @@ use camino::Utf8PathBuf;
 use clap::{ValueEnum, builder::StyledStr, crate_authors};
 use fluent_uri::Iri;
 use semver::VersionReq;
-use sysand_core::{
-    add::expand_sysand_purl_shorthand, build::KparCompressionMethod,
-    model::InterchangeProjectValidationError, purl::SysandPurlError,
-};
+use sysand_core::{add::expand_sysand_purl_shorthand, build::KparCompressionMethod};
 use url::Url;
 
 use crate::env_vars;
@@ -274,9 +271,9 @@ pub enum Command {
 pub struct AddProjectLocatorArgs {
     /// IRI/URI/URL identifying the project to be used, or
     /// <publisher>/<name> shorthand for pkg:sysand/<publisher>/<name>.
-    /// Paths must use --path.
+    /// Paths must use `--path`
     #[clap(default_value = None, value_parser = parse_usage_locator_suggest_path)]
-    pub iri: Option<String>,
+    pub iri: Option<Iri<String>>,
     /// Path to the project to be added. Since every usage is identified
     /// by an IRI, `file://` URL will be used to refer to the project.
     /// Warning: using this makes the project not portable between different
@@ -296,9 +293,9 @@ pub struct AddProjectLocatorArgs {
 pub struct RemoveProjectLocatorArgs {
     /// IRI identifying the project usage to be removed, or
     /// <publisher>/<name> shorthand for pkg:sysand/<publisher>/<name>.
-    /// Paths must use --path.
+    /// Paths must use `--path`
     #[clap(default_value = None, value_parser = parse_usage_locator_suggest_path)]
-    pub iri: Option<String>,
+    pub iri: Option<Iri<String>>,
     /// Path to the project to be removed from usages. Since every usage is
     /// identified by an IRI, the path will be transformed into a `file://` URL
     #[arg(
@@ -1726,29 +1723,18 @@ impl ValueEnum for MetamodelVersion {
     }
 }
 
-fn parse_usage_locator_suggest_path(s: &str) -> Result<String, String> {
-    match Iri::parse(s.to_owned()) {
-        Ok(_) => Ok(s.to_owned()),
-        Err((err, _val)) => {
-            if is_sysand_purl_shorthand_input(s) {
-                Ok(s.to_owned())
-            } else {
-                use crate::style::USAGE;
-                Err(format!(
-                    "{err}\n{USAGE}hint:{USAGE:#} if you wanted to use a path, use `--path` instead"
-                ))
-            }
-        }
-    }
-}
-
-fn is_sysand_purl_shorthand_input(s: &str) -> bool {
-    match expand_sysand_purl_shorthand(s) {
-        Ok(expanded) => expanded != s,
-        Err(InterchangeProjectValidationError::MalformedSysandPurl {
-            source: SysandPurlError::NotNormalized { .. },
-            ..
-        }) => true,
-        Err(_) => false,
+fn parse_usage_locator_suggest_path(s: &str) -> Result<Iri<String>, String> {
+    use crate::style::USAGE;
+    match Iri::parse(s) {
+        Ok(i) => Ok(i.to_owned()),
+        Err(err) => match expand_sysand_purl_shorthand(s) {
+            Ok(Some(purl)) => Ok(Iri::parse(purl).expect("BUG: Sysand PURL is invalid IRI")),
+            Ok(None) => Err(format!(
+                "{err}\n{USAGE}hint:{USAGE:#} if you wanted to use a path, use `--path` instead"
+            )),
+            Err(e) => Err(format!(
+                "{e}\n{USAGE}hint:{USAGE:#} if you wanted to use a path, use `--path` instead"
+            )),
+        },
     }
 }

--- a/sysand/src/commands/remove.rs
+++ b/sysand/src/commands/remove.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use camino::Utf8PathBuf;
 
+use fluent_uri::Iri;
 use sysand_core::{
     config::local_fs::{CONFIG_FILE, remove_project_source_from_config},
     context::ProjectContext,
@@ -12,8 +13,8 @@ use sysand_core::{
 
 use crate::CliError;
 
-pub fn command_remove<S: AsRef<str>>(
-    iri: S,
+pub fn command_remove(
+    iri: Iri<String>,
     ctx: ProjectContext,
     config_file: Option<String>,
     no_config: bool,
@@ -30,7 +31,7 @@ pub fn command_remove<S: AsRef<str>>(
         remove_project_source_from_config(path, &iri)?;
     }
 
-    let usages = do_remove(&mut current_project, &iri)?;
+    let usages = do_remove(&mut current_project, iri.into_string())?;
 
     let removed = "Removed";
     let header = sysand_core::style::get_style_config().header;

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -22,6 +22,7 @@ use fluent_uri::Iri;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use sysand_core::{
+    add::expand_sysand_purl_shorthand,
     auth::{HTTPAuthentication, StandardHTTPAuthenticationBuilder},
     commands::lock::DEFAULT_LOCKFILE_NAME,
     config::{
@@ -632,7 +633,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             resolution_opts,
             source_opts,
         } => {
-            let iri = iri_or_path_to_iri(locator.iri, locator.path)?;
+            let iri = usage_locator_to_iri(locator.iri, locator.path)?;
             command_add(
                 iri,
                 version_constraint,
@@ -650,7 +651,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             )
         }
         Command::Remove { locator } => {
-            let iri = iri_or_path_to_iri(locator.iri, locator.path)?;
+            let iri = usage_locator_to_iri(locator.iri, locator.path)?;
             command_remove(
                 iri,
                 ctx,
@@ -750,20 +751,20 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     }
 }
 
-fn iri_or_path_to_iri(
-    iri: Option<Iri<String>>,
+fn usage_locator_to_iri(
+    iri: Option<String>,
     path: Option<Utf8PathBuf>,
 ) -> Result<Iri<String>, anyhow::Error> {
     Ok(if let Some(iri) = iri {
-        iri
+        let iri = expand_sysand_purl_shorthand(&iri)?;
+        Iri::parse(iri).expect("BUG: usage locator is invalid IRI")
     } else {
         let Some(path) = path else { unreachable!() };
         let abs_path = wrapfs::canonicalize(&path)?;
         let url: String = Url::from_file_path(abs_path)
             .map_err(|()| anyhow!("unsupported path type of `{path}`"))?
             .into();
-        // This cannot fail, since URL from a path will never have a fragment
-        Iri::parse(url).unwrap()
+        Iri::parse(url).expect("BUG: file URL from path is invalid IRI")
     })
 }
 

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -22,7 +22,6 @@ use fluent_uri::Iri;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use sysand_core::{
-    add::expand_sysand_purl_shorthand,
     auth::{HTTPAuthentication, StandardHTTPAuthenticationBuilder},
     commands::lock::DEFAULT_LOCKFILE_NAME,
     config::{
@@ -633,7 +632,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             resolution_opts,
             source_opts,
         } => {
-            let iri = usage_locator_to_iri(locator.iri, locator.path)?;
+            let iri = iri_or_path_to_iri(locator.iri, locator.path)?;
             command_add(
                 iri,
                 version_constraint,
@@ -651,7 +650,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             )
         }
         Command::Remove { locator } => {
-            let iri = usage_locator_to_iri(locator.iri, locator.path)?;
+            let iri = iri_or_path_to_iri(locator.iri, locator.path)?;
             command_remove(
                 iri,
                 ctx,
@@ -751,13 +750,12 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     }
 }
 
-fn usage_locator_to_iri(
-    iri: Option<String>,
+fn iri_or_path_to_iri(
+    iri: Option<Iri<String>>,
     path: Option<Utf8PathBuf>,
 ) -> Result<Iri<String>, anyhow::Error> {
     Ok(if let Some(iri) = iri {
-        let iri = expand_sysand_purl_shorthand(&iri)?;
-        Iri::parse(iri).expect("BUG: usage locator is invalid IRI")
+        iri
     } else {
         let Some(path) = path else { unreachable!() };
         let abs_path = wrapfs::canonicalize(&path)?;

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -63,6 +63,190 @@ fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn add_accepts_sysand_shorthand_without_lock() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "add_shorthand"],
+        None,
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["add", "--no-lock", "acme-labs/my.project"], None)?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        "Adding usage: `pkg:sysand/acme-labs/my.project`",
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "add_shorthand",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "resource": "pkg:sysand/acme-labs/my.project"
+    }
+  ]
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "reject_add_shorthand",
+        ],
+        None,
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["add", "--no-lock", "Acme Labs/My.Project"], None)?;
+
+    out.assert().failure().stderr(
+        predicate::str::contains("Acme Labs/My.Project")
+            .and(predicate::str::contains("pkg:sysand/acme-labs/my.project")),
+    );
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "reject_add_shorthand",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": []
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_path_like_positional_suggests_path_option() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, _cwd, out) = run_sysand(["add", "a/b/c"], None)?;
+
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("use `--path` instead"));
+
+    Ok(())
+}
+
+#[test]
+fn remove_accepts_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "remove_shorthand"],
+        None,
+    )?;
+
+    out.assert().success();
+
+    run_sysand_in(
+        &cwd,
+        ["add", "--no-lock", "pkg:sysand/acme-labs/my.project"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(&cwd, ["remove", "acme-labs/my.project"], None)?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        "Removed `pkg:sysand/acme-labs/my.project`",
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "remove_shorthand",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": []
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn remove_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "reject_remove_shorthand",
+        ],
+        None,
+    )?;
+
+    out.assert().success();
+
+    run_sysand_in(
+        &cwd,
+        ["add", "--no-lock", "pkg:sysand/acme-labs/my.project"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(&cwd, ["remove", "Acme Labs/My.Project"], None)?;
+
+    out.assert().failure().stderr(
+        predicate::str::contains("Acme Labs/My.Project")
+            .and(predicate::str::contains("pkg:sysand/acme-labs/my.project")),
+    );
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "reject_remove_shorthand",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "resource": "pkg:sysand/acme-labs/my.project"
+    }
+  ]
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn remove_path_like_positional_suggests_path_option() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, _cwd, out) = run_sysand(["remove", "a/b/c"], None)?;
+
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("use `--path` instead"));
+
+    Ok(())
+}
+
 /// Add and remove usages with `--path <path>`
 #[test]
 fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -1046,6 +1046,200 @@ sources = [
 // #[test]
 // fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> { ... }
 
+/// Passing the full `pkg:sysand/publisher/name` PURL form directly must not
+/// cause double-expansion. The scheme's colon prevents it from matching the
+/// `publisher/name` shorthand heuristic, so the value is stored verbatim.
+#[test]
+fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "add_full_purl"],
+        None,
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(
+        &cwd,
+        ["add", "--no-lock", "pkg:sysand/acme-labs/my.project"],
+        None,
+    )?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        "Adding usage: `pkg:sysand/acme-labs/my.project`",
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "add_full_purl",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "resource": "pkg:sysand/acme-labs/my.project"
+    }
+  ]
+}
+"#
+    );
+
+    let out = run_sysand_in(&cwd, ["remove", "pkg:sysand/acme-labs/my.project"], None)?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        r#"Removing `pkg:sysand/acme-labs/my.project` from usages
+     Removed `pkg:sysand/acme-labs/my.project`"#,
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "add_full_purl",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": []
+}
+"#
+    );
+
+    Ok(())
+}
+
+/// A `urn:` IRI whose path segment contains a slash has exactly two slash-separated
+/// parts (`urn:kpar:acme-labs` and `my.project`), making it superficially resemble
+/// `publisher/name` shorthand. The colon in the scheme must prevent any shorthand
+/// expansion so the IRI is stored and removed verbatim.
+#[test]
+fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_temp_dir, cwd, out) =
+        run_sysand(["init", "--version", "1.2.3", "--name", "urn_slash"], None)?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(
+        &cwd,
+        ["add", "--no-lock", "urn:kpar:acme-labs/my.project"],
+        None,
+    )?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        "Adding usage: `urn:kpar:acme-labs/my.project`",
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "urn_slash",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "resource": "urn:kpar:acme-labs/my.project"
+    }
+  ]
+}
+"#
+    );
+
+    let out = run_sysand_in(&cwd, ["remove", "urn:kpar:acme-labs/my.project"], None)?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        r#"Removing `urn:kpar:acme-labs/my.project` from usages
+     Removed `urn:kpar:acme-labs/my.project`"#,
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "urn_slash",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": []
+}
+"#
+    );
+
+    Ok(())
+}
+
+/// Adding via the `publisher/name` shorthand and removing via the full
+/// `pkg:sysand/publisher/name` PURL form must work — the stored resource is
+/// identical regardless of which form was used on input.
+#[test]
+fn add_shorthand_then_remove_full_purl() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "shorthand_then_full_purl",
+        ],
+        None,
+    )?;
+
+    out.assert().success();
+
+    run_sysand_in(&cwd, ["add", "--no-lock", "acme-labs/my.project"], None)?
+        .assert()
+        .success();
+
+    let out = run_sysand_in(&cwd, ["remove", "pkg:sysand/acme-labs/my.project"], None)?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        "Removed `pkg:sysand/acme-labs/my.project`",
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "shorthand_then_full_purl",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": []
+}
+"#
+    );
+
+    Ok(())
+}
+
+/// When removing a shorthand that is not present, the error message must name
+/// the expanded PURL form so the user understands what was looked up.
+#[test]
+fn remove_nonexistent_shorthand() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "remove_nonexistent_shorthand",
+        ],
+        None,
+    )?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["remove", "acme-labs/nonexistent"], None)?;
+
+    out.assert().failure().stderr(predicate::str::contains(
+        "could not find usage for `pkg:sysand/acme-labs/nonexistent`",
+    ));
+
+    Ok(())
+}
+
 #[test]
 fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir_dep, cwd_dep, out) = run_sysand(


### PR DESCRIPTION
Users can identify indexed packages as `publisher/name`, but
`sysand add` previously required the full
`pkg:sysand/publisher/name` IRI. The CLI also parsed the positional
add locator as an IRI before core add logic could apply add-specific
behavior.

Expand valid Sysand PURL shorthand in the add path so normalized
`publisher/name` input is stored as the canonical PURL. Reject shorthand
that would require normalization first. Leave other add resources to
existing usage validation. Keep the shorthand scoped to add by leaving
general project usage validation and remove parsing unchanged. Update
CLI parsing, docs, and Python binding coverage for the new add behavior.