### PR TITLE
fix: ensure docker image is built when github releases are published

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,7 +2,7 @@ name: Publish Image
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
This is just for future releases - I'll manually trigger this workflow manually now for the 0.1.0 release that didn't trigger the workflow as it should.