### PR TITLE
fix: remove old symbols if the same file is included multiple times

### DIFF
--- a/core/src/commands/include.rs
+++ b/core/src/commands/include.rs
@@ -38,7 +38,8 @@ impl<ProjectError> From<ProjectOrIOError<ProjectError>> for IncludeError<Project
     }
 }
 
-// TODO: Add some option to make the file format explicit
+// TODO: Add a CLI option to make the file format explicit (useful in cases
+// of non-standard file extensions)
 pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
     project: &mut Pr,
     path: P,
@@ -58,7 +59,7 @@ pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
                 )
                 .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e))?;
 
-                project.merge_index(new_symbols.into_iter().map(|x| (x, path.as_ref())), true)?;
+                project.replace_index_for_file(new_symbols.into_iter(), &path, true)?;
             }
             Some(Language::KerML) => {
                 let new_symbols = crate::symbols::top_level_kerml(
@@ -66,7 +67,7 @@ pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
                 )
                 .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e))?;
 
-                project.merge_index(new_symbols.into_iter().map(|x| (x, path.as_ref())), true)?;
+                project.replace_index_for_file(new_symbols.into_iter(), &path, true)?;
             }
             _ => {
                 return Err(IncludeError::UnknownFormat(path.as_ref().as_str().into()));

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -975,25 +975,39 @@ pub trait ProjectMut: ProjectRead {
         })
     }
 
