### PR TITLE
feat: support cloning local kpars

### DIFF
--- a/bindings/java/java-deploy-test/src/test/java/com/sensmetry/sysand/DeployedTest.java
+++ b/bindings/java/java-deploy-test/src/test/java/com/sensmetry/sysand/DeployedTest.java
@@ -21,7 +21,7 @@ public class DeployedTest {
             assertTrue(java.nio.file.Files.exists(tempDir.resolve(".meta.json")), "Metadata file should exist");
 
             String projectJson = java.nio.file.Files.readString(tempDir.resolve(".project.json"));
-            assertEquals("{\n  \"name\": \"test\",\n  \"version\": \"1.0.0\",\n  \"usage\": []\n}", projectJson);
+            assertEquals("{\n  \"name\": \"test\",\n  \"version\": \"1.0.0\"\n}", projectJson);
 
             String metaJson = java.nio.file.Files.readString(tempDir.resolve(".meta.json"));
             Pattern regex = Pattern.compile(

--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
@@ -26,7 +26,7 @@ public class BasicTest {
             // java.nio.file.Files.readString is available in Java 11+
             // String projectJson = java.nio.file.Files.readString(tempDir.resolve(".project.json"));
             String projectJson = new String(Files.readAllBytes(tempDir.resolve(".project.json")));
-            assertEquals("{\n  \"name\": \"test\",\n  \"publisher\": \"a\",\n  \"version\": \"1.0.0\",\n  \"usage\": []\n}\n", projectJson);
+            assertEquals("{\n  \"name\": \"test\",\n  \"publisher\": \"a\",\n  \"version\": \"1.0.0\"\n}\n", projectJson);
 
             // String metaJson = Files.readString(tempDir.resolve(".meta.json"));
             String metaJson = new String(Files.readAllBytes(tempDir.resolve(".meta.json")));

--- a/bindings/js/spec/browser/browser_basic.spec.js
+++ b/bindings/js/spec/browser/browser_basic.spec.js
@@ -34,7 +34,7 @@ it("can initialise a project in browser local storage", async function () {
     "/",
   );
   expect(window.localStorage.getItem("sysand_storage/.project.json")).toBe(
-    '{"name":"basic_init","publisher":"a","version":"1.2.3","usage":[]}',
+    '{"name":"basic_init","publisher":"a","version":"1.2.3"}',
   );
   expect(window.localStorage.getItem("sysand_storage/.meta.json")).toMatch(
     /\{"index":\{\},"created":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"}/,

--- a/bindings/js/tests/basic_browser.rs
+++ b/bindings/js/tests/basic_browser.rs
@@ -37,7 +37,7 @@ mod browser_tests {
             local_storage
                 .get_item("sysand_storage/.project.json")
                 .unwrap(),
-            Some(r#"{"name":"basic_init","publisher":"a","version":"1.2.3","license":"MIT OR Apache-2.0","usage":[]}"#.to_string())
+            Some(r#"{"name":"basic_init","publisher":"a","version":"1.2.3","license":"MIT OR Apache-2.0"}"#.to_string())
         );
 
         let re = Regex::new(r#"\{"index":\{\},"created":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"}"#)

--- a/bindings/py/tests/basic.rs
+++ b/bindings/py/tests/basic.rs
@@ -38,8 +38,7 @@ fn basic_init() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "basic_init",
   "publisher": "a",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -32,7 +32,7 @@ def test_basic_init(caplog: pytest.LogCaptureFixture) -> None:
         with open(Path(tmpdirname) / ".project.json", "r") as f:
             assert (
                 f.read()
-                == '{\n  "name": "test_basic_init",\n  "publisher": "a",\n  "version": "1.2.3",\n  "usage": []\n}\n'
+                == '{\n  "name": "test_basic_init",\n  "publisher": "a",\n  "version": "1.2.3"\n}\n'
             )
         with open(Path(tmpdirname) / ".meta.json", "r") as f:
             assert re.match(
@@ -74,7 +74,7 @@ def test_remove_accepts_sysand_shorthand() -> None:
 
         assert (
             (Path(tmpdirname) / ".project.json").read_text()
-            == '{\n  "name": "test_remove_accepts_sysand_shorthand",\n  "publisher": "a",\n  "version": "1.2.3",\n  "usage": []\n}\n'
+            == '{\n  "name": "test_remove_accepts_sysand_shorthand",\n  "publisher": "a",\n  "version": "1.2.3"\n}\n'
         )
 
 
@@ -123,7 +123,7 @@ def test_http_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) -> 
     caplog.set_level(level)
 
     httpserver.expect_request("/.project.json").respond_with_json(
-        {"name": "test_http_info", "publisher": "a", "version": "1.2.3", "usage": []}
+        {"name": "test_http_info", "publisher": "a", "version": "1.2.3"}
     )
     httpserver.expect_request("/.meta.json").respond_with_json(
         {"index": {}, "created": "0000-00-00T00:00:00.123456789Z"}
@@ -175,7 +175,7 @@ def test_index_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) ->
         }
     )
     httpserver.expect_request(f"{iri_dir}/1.2.3/.project.json").respond_with_json(
-        {"name": "test_index_info", "version": "1.2.3", "usage": []}
+        {"name": "test_index_info", "version": "1.2.3"}
     )
     httpserver.expect_request(f"{iri_dir}/1.2.3/.meta.json").respond_with_json(
         {"index": {}, "created": "2026-01-01T00:00:00Z"}

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -205,7 +205,7 @@ pub enum PublishError {
         source: semver::Error,
     },
     #[error(
-        "version field `{version}` is invalid for publishing: build metadata (`+...`) is forbidden by the index protocol"
+        "version field `{version}` is invalid for publishing: build metadata (`+...`) cannot be used for projects in the index"
     )]
     VersionBuildMetadata { version: Box<str> },
 
@@ -213,11 +213,11 @@ pub enum PublishError {
     MissingLicense,
 
     #[error(
-        "license field `{license}` is invalid for publishing: must be a valid SPDX license expression ({source})"
+        "license field `{license}` is invalid for publishing, it must be a valid SPDX license expression, but failed to parse:\n{err}"
     )]
     InvalidLicense {
         license: Box<str>,
-        source: spdx::error::ParseError,
+        err: spdx::error::ParseError,
     },
 
     #[error("invalid index URL `{url}` for publish: {reason}")]
@@ -304,9 +304,9 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
             version: version.as_str().into(),
         });
     }
-    spdx::Expression::parse(license).map_err(|source| PublishError::InvalidLicense {
+    spdx::Expression::parse(license).map_err(|err| PublishError::InvalidLicense {
         license: license.into(),
-        source,
+        err,
     })?;
     let normalized_publisher = normalize_field(publisher);
     let normalized_name = normalize_field(name);

--- a/core/src/commands/sync_tests.rs
+++ b/core/src/commands/sync_tests.rs
@@ -146,7 +146,7 @@ fn try_install_fails_to_install_wrong_checksum() {
     assert_eq!(
         actual,
         ProjectChecksum::Project(
-            "ac2849f645933d92010698c857cfa0dcde74d7a06028d4bc8a4d607452c72d13".to_owned()
+            "9612357c41e64a174582b813ca2f1695fd11baf7166624ea2bdf76b406ee2d71".to_owned()
         )
     );
 

--- a/core/src/env/index_tests.rs
+++ b/core/src/env/index_tests.rs
@@ -226,7 +226,7 @@ fn mock_json_get_count(
 //     src_body: &str,
 // ) -> (Vec<u8>, String, &'static str) {
 //     use std::io::Write as _;
-//     let info_json = format!(r#"{{"name":"{name}","version":"{version}","usage":[]}}"#);
+//     let info_json = format!(r#"{{"name":"{name}","version":"{version}"}}"#);
 //     let meta_json: &'static str = r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#;
 //     let mut buf: Vec<u8> = Vec::new();
 //     {

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -122,6 +122,8 @@ pub struct InterchangeProjectInfoG<Iri, Version, VersionReq> {
     #[serde(default)]
     pub topic: Vec<String>,
 
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub usage: Vec<InterchangeProjectUsageG<Iri, VersionReq>>,
 }
 

--- a/core/src/model_tests.rs
+++ b/core/src/model_tests.rs
@@ -44,16 +44,16 @@ fn json_hash_agrees_with_shell() {
 
     assert_eq!(
         serde_json::to_string(&info).unwrap(),
-        r#"{"name":"json_hash_agrees_with_shell","version":"1.2.3","usage":[]}"#
+        r#"{"name":"json_hash_agrees_with_shell","version":"1.2.3"}"#
     );
     assert_eq!(
         serde_json::to_string(&meta).unwrap(),
         r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#
     );
 
-    // cat <(echo -n '{"name":"json_hash_agrees_with_shell","version":"1.2.3","usage":[]}') <(echo -n '{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}') | sha256sum | cut -f 1 -d ' '
+    // cat <(echo -n '{"name":"json_hash_agrees_with_shell","version":"1.2.3"}') <(echo -n '{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}') | sha256sum | cut -f 1 -d ' '
     assert_eq!(
         lowercase_hex(super::project_hash_raw(&info, &meta)),
-        "b98340d7d7f41cefc3f7dd2b30d65fb48836b12a8d47884975e5c8637edfeea1"
+        "3b08c7119d89c406de6bdfbed29566077209d295736264229ad5d2e33991b3b4"
     );
 }

--- a/core/src/project/gix_git_download_tests.rs
+++ b/core/src/project/gix_git_download_tests.rs
@@ -44,7 +44,7 @@ pub fn basic_gix_access() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: Replace by commands::*::do_* when sufficiently complete, also use gix to create repo?
     std::fs::write(
         repo_dir.path().join(".project.json"),
-        r#"{"name":"basic_gix_access","version":"1.2.3","usage":[]}"#,
+        r#"{"name":"basic_gix_access","version":"1.2.3"}"#,
     )?;
     Command::new("git")
         .arg("add")

--- a/core/src/project/local_kpar_tests.rs
+++ b/core/src/project/local_kpar_tests.rs
@@ -24,7 +24,7 @@ fn basic_kpar_archive() -> Result<(), Box<dyn std::error::Error>> {
             .unix_permissions(0o755);
 
         zip.start_file(".project.json", options)?;
-        zip.write_all(br#"{"name":"basic_kpar_archive","version":"1.2.3","usage":[]}"#)?;
+        zip.write_all(br#"{"name":"basic_kpar_archive","version":"1.2.3"}"#)?;
         zip.start_file(".meta.json", options)?;
         zip.write_all(br#"{"index":{},"created":"123"}"#)?;
         zip.start_file("test.sysml", options)?;
@@ -67,7 +67,7 @@ fn nested_kpar_archive() -> Result<(), Box<dyn std::error::Error>> {
             .unix_permissions(0o755);
 
         zip.start_file("some_root_dir/.project.json", options)?;
-        zip.write_all(br#"{"name":"nested_kpar_archive","version":"1.2.3","usage":[]}"#)?;
+        zip.write_all(br#"{"name":"nested_kpar_archive","version":"1.2.3"}"#)?;
         zip.start_file("some_root_dir/.meta.json", options)?;
         zip.write_all(br#"{"index":{},"created":"123"}"#)?;
         zip.start_file("some_root_dir/test.sysml", options)?;

--- a/core/src/project/reqwest_kpar_download_tests.rs
+++ b/core/src/project/reqwest_kpar_download_tests.rs
@@ -34,7 +34,7 @@ fn basic_download_request() -> Result<(), Box<dyn std::error::Error>> {
             .unix_permissions(0o755);
 
         zip.start_file("some_root_dir/.project.json", options)?;
-        zip.write_all(br#"{"name":"basic_download_request","version":"1.2.3","usage":[]}"#)?;
+        zip.write_all(br#"{"name":"basic_download_request","version":"1.2.3"}"#)?;
         zip.start_file("some_root_dir/.meta.json", options)?;
         zip.write_all(br#"{"index":{},"created":"123"}"#)?;
         zip.start_file("some_root_dir/test.sysml", options)?;
@@ -114,7 +114,7 @@ fn concurrent_downloads_fan_in_to_single_fetch() -> Result<(), Box<dyn std::erro
             .compression_method(zip::CompressionMethod::Stored)
             .unix_permissions(0o755);
         zip.start_file(".project.json", options)?;
-        zip.write_all(br#"{"name":"concurrent","version":"1.0.0","usage":[]}"#)?;
+        zip.write_all(br#"{"name":"concurrent","version":"1.0.0"}"#)?;
         zip.start_file(".meta.json", options)?;
         zip.write_all(br#"{"index":{},"created":"x"}"#)?;
         zip.finish().unwrap();
@@ -183,7 +183,7 @@ fn expected_size_mismatch_rejects_download() -> Result<(), Box<dyn std::error::E
             .compression_method(zip::CompressionMethod::Stored)
             .unix_permissions(0o755);
         zip.start_file(".project.json", options)?;
-        zip.write_all(br#"{"name":"size-mismatch","version":"1.0.0","usage":[]}"#)?;
+        zip.write_all(br#"{"name":"size-mismatch","version":"1.0.0"}"#)?;
         zip.start_file(".meta.json", options)?;
         zip.write_all(br#"{"index":{},"created":"x"}"#)?;
         zip.finish().unwrap();

--- a/core/src/project/reqwest_src_tests.rs
+++ b/core/src/project/reqwest_src_tests.rs
@@ -48,7 +48,7 @@ fn basic_project_urls_http_src() -> Result<(), Box<dyn std::error::Error>> {
         .mock("GET", "/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"basic_project_urls","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"basic_project_urls","version":"1.2.3"}"#)
         .match_request(|r| r.has_header(header::USER_AGENT))
         .expect(1)
         .create();

--- a/core/src/resolve/reqwest_http_tests.rs
+++ b/core/src/resolve/reqwest_http_tests.rs
@@ -21,7 +21,7 @@ fn basic_http_src_url_non_lax() -> Result<(), Box<dyn std::error::Error>> {
         .mock("GET", "/foo/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"basic_http_src_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"basic_http_src_url","version":"1.2.3"}"#)
         .expect(1)
         .create();
 
@@ -168,7 +168,7 @@ fn basic_http_url_lax_without_slash_not_prefer_ranged() -> Result<(), Box<dyn st
 
 //         zip.start_file("some_root_dir/.project.json", options)?;
 //         zip.write_all(
-//             br#"{"name":"resolves_ranged_if_successful","version":"1.2.3","usage":[]}"#,
+//             br#"{"name":"resolves_ranged_if_successful","version":"1.2.3"}"#,
 //         )?;
 //         zip.start_file("some_root_dir/.meta.json", options)?;
 //         zip.write_all(br#"{"index":{},"created":"123"}"#)?;
@@ -233,7 +233,7 @@ fn basic_http_url_lax_without_slash_not_prefer_ranged() -> Result<(), Box<dyn st
 
 //         zip.start_file("some_root_dir/.project.json", options)?;
 //         zip.write_all(
-//             br#"{"name":"resolves_non_ranged_if_unsupported","version":"1.2.3","usage":[]}"#,
+//             br#"{"name":"resolves_non_ranged_if_unsupported","version":"1.2.3"}"#,
 //         )?;
 //         zip.start_file("some_root_dir/.meta.json", options)?;
 //         zip.write_all(br#"{"index":{},"created":"123"}"#)?;

--- a/core/tests/index_management.rs
+++ b/core/tests/index_management.rs
@@ -167,8 +167,7 @@ fn file_state_test() {
         json!({
           "name": "Test.project1",
           "publisher": "Test Publisher",
-          "version": "0.1.0",
-          "usage": []
+          "version": "0.1.0"
         })
     );
     assert_eq!(
@@ -188,8 +187,7 @@ fn file_state_test() {
         json!({
           "name": "Test.project1",
           "publisher": "Test Publisher",
-          "version": "0.2.0",
-          "usage": []
+          "version": "0.2.0"
         })
     );
     assert_eq!(

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -14,7 +14,10 @@ use sysand_core::{
     config::Config,
     context::ProjectContext,
     env::{local_directory::utils::clean_dir, utils::clone_project},
-    project::{ProjectRead, editable::EditableProject, local_src::LocalSrcProject, utils::wrapfs},
+    project::{
+        ProjectRead, editable::EditableProject, local_kpar::LocalKParProjectRaw,
+        local_src::LocalSrcProject, utils::wrapfs,
+    },
     resolve::{
         ResolutionOutcome, ResolveRead,
         memory::{AcceptAll, MemoryResolver},
@@ -273,40 +276,71 @@ fn obtain_project<Policy: HTTPAuthentication>(
             );
         }
         ProjectLocator::Path(path) => {
-            // TODO: support cloning KPARs
-            let remote_project = LocalSrcProject {
-                nominal_path: None,
-                project_path: path.into(),
-                expected_checksum: None,
+            if wrapfs::is_file(path)? {
+                let remote_project = LocalKParProjectRaw::new_guess_root(path)?;
+                clone_local(
+                    version,
+                    cloning,
+                    cloned,
+                    header,
+                    &mut local_project,
+                    path,
+                    remote_project,
+                )?;
+            } else {
+                let remote_project = LocalSrcProject {
+                    nominal_path: None,
+                    project_path: path.into(),
+                    expected_checksum: None,
+                };
+                clone_local(
+                    version,
+                    cloning,
+                    cloned,
+                    header,
+                    &mut local_project,
+                    path,
+                    remote_project,
+                )?;
             };
-            if let Some(version) = version {
-                let project_version = remote_project
-                    .get_info()?
-                    .ok_or_else(|| anyhow!("missing project info"))?
-                    .version;
-                if version != project_version {
-                    bail!(
-                        "given version {version} does not match project version {project_version}"
-                    )
-                }
-            }
-            log::info!(
-                "{header}{cloning:>12}{header:#} project from `{}` to\n\
-                {:>12} `{}`",
-                wrapfs::canonicalize(&remote_project.project_path)?,
-                ' ',
-                local_project.project_path,
-            );
-            let (info, _meta) = clone_project(&remote_project, &mut local_project, true)?;
-            log::info!(
-                "{header}{cloned:>12}{header:#} `{}` {}",
-                info.name,
-                info.version
-            );
         }
     }
 
     Ok((include_std, locator, local_project, std_resolver))
+}
+
+fn clone_local<P: ProjectRead>(
+    version: Option<String>,
+    cloning: &str,
+    cloned: &str,
+    header: clap::builder::styling::Style,
+    local_project: &mut LocalSrcProject,
+    path: &Utf8PathBuf,
+    remote_project: P,
+) -> Result<(), anyhow::Error> {
+    if let Some(version) = version {
+        let project_version = remote_project
+            .get_info()?
+            .ok_or_else(|| anyhow!("missing project info"))?
+            .version;
+        if version != project_version {
+            bail!("given version {version} does not match project version {project_version}")
+        }
+    }
+    log::info!(
+        "{header}{cloning:>12}{header:#} project from `{}` to\n\
+                {:>12} `{}`",
+        wrapfs::canonicalize(path)?,
+        ' ',
+        local_project.project_path,
+    );
+    let (info, _meta) = clone_project(&remote_project, local_project, true)?;
+    log::info!(
+        "{header}{cloned:>12}{header:#} `{}` {}",
+        info.name,
+        info.version
+    );
+    Ok(())
 }
 
 /// Obtains a project identified by `iri` via `resolver`. If

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -54,8 +54,7 @@ fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -127,8 +126,7 @@ fn add_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::erro
         r#"{
   "name": "reject_add_shorthand",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -177,8 +175,7 @@ fn remove_accepts_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "remove_shorthand",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -320,8 +317,7 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "add_and_remove_path1",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -413,8 +409,7 @@ sources = [
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -508,8 +503,7 @@ sources = [
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -603,8 +597,7 @@ sources = [
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -698,8 +691,7 @@ sources = [
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -793,8 +785,7 @@ sources = [
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -888,8 +879,7 @@ sources = [
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -1031,8 +1021,7 @@ sources = [
         r#"{
   "name": "add_and_remove",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -1127,8 +1116,7 @@ fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "add_from_url",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -1191,8 +1179,7 @@ fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::err
         r#"{
   "name": "add_full_purl",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -1253,8 +1240,7 @@ fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dy
         r#"{
   "name": "urn_slash",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -1297,8 +1283,7 @@ fn add_shorthand_then_remove_full_purl() -> Result<(), Box<dyn std::error::Error
         r#"{
   "name": "shorthand_then_full_purl",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -1434,8 +1419,7 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
         r#"{
   "name": "add_and_remove_with_lock_preinstall",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );

--- a/sysand/tests/cli_clone.rs
+++ b/sysand/tests/cli_clone.rs
@@ -95,6 +95,28 @@ fn clone_project_default_target() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn clone_local_kpar_project_default_target() -> Result<(), Box<dyn std::error::Error>> {
+    let test_path = fixture_path("test_lib.kpar");
+    let test_path_str = test_path.as_str();
+
+    let (_temp_dir, cwd, out) = run_sysand(["clone", test_path_str], None)?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Cloned `Lib test` 0.0.1"));
+    assert_libtest_cloned_synced(&cwd);
+
+    let (_temp_dir, cwd, out) = run_sysand(["clone", "--path", test_path_str], None)?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Cloned `Lib test` 0.0.1"));
+    assert_libtest_cloned_synced(&cwd);
+
+    Ok(())
+}
+
 // clone remote project
 // #[test]
 // fn clone_remote_project() -> Result<(), Box<dyn std::error::Error>> {

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -80,7 +80,7 @@ path = "lib/kpar.test_0.0.1"
 identifiers = [
     "urn:kpar:test",
 ]
-src_cksum = "69311f2c1fcc3cc8649461ff1961e17df46237399bad1596e099e8483865e3f4"
+src_cksum = "c83ef78e3b8d52d622dea6db2e7c6c326801500ae1e99f6a54c39a1f473367b3"
 "#
     );
 

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -167,7 +167,7 @@ fn info_basic_http_url_noauth() -> Result<(), Box<dyn Error>> {
         .mock("HEAD", "/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(1)
         .create();
 
@@ -175,7 +175,7 @@ fn info_basic_http_url_noauth() -> Result<(), Box<dyn Error>> {
         .mock("GET", "/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(3) // TODO: Reduce this to 1
         .create();
 
@@ -239,7 +239,7 @@ fn info_basic_http_url_irrelevant_auth() -> Result<(), Box<dyn Error>> {
         .mock("HEAD", "/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(1)
         .create();
 
@@ -247,7 +247,7 @@ fn info_basic_http_url_irrelevant_auth() -> Result<(), Box<dyn Error>> {
         .mock("GET", "/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(3) // TODO: Reduce this to 1
         .create();
 
@@ -337,7 +337,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(1) // TODO: Reduce this
         .create();
 
@@ -349,7 +349,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(1) // TODO: Reduce this
         .create();
 
@@ -358,7 +358,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(3) // TODO: Reduce this to 1
         .create();
 
@@ -370,7 +370,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(3) // TODO: Reduce this to 1
         .create();
 
@@ -492,7 +492,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(1) // TODO: Reduce this
         .create();
 
@@ -504,7 +504,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(1) // TODO: Reduce this
         .create();
 
@@ -513,7 +513,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(3) // TODO: Reduce this to 1
         .create();
 
@@ -525,7 +525,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
         .expect(3) // TODO: Reduce this to 1
         .create();
 
@@ -616,7 +616,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
 //             .unix_permissions(0o755);
 
 //         zip.start_file("some_root_dir/.project.json", options)?;
-//         zip.write_all(br#"{"name":"info_non_ranged_http_kpar","version":"1.2.3","usage":[]}"#)?;
+//         zip.write_all(br#"{"name":"info_non_ranged_http_kpar","version":"1.2.3"}"#)?;
 //         zip.start_file("some_root_dir/.meta.json", options)?;
 //         zip.write_all(br#"{"index":{},"created":"123"}"#)?;
 //         zip.start_file("some_root_dir/test.sysml", options)?;
@@ -673,7 +673,7 @@ fn info_basic_local_kpar() -> Result<(), Box<dyn Error>> {
             .unix_permissions(0o755);
 
         zip.start_file("some_root_dir/.project.json", options)?;
-        zip.write_all(br#"{"name":"info_basic_local_kpar","version":"1.2.3","usage":[]}"#)?;
+        zip.write_all(br#"{"name":"info_basic_local_kpar","version":"1.2.3"}"#)?;
         zip.start_file("some_root_dir/.meta.json", options)?;
         zip.write_all(br#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)?;
 
@@ -703,7 +703,7 @@ fn info_basic_file_git() -> Result<(), Box<dyn Error>> {
         // TODO: Replace by commands::*::do_* when sufficiently complete, also use gix to create repo?
         std::fs::write(
             cwd.path().join(".project.json"),
-            r#"{"name":"info_basic_file_git","version":"1.2.3","usage":[]}"#,
+            r#"{"name":"info_basic_file_git","version":"1.2.3"}"#,
         )?;
         Command::new("git")
             .arg("add")
@@ -760,7 +760,7 @@ fn info_basic_file_git() -> Result<(), Box<dyn Error>> {
 
 /// Render a minimal `.project.json` body for the given name/version.
 fn project_json_for(name: &str, version: &str) -> String {
-    format!(r#"{{"name":"{name}","version":"{version}","usage":[]}}"#)
+    format!(r#"{{"name":"{name}","version":"{version}"}}"#)
 }
 
 /// Render a minimal `.meta.json` body. The fixed timestamp keeps any test

--- a/sysand/tests/cli_init.rs
+++ b/sysand/tests/cli_init.rs
@@ -31,8 +31,7 @@ fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "init_basic",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -65,8 +64,7 @@ fn init_basic_cwd() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "init_basic_cwd",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );
@@ -109,8 +107,7 @@ fn init_explicit_name() -> Result<(), Box<dyn std::error::Error>> {
         r#"{
   "name": "other_than_init_explicit_name",
   "publisher": "untitled",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#
     );

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -364,7 +364,7 @@ fn build_index_kpar_bytes(
 ) {
     use std::io::Write as _;
 
-    let info_json = format!(r#"{{"name":"{name}","version":"{version}","usage":[]}}"#);
+    let info_json = format!(r#"{{"name":"{name}","version":"{version}"}}"#);
     // Fixed created-timestamp so the digest is reproducible.
     let meta_json = r#"{"index":{},"created":"2026-01-01T00:00:00.000000000Z"}"#;
 

--- a/sysand/tests/cli_sync.rs
+++ b/sysand/tests/cli_sync.rs
@@ -85,8 +85,7 @@ fn sync_to_local() -> Result<(), Box<dyn std::error::Error>> {
         proj_dir.join(".project.json"),
         r#"{
   "name": "sync_to_local",
-  "version": "1.2.3",
-  "usage": []
+  "version": "1.2.3"
 }
 "#,
     )?;
@@ -108,7 +107,7 @@ name = "sync_to_local"
 version = "1.2.3"
 identifiers = ["urn:kpar:sync_to_local"]
 sources = [
-    { src_path = "lib/sync_to_local", checksum = "4b3adfb7bea950c7c598093c50323fa2ea9f816cb4b10cd299b205bfd4b47a5c" },
+    { src_path = "lib/sync_to_local", checksum = "fd4566669f12f969e04aa970d27659057357d078d00530d442de21d517959f92" },
 ]
 "#,
     )?;
@@ -137,7 +136,7 @@ path = "lib/kpar.sync_to_local_1.2.3"
 identifiers = [
     "urn:kpar:sync_to_local",
 ]
-src_cksum = "4b3adfb7bea950c7c598093c50323fa2ea9f816cb4b10cd299b205bfd4b47a5c"
+src_cksum = "fd4566669f12f969e04aa970d27659057357d078d00530d442de21d517959f92"
 "#
         )
     );
@@ -167,7 +166,7 @@ fn sync_to_remote() -> Result<(), Box<dyn std::error::Error>> {
         .mock("GET", "/.project.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3"}"#)
         .expect(2) // TODO: Reduce this to 1 after caching
         .match_request(|r| r.has_header(header::USER_AGENT))
         .create();
@@ -191,7 +190,7 @@ name = "sync_to_remote"
 version = "1.2.3"
 identifiers = ["urn:kpar:sync_to_remote"]
 sources = [
-    {{ remote_src = "{}", checksum = "39f49107a084ab27624ee78d4d37f87a1f7606a2b5d242cdcd9374cf20ab1895" }},
+    {{ remote_src = "{}", checksum = "3bd4c3c6b54690d38eeb035e136b667b4307063451b140feb2f49d266f653a26" }},
 ]
 "#,
             &server.url()
@@ -225,7 +224,7 @@ path = "lib/kpar.sync_to_remote_1.2.3"
 identifiers = [
     "urn:kpar:sync_to_remote",
 ]
-src_cksum = "39f49107a084ab27624ee78d4d37f87a1f7606a2b5d242cdcd9374cf20ab1895"
+src_cksum = "3bd4c3c6b54690d38eeb035e136b667b4307063451b140feb2f49d266f653a26"
 "#
         )
     );
@@ -259,7 +258,7 @@ fn sync_to_remote_auth() -> Result<(), Box<dyn std::error::Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3"}"#)
         .expect(2) // TODO: Reduce this to 1
         .create();
 
@@ -271,7 +270,7 @@ fn sync_to_remote_auth() -> Result<(), Box<dyn std::error::Error>> {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3"}"#)
         .expect(2) // TODO: Reduce this to 1
         .create();
 
@@ -306,7 +305,7 @@ name = "sync_to_remote"
 version = "1.2.3"
 identifiers = ["urn:kpar:sync_to_remote"]
 sources = [
-    {{ remote_src = "{}", checksum = "39f49107a084ab27624ee78d4d37f87a1f7606a2b5d242cdcd9374cf20ab1895" }},
+    {{ remote_src = "{}", checksum = "3bd4c3c6b54690d38eeb035e136b667b4307063451b140feb2f49d266f653a26" }},
 ]
 "#,
             &server.url()
@@ -328,16 +327,16 @@ sources = [
         ]),
     )?;
 
-    info_mock.assert();
-    info_mock_auth.assert();
-    meta_mock.assert();
-    meta_mock_auth.assert();
-
     out.assert()
         .success()
         .stderr(predicate::str::contains("Creating"))
         .stderr(predicate::str::contains("Syncing"))
         .stderr(predicate::str::contains("Installing"));
+
+    info_mock.assert();
+    info_mock_auth.assert();
+    meta_mock.assert();
+    meta_mock_auth.assert();
 
     let out = run_sysand_in(&cwd, ["env", "list"], None)?;
 
@@ -378,7 +377,7 @@ fn sync_to_remote_incorrect_auth() -> Result<(), Box<dyn std::error::Error>> {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3","usage":[]}"#)
+        .with_body(r#"{"name":"sync_to_remote","version":"1.2.3"}"#)
         .expect(0)
         .create();
 
@@ -411,7 +410,7 @@ name = "sync_to_remote"
 version = "1.2.3"
 identifiers = ["urn:kpar:sync_to_remote"]
 sources = [
-    {{ remote_src = "{}", checksum = "39f49107a084ab27624ee78d4d37f87a1f7606a2b5d242cdcd9374cf20ab1895" }},
+    {{ remote_src = "{}", checksum = "3bd4c3c6b54690d38eeb035e136b667b4307063451b140feb2f49d266f653a26" }},
 ]
 "#,
             &server.url()


### PR DESCRIPTION
Also improve a few error messages and improve spec compliance.

The large number of changed files is almost entirely removing `usage: []` and subsequently changed checksums.