### PR TITLE
feat(build): update index and checksum by default, provide opt out for index

### DIFF
--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -527,8 +527,11 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_buildProject<'local>(
         &project,
         &output_path,
         compression,
+        // Currently keeping index updating disabled, since users can set their own index,
+        // and flipping this to true would overwrite that potentially custom index.
+        // TODO: add this as argument
         false,
-        false,
+        true,
     );
     match command_result {
         Ok(_) => {}
@@ -575,8 +578,11 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_buildWorkspace<'local>(
         &workspace,
         &output_path,
         compression,
-        true,
+        // Currently keeping index updating disabled, since users can set their own index,
+        // and flipping this to true would overwrite that potentially custom index.
+        // TODO: add this as argument
         false,
+        true,
     );
     match command_result {
         Ok(_) => {}

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -225,7 +225,7 @@ fn do_build_py(
         None => KparCompressionMethod::default(),
     };
 
-    do_build_kpar(&project, &output_path, compression, false, false)
+    do_build_kpar(&project, &output_path, compression, true, true)
         .map(|_| ())
         .map_err(|err| match err {
             KParBuildError::ProjectRead(_) => PyRuntimeError::new_err(err.to_string()),

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -253,14 +253,14 @@ pub fn do_build_kpar<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
     compression: KparCompressionMethod,
-    update_index_checksum: bool,
+    update_index: bool,
     allow_path_usage: bool,
 ) -> Result<LocalKParProjectRaw, KParBuildError<Pr::Error>> {
     do_build_kpar_inner(
         project,
         path,
         compression,
-        update_index_checksum,
+        update_index,
         allow_path_usage,
         None,
     )
@@ -270,7 +270,7 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
     compression: KparCompressionMethod,
-    update_index_checksum: bool,
+    update_index: bool,
     allow_path_usage: bool,
     workspace_metamodel: Option<&str>,
 ) -> Result<LocalKParProjectRaw, KParBuildError<Pr::Error>> {
@@ -340,12 +340,13 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
 
     let meta = meta.validate()?;
     // Check whether index symbols are up to date
-    if update_index_checksum {
+    if update_index {
         for p in meta.source_paths(true) {
             do_include(&mut local_project, p, true, true, None)?
         }
     } else {
         for p in meta.source_paths(true) {
+            do_include(&mut local_project, &p, true, false, None)?;
             let new_symbols = extract_symbols(&mut local_project, &p, None)?;
             let new_symbols: HashSet<String> = new_symbols.into_iter().collect();
             let old_symbols = meta.file_index_symbols(&p);
@@ -360,7 +361,7 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                 log::warn!(
                     "index is missing symbol `{only_in_new}` found in file `{p}`;\n\
                     if this is not intentional, include the file again to update its\n\
-                    exported symbols, or pass `--update-meta` to do so for all files"
+                    exported symbols, or omit `--keep-index` to do so for all files"
                 );
             }
         }
@@ -419,7 +420,7 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
     workspace: &Workspace,
     path: P,
     compression: KparCompressionMethod,
-    update_index_checksum: bool,
+    update_index: bool,
     allow_path_usage: bool,
 ) -> Result<Vec<LocalKParProjectRaw>, KParBuildError<LocalSrcError>> {
     let ws_metamodel = workspace.metamodel().map(|iri| iri.as_str());
@@ -438,7 +439,7 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
             &project,
             &output_path,
             compression,
-            update_index_checksum,
+            update_index,
             allow_path_usage,
             ws_metamodel,
         )?;

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -183,11 +183,14 @@ pub enum Command {
         /// For multiple related projects, consider using a workspace instead
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         allow_path_usage: bool,
-        /// Update project metadata to be included in the build artifacts. This
-        /// includes updating project symbol index and adding/updating source file
-        /// checksums. Original project(s) will not be affected
+        /// Note: this is now the default and kept only for compatibility.
+        /// Update project metadata before building. This includes updating
+        /// project symbol index and adding/updating source file checksums
         #[arg(long, short, default_value_t = false, verbatim_doc_comment)]
         update_meta: bool,
+        /// Don't update exported symbols index in the built KPAR metadata
+        #[arg(long, conflicts_with = "update_meta")]
+        keep_index: bool,
     },
     /// Publish a KPAR to a sysand package index
     Publish {

--- a/sysand/src/commands/build.rs
+++ b/sysand/src/commands/build.rs
@@ -13,14 +13,14 @@ pub fn command_build_for_project<P: AsRef<Utf8Path>>(
     path: P,
     compression: KparCompressionMethod,
     current_project: LocalSrcProject,
-    update_index_checksum: bool,
+    update_index: bool,
     allow_path_usage: bool,
 ) -> Result<()> {
     match do_build_kpar(
         &current_project,
         &path,
         compression,
-        update_index_checksum,
+        update_index,
         allow_path_usage,
     ) {
         Ok(_) => Ok(()),
@@ -38,7 +38,7 @@ pub fn command_build_for_workspace<P: AsRef<Utf8Path>>(
     path: P,
     compression: KparCompressionMethod,
     workspace: Workspace,
-    update_index_checksum: bool,
+    update_index: bool,
     allow_path_usage: bool,
 ) -> Result<()> {
     log::warn!(
@@ -51,7 +51,7 @@ pub fn command_build_for_workspace<P: AsRef<Utf8Path>>(
         &workspace,
         &path,
         compression,
-        update_index_checksum,
+        update_index,
         allow_path_usage,
     )?;
 

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -414,6 +414,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             }
         }
         Command::Sync { resolution_opts } => {
+            // TODO: only print this if we actually skip install of any std libs
             let provided_iris = if !resolution_opts.include_std {
                 crate::logger::warn_std_deps();
                 known_std_libs()
@@ -669,7 +670,11 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             compression,
             update_meta,
             allow_path_usage,
+            keep_index,
         } => {
+            if update_meta {
+                log::warn!("`--update-meta` is now the default behavior and is no longer needed")
+            }
             if let Some(current_project) = ctx.current_project {
                 // Even if we are in a workspace, the project takes precedence.
                 let path = if let Some(path) = path {
@@ -691,7 +696,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     path,
                     compression.into(),
                     current_project,
-                    update_meta,
+                    !keep_index,
                     allow_path_usage,
                 )
             } else {
@@ -710,7 +715,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     output_dir,
                     compression.into(),
                     current_workspace,
-                    update_meta,
+                    !keep_index,
                     allow_path_usage,
                 )
             }

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -4,6 +4,7 @@
 use assert_cmd::prelude::*;
 use camino::Utf8PathBuf;
 use clap::ValueEnum;
+use indexmap::IndexMap;
 use predicates::prelude::*;
 use serde_json::json;
 use std::{
@@ -23,6 +24,22 @@ use sysand_core::{
 mod common;
 pub use common::*;
 
+// Checksum for file `test.sysml` containing only `package P;`
+fn expected_checksum() -> Option<IndexMap<String, InterchangeProjectChecksumRaw>> {
+    Some(IndexMap::from([(
+        "test.sysml".to_owned(),
+        InterchangeProjectChecksumRaw {
+            value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8".to_string(),
+            algorithm: KerMlChecksumAlg::Sha256.into(),
+        },
+    )]))
+}
+
+// Index §for file `test.sysml` containing only `package P;`
+fn expected_index() -> IndexMap<String, String> {
+    IndexMap::from([("P".to_owned(), "test.sysml".to_owned())])
+}
+
 #[test]
 fn project_build() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) =
@@ -40,7 +57,7 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
     let orig_info_contents = fs::read_to_string(&orig_info_path)?;
     let orig_meta_contents = fs::read_to_string(&orig_meta_path)?;
 
-    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar", "--keep-index"], None)?;
 
     out.assert().success();
 
@@ -61,20 +78,26 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
         panic!("failed to get built project info/meta");
     };
 
-    // Ensure the build artifact matches original project
-    let original_meta: InterchangeProjectMetadataRaw = serde_json::from_str(&orig_meta_contents)?;
-    let original_info: InterchangeProjectInfoRaw = serde_json::from_str(&orig_info_contents)?;
-    assert_eq!(original_info, info);
-    assert_eq!(original_meta, meta);
-
     // Ensure no changes were made to the original project
     let new_info_contents = fs::read_to_string(&orig_info_path)?;
     let new_meta_contents = fs::read_to_string(&orig_meta_path)?;
     assert_eq!(orig_info_contents, new_info_contents);
     assert_eq!(orig_meta_contents, new_meta_contents);
 
+    // Ensure build artifact info matches original project
+    let original_meta: InterchangeProjectMetadataRaw = serde_json::from_str(&orig_meta_contents)?;
+    let original_info: InterchangeProjectInfoRaw = serde_json::from_str(&orig_info_contents)?;
+    assert_eq!(original_info, info);
+
+    let expected_checksum = expected_checksum();
+
+    // Index should not change
+    assert_eq!(meta.index, original_meta.index);
+    // File hash should still be updated
+    assert_eq!(meta.checksum, expected_checksum);
+
     // Now canonicalize meta during build
-    let out = run_sysand_in(&cwd, ["build", "--update-meta", "./test_build2.kpar"], None)?;
+    let out = run_sysand_in(&cwd, ["build", "./test_build2.kpar"], None)?;
     out.assert().success();
     let kpar_project = LocalKParProjectRaw::new_guess_root(cwd.join("test_build2.kpar"))?;
 
@@ -82,17 +105,9 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
         panic!("failed to get built project info/meta");
     };
     // File hash should be updated
-    assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
-    assert_eq!(
-        meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
-        &InterchangeProjectChecksumRaw {
-            value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8".to_string(),
-            algorithm: KerMlChecksumAlg::Sha256.into()
-        }
-    );
+    assert_eq!(meta.checksum, expected_checksum);
 
-    assert_eq!(meta.index.len(), 1);
-    assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+    assert_eq!(meta.index, expected_index());
 
     // Ensure no changes were made to the original project
     let new_info_contents = fs::read_to_string(&orig_info_path)?;
@@ -104,8 +119,7 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn project_build_errors_when_index_symbol_is_missing_from_file()
--> Result<(), Box<dyn std::error::Error>> {
+fn build_errors_when_index_symbol_is_missing_from_file() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
@@ -138,11 +152,18 @@ fn project_build_errors_when_index_symbol_is_missing_from_file()
     });
     std::fs::write(&meta_path, serde_json::to_string_pretty(&meta)?)?;
 
-    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    let out = run_sysand_in(&cwd, ["build", "./test_build_good.kpar"], None)?;
+    out.assert().success();
+    // Build should only fail when symbols are not updated
+    let out = run_sysand_in(
+        &cwd,
+        ["build", "./test_build_bad.kpar", "--keep-index"],
+        None,
+    )?;
     out.assert().failure().stderr(predicate::str::contains(
         "file `test.sysml` is missing symbol `Missing` found in index",
     ));
-    assert!(!cwd.join("test_build.kpar").exists());
+    assert!(!cwd.join("test_build_bad.kpar").exists());
 
     Ok(())
 }
@@ -175,7 +196,7 @@ fn project_build_warns_when_file_symbol_is_missing_from_index()
     )?;
     out.assert().success();
 
-    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?;
+    let out = run_sysand_in(&cwd, ["build", "./test_build.kpar", "--keep-index"], None)?;
     out.assert().success().stderr(predicate::str::contains(
         "index is missing symbol `Present` found in file `test.sysml`",
     ));
@@ -316,7 +337,9 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
         WProject::new(project3_cwd)?,
     ];
 
-    let out = run_sysand_in(&cwd, ["build"], None)?;
+    let expected_checksum = expected_checksum();
+
+    let out = run_sysand_in(&cwd, ["build", "--keep-index"], None)?;
     out.assert().success();
 
     for project in &projects {
@@ -348,7 +371,10 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
         let original_info: InterchangeProjectInfoRaw =
             serde_json::from_str(&project.orig_info_contents)?;
         assert_eq!(original_info, info);
-        assert_eq!(original_meta, meta);
+        // Index should not change
+        assert_eq!(meta.index, original_meta.index);
+        // File hash should still be updated
+        assert_eq!(meta.checksum, expected_checksum);
 
         // Ensure no changes were made to the original project
         let new_info_contents = fs::read_to_string(&project.info_path)?;
@@ -358,11 +384,11 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Now canonicalize meta during build. Previous artifacts should be overwritten
-    let out = run_sysand_in(&cwd, ["build", "--update-meta"], None)?;
+    let out = run_sysand_in(&cwd, ["build"], None)?;
     out.assert().success();
+    let expected_index = expected_index();
 
     for project in &projects {
-        println!("W9: {}", project.name);
         let kpar_path = cwd
             .join("output")
             .join(format!("{}-1.2.3.kpar", project.name));
@@ -386,18 +412,9 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         // File hash should be updated
-        assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
-        assert_eq!(
-            meta.checksum.as_ref().unwrap().get("test.sysml").unwrap(),
-            &InterchangeProjectChecksumRaw {
-                value: "b4ee9d8a3ffb51787bd30ab1a74c2333565fd2b8be1334e827c5937f44d54dd8"
-                    .to_string(),
-                algorithm: KerMlChecksumAlg::Sha256.into()
-            }
-        );
+        assert_eq!(meta.checksum, expected_checksum);
 
-        assert_eq!(meta.index.len(), 1);
-        assert_eq!(meta.index.get("P").unwrap(), "test.sysml");
+        assert_eq!(meta.index, expected_index);
 
         // Ensure no changes were made to the original project
         let new_info_contents = fs::read_to_string(&project.info_path)?;
@@ -1222,7 +1239,14 @@ fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::erro
     let out = match compression {
         Some(compression) => run_sysand_in(
             &cwd,
-            ["build", "--compression", compression, "./test_build.kpar"],
+            [
+                "build",
+                "--compression",
+                compression,
+                "./test_build.kpar",
+                // Pass `--update-meta` to see that its behaviour is same as default
+                "--update-meta",
+            ],
             None,
         )?,
         None => run_sysand_in(&cwd, ["build", "./test_build.kpar"], None)?,
@@ -1250,8 +1274,8 @@ fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::erro
     assert_eq!(info.name, "test_build");
     assert_eq!(info.version, "1.2.3");
 
-    assert_eq!(meta.checksum.as_ref().unwrap().len(), 1);
-    assert_eq!(meta.index.len(), 0);
+    assert_eq!(meta.checksum, expected_checksum());
+    assert_eq!(meta.index, expected_index());
     let mut src = String::new();
     kpar_project
         .read_source("test.sysml")?


### PR DESCRIPTION
This reverts the default flip done by #298. Index-only opt-out is provided, since it doesn't make sense to not update checksums to match actual file contents. Java bindings (and only these) will not update index, as the user can supply custom project metadata, including index, and updating the index silently on build would override the supplied one.

Now the behaviour matches user expectations in almost all cases, and requires less friction to build KPARs publishable to the index.

In bindings, also allow path usages in the KPARs being built, since this is not yet configurable by the caller.

Fixes #378