### PR TITLE
feat: add installation scripts

### DIFF
--- a/.github/workflows/installation-script.yml
+++ b/.github/workflows/installation-script.yml
@@ -1,4 +1,4 @@
-name: Test Install Script
+name: Test Installation Script
 
 on:
   push:
@@ -31,7 +31,7 @@ jobs:
               - 'docs/src/install.sh'
               - 'docs/src/install.ps1'
               - 'docs/src/getting_started/installation.md'
-              - '.github/workflows/test-install-script.yml'
+              - '.github/workflows/installation-script.yml'
       - id: decisions
         run: |
           test=${{ steps.filter.outputs.src == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
@@ -73,6 +73,15 @@ jobs:
           grep -F -- "--system-install" "$RUNNER_TEMP/install-help.txt"
           grep -F -- "latest non-prerelease" "$RUNNER_TEMP/install-help.txt"
 
+      - name: Reject invalid version
+        run: |
+          for invalid_version in 0.0.0_test 0.0.0+build; do
+            if sh docs/src/install.sh --version "$invalid_version"; then
+              echo "expected version '$invalid_version' to fail" >&2
+              exit 1
+            fi
+          done
+
       - name: Create fake release archive
         run: |
           mkdir -p "$RUNNER_TEMP/fake-release" "$RUNNER_TEMP/fake-archive"
@@ -87,7 +96,6 @@ jobs:
         run: |
           cd "$RUNNER_TEMP/fake-release"
           python3 -m http.server 8765 --bind 127.0.0.1 &
-          echo "$!" > "$RUNNER_TEMP/http-server.pid"
 
           for attempt in $(seq 1 20); do
             if curl -fsS "http://127.0.0.1:8765/${{ matrix.asset }}" >/dev/null; then
@@ -118,13 +126,6 @@ jobs:
           if sh docs/src/install.sh --system-install --install-dir "$RUNNER_TEMP/sysand-bin"; then
             echo "expected --system-install followed by --install-dir to fail" >&2
             exit 1
-          fi
-
-      - name: Stop fake release server
-        if: always()
-        run: |
-          if [ -f "$RUNNER_TEMP/http-server.pid" ]; then
-            kill "$(cat "$RUNNER_TEMP/http-server.pid")" || true
           fi
 
   windows:
@@ -170,6 +171,22 @@ jobs:
               }
           }
 
