### PR TITLE
feat: update to new docs domain and index domain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["Sensmetry <opensource@sensmetry.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sensmetry/sysand"
 description = "A package manager for SysML v2 and KerML"
-documentation = "https://docs.sysand.org"
+documentation = "https://client.sysand.com"
 homepage = "https://sysand.com"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/sensmetry/sysand"
 description = "A package manager for SysML v2 and KerML"
 documentation = "https://docs.sysand.org"
-homepage = "https://beta.sysand.org"
+homepage = "https://sysand.com"
 
 [workspace.dependencies]
 camino = { version = "1.2", features = ["serde1"] }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,7 +143,7 @@ to make sure that all tests pass locally before submitting a pull request.
 ## Documentation
 
 The "Sysand User Guide" is currently a work in progress. It is located in `docs/`.
-Official version is hosted at [docs.sysand.org](https://docs.sysand.org/).
+Official version is hosted at [client.sysand.com](https://client.sysand.com/).
 To preview it locally, make sure you have [`mdbook`](https://github.com/rust-lang/mdBook)
 installed (`cargo install mdbook`), then either run
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Java are supported).
 ## Documentation
 
 Sysand usage documentation is provided in User Guide at
-[docs.sysand.org](https://docs.sysand.org/).
+[client.sysand.com](https://client.sysand.com/).
 
 ## Installation
 
-See [installation section in User Guide](http://docs.sysand.org/getting_started/installation.html)
+See [installation section in User Guide](https://client.sysand.com/getting_started/installation.html)
 for various ways to download Sysand.
 
 ## Contributing

--- a/bindings/java/java/pom.xml
+++ b/bindings/java/java/pom.xml
@@ -13,7 +13,7 @@ SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
   <version>VERSION</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A package manager for SysML v2 and KerML.</description>
-  <url>https://sysand.org/</url>
+  <url>https://sysand.com/</url>
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>

--- a/bindings/java/plugin/pom.xml
+++ b/bindings/java/plugin/pom.xml
@@ -13,7 +13,7 @@ SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
   <packaging>maven-plugin</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Maven plugin for using Sysand.</description>
-  <url>https://sysand.org/</url>
+  <url>https://sysand.com/</url>
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>

--- a/bindings/py/pyproject.toml
+++ b/bindings/py/pyproject.toml
@@ -31,7 +31,7 @@ import-names = ["sysand"]
 
 [project.urls]
 documentation = "https://docs.sysand.org"
-homepage = "https://beta.sysand.org"
+homepage = "https://sysand.com"
 source = "https://github.com/sensmetry/sysand"
 issues = "https://github.com/sensmetry/sysand/issues"
 forum = "https://forum.sensmetry.com/c/sysand/24"

--- a/bindings/py/pyproject.toml
+++ b/bindings/py/pyproject.toml
@@ -30,7 +30,7 @@ maintainers = [
 import-names = ["sysand"]
 
 [project.urls]
-documentation = "https://docs.sysand.org"
+documentation = "https://client.sysand.com"
 homepage = "https://sysand.com"
 source = "https://github.com/sensmetry/sysand"
 issues = "https://github.com/sensmetry/sysand/issues"

--- a/core/src/project/gix_git_download_tests.rs
+++ b/core/src/project/gix_git_download_tests.rs
@@ -21,7 +21,7 @@ fn git_init(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
         .assert()
         .success();
     Command::new("git")
-        .args(["config", "user.email", "user@sysand.org"])
+        .args(["config", "user.email", "user@sysand.com"])
         .current_dir(path)
         .output()?
         .assert()

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@
 
 - [workspaces] Add `metadata` field to `.workspace.json` to allow setting metadata for the whole workspace ([#238](https://github.com/sensmetry/sysand/pull/238)). Fields from there are read and replace keys from `.meta.json` when building the kpars. Currently only `metamodel` is supported. As with all workspace functionality, this is expected to change in the future.
 - [workspaces] Allow specifying custom `meta.index` for each project in workspace ([#241](https://github.com/sensmetry/sysand/pull/241)). Currently this functionality is only exposed through Java bindings.
-- Add `sysand publish` command ([#249](https://github.com/sensmetry/sysand/pull/249)). It allows publishing to an index. Note: this is not ready for use, as `beta.sysand.org` index does not support publishing via an API yet.
+- Add `sysand publish` command ([#249](https://github.com/sensmetry/sysand/pull/249)). It allows publishing to an index. Note: this is not ready for use, as `sysand.com` index does not support publishing via an API yet.
 - Include `README.md` when building the kpar if the file is present ([#239](https://github.com/sensmetry/sysand/pull/239))
 - Add environment metadata file `env.toml`, which resides in `sysand_env` ([#175](https://github.com/sensmetry/sysand/pull/175)). Currently `entries.txt` and per-project `versions.txt` are still also used, but will be removed in the future.
 - Change formatting/linting to use pre-commit hooks, and use `prek` to run those hooks in CI instead of a separate implementations in `**/run_chores.sh` and CI ([#250](https://github.com/sensmetry/sysand/pull/250)).

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,7 +19,7 @@
 #### Added
 
 - Support git usages, using either regular or `git+` IRIs.
-- Support for configuring usage sources. See [docs](https://docs.sysand.org/config/dependencies.html) for details.
+- Support for configuring usage sources. See [docs](https://client.sysand.com/config/dependencies.html) for details.
 - Allow adding usages by path: `sysand add --path ../path/to/the/usage`. Both relative and absolute paths
   are supported. Note that this will likely not work for project sharing, since usages are stored in `.project.json` as
   absolute paths, and so are unlikely to be available on other computers at the same location.
@@ -39,8 +39,8 @@
 
 #### Documentation
 
-- Add documentation about [`sysand clone` command](https://docs.sysand.org/commands/clone.html).
-- Improve documentation about [`sysand info` command](https://docs.sysand.org/commands/info.html).
+- Add documentation about [`sysand clone` command](https://client.sysand.com/commands/clone.html).
+- Improve documentation about [`sysand info` command](https://client.sysand.com/commands/info.html).
 
 ### v0.0.9 - 2026-02-03
 

--- a/docs/src/commands/partials/resolution_opts.md
+++ b/docs/src/commands/partials/resolution_opts.md
@@ -7,7 +7,7 @@
   indexes
 - `--default-index [<DEFAULT_INDEX>...]`: Comma-delimited list of URLs to use
   as default index URLs. Default indexes are tried before other indexes
-  (default `https://beta.sysand.org`)
+  (default `https://sysand.com`)
 - `--no-index`: Do not use any index when resolving project(s) and/or their
   dependencies
 - `--include-std`: Don't ignore KerML/SysML v2 standard libraries if specified

--- a/docs/src/commands/publish.md
+++ b/docs/src/commands/publish.md
@@ -50,7 +50,7 @@ away).
 
 - `--index <URL>`: URL of the package index to publish to. Required.
   This may point to a path containing `sysand-index-config.json` (for example,
-  `https://sysand.org`), or directly to the API root that receives publish
+  `https://sysand.com`), or directly to the API root that receives publish
   uploads (for example, `https://my-index.example.com/api`).
 
 {{#include ./partials/global_opts.md}}
@@ -61,13 +61,13 @@ Build and publish the current project:
 
 ```sh
 sysand build
-sysand publish --index https://sysand.org
+sysand publish --index https://sysand.com
 ```
 
 Publish a specific KPAR file:
 
 ```sh
-sysand publish --index https://sysand.org ./my-project-1.0.0.kpar
+sysand publish --index https://sysand.com ./my-project-1.0.0.kpar
 ```
 
 Publish to a custom index:

--- a/docs/src/config/indexes.md
+++ b/docs/src/config/indexes.md
@@ -1,6 +1,6 @@
 # Indexes
 
-Sysand defaults to using the index [beta.sysand.org](https://beta.sysand.org)
+Sysand defaults to using the index [sysand.com](https://sysand.com)
 but it is possible to specify additional indexes or override this default index.
 
 URLs for additional indexes can be specified with the command line argument `--index`.
@@ -14,7 +14,7 @@ configuration files.
 
 The command line argument `--default-index` (and environment variable
 `SYSAND_DEFAULT_INDEX`) functions the same as `--index` but will override the default
-index `https://beta.sysand.org` and any default indexes defined in configuration
+index `https://sysand.com` and any default indexes defined in configuration
 files.
 
 ## Defining an index in a configuration file

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -8,7 +8,7 @@ then try out the steps in the tutorial.
 
 Some useful resources related to Sysand:
 
-- [Sysand Package Index](https://beta.sysand.org/index.html)
+- [Sysand Package Index](https://sysand.com/index.html)
 - [GitHub repository](https://github.com/sensmetry/sysand)
 - [Sysand community forum](https://forum.sensmetry.com/c/sysand/24/)
 - Reach out to [sysand@sensmetry.com](mailto:sysand@sensmetry.com) if you

--- a/docs/src/getting_started/tutorial.md
+++ b/docs/src/getting_started/tutorial.md
@@ -80,7 +80,7 @@ to install packages from the URL that points to the `.kpar` file or to a directo
 that contains the project.
 
 [iri]: https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier
-[index]: https://beta.sysand.org/
+[index]: https://sysand.com/
 
 Install usage `SYSMOD` from Sysand Package Index:
 

--- a/docs/src/hosting_index.md
+++ b/docs/src/hosting_index.md
@@ -12,7 +12,7 @@ Sysand project index. The guide describes three ways to run the index:
 > [!note]
 > This guide is only concerned about hosting the project files in the
 > structure that Sysand CLI can understand. Hosting of a front-end website
-> (such as [beta.sysand.org][sysand_index]) is not a part of this guide.
+> (such as [sysand.com][sysand_index]) is not a part of this guide.
 
 > [!warning]
 > Sysand is in active development. The structure of indexes and
@@ -109,7 +109,7 @@ the [User Guide](tutorial.md).
 
 Then, when adding a new usage to the project, use the `--index` argument
 to point to your private project index instead of the public
-[beta.sysand.org][sysand_index], for example:
+[sysand.com][sysand_index], for example:
 
 ```sh
 sysand add pkg:sysand/my-publisher/my-project --index http://localhost:8080
@@ -148,6 +148,6 @@ approach. It is licensed under the Creative Commons Zero license and can be
 freely forked and used in any setting. The repository README contains a detailed
 explanation of how to set up such a repository and use it.
 
-[sysand_index]: https://beta.sysand.org/
+[sysand_index]: https://sysand.com/
 [github_repo]: https://github.com/sensmetry/sysand-private-index
 [gitlab_repo]: https://gitlab.com/sensmetry/public/sysand-private-index

--- a/docs/src/index-protocol.md
+++ b/docs/src/index-protocol.md
@@ -56,8 +56,8 @@ fields:
 
 ```json
 {
-  "index_root": "https://sysand.org/index/",
-  "api_root": "https://sysand.org/api/"
+  "index_root": "https://sysand.com/index/",
+  "api_root": "https://sysand.com/api/"
 }
 ```
 

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -90,7 +90,7 @@ Sysand currently supports (i.e. knows how to obtain) these IRI schemes:
   the project. Can also point to a directory containing a git repository, but
   the directory will be treated as a project directory, unless `git+file` is used.
 - `urn:kpar`: this is by convention used by all projects in the
-  [Sysand index](https://beta.sysand.org/), but otherwise has no special meaning
+  [Sysand index](https://sysand.com/), but otherwise has no special meaning
 - `ssh`: note that currently only git repositories are supported for this type.
   SSH repository URLs supported by git have to be translated to use standard IRI
   to be accepted by sysand. For example:

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -190,9 +190,9 @@ pub enum Command {
         #[clap(verbatim_doc_comment)]
         path: Option<Utf8PathBuf>,
 
-        /// Configured index URL to publish to (e.g. https://sysand.org)
+        /// Configured index URL to publish to (e.g. https://sysand.com)
         /// May point to a path containing sysand-index-config.json, or directly
-        /// to the API root (e.g. https://sysand.org/api)
+        /// to the API root (e.g. https://sysand.com/api)
         #[arg(long, value_name = "URL", verbatim_doc_comment)]
         index: Url,
     },

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -21,7 +21,7 @@ use crate::env_vars;
 /// Documentation:
 /// <https://docs.sysand.org/>
 /// Package index and more information:
-/// <https://beta.sysand.org/>
+/// <https://sysand.com/>
 /// Project repository:
 /// <https://github.com/sensmetry/sysand/>
 #[derive(clap::Parser, Debug)]
@@ -1491,7 +1491,7 @@ pub struct ResolutionOptions {
     pub index: Vec<String>,
     /// Comma-delimited list of URLs to use as default index
     /// URLs. Default indexes are tried before other indexes
-    /// (default `https://beta.sysand.org`)
+    /// (default `https://sysand.com`)
     // TODO: verify index use order
     #[arg(
         long,

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -19,7 +19,7 @@ use crate::env_vars;
 /// A package manager for SysML v2 and KerML
 ///
 /// Documentation:
-/// <https://docs.sysand.org/>
+/// <https://client.sysand.com/>
 /// Package index and more information:
 /// <https://sysand.com/>
 /// Project repository:

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -69,7 +69,7 @@ use crate::{
     },
 };
 
-pub const DEFAULT_INDEX_URL: &str = "https://beta.sysand.org";
+pub const DEFAULT_INDEX_URL: &str = "https://sysand.com";
 
 pub mod cli;
 pub mod commands;

--- a/sysand/tests/common/mod.rs
+++ b/sysand/tests/common/mod.rs
@@ -32,7 +32,7 @@ pub fn git_init(path: &Path) -> Result<(), Box<dyn Error>> {
         .assert()
         .success();
     Command::new("git")
-        .args(["config", "user.email", "user@sysand.org"])
+        .args(["config", "user.email", "user@sysand.com"])
         .current_dir(path)
         .output()?
         .assert()


### PR DESCRIPTION
- We had references to beta.sysand.org, which became sysand.com
- We had references to sysand.org, which became sysand.com now
- We had references to docs.sysand.org, which became client.sysand.com