### PR TITLE
feat(dockerimage): provide flexible tags

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -11,9 +11,8 @@ on:
         type: string
       use_default_branch_dockerfile:
         description: Use the Dockerfile from the default branch instead of the release tag
-        required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -23,15 +22,32 @@ jobs:
   publish-image:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.use_default_branch_dockerfile && github.event.repository.default_branch || inputs.tag || github.event.release.tag_name }}
 
-      - name: Declare image tag
-        id: image
+      # For builds triggered for a git tag 1.2.3, we calculate image tags like:
+      # [{prefix}:1.2.3, {prefix}:1.2, {prefix}:1, {prefix}:latest]
+      #
+      # ref: https://github.com/jupyterhub/action-major-minor-tag-calculator
+      #
+      - name: Fetch repository tags
+        id: repo-tags
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag || github.event.release.tag_name }}
-        run: echo "tag=${TAG#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          tags="$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/tags" | jq -c '[.[][] | .name]')"
+          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+          echo "new=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Declare image tags
+        id: tags
+        uses: jupyterhub/action-major-minor-tag-calculator@40566ffdf246e5a9e640cf768df890ead4424b22 # v4.0.0
+        with:
+          existingTags: ${{ steps.repo-tags.outputs.tags }}
+          newTag: ${{ steps.repo-tags.outputs.new }}
+          prefix: "ghcr.io/${{ github.repository }}:"
 
       - name: Wait for release assets to be uploaded
         env:
@@ -71,25 +87,25 @@ jobs:
           tar -xJf sysand-linux-arm64.tar.xz -C sysand-arm64
 
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx (for multi-arch builds)
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to ghcr.io (GitHub Container Registry)
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }}
+          tags: ${{ join(fromJson(steps.tags.outputs.tags)) }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}


### PR DESCRIPTION
With this, we get `latest`, `1.2.3`, `1.2`, `1` tags, not just `1.2.3` tag for example. `latest` will only update if its actually the latest stable tag (pre-releases not considered).