+      - name: Reject invalid version
+        shell: pwsh
+        run: |
+          foreach ($invalidVersion in @("0.0.0_test", "0.0.0+build")) {
+              $process = Start-Process `
+                  -FilePath pwsh `
+                  -ArgumentList "-NoProfile", "-File", ".\docs\src\install.ps1", "-Version", $invalidVersion `
+                  -Wait `
+                  -PassThru `
+                  -NoNewWindow
+              if ($process.ExitCode -eq 0) {
+                  Write-Error "expected version '$invalidVersion' to fail"
+                  exit 1
+              }
+          }
+
       - name: Create fake sysand.exe
         shell: pwsh
         run: |
@@ -204,7 +221,6 @@ jobs:
               -ArgumentList "-m", "http.server", "8765", "--bind", "127.0.0.1" `
               -WorkingDirectory $releaseDir `
               -PassThru
-          $process.Id | Set-Content -Path (Join-Path $env:RUNNER_TEMP "http-server.pid")
 
           for ($attempt = 1; $attempt -le 20; $attempt++) {
               try {
@@ -231,15 +247,6 @@ jobs:
               exit 1
           }
 
-      - name: Stop fake release server
-        if: always()
-        shell: pwsh
-        run: |
-          $pidFile = Join-Path $env:RUNNER_TEMP "http-server.pid"
-          if (Test-Path $pidFile) {
-              Stop-Process -Id (Get-Content $pidFile) -Force -ErrorAction SilentlyContinue
-          }
-
   docs:
     name: Installer docs
     needs: [plan]
@@ -262,7 +269,7 @@ jobs:
           test -f docs/book/install.ps1
 
   ci-gate:
-    name: Test Install Script CI Gate
+    name: Installation Script CI Gate
     needs: [plan, unix, windows, docs]
     if: needs.plan.outputs.gate == 'true' && !cancelled()
     runs-on: ubuntu-slim

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -1,0 +1,273 @@
+name: Test Install Script
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    runs-on: ubuntu-slim
+    outputs:
+      test: ${{ steps.decisions.outputs.test }}
+      gate: ${{ steps.decisions.outputs.gate }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'docs/src/install.sh'
+              - 'docs/src/install.ps1'
+              - 'docs/src/getting_started/installation.md'
+              - '.github/workflows/test-install-script.yml'
+      - id: decisions
+        run: |
+          test=${{ steps.filter.outputs.src == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          gate=${{ github.event_name == 'pull_request' }}
+          echo "test=$test" >> "$GITHUB_OUTPUT"
+          echo "gate=$gate" >> "$GITHUB_OUTPUT"
+
+  unix:
+    name: Unix installer (${{ matrix.os }})
+    needs: [plan]
+    if: needs.plan.outputs.test == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            asset: sysand-linux-x86_64.tar.gz
+          - os: ubuntu-24.04-arm
+            asset: sysand-linux-arm64.tar.gz
+          - os: macos-15-intel
+            asset: sysand-macos-x86_64.tar.gz
+          - os: macos-latest
+            asset: sysand-macos-arm64.tar.gz
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check shell syntax
+        run: sh -n docs/src/install.sh
+
+      - name: Run shellcheck
+        if: runner.os == 'Linux'
+        run: shellcheck docs/src/install.sh
+
+      - name: Check help text
+        run: |
+          docs/src/install.sh --help > "$RUNNER_TEMP/install-help.txt"
+          grep -F -- "--install-dir" "$RUNNER_TEMP/install-help.txt"
+          grep -F -- "--system-install" "$RUNNER_TEMP/install-help.txt"
+          grep -F -- "latest non-prerelease" "$RUNNER_TEMP/install-help.txt"
+
+      - name: Create fake release archive
+        run: |
+          mkdir -p "$RUNNER_TEMP/fake-release" "$RUNNER_TEMP/fake-archive"
+          cat > "$RUNNER_TEMP/fake-archive/sysand" <<'EOF'
+          #!/bin/sh
+          echo "sysand 0.0.0-test"
+          EOF
+          chmod +x "$RUNNER_TEMP/fake-archive/sysand"
+          tar -czf "$RUNNER_TEMP/fake-release/${{ matrix.asset }}" -C "$RUNNER_TEMP/fake-archive" sysand
+
+      - name: Serve fake release archive
+        run: |
+          cd "$RUNNER_TEMP/fake-release"
+          python3 -m http.server 8765 --bind 127.0.0.1 &
+          echo "$!" > "$RUNNER_TEMP/http-server.pid"
+
+          for attempt in $(seq 1 20); do
+            if curl -fsS "http://127.0.0.1:8765/${{ matrix.asset }}" >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "fake release server did not start" >&2
+          exit 1
+
+      - name: Run installer against fake release archive
+        run: |
+          install_dir="$RUNNER_TEMP/sysand-bin"
+          SYSAND_INSTALL_BASE_URL="http://127.0.0.1:8765" \
+            sh docs/src/install.sh --install-dir "$install_dir" --version 0.0.0-test
+
+          version="$("$install_dir/sysand" --version)"
+          test "$version" = "sysand 0.0.0-test"
+
+      - name: Check conflicting install flags
+        run: |
+          if sh docs/src/install.sh --install-dir "$RUNNER_TEMP/sysand-bin" --system-install; then
+            echo "expected --install-dir followed by --system-install to fail" >&2
+            exit 1
+          fi
+
+          if sh docs/src/install.sh --system-install --install-dir "$RUNNER_TEMP/sysand-bin"; then
+            echo "expected --system-install followed by --install-dir to fail" >&2
+            exit 1
+          fi
+
+      - name: Stop fake release server
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/http-server.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/http-server.pid")" || true
+          fi
+
+  windows:
+    name: Windows installer (${{ matrix.os }})
+    needs: [plan]
+    if: needs.plan.outputs.test == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            asset: sysand-windows-x86_64.zip
+            runtime: win-x64
+          - os: windows-11-arm
+            asset: sysand-windows-arm64.zip
+            runtime: win-arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check PowerShell syntax
+        shell: pwsh
+        run: |
+          $errors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+              "$PWD\docs\src\install.ps1",
+              [ref]$null,
+              [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+              $errors | Format-List | Out-String | Write-Error
+              exit 1
+          }
+
+      - name: Check help text
+        shell: pwsh
+        run: |
+          $help = .\docs\src\install.ps1 -Help
+          foreach ($expected in @("-InstallDir", "-Version", "latest non-prerelease")) {
+              if (($help -join "`n") -notlike "*$expected*") {
+                  Write-Error "help text did not contain: $expected"
+                  exit 1
+              }
+          }
+
+      - name: Create fake sysand.exe
+        shell: pwsh
+        run: |
+          $projectDir = Join-Path $env:RUNNER_TEMP "fake-sysand-src"
+          $publishDir = Join-Path $env:RUNNER_TEMP "fake-sysand-publish"
+          dotnet new console --output $projectDir --framework net8.0
+          @'
+          Console.WriteLine("sysand 0.0.0-test");
+          '@ | Set-Content -Path (Join-Path $projectDir "Program.cs")
+          dotnet publish `
+              $projectDir `
+              --configuration Release `
+              --runtime ${{ matrix.runtime }} `
+              --self-contained true `
+              --output $publishDir `
+              -p:AssemblyName=sysand `
+              -p:PublishSingleFile=true
+
+          $releaseDir = Join-Path $env:RUNNER_TEMP "fake-release"
+          New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
+          Compress-Archive `
+              -Path (Join-Path $publishDir "sysand.exe") `
+              -DestinationPath (Join-Path $releaseDir "${{ matrix.asset }}") `
+              -Force
+
+      - name: Serve fake release archive
+        shell: pwsh
+        run: |
+          $releaseDir = Join-Path $env:RUNNER_TEMP "fake-release"
+          $process = Start-Process `
+              -FilePath python `
+              -ArgumentList "-m", "http.server", "8765", "--bind", "127.0.0.1" `
+              -WorkingDirectory $releaseDir `
+              -PassThru
+          $process.Id | Set-Content -Path (Join-Path $env:RUNNER_TEMP "http-server.pid")
+
+          for ($attempt = 1; $attempt -le 20; $attempt++) {
+              try {
+                  Invoke-WebRequest -Uri "http://127.0.0.1:8765/${{ matrix.asset }}" -UseBasicParsing | Out-Null
+                  exit 0
+              } catch {
+                  Start-Sleep -Seconds 1
+              }
+          }
+
+          Write-Error "fake release server did not start"
+          exit 1
+
+      - name: Run installer against fake release archive
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:RUNNER_TEMP "sysand-bin"
+          $env:SYSAND_INSTALL_BASE_URL = "http://127.0.0.1:8765"
+          .\docs\src\install.ps1 -InstallDir $installDir -Version 0.0.0-test
+
+          $version = & (Join-Path $installDir "sysand.exe") --version
+          if ($version -ne "sysand 0.0.0-test") {
+              Write-Error "unexpected version output: $version"
+              exit 1
+          }
+
+      - name: Stop fake release server
+        if: always()
+        shell: pwsh
+        run: |
+          $pidFile = Join-Path $env:RUNNER_TEMP "http-server.pid"
+          if (Test-Path $pidFile) {
+              Stop-Process -Id (Get-Content $pidFile) -Force -ErrorAction SilentlyContinue
+          }
+
+  docs:
+    name: Installer docs
+    needs: [plan]
+    if: needs.plan.outputs.test == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
+        with:
+          mdbook-version: "latest"
+
+      - name: Build docs
+        run: mdbook build docs
+
+      - name: Check installer files are in the Pages artifact root
+        run: |
+          test -f docs/book/install.sh
+          test -f docs/book/install.ps1
+
+  ci-gate:
+    name: Test Install Script CI Gate
+    needs: [plan, unix, windows, docs]
+    if: needs.plan.outputs.gate == 'true' && !cancelled()
+    runs-on: ubuntu-slim
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            exit 1
+          fi

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -217,7 +217,7 @@ sysand --version
 
 You should see an output similar to: `sysand X.Y.Z`
 
