### PR TITLE
fix(docs): correct links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["Sensmetry <opensource@sensmetry.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sensmetry/sysand"
 description = "A package manager for SysML v2 and KerML"
-documentation = "https://docs.sysand.com"
+documentation = "https://docs.sysand.com/client/"
 homepage = "https://sysand.com"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Java are supported).
 ## Documentation
 
 Sysand client usage documentation is provided in
-[Sysand Client Documentation](https://docs.sysand.com/).
+[Sysand Client Documentation](https://docs.sysand.com/client/).
 
 ## Installation
 
 See the
-[installation section in Sysand Client Documentation](https://docs.sysand.com/getting-started/installation/)
+[installation section in Sysand Client Documentation](https://docs.sysand.com/client/getting-started/installation/)
 for various ways to download Sysand.
 
 ## Contributing

--- a/bindings/py/pyproject.toml
+++ b/bindings/py/pyproject.toml
@@ -30,7 +30,7 @@ maintainers = [
 import-names = ["sysand"]
 
 [project.urls]
-documentation = "https://docs.sysand.com"
+documentation = "https://docs.sysand.com/client/"
 homepage = "https://sysand.com"
 source = "https://github.com/sensmetry/sysand"
 issues = "https://github.com/sensmetry/sysand/issues"

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -19,7 +19,7 @@ use crate::env_vars;
 /// A package manager for SysML v2 and KerML
 ///
 /// Documentation:
-/// <https://docs.sysand.com/>
+/// <https://docs.sysand.com/client/>
 /// Package index and more information:
 /// <https://sysand.com/>
 /// Project repository:


### PR DESCRIPTION
Client docs live at https://docs.sysand.com/client/