-    fn merge_index<S: AsRef<str>, P: AsRef<Utf8UnixPath>, I: Iterator<Item = (S, P)>>(
+    /// Replace `index` entries pointing to `path` with `symbols`. If `overwrite == true`,
+    /// also point any pre-existing `symbols` to `path`
+    fn replace_index_for_file<S: AsRef<str>, P: AsRef<Utf8UnixPath>, I: Iterator<Item = S>>(
         &mut self,
         symbols: I,
+        path: P,
         overwrite: bool,
     ) -> Result<IndexMergeOutcome, ProjectOrIOError<Self::Error>> {
+        let path = path.as_ref();
         let mut meta = self
             .get_meta()
             .map_err(ProjectOrIOError::Project)?
             .unwrap_or_default();
 
+        // Remove if present any existing symbols from the same file
+        meta.index.retain(|s, v| {
+            if v == path {
+                log::debug!("meta.index: removing obsolete symbol `{s}` (file `{v}`)");
+                false
+            } else {
+                true
+            }
+        });
+
         let mut new = vec![];
         let mut existing = vec![];
 
-        for (symbol, path) in symbols {
+        for symbol in symbols {
             let this_symbol = symbol.as_ref().to_string();
             match meta.index.entry(this_symbol.clone()) {
                 indexmap::map::Entry::Occupied(mut occupied_entry) => {
                     let current = if overwrite {
-                        occupied_entry.insert(path.as_ref().to_string())
+                        occupied_entry.insert(path.to_string())
                     } else {
                         occupied_entry.get().clone()
                     };
@@ -1001,7 +1015,7 @@ pub trait ProjectMut: ProjectRead {
                     existing.push((this_symbol, current));
                 }
                 indexmap::map::Entry::Vacant(vacant_entry) => {
-                    vacant_entry.insert(path.as_ref().to_string());
+                    vacant_entry.insert(path.to_string());
                     new.push(this_symbol);
                 }
             }
@@ -1065,12 +1079,13 @@ impl<T: ProjectMut> ProjectMut for &mut T {
         (**self).exclude_source(path)
     }
 
-    fn merge_index<S: AsRef<str>, P: AsRef<Utf8UnixPath>, I: Iterator<Item = (S, P)>>(
+    fn replace_index_for_file<S: AsRef<str>, P: AsRef<Utf8UnixPath>, I: Iterator<Item = S>>(
         &mut self,
         symbols: I,
+        path: P,
         overwrite: bool,
     ) -> Result<IndexMergeOutcome, ProjectOrIOError<Self::Error>> {
-        (**self).merge_index(symbols, overwrite)
+        (**self).replace_index_for_file(symbols, path, overwrite)
     }
 }
 

--- a/docs/src/commands/include.md
+++ b/docs/src/commands/include.md
@@ -1,6 +1,8 @@
 # `sysand include`
 
-Include model interchange files in project metadata
+Include model interchange files in project metadata. This can
+be used multiple times for the same file to update its metadata,
+as the metadata will not be updated automatically
 
 ## Usage
 

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -139,7 +139,9 @@ pub enum Command {
         #[command(flatten)]
         resolution_opts: ResolutionOptions,
     },
-    /// Include model interchange files in project metadata
+    /// Include model interchange files in project metadata. This can
+    /// be used multiple times for the same file to update its metadata,
+    /// as the metadata will not be updated automatically
     Include {
         /// File(s) to include in the project.
         #[arg(num_args = 1..)]

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -273,6 +273,7 @@ fn obtain_project<Policy: HTTPAuthentication>(
             );
         }
         ProjectLocator::Path(path) => {
+            // TODO: support cloning KPARs
             let remote_project = LocalSrcProject {
                 nominal_path: None,
                 project_path: path.into(),

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -1389,7 +1389,11 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
 
     run_sysand_in(
         &cwd,
-        ["add", "urn:kpar:add_and_remove_with_lock_preinstall_dep"],
+        [
+            "add",
+            "urn:kpar:add_and_remove_with_lock_preinstall_dep",
+            "--no-index",
+        ],
         None,
     )?
     .assert()

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -295,7 +295,11 @@ fn install_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
 
     out.assert().success();
 
-    let out = run_sysand_in(&cwd, ["add", "urn:kpar:install_nonexistent"], None)?;
+    let out = run_sysand_in(
+        &cwd,
+        ["add", "urn:kpar:install_nonexistent", "--no-index"],
+        None,
+    )?;
 
     out.assert().failure().stderr(predicate::str::contains(
         "no resolver was able to resolve the IRI",

--- a/sysand/tests/cli_include_exclude.rs
+++ b/sysand/tests/cli_include_exclude.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::io::Write;
+use std::{fs, io::Write};
 
 use assert_cmd::prelude::*;
 use indexmap::IndexMap;
@@ -27,7 +27,7 @@ fn include_and_exclude_simple() -> Result<(), Box<dyn std::error::Error>> {
         None,
     )?;
 
-    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
     out.assert().success();
 
@@ -36,7 +36,7 @@ fn include_and_exclude_simple() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     assert_eq!(
         meta.index,
@@ -60,7 +60,7 @@ fn include_and_exclude_simple() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     // let meta = meta.validate()?;
 
@@ -83,7 +83,7 @@ fn include_no_checksum() -> Result<(), Box<dyn std::error::Error>> {
         None,
     )?;
 
-    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
     out.assert().success();
 
@@ -92,7 +92,7 @@ fn include_no_checksum() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     assert_eq!(
         meta.index,
@@ -126,7 +126,7 @@ fn include_no_index() -> Result<(), Box<dyn std::error::Error>> {
         None,
     )?;
 
-    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
     out.assert().success();
 
@@ -144,7 +144,7 @@ fn include_no_index() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     assert!(meta.index.is_empty());
 
@@ -176,7 +176,7 @@ fn include_empty_and_update() -> Result<(), Box<dyn std::error::Error>> {
         None,
     )?;
 
-    let mut sysml_file = std::fs::File::create(cwd.join("test.sysml"))?;
+    let mut sysml_file = fs::File::create(cwd.join("test.sysml"))?;
     sysml_file.sync_all()?;
 
     out.assert().success();
@@ -186,7 +186,7 @@ fn include_empty_and_update() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     assert!(meta.index.is_empty());
 
@@ -210,7 +210,7 @@ fn include_empty_and_update() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     assert_eq!(
         meta.index,
@@ -233,6 +233,55 @@ fn include_empty_and_update() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn include_same_file_replaces_old_symbols() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "include_same_file_replaces_old_symbols",
+        ],
+        None,
+    )?;
+
+    fs::write(cwd.join("test.sysml"), b"package A;\npackage B;\n")?;
+
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["include", "test.sysml"], None)?;
+
+    out.assert().success();
+
+    let meta: InterchangeProjectMetadataRaw =
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
+
+    assert_eq!(
+        meta.index,
+        IndexMap::from([
+            ("A".to_string(), "test.sysml".to_string()),
+            ("B".to_string(), "test.sysml".to_string()),
+        ])
+    );
+
+    fs::write(cwd.join("test.sysml"), b"package C;\n")?;
+
+    let out = run_sysand_in(&cwd, ["include", "test.sysml"], None)?;
+
+    out.assert().success();
+
+    let meta: InterchangeProjectMetadataRaw =
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
+
+    assert_eq!(
+        meta.index,
+        IndexMap::from([("C".to_string(), "test.sysml".to_string()),])
+    );
+
+    Ok(())
+}
+
+#[test]
 fn include_and_exclude_both_nested() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
@@ -245,9 +294,9 @@ fn include_and_exclude_both_nested() -> Result<(), Box<dyn std::error::Error>> {
         None,
     )?;
 
-    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
-    std::fs::create_dir(cwd.join("extra"))?;
-    std::fs::write(cwd.join("extra").join("test.sysml"), b"package Extra;\n")?;
+    fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    fs::create_dir(cwd.join("extra"))?;
+    fs::write(cwd.join("extra").join("test.sysml"), b"package Extra;\n")?;
 
     out.assert().success();
 
@@ -265,7 +314,7 @@ fn include_and_exclude_both_nested() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     // let meta = meta.validate()?;
 
@@ -304,7 +353,7 @@ fn include_and_exclude_both_nested() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     // let meta = meta.validate()?;
 
@@ -327,11 +376,11 @@ fn include_and_exclude_single_nested() -> Result<(), Box<dyn std::error::Error>>
         None,
     )?;
 
-    std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
+    fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
-    std::fs::create_dir(cwd.join("extra"))?;
+    fs::create_dir(cwd.join("extra"))?;
 
-    std::fs::write(cwd.join("extra").join("test.sysml"), b"package Extra;\n")?;
+    fs::write(cwd.join("extra").join("test.sysml"), b"package Extra;\n")?;
 
     out.assert().success();
 
@@ -349,7 +398,7 @@ fn include_and_exclude_single_nested() -> Result<(), Box<dyn std::error::Error>>
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     // let meta = meta.validate()?;
 
@@ -388,7 +437,7 @@ fn include_and_exclude_single_nested() -> Result<(), Box<dyn std::error::Error>>
     out.assert().success();
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     // let meta = meta.validate()?;
 
@@ -434,7 +483,7 @@ fn include_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     // let meta = meta.validate()?;
 
@@ -466,7 +515,7 @@ fn exclude_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     let meta: InterchangeProjectMetadataRaw =
-        serde_json::from_reader(std::fs::File::open(cwd.join(".meta.json"))?)?;
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
 
     // let meta = meta.validate()?;
 


### PR DESCRIPTION
- Remove old symbols if the same file is included multiple times
- Explicitly disable index access in the few tests that happen to touch it. This prevents test failures whenever index is offline

Fixes #358