-## Install script
+## Installation script
 
 Sysand provides a script to download and install sysand.
 

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -1,11 +1,10 @@
 # Installation
 
-There are a few ways to download Sysand:
+There are a few ways to install Sysand:
 
-- From PyPI
-- From this page
-- From GitHub releases
-- Compile from source
+- By installing the `sysand` Python package from PyPI
+- By downloading a sysand binary manually or with an installation script
+- By compiling Sysand from its source code
 
 ## PyPI
 
@@ -217,6 +216,100 @@ sysand --version
 ```
 
 You should see an output similar to: `sysand X.Y.Z`
+
+## Install script
+
+Sysand provides a script to download and install sysand.
+
+The scripts download the official GitHub Release archive for your platform,
+extract the `sysand` executable, and copy it into an install directory. By
+default, `latest` means the latest non-prerelease GitHub release. To install a
+prerelease, pass an explicit version.
+
+The scripts do not edit your shell profile or `PATH` settings. If the install
+directory is not already on `PATH`, the script prints a note after installation.
+
+### Windows
+
+The default install directory is `%LOCALAPPDATA%\Programs\Sysand`.
+On Windows, the `PATH` note checks your user `Path` setting.
+
+Download, inspect, then run the script:
+
+```powershell
+Invoke-WebRequest https://client.sysand.com/install.ps1 -OutFile install.ps1
+notepad install.ps1
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+Or run it directly:
+
+```powershell
+irm https://client.sysand.com/install.ps1 | iex
+```
+
+To install a specific release version, use `-Version`. The leading `v` is
+optional.
+
+```powershell
+.\install.ps1 -Version 0.1.0
+.\install.ps1 -Version 0.1.0-rc.1
+.\install.ps1 -Version v0.1.0-rc.1
+```
+
+To choose a different install directory:
+
+```powershell
+.\install.ps1 -InstallDir "$env:USERPROFILE\bin"
+```
+
+Download the script first when passing `-Version` or `-InstallDir`.
+
+### macOS and Linux
+
+The default install directory is `$HOME/.local/bin`.
+
+Download, inspect, then run the script:
+
+```sh
+curl -fsSLO https://client.sysand.com/install.sh
+less install.sh
+sh install.sh
+```
+
+Or run it directly:
+
+```sh
+curl -fsSL https://client.sysand.com/install.sh | sh
+```
+
+To install a specific release version, use `--version`. The leading `v` is
+optional.
+
+```sh
+sh install.sh --version 0.1.0
+sh install.sh --version 0.1.0-rc.1
+sh install.sh --version v0.1.0-rc.1
+```
+
+To choose a different install directory:
+
+```sh
+sh install.sh --install-dir "$HOME/bin"
+```
+
+To install into `/usr/local/bin`, use `--system-install`. If the current user is
+not root, the install step uses `sudo`.
+
+```sh
+sh install.sh --system-install
+```
+
+Flags can also be passed when piping the script:
+
+```sh
+curl -fsSL https://client.sysand.com/install.sh | sh -s -- --install-dir "$HOME/bin"
+```
 
 ## Download development version
 

--- a/docs/src/install.ps1
+++ b/docs/src/install.ps1
@@ -1,0 +1,127 @@
+# Sysand installer for Windows.
+#
+# This script is intentionally small and direct so it can be inspected before
+# running. It downloads a release archive, extracts sysand.exe, and copies it
+# into an install directory.
+
+param(
+    [string]$Version = "latest",
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\Sysand",
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+function Show-Usage {
+    @"
+Sysand installer for Windows
+
+Usage:
+  .\install.ps1 [-Version <version>] [-InstallDir <path>] [-Help]
+
+Options:
+  -Version <version>    Install a specific release version, for example 0.1.0
+                        or 0.1.0-rc.1. A leading "v" is also accepted.
+                        Default: latest non-prerelease.
+
+  -InstallDir <path>    Install into a specific directory.
+                        Default: `$env:LOCALAPPDATA\Programs\Sysand
+
+  -Help                 Print this help text.
+"@
+}
+
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    Fail "Version must not be empty."
+}
+
+if ($Version -notmatch '^[A-Za-z0-9._-]+$') {
+    Fail "Version may only contain letters, numbers, dots, underscores, and dashes."
+}
+
+# Accept versions with or without a leading "v". GitHub release tags use "v".
+if ($Version -eq "latest") {
+    $Tag = "latest"
+} elseif ($Version.StartsWith("v")) {
+    $Tag = $Version
+} else {
+    $Tag = "v$Version"
+}
+
+# Detect the CPU architecture name used by Sysand release assets.
+$ProcessorArchitecture = if ($env:PROCESSOR_ARCHITEW6432) {
+    $env:PROCESSOR_ARCHITEW6432
+} else {
+    $env:PROCESSOR_ARCHITECTURE
+}
+
+switch ($ProcessorArchitecture) {
+    "AMD64" { $Arch = "x86_64" }
+    "ARM64" { $Arch = "arm64" }
+    default { Fail "Unsupported architecture: $ProcessorArchitecture" }
+}
+
+# Build the release asset URL. "latest" means GitHub's latest non-prerelease.
+$Repo = "sensmetry/sysand"
+$Asset = "sysand-windows-$Arch.zip"
+
+# SYSAND_INSTALL_BASE_URL is for local tests. It should point at a directory
+# containing the release asset files.
+if ($env:SYSAND_INSTALL_BASE_URL) {
+    $BaseUrl = $env:SYSAND_INSTALL_BASE_URL.TrimEnd("/")
+    $DownloadUrl = "$BaseUrl/$Asset"
+} elseif ($Tag -eq "latest") {
+    $DownloadUrl = "https://github.com/$Repo/releases/latest/download/$Asset"
+} else {
+    $DownloadUrl = "https://github.com/$Repo/releases/download/$Tag/$Asset"
+}
+
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+$Archive = Join-Path $TempDir $Asset
+$ExtractDir = Join-Path $TempDir "extract"
+
+try {
+    New-Item -ItemType Directory -Path $TempDir, $ExtractDir -Force | Out-Null
+
+    Write-Host "Downloading $DownloadUrl"
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $Archive
+
+    Write-Host "Extracting $Asset"
+    Expand-Archive -Path $Archive -DestinationPath $ExtractDir -Force
+
+    $ExtractedBinary = Join-Path $ExtractDir "sysand.exe"
+    if (-not (Test-Path -Path $ExtractedBinary -PathType Leaf)) {
+        Fail "Archive did not contain a sysand.exe binary at its root."
+    }
+
+    $InstalledBinary = Join-Path $InstallDir "sysand.exe"
+
+    Write-Host "Installing sysand to $InstalledBinary"
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Copy-Item -Path $ExtractedBinary -Destination $InstalledBinary -Force
+
+    $InstalledVersion = & $InstalledBinary --version
+    Write-Host "Installed $InstalledVersion"
+
+    $PathEntries = [Environment]::GetEnvironmentVariable("Path", "User") -split ";"
+    if ($PathEntries -notcontains $InstallDir) {
+        Write-Host ""
+        Write-Host "Note: $InstallDir is not currently on your user PATH."
+        Write-Host "Add it to PATH to run sysand by name from a new terminal."
+    }
+} finally {
+    if (Test-Path $TempDir) {
+        Remove-Item -Path $TempDir -Recurse -Force
+    }
+}

--- a/docs/src/install.ps1
+++ b/docs/src/install.ps1
@@ -46,8 +46,8 @@ if ([string]::IsNullOrWhiteSpace($Version)) {
     Fail "Version must not be empty."
 }
 
-if ($Version -notmatch '^[A-Za-z0-9._-]+$') {
-    Fail "Version may only contain letters, numbers, dots, underscores, and dashes."
+if ($Version -notmatch '^[A-Za-z0-9.-]+$') {
+    Fail "Version may only contain letters, numbers, dots, and dashes."
 }
 
 # Accept versions with or without a leading "v". GitHub release tags use "v".

--- a/docs/src/install.sh
+++ b/docs/src/install.sh
@@ -99,8 +99,8 @@ validate_version() {
   [ -n "$version" ] || fail "version must not be empty"
 
   case "$version" in
-    *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-]*)
-      fail "version may only contain letters, numbers, dots, underscores, and dashes"
+    *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-]*)
+      fail "version may only contain letters, numbers, dots, and dashes"
       ;;
   esac
 }

--- a/docs/src/install.sh
+++ b/docs/src/install.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+# Sysand installer for Linux and macOS.
+#
+# This script is intentionally small and direct so it can be inspected before
+# running. It downloads a release archive, extracts the sysand binary, and copies
+# it into an install directory.
+
+set -eu
+
+repo="sensmetry/sysand"
+version="latest"
+install_dir="${HOME}/.local/bin"
+custom_install_dir="false"
+system_install="false"
+
+print_usage() {
+  cat <<'EOF'
+Sysand installer for Linux and macOS
+
+Usage:
+  sh install.sh [options]
+
+Options:
+  --version <version>   Install a specific release version, for example 0.1.0
+                        or 0.1.0-rc.1. A leading "v" is also accepted.
+                        Default: latest non-prerelease.
+
+  --install-dir <path>  Install into a specific directory.
+                        Default: $HOME/.local/bin
+
+  --system-install      Install into /usr/local/bin.
+                        If the current user is not root, the install step uses
+                        sudo.
+
+  -h, --help            Print this help text.
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || fail "--version requires a value"
+      version="$2"
+      shift 2
+      ;;
+    --install-dir)
+      [ "$#" -ge 2 ] || fail "--install-dir requires a value"
+      [ "$system_install" = "false" ] || fail "--install-dir cannot be used with --system-install"
+      install_dir="$2"
+      custom_install_dir="true"
+      shift 2
+      ;;
+    --system-install)
+      [ "$custom_install_dir" = "false" ] || fail "--system-install cannot be used with --install-dir"
+      install_dir="/usr/local/bin"
+      system_install="true"
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+# Accept versions with or without a leading "v". GitHub release tags use "v".
+normalize_version() {
+  case "$version" in
+    latest)
+      tag="latest"
+      ;;
+    v*)
+      tag="$version"
+      ;;
+    *)
+      tag="v$version"
+      ;;
+  esac
+}
+
+# Keep the version value narrow so it cannot accidentally form a surprising URL.
+validate_version() {
+  [ -n "$version" ] || fail "version must not be empty"
+
+  case "$version" in
+    *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-]*)
+      fail "version may only contain letters, numbers, dots, underscores, and dashes"
+      ;;
+  esac
+}
+
+# Detect the operating system name used by Sysand release assets.
+detect_os() {
+  case "$(uname -s)" in
+    Linux)
+      os="linux"
+      ;;
+    Darwin)
+      os="macos"
+      ;;
+    *)
+      fail "unsupported operating system: $(uname -s)"
+      ;;
+  esac
+}
+
+# Detect the CPU architecture name used by Sysand release assets.
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)
+      arch="x86_64"
+      ;;
+    arm64|aarch64)
+      arch="arm64"
+      ;;
+    *)
+      fail "unsupported architecture: $(uname -m)"
+      ;;
+  esac
+}
+
+# Build the release asset URL. "latest" means GitHub's latest non-prerelease.
+build_download_url() {
+  asset="sysand-${os}-${arch}.tar.gz"
+
+  # SYSAND_INSTALL_BASE_URL is for local tests. It should point at a directory
+  # containing the release asset files.
+  if [ -n "${SYSAND_INSTALL_BASE_URL:-}" ]; then
+    base_url="${SYSAND_INSTALL_BASE_URL%/}"
+    download_url="${base_url}/${asset}"
+  elif [ "$tag" = "latest" ]; then
+    download_url="https://github.com/${repo}/releases/latest/download/${asset}"
+  else
+    download_url="https://github.com/${repo}/releases/download/${tag}/${asset}"
+  fi
+}
+
+download_file() {
+  url="$1"
+  output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$output"
+  else
+    fail "curl or wget is required"
+  fi
+}
+
+run_system_install() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    fail "sudo is required for --system-install when not running as root"
+  fi
+}
+
+install_binary() {
+  if [ "$system_install" = "true" ]; then
+    run_system_install mkdir -p "$install_dir"
+    run_system_install cp "$extracted_binary" "${install_dir}/sysand"
+  else
+    mkdir -p "$install_dir"
+    cp "$extracted_binary" "${install_dir}/sysand"
+  fi
+}
+
+print_path_note() {
+  case ":${PATH:-}:" in
+    *":${install_dir}:"*)
+      ;;
+    *)
+      echo
+      echo "Note: ${install_dir} is not currently on PATH."
+      echo "Add it to your shell profile to run sysand by name, for example:"
+      echo "  export PATH=\"${install_dir}:\$PATH\""
+      ;;
+  esac
+}
+
+need_cmd uname
+need_cmd mktemp
+need_cmd tar
+
+validate_version
+normalize_version
+detect_os
+detect_arch
+build_download_url
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+archive="${tmp_dir}/${asset}"
+extract_dir="${tmp_dir}/extract"
+mkdir -p "$extract_dir"
+
+echo "Downloading ${download_url}"
+download_file "$download_url" "$archive"
+
+echo "Extracting ${asset}"
+tar -xzf "$archive" -C "$extract_dir"
+
+extracted_binary="${extract_dir}/sysand"
+[ -f "$extracted_binary" ] || fail "archive did not contain a sysand binary at its root"
+
+echo "Installing sysand to ${install_dir}/sysand"
+install_binary
+
+echo "Installed $("${install_dir}/sysand" --version)"
+print_path_note

--- a/docs/src/install.sh
+++ b/docs/src/install.sh
@@ -167,10 +167,8 @@ download_file() {
 run_system_install() {
   if [ "$(id -u)" = "0" ]; then
     "$@"
-  elif command -v sudo >/dev/null 2>&1; then
-    sudo "$@"
   else
-    fail "sudo is required for --system-install when not running as root"
+    sudo "$@"
   fi
 }
 


### PR DESCRIPTION
Add inspectable Unix and Windows install scripts, document cautious
and convenience install paths, and add a workflow that tests the
scripts against fake release archives.

Signed-off-by: Erik Sundell <erik.sundell@sensmetry.com>

---

I think it could be fine to put this higher up in the docs about installation, but figured its freshly introduced and not tested properly yet, so it could be better left below other install options for now.

I'm looking land this tomorrow and write trusted publishing docs with examples making use of it in CI context.

Instead of providing this example, it would become:

```yaml
      - name: Install sysand
        run: |
          ARCH=$(uname -m | sed 's/aarch64/arm64/')
          SYSAND_VERSION=$(
            curl -fsSL https://api.github.com/repos/sensmetry/sysand/releases \
              | awk -F'"' '/"tag_name":/ { tag=$4 } /"prerelease": true/ && !found { found=tag } END { if (found) print found }'
          )
          SYSAND_ARCHIVE="sysand-linux-${ARCH}.tar.xz"
          curl -fsSL "https://github.com/sensmetry/sysand/releases/download/${SYSAND_VERSION}/sysand-linux-${ARCH}.tar.xz" \
            | tar -xJ sysand
          install -m 0755 sysand /usr/local/bin/sysand
          sysand --version
```

```yaml
      - name: Install sysand
        run: |
          curl -fsSL https://client.sysand.com/install.sh | sh
```

- fixes #367 