### PR TITLE
feat!: rework installation scripts to improve UX and support alpine etc

### DIFF
--- a/.github/workflows/installation-script.yml
+++ b/.github/workflows/installation-script.yml
@@ -49,12 +49,20 @@ jobs:
         include:
           - os: ubuntu-24.04
             asset: sysand-linux-x86_64-gnu.tar.gz
+            shell: /bin/bash
+            profile: .bashrc
           - os: ubuntu-24.04-arm
             asset: sysand-linux-arm64-gnu.tar.gz
+            shell: /bin/bash
+            profile: .bashrc
           - os: macos-15-intel
             asset: sysand-macos-x86_64.tar.gz
+            shell: /bin/zsh
+            profile: .zshrc
           - os: macos-latest
             asset: sysand-macos-arm64.tar.gz
+            shell: /bin/zsh
+            profile: .zshrc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -68,36 +76,64 @@ jobs:
       - name: Check help text
         run: |
           scripts/install.sh --help > "$RUNNER_TEMP/install-help.txt"
-          grep -F -- "--install-dir" "$RUNNER_TEMP/install-help.txt"
-          grep -F -- "--system-install" "$RUNNER_TEMP/install-help.txt"
-          grep -F -- "latest non-prerelease" "$RUNNER_TEMP/install-help.txt"
+          grep -F "SYSAND_VERSION" "$RUNNER_TEMP/install-help.txt"
+          grep -F "latest non-prerelease" "$RUNNER_TEMP/install-help.txt"
+
+      - name: Reject removed flags with migration errors
+        run: |
+          if out=$(sh scripts/install.sh --version 1.0 2>&1); then
+            echo "expected --version to fail" >&2
+            exit 1
+          fi
+          echo "$out" | grep -F "SYSAND_VERSION"
+
+          if out=$(sh scripts/install.sh --install-dir "$RUNNER_TEMP/x" 2>&1); then
+            echo "expected --install-dir to fail" >&2
+            exit 1
+          fi
+          echo "$out" | grep -F ".local/bin"
+
+          if sh scripts/install.sh --system-install; then
+            echo "expected --system-install to fail" >&2
+            exit 1
+          fi
+
+          if sh scripts/install.sh --bogus; then
+            echo "expected unknown option to fail" >&2
+            exit 1
+          fi
 
       - name: Reject invalid version
         run: |
-          for invalid_version in 0.0.0_test 0.0.0+build; do
-            if sh scripts/install.sh --version "$invalid_version"; then
+          for invalid_version in 0.0.0_test 0.0.0+build 0.0.0-TEST; do
+            if SYSAND_VERSION="$invalid_version" sh scripts/install.sh; then
               echo "expected version '$invalid_version' to fail" >&2
               exit 1
             fi
           done
 
-      - name: Create fake release archive
+      - name: Create fake release archives
         run: |
-          mkdir -p "$RUNNER_TEMP/fake-release" "$RUNNER_TEMP/fake-archive"
-          cat > "$RUNNER_TEMP/fake-archive/sysand" <<'EOF'
+          for fake in v1:0.0.0-test1 v2:0.0.0-test2; do
+            subdir="${fake%%:*}"
+            fake_version="${fake#*:}"
+            mkdir -p "$RUNNER_TEMP/fake-release/$subdir" "$RUNNER_TEMP/fake-archive"
+            cat > "$RUNNER_TEMP/fake-archive/sysand" <<EOF
           #!/bin/sh
-          echo "sysand 0.0.0-test"
+          echo "sysand $fake_version"
           EOF
-          chmod +x "$RUNNER_TEMP/fake-archive/sysand"
-          tar -czf "$RUNNER_TEMP/fake-release/${{ matrix.asset }}" -C "$RUNNER_TEMP/fake-archive" sysand
+            chmod +x "$RUNNER_TEMP/fake-archive/sysand"
+            tar -czf "$RUNNER_TEMP/fake-release/$subdir/${{ matrix.asset }}" \
+              -C "$RUNNER_TEMP/fake-archive" sysand
+          done
 
-      - name: Serve fake release archive
+      - name: Serve fake release archives
         run: |
           cd "$RUNNER_TEMP/fake-release"
           python3 -m http.server 8765 --bind 127.0.0.1 &
 
           for attempt in $(seq 1 20); do
-            if curl -fsS "http://127.0.0.1:8765/${{ matrix.asset }}" >/dev/null; then
+            if curl -fsS "http://127.0.0.1:8765/v1/${{ matrix.asset }}" >/dev/null; then
               exit 0
             fi
             sleep 1
@@ -106,47 +142,165 @@ jobs:
           echo "fake release server did not start" >&2
           exit 1
 
-      - name: Run installer against fake release archive
+      - name: Install via the GITHUB_PATH branch
         run: |
-          install_dir="$RUNNER_TEMP/sysand-bin"
-          SYSAND_INSTALL_BASE_URL="http://127.0.0.1:8765" \
-            sh scripts/install.sh --install-dir "$install_dir" --version 0.0.0-test
+          fake_home="$RUNNER_TEMP/fake-home"
+          gh_path="$RUNNER_TEMP/gh-path"
+          : > "$gh_path"
 
-          version="$("$install_dir/sysand" --version)"
+          HOME="$fake_home" GITHUB_PATH="$gh_path" \
+            SYSAND_INSTALL_BASE_URL="http://127.0.0.1:8765/v1" \
+            sh scripts/install.sh
+
+          version="$("$fake_home/.local/bin/sysand" --version)"
+          test "$version" = "sysand 0.0.0-test1"
+          grep -qx "$fake_home/.local/bin" "$gh_path"
+
+      - name: Update over existing install with profile persistence
+        run: |
+          fake_home="$RUNNER_TEMP/fake-home"
+
+          # Two sequential runs: an update over v1 and an idempotency check.
+          out=""
+          for run in 1 2; do
+            out="$(env -u GITHUB_PATH -u CI \
+              HOME="$fake_home" SHELL="${{ matrix.shell }}" \
+              SYSAND_INSTALL_BASE_URL="http://127.0.0.1:8765/v2" \
+              sh scripts/install.sh)"
+            echo "$out"
+          done
+
+          if echo "$out" | grep -F "To use sysand"; then
+            echo "expected no session PATH instructions when already persisted" >&2
+            exit 1
+          fi
+
+          version="$("$fake_home/.local/bin/sysand" --version)"
+          test "$version" = "sysand 0.0.0-test2"
+
+          count="$(grep -cF 'export PATH="$HOME/.local/bin:$PATH"' "$fake_home/${{ matrix.profile }}")"
+          test "$count" = "1"
+
+          extra="$(cd "$fake_home/.local/bin" && ls -A | grep -vx sysand || true)"
+          if [ -n "$extra" ]; then
+            echo "unexpected files in install dir: $extra" >&2
+            exit 1
+          fi
+
+      - name: Skip profile persistence when CI is set
+        run: |
+          fake_home="$RUNNER_TEMP/fake-home-ci"
+          out="$(env -u GITHUB_PATH CI=true \
+            HOME="$fake_home" SHELL="${{ matrix.shell }}" \
+            SYSAND_INSTALL_BASE_URL="http://127.0.0.1:8765/v1" \
+            sh scripts/install.sh)"
+          echo "$out"
+          echo "$out" | grep -F "CI environment detected"
+          if [ -f "$fake_home/${{ matrix.profile }}" ]; then
+            echo "expected no profile to be written in CI" >&2
+            exit 1
+          fi
+
+  linux-container:
+    name: Linux installer (${{ matrix.image }})
+    needs: [plan]
+    if: needs.plan.outputs.test == 'true'
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.image }}
+    defaults:
+      run:
+        shell: sh -e {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # No glibc; also proves the script runs under busybox sh. Checkout
+          # works because the runner ships a musl build of node for Alpine.
+          - image: alpine:3.20
+            setup: apk add curl python3 tar
+          # glibc 2.31, older than the gnu build's 2.35 requirement.
+          - image: debian:11
+            setup: apt-get update && apt-get install -y curl python3
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install dependencies
+        run: ${{ matrix.setup }}
+
+      - name: Run installer against fake musl release
+        run: |
+          # Serving only the musl asset makes a wrong libc choice fail the
+          # download.
+          mkdir -p "$RUNNER_TEMP/fake-release" "$RUNNER_TEMP/fake-archive"
+          cat > "$RUNNER_TEMP/fake-archive/sysand" <<'EOF'
+          #!/bin/sh
+          echo "sysand 0.0.0-test"
+          EOF
+          chmod +x "$RUNNER_TEMP/fake-archive/sysand"
+          tar -czf "$RUNNER_TEMP/fake-release/sysand-linux-x86_64-musl.tar.gz" \
+            -C "$RUNNER_TEMP/fake-archive" sysand
+
+          cd "$RUNNER_TEMP/fake-release"
+          python3 -m http.server 8765 --bind 127.0.0.1 &
+          cd "$GITHUB_WORKSPACE"
+
+          started=""
+          for attempt in $(seq 1 20); do
+            if curl -fsS "http://127.0.0.1:8765/sysand-linux-x86_64-musl.tar.gz" >/dev/null; then
+              started="yes"
+              break
+            fi
+            sleep 1
+          done
+          if [ -z "$started" ]; then
+            echo "fake release server did not start" >&2
+            exit 1
+          fi
+
+          fake_home="$RUNNER_TEMP/fake-home"
+          gh_path="$RUNNER_TEMP/gh-path"
+          : > "$gh_path"
+
+          HOME="$fake_home" GITHUB_PATH="$gh_path" \
+            SYSAND_INSTALL_BASE_URL="http://127.0.0.1:8765" \
+            sh scripts/install.sh > "$RUNNER_TEMP/install-output.txt"
+          cat "$RUNNER_TEMP/install-output.txt"
+
+          grep -F "musl build" "$RUNNER_TEMP/install-output.txt"
+          version="$("$fake_home/.local/bin/sysand" --version)"
           test "$version" = "sysand 0.0.0-test"
-
-      - name: Check conflicting install flags
-        run: |
-          if sh scripts/install.sh --install-dir "$RUNNER_TEMP/sysand-bin" --system-install; then
-            echo "expected --install-dir followed by --system-install to fail" >&2
-            exit 1
-          fi
-
-          if sh scripts/install.sh --system-install --install-dir "$RUNNER_TEMP/sysand-bin"; then
-            echo "expected --system-install followed by --install-dir to fail" >&2
-            exit 1
-          fi
+          grep -qx "$fake_home/.local/bin" "$gh_path"
 
   windows:
-    name: Windows installer (${{ matrix.os }})
+    name: Windows installer (${{ matrix.os }}, ${{ matrix.pshell }})
     needs: [plan]
     if: needs.plan.outputs.test == 'true'
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.pshell }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: windows-latest
+            pshell: pwsh
+            asset: sysand-windows-x86_64.zip
+            runtime: win-x64
+          # Windows PowerShell 5.1: pwsh's parser accepts newer syntax the
+          # script must avoid, so parse and install under 5.1 as well.
+          - os: windows-latest
+            pshell: powershell
             asset: sysand-windows-x86_64.zip
             runtime: win-x64
           - os: windows-11-arm
+            pshell: pwsh
             asset: sysand-windows-arm64.zip
             runtime: win-arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check PowerShell syntax
-        shell: pwsh
         run: |
           $errors = $null
           $null = [System.Management.Automation.Language.Parser]::ParseFile(
@@ -160,58 +314,83 @@ jobs:
           }
 
       - name: Check help text
-        shell: pwsh
         run: |
-          $help = .\scripts\install.ps1 -Help
-          foreach ($expected in @("-InstallDir", "-Version", "latest non-prerelease")) {
-              if (($help -join "`n") -notlike "*$expected*") {
+          $help = (& .\scripts\install.ps1 -Help) -join "`n"
+          foreach ($expected in @("SYSAND_VERSION", "latest non-prerelease")) {
+              if ($help -notlike "*$expected*") {
                   Write-Error "help text did not contain: $expected"
                   exit 1
               }
           }
 
-      - name: Reject invalid version
-        shell: pwsh
+      - name: Reject arguments with a migration error
         run: |
-          foreach ($invalidVersion in @("0.0.0_test", "0.0.0+build")) {
-              $process = Start-Process `
-                  -FilePath pwsh `
-                  -ArgumentList "-NoProfile", "-File", ".\scripts\install.ps1", "-Version", $invalidVersion `
-                  -Wait `
-                  -PassThru `
-                  -NoNewWindow
-              if ($process.ExitCode -eq 0) {
+          $failed = $false
+          try {
+              & .\scripts\install.ps1 -Version "1.0"
+          } catch {
+              $failed = $true
+              if ("$_" -notlike "*SYSAND_VERSION*") {
+                  Write-Error "unexpected message: $_"
+                  exit 1
+              }
+          }
+          if (-not $failed) {
+              Write-Error "expected arguments to be rejected"
+              exit 1
+          }
+
+      - name: Reject invalid version
+        run: |
+          foreach ($invalidVersion in @("0.0.0_test", "0.0.0+build", "0.0.0-TEST")) {
+              $env:SYSAND_VERSION = $invalidVersion
+              $failed = $false
+              try {
+                  & .\scripts\install.ps1
+              } catch {
+                  $failed = $true
+              }
+              if (-not $failed) {
                   Write-Error "expected version '$invalidVersion' to fail"
                   exit 1
               }
           }
 
-      - name: Create fake sysand.exe
+      - name: Create fake release archives
         shell: pwsh
         run: |
-          $projectDir = Join-Path $env:RUNNER_TEMP "fake-sysand-src"
-          $publishDir = Join-Path $env:RUNNER_TEMP "fake-sysand-publish"
-          dotnet new console --output $projectDir --framework net8.0
-          @'
-          Console.WriteLine("sysand 0.0.0-test");
-          '@ | Set-Content -Path (Join-Path $projectDir "Program.cs")
-          dotnet publish `
-              $projectDir `
-              --configuration Release `
-              --runtime ${{ matrix.runtime }} `
-              --self-contained true `
-              --output $publishDir `
-              -p:AssemblyName=sysand `
-              -p:PublishSingleFile=true
+          foreach ($fake in @(@("v1", "0.0.0-test1"), @("v2", "0.0.0-test2"))) {
+              $subdir = $fake[0]
+              $fakeVersion = $fake[1]
+              $projectDir = Join-Path $env:RUNNER_TEMP "fake-sysand-src-$subdir"
+              $publishDir = Join-Path $env:RUNNER_TEMP "fake-sysand-publish-$subdir"
+              dotnet new console --output $projectDir --framework net8.0
+              @"
+          if (args.Length > 0 && args[0] == "wait")
+          {
+              System.Threading.Thread.Sleep(120000);
+              return;
+          }
+          Console.WriteLine("sysand $fakeVersion");
+          "@ | Set-Content -Path (Join-Path $projectDir "Program.cs")
+              dotnet publish `
+                  $projectDir `
+                  --configuration Release `
+                  --runtime ${{ matrix.runtime }} `
+                  --self-contained true `
+                  --output $publishDir `
+                  -p:AssemblyName=sysand `
+                  -p:PublishSingleFile=true
 
-          $releaseDir = Join-Path $env:RUNNER_TEMP "fake-release"
-          New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
-          Compress-Archive `
-              -Path (Join-Path $publishDir "sysand.exe") `
-              -DestinationPath (Join-Path $releaseDir "${{ matrix.asset }}") `
-              -Force
+              $releaseDir = Join-Path $env:RUNNER_TEMP "fake-release\$subdir"
+              New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
+              Compress-Archive `
+                  -Path (Join-Path $publishDir "sysand.exe") `
+                  -DestinationPath (Join-Path $releaseDir "${{ matrix.asset }}") `
+                  -Force
+          }
 
-      - name: Serve fake release archive
+      - name: Serve fake release archives
         shell: pwsh
         run: |
           $releaseDir = Join-Path $env:RUNNER_TEMP "fake-release"
@@ -223,7 +402,7 @@ jobs:
 
           for ($attempt = 1; $attempt -le 20; $attempt++) {
               try {
-                  Invoke-WebRequest -Uri "http://127.0.0.1:8765/${{ matrix.asset }}" -UseBasicParsing | Out-Null
+                  Invoke-WebRequest -Uri "http://127.0.0.1:8765/v1/${{ matrix.asset }}" -UseBasicParsing | Out-Null
                   exit 0
               } catch {
                   Start-Sleep -Seconds 1
@@ -233,22 +412,184 @@ jobs:
           Write-Error "fake release server did not start"
           exit 1
 
-      - name: Run installer against fake release archive
-        shell: pwsh
+      - name: Back up user PATH registry value
         run: |
-          $installDir = Join-Path $env:RUNNER_TEMP "sysand-bin"
-          $env:SYSAND_INSTALL_BASE_URL = "http://127.0.0.1:8765"
-          .\scripts\install.ps1 -InstallDir $installDir -Version 0.0.0-test
+          $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
+          $backup = @{ HasPath = $false; RawPath = ""; Kind = "" }
+          if ($envKey.GetValueNames() -contains "Path") {
+              $backup.HasPath = $true
+              $backup.RawPath = $envKey.GetValue(
+                  "Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+              $backup.Kind = $envKey.GetValueKind("Path").ToString()
+          }
+          $envKey.Dispose()
+          $backup | Export-Clixml -Path (Join-Path $env:RUNNER_TEMP "user-path-backup.xml")
 
+      - name: Install via the GITHUB_PATH branch
+        run: |
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "fake-localappdata"
+          $ghPath = Join-Path $env:RUNNER_TEMP "gh-path"
+          Set-Content -Path $ghPath -Value ""
+          $env:GITHUB_PATH = $ghPath
+          $env:SYSAND_INSTALL_BASE_URL = "http://127.0.0.1:8765/v1"
+
+          & .\scripts\install.ps1
+
+          $installDir = Join-Path $env:LOCALAPPDATA "Programs\Sensmetry\Sysand\bin"
           $version = & (Join-Path $installDir "sysand.exe") --version
-          if ($version -ne "sysand 0.0.0-test") {
+          if ($version -ne "sysand 0.0.0-test1") {
               Write-Error "unexpected version output: $version"
               exit 1
           }
+          if (-not (Select-String -Path $ghPath -SimpleMatch $installDir -Quiet)) {
+              Write-Error "GITHUB_PATH does not contain the install directory"
+              exit 1
+          }
+
+      - name: Skip user PATH update when CI is set
+        run: |
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "fake-localappdata"
+          $env:GITHUB_PATH = ""
+          $env:CI = "true"
+          $env:SYSAND_INSTALL_BASE_URL = "http://127.0.0.1:8765/v1"
+
+          function Get-RawUserPath {
+              $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
+              try {
+                  if ($envKey.GetValueNames() -contains "Path") {
+                      return $envKey.GetValue(
+                          "Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+                  }
+                  return $null
+              } finally {
+                  $envKey.Dispose()
+              }
+          }
+
+          $before = Get-RawUserPath
+          & .\scripts\install.ps1
+          $after = Get-RawUserPath
+          if ($after -ne $before) {
+              Write-Error "user PATH was modified in CI: '$before' -> '$after'"
+              exit 1
+          }
+
+      - name: Update in-use install with PATH and legacy cleanup
+        run: |
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "fake-localappdata"
+          $installDir = Join-Path $env:LOCALAPPDATA "Programs\Sensmetry\Sysand\bin"
+          $legacyDir = Join-Path $env:LOCALAPPDATA "Programs\Sysand"
+          $env:GITHUB_PATH = ""
+          $env:CI = ""
+          $env:SYSAND_INSTALL_BASE_URL = "http://127.0.0.1:8765/v2"
+
+          # Pre-seed a REG_EXPAND_SZ user PATH with an unexpanded entry plus
+          # the legacy install directory.
+          $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+          $envKey.SetValue(
+              "Path",
+              "%USERPROFILE%\bin;$legacyDir",
+              [Microsoft.Win32.RegistryValueKind]::ExpandString)
+          $envKey.Dispose()
+
+          # Pre-create a legacy installation.
+          New-Item -ItemType Directory -Path $legacyDir -Force | Out-Null
+          Copy-Item -Path (Join-Path $installDir "sysand.exe") -Destination (Join-Path $legacyDir "sysand.exe")
+
+          # Keep the installed v1 binary running during the update.
+          $proc = Start-Process `
+              -FilePath (Join-Path $installDir "sysand.exe") `
+              -ArgumentList "wait" `
+              -PassThru `
+              -NoNewWindow
+          try {
+              & .\scripts\install.ps1
+          } finally {
+              Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+          }
+
+          $version = & (Join-Path $installDir "sysand.exe") --version
+          if ($version -ne "sysand 0.0.0-test2") {
+              Write-Error "unexpected version after update: $version"
+              exit 1
+          }
+          $oldFiles = @(Get-ChildItem -Path $installDir -File | Where-Object { $_.Name -like "sysand.exe.old.*" })
+          if ($oldFiles.Count -eq 0) {
+              Write-Error "expected a sysand.exe.old.* file after updating an in-use binary"
+              exit 1
+          }
+          if (Test-Path (Join-Path $legacyDir "sysand.exe")) {
+              Write-Error "legacy binary was not removed"
+              exit 1
+          }
+
+          $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
+          $rawPath = $envKey.GetValue(
+              "Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+          $kind = $envKey.GetValueKind("Path")
+          $envKey.Dispose()
+          if ($kind -ne [Microsoft.Win32.RegistryValueKind]::ExpandString) {
+              Write-Error "user PATH value kind changed to $kind"
+              exit 1
+          }
+          if ($rawPath -notlike "*%USERPROFILE%\bin*") {
+              Write-Error "unexpanded PATH entry was clobbered: $rawPath"
+              exit 1
+          }
+          $entries = @($rawPath -split ";" | Where-Object { $_ -ne "" })
+          if (@($entries | Where-Object { $_ -eq $installDir }).Count -ne 1) {
+              Write-Error "install dir not on user PATH exactly once: $rawPath"
+              exit 1
+          }
+          if (@($entries | Where-Object { $_ -eq $legacyDir }).Count -ne 0) {
+              Write-Error "legacy PATH entry was not removed: $rawPath"
+              exit 1
+          }
+
+          # A re-run with nothing in use cleans leftovers, adds no duplicate
+          # PATH entry, and repeats no session PATH instructions.
+          $rerunOutput = (& .\scripts\install.ps1) -join "`n"
+          Write-Host $rerunOutput
+          if ($rerunOutput -like "*To use sysand in this session*") {
+              Write-Error "expected no session PATH instructions when already persisted"
+              exit 1
+          }
+
+          $leftovers = @(Get-ChildItem -Path $installDir -File | Where-Object { $_.Name -ne "sysand.exe" })
+          if ($leftovers.Count -ne 0) {
+              Write-Error "unexpected leftovers after re-run: $($leftovers.Name -join ', ')"
+              exit 1
+          }
+          $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
+          $rawPath = $envKey.GetValue(
+              "Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+          $envKey.Dispose()
+          $entries = @($rawPath -split ";" | Where-Object { $_ -ne "" })
+          if (@($entries | Where-Object { $_ -eq $installDir }).Count -ne 1) {
+              Write-Error "install dir duplicated on user PATH: $rawPath"
+              exit 1
+          }
+
+      - name: Restore user PATH registry value
+        if: always()
+        run: |
+          $backupFile = Join-Path $env:RUNNER_TEMP "user-path-backup.xml"
+          if (-not (Test-Path $backupFile)) {
+              exit 0
+          }
+          $backup = Import-Clixml -Path $backupFile
+          $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+          if ($backup.HasPath) {
+              $kind = [Enum]::Parse([Microsoft.Win32.RegistryValueKind], $backup.Kind)
+              $envKey.SetValue("Path", $backup.RawPath, $kind)
+          } elseif ($envKey.GetValueNames() -contains "Path") {
+              $envKey.DeleteValue("Path")
+          }
+          $envKey.Dispose()
 
   ci-gate:
     name: Installation Script CI Gate
-    needs: [plan, unix, windows]
+    needs: [plan, unix, linux-container, windows]
     if: needs.plan.outputs.gate == 'true' && !cancelled()
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/installation-script.yml
+++ b/.github/workflows/installation-script.yml
@@ -446,6 +446,28 @@ jobs:
               exit 1
           }
 
+      - name: Install via piped invocation (irm | iex)
+        run: |
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "fake-localappdata-iex"
+          $ghPath = Join-Path $env:RUNNER_TEMP "gh-path-iex"
+          Set-Content -Path $ghPath -Value ""
+          $env:GITHUB_PATH = $ghPath
+          $env:SYSAND_INSTALL_BASE_URL = "http://127.0.0.1:8765/v1"
+
+          $preferenceBefore = $ErrorActionPreference
+          Get-Content -Path .\scripts\install.ps1 -Raw | Invoke-Expression
+          if ($ErrorActionPreference -ne $preferenceBefore) {
+              Write-Error "ErrorActionPreference leaked out of the installer"
+              exit 1
+          }
+
+          $installDir = Join-Path $env:LOCALAPPDATA "Programs\Sensmetry\Sysand\bin"
+          $version = & (Join-Path $installDir "sysand.exe") --version
+          if ($version -ne "sysand 0.0.0-test1") {
+              Write-Error "unexpected version output: $version"
+              exit 1
+          }
+
       - name: Skip user PATH update when CI is set
         run: |
           $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "fake-localappdata"

--- a/.github/workflows/installation-script.yml
+++ b/.github/workflows/installation-script.yml
@@ -112,6 +112,22 @@ jobs:
             fi
           done
 
+      - name: Reject unsupported version
+        run: |
+          for unsupported_version in 0.1.1 v0.1.1 0.1.0 0.1.1-rc.1; do
+            if out=$(SYSAND_VERSION="$unsupported_version" sh scripts/install.sh 2>&1); then
+              echo "expected version '$unsupported_version' to fail" >&2
+              exit 1
+            fi
+            echo "$out" | grep -F "0.1.2 or later"
+          done
+
+          if out=$(SYSAND_VERSION="0.1" sh scripts/install.sh 2>&1); then
+            echo "expected version '0.1' to fail" >&2
+            exit 1
+          fi
+          echo "$out" | grep -F "could not parse"
+
       - name: Create fake release archives
         run: |
           for fake in v1:0.0.0-test1 v2:0.0.0-test2; do
@@ -148,7 +164,10 @@ jobs:
           gh_path="$RUNNER_TEMP/gh-path"
           : > "$gh_path"
 
+          # A semver prerelease version must pass the supported-version check;
+          # the fake base URL ignores the tag, so this only exercises the check.
           HOME="$fake_home" GITHUB_PATH="$gh_path" \
+            SYSAND_VERSION="1.2.3-alpha.1" \
             SYSAND_INSTALL_BASE_URL="http://127.0.0.1:8765/v1" \
             sh scripts/install.sh
 
@@ -356,6 +375,42 @@ jobs:
               }
           }
 
+      - name: Reject unsupported version
+        run: |
+          foreach ($unsupportedVersion in @("0.1.1", "v0.1.1", "0.1.0", "0.1.1-rc.1")) {
+              $env:SYSAND_VERSION = $unsupportedVersion
+              $failed = $false
+              try {
+                  & .\scripts\install.ps1
+              } catch {
+                  $failed = $true
+                  if ("$_" -notlike "*0.1.2 or later*") {
+                      Write-Error "unexpected message for '$unsupportedVersion': $_"
+                      exit 1
+                  }
+              }
+              if (-not $failed) {
+                  Write-Error "expected version '$unsupportedVersion' to fail"
+                  exit 1
+              }
+          }
+
+          $env:SYSAND_VERSION = "0.1"
+          $failed = $false
+          try {
+              & .\scripts\install.ps1
+          } catch {
+              $failed = $true
+              if ("$_" -notlike "*could not parse*") {
+                  Write-Error "unexpected message for '0.1': $_"
+                  exit 1
+              }
+          }
+          if (-not $failed) {
+              Write-Error "expected version '0.1' to fail"
+              exit 1
+          }
+
       - name: Create fake release archives
         shell: pwsh
         run: |
@@ -412,19 +467,6 @@ jobs:
           Write-Error "fake release server did not start"
           exit 1
 
-      - name: Back up user PATH registry value
-        run: |
-          $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
-          $backup = @{ HasPath = $false; RawPath = ""; Kind = "" }
-          if ($envKey.GetValueNames() -contains "Path") {
-              $backup.HasPath = $true
-              $backup.RawPath = $envKey.GetValue(
-                  "Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
-              $backup.Kind = $envKey.GetValueKind("Path").ToString()
-          }
-          $envKey.Dispose()
-          $backup | Export-Clixml -Path (Join-Path $env:RUNNER_TEMP "user-path-backup.xml")
-
       - name: Install via the GITHUB_PATH branch
         run: |
           $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "fake-localappdata"
@@ -432,6 +474,9 @@ jobs:
           Set-Content -Path $ghPath -Value ""
           $env:GITHUB_PATH = $ghPath
           $env:SYSAND_INSTALL_BASE_URL = "http://127.0.0.1:8765/v1"
+          # A semver prerelease version must pass the supported-version check;
+          # the fake base URL ignores the tag, so this only exercises the check.
+          $env:SYSAND_VERSION = "1.2.3-alpha.1"
 
           & .\scripts\install.ps1
 
@@ -591,23 +636,6 @@ jobs:
               Write-Error "install dir duplicated on user PATH: $rawPath"
               exit 1
           }
-
-      - name: Restore user PATH registry value
-        if: always()
-        run: |
-          $backupFile = Join-Path $env:RUNNER_TEMP "user-path-backup.xml"
-          if (-not (Test-Path $backupFile)) {
-              exit 0
-          }
-          $backup = Import-Clixml -Path $backupFile
-          $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
-          if ($backup.HasPath) {
-              $kind = [Enum]::Parse([Microsoft.Win32.RegistryValueKind], $backup.Kind)
-              $envKey.SetValue("Path", $backup.RawPath, $kind)
-          } elseif ($envKey.GetValueNames() -contains "Path") {
-              $envKey.DeleteValue("Path")
-          }
-          $envKey.Dispose()
 
   ci-gate:
     name: Installation Script CI Gate

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,53 +1,65 @@
 # Sysand installer for Windows.
 #
-# This script is intentionally small and direct so it can be inspected before
-# running. It downloads a release archive, extracts sysand.exe, and copies it
-# into an install directory.
+# This script is intentionally direct so it can be inspected before running.
+# It downloads a release archive, extracts sysand.exe, installs it atomically
+# into %LOCALAPPDATA%\Programs\Sensmetry\Sysand\bin (replacing any existing
+# installation), and ensures that directory is on the user PATH.
+#
+# Configuration is via environment variables:
+#   SYSAND_VERSION           Release version to install, for example 0.1.0 or
+#                            v0.1.0-rc.1. Default: latest non-prerelease.
+#   SYSAND_INSTALL_BASE_URL  For local tests. It should point at a directory
+#                            containing the release asset files.
+#
+# Requires Windows 10 or newer.
 
-param(
-    [string]$Version = "latest",
-    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\Sysand",
-    [switch]$Help
-)
-
-$ErrorActionPreference = "Stop"
-
-function Show-Usage {
-    @"
+if ($args.Count -gt 0) {
+    if ($args[0] -in @("-h", "--help", "-help", "/?")) {
+        @'
 Sysand installer for Windows
 
 Usage:
-  .\install.ps1 [-Version <version>] [-InstallDir <path>] [-Help]
+  .\install.ps1 [-Help]
 
-Options:
-  -Version <version>    Install a specific release version, for example 0.1.0
-                        or 0.1.0-rc.1. A leading "v" is also accepted.
-                        Default: latest non-prerelease.
+Installs sysand.exe to %LOCALAPPDATA%\Programs\Sensmetry\Sysand\bin,
+replacing any existing installation, and ensures that directory is on the
+user PATH.
 
-  -InstallDir <path>    Install into a specific directory.
-                        Default: `$env:LOCALAPPDATA\Programs\Sysand
+Configuration via environment variables:
+  SYSAND_VERSION   Release version to install, for example 0.1.0 or
+                   0.1.0-rc.1. A leading "v" is also accepted.
+                   Default: latest non-prerelease.
 
-  -Help                 Print this help text.
-"@
+Uninstall by deleting %LOCALAPPDATA%\Programs\Sensmetry\Sysand and removing
+the install directory from your user PATH.
+'@
+        return
+    }
+    throw "error: this installer takes no arguments besides -Help; set SYSAND_VERSION=<version> to pick a version. The install directory is fixed to %LOCALAPPDATA%\Programs\Sensmetry\Sysand\bin."
 }
+
+# The body runs in its own scope so that, when invoked via "irm ... | iex",
+# preference and helper variables do not leak into the calling session.
+& {
+
+$ErrorActionPreference = "Stop"
 
 function Fail {
     param([string]$Message)
-    Write-Error $Message
-    exit 1
+    throw "error: $Message"
 }
 
-if ($Help) {
-    Show-Usage
-    exit 0
+# Windows 10 also implies the PowerShell (5.1+) and .NET (TLS 1.2 capable)
+# versions this script needs.
+if ([Environment]::OSVersion.Version.Major -lt 10) {
+    Fail "sysand requires Windows 10 or newer (found $([Environment]::OSVersion.Version))"
 }
 
-if ([string]::IsNullOrWhiteSpace($Version)) {
-    Fail "Version must not be empty."
-}
+$Version = if ($env:SYSAND_VERSION) { $env:SYSAND_VERSION } else { "latest" }
 
-if ($Version -notmatch '^[A-Za-z0-9.-]+$') {
-    Fail "Version may only contain letters, numbers, dots, and dashes."
+# Keep the version value narrow so it cannot accidentally form a surprising URL.
+if ($Version -cnotmatch '^[a-z0-9.-]+$') {
+    Fail "SYSAND_VERSION may only contain lowercase letters, numbers, dots, and dashes"
 }
 
 # Accept versions with or without a leading "v". GitHub release tags use "v".
@@ -69,15 +81,13 @@ $ProcessorArchitecture = if ($env:PROCESSOR_ARCHITEW6432) {
 switch ($ProcessorArchitecture) {
     "AMD64" { $Arch = "x86_64" }
     "ARM64" { $Arch = "arm64" }
-    default { Fail "Unsupported architecture: $ProcessorArchitecture" }
+    default { Fail "unsupported architecture: $ProcessorArchitecture" }
 }
 
 # Build the release asset URL. "latest" means GitHub's latest non-prerelease.
 $Repo = "sensmetry/sysand"
 $Asset = "sysand-windows-$Arch.zip"
 
-# SYSAND_INSTALL_BASE_URL is for local tests. It should point at a directory
-# containing the release asset files.
 if ($env:SYSAND_INSTALL_BASE_URL) {
     $BaseUrl = $env:SYSAND_INSTALL_BASE_URL.TrimEnd("/")
     $DownloadUrl = "$BaseUrl/$Asset"
@@ -85,6 +95,128 @@ if ($env:SYSAND_INSTALL_BASE_URL) {
     $DownloadUrl = "https://github.com/$Repo/releases/latest/download/$Asset"
 } else {
     $DownloadUrl = "https://github.com/$Repo/releases/download/$Tag/$Asset"
+}
+
+$InstallDir = Join-Path $env:LOCALAPPDATA "Programs\Sensmetry\Sysand\bin"
+$LegacyDir = Join-Path $env:LOCALAPPDATA "Programs\Sysand"
+
+function Test-SamePathEntry {
+    param([string]$A, [string]$B)
+    return $A.TrimEnd("\") -eq $B.TrimEnd("\")
+}
+
+# Install the staged exe with renames so the destination never holds a partial
+# binary. A running sysand.exe can be renamed but not deleted or overwritten,
+# so an update moves it aside first and cleans it up on the next run.
+function Install-Binary {
+    param([string]$ExtractedBinary)
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    $Dest = Join-Path $InstallDir "sysand.exe"
+
+    Get-ChildItem -Path $InstallDir -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like "sysand.exe.old.*" -or $_.Name -like "sysand.exe.new.*" } |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+
+    $Staging = Join-Path $InstallDir ("sysand.exe.new." + [System.IO.Path]::GetRandomFileName())
+    Copy-Item -Path $ExtractedBinary -Destination $Staging
+
+    $Old = $null
+    if (Test-Path -Path $Dest) {
+        $Old = Join-Path $InstallDir ("sysand.exe.old." + [System.IO.Path]::GetRandomFileName())
+        Move-Item -Path $Dest -Destination $Old
+    }
+    try {
+        Move-Item -Path $Staging -Destination $Dest
+    } catch {
+        if ($Old) { Move-Item -Path $Old -Destination $Dest }
+        throw
+    }
+    if ($Old) { Remove-Item -Path $Old -Force -ErrorAction SilentlyContinue }
+}
+
+# Earlier installer versions placed sysand.exe directly in Programs\Sysand;
+# leaving it would keep shadowing or duplicating the new installation.
+function Remove-LegacyInstall {
+    $LegacyBinary = Join-Path $LegacyDir "sysand.exe"
+    if (Test-Path -Path $LegacyBinary) {
+        try {
+            Remove-Item -Path $LegacyBinary -Force
+            Write-Host "Removed previous installation at $LegacyBinary"
+        } catch {
+            Write-Warning "could not remove previous installation at $LegacyBinary; delete it manually"
+        }
+    }
+}
+
+# Add the install directory to the persisted user PATH, editing the registry
+# value directly so a REG_EXPAND_SZ PATH keeps its kind and its unexpanded
+# %VAR% entries (which [Environment]::SetEnvironmentVariable would clobber).
+# Also drops the legacy Programs\Sysand entry. Best effort: warns on failure.
+# Returns $true when the install directory was already persisted.
+function Update-UserPath {
+    $EnvKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+    try {
+        $HasPath = $EnvKey.GetValueNames() -contains "Path"
+        $RawPath = ""
+        $Kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+        if ($HasPath) {
+            $RawPath = $EnvKey.GetValue(
+                "Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            $Kind = $EnvKey.GetValueKind("Path")
+        }
+
+        $Entries = @($RawPath -split ";" | Where-Object { $_ -ne "" })
+        $Kept = @($Entries | Where-Object { -not (Test-SamePathEntry $_ $LegacyDir) })
+        $AlreadyPresent = @($Kept | Where-Object { Test-SamePathEntry $_ $InstallDir }).Count -gt 0
+
+        if ($AlreadyPresent -and $Kept.Count -eq $Entries.Count) {
+            return $true
+        }
+        if (-not $AlreadyPresent) {
+            $Kept += $InstallDir
+        }
+        $EnvKey.SetValue("Path", ($Kept -join ";"), $Kind)
+        if ($AlreadyPresent) {
+            Write-Host "Removed legacy $LegacyDir from your user PATH"
+        } else {
+            Write-Host "Added $InstallDir to your user PATH (takes effect after you sign out and back in)"
+        }
+        return $AlreadyPresent
+    } finally {
+        $EnvKey.Dispose()
+    }
+}
+
+function Set-SysandOnPath {
+    if ($env:GITHUB_PATH) {
+        Add-Content -Path $env:GITHUB_PATH -Value $InstallDir
+        Write-Host "Added $InstallDir to GITHUB_PATH"
+        return
+    }
+
+    # In CI the job shell is the only session; a persisted PATH edit would be
+    # a pointless write to an ephemeral environment.
+    $AlreadyPersisted = $false
+    if ($env:CI) {
+        Write-Host "CI environment detected; not updating the user PATH"
+    } else {
+        try {
+            $AlreadyPersisted = Update-UserPath
+        } catch {
+            Write-Warning "could not update your user PATH ($_); add $InstallDir to it manually"
+        }
+    }
+
+    # An already persisted PATH means an earlier run printed the session
+    # instructions; repeating them is noise.
+    $OnLivePath = @($env:Path -split ";" | Where-Object { Test-SamePathEntry $_ $InstallDir }).Count -gt 0
+    if (-not $OnLivePath -and -not $AlreadyPersisted) {
+        Write-Host ""
+        Write-Host "To use sysand in this session:"
+        Write-Host "  PowerShell:  `$env:Path = `"$InstallDir;`" + `$env:Path"
+        Write-Host "  cmd.exe:     set PATH=$InstallDir;%PATH%"
+    }
 }
 
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
@@ -95,33 +227,32 @@ try {
     New-Item -ItemType Directory -Path $TempDir, $ExtractDir -Force | Out-Null
 
     Write-Host "Downloading $DownloadUrl"
-    Invoke-WebRequest -Uri $DownloadUrl -OutFile $Archive
+    try {
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $Archive -UseBasicParsing
+    } catch {
+        Fail "failed to download $Asset from $DownloadUrl ($_)"
+    }
 
     Write-Host "Extracting $Asset"
     Expand-Archive -Path $Archive -DestinationPath $ExtractDir -Force
 
     $ExtractedBinary = Join-Path $ExtractDir "sysand.exe"
     if (-not (Test-Path -Path $ExtractedBinary -PathType Leaf)) {
-        Fail "Archive did not contain a sysand.exe binary at its root."
+        Fail "archive did not contain a sysand.exe binary at its root"
     }
 
-    $InstalledBinary = Join-Path $InstallDir "sysand.exe"
+    Write-Host "Installing sysand to $(Join-Path $InstallDir "sysand.exe")"
+    Install-Binary -ExtractedBinary $ExtractedBinary
 
-    Write-Host "Installing sysand to $InstalledBinary"
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-    Copy-Item -Path $ExtractedBinary -Destination $InstalledBinary -Force
-
-    $InstalledVersion = & $InstalledBinary --version
+    $InstalledVersion = & (Join-Path $InstallDir "sysand.exe") --version
     Write-Host "Installed $InstalledVersion"
 
-    $PathEntries = [Environment]::GetEnvironmentVariable("Path", "User") -split ";"
-    if ($PathEntries -notcontains $InstallDir) {
-        Write-Host ""
-        Write-Host "Note: $InstallDir is not currently on your user PATH."
-        Write-Host "Add it to PATH to run sysand by name from a new terminal."
-    }
+    Remove-LegacyInstall
+    Set-SysandOnPath
 } finally {
     if (Test-Path $TempDir) {
         Remove-Item -Path $TempDir -Recurse -Force
     }
+}
+
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -6,8 +6,9 @@
 # installation), and ensures that directory is on the user PATH.
 #
 # Configuration is via environment variables:
-#   SYSAND_VERSION           Release version to install, for example 0.1.0 or
-#                            v0.1.0-rc.1. Default: latest non-prerelease.
+#   SYSAND_VERSION           Release version to install, for example 0.1.2 or
+#                            v0.1.2-rc.1. Must be 0.1.2 or later.
+#                            Default: latest non-prerelease.
 #   SYSAND_INSTALL_BASE_URL  For local tests. It should point at a directory
 #                            containing the release asset files.
 #
@@ -26,9 +27,9 @@ replacing any existing installation, and ensures that directory is on the
 user PATH.
 
 Configuration via environment variables:
-  SYSAND_VERSION   Release version to install, for example 0.1.0 or
-                   0.1.0-rc.1. A leading "v" is also accepted.
-                   Default: latest non-prerelease.
+  SYSAND_VERSION   Release version to install, for example 0.1.2 or
+                   0.1.2-dev.1. A leading "v" is also accepted. Must be
+                   0.1.2 or later. Default: latest non-prerelease.
 
 Uninstall by deleting %LOCALAPPDATA%\Programs\Sensmetry\Sysand and removing
 the install directory from your user PATH.
@@ -69,6 +70,20 @@ if ($Version -eq "latest") {
     $Tag = $Version
 } else {
     $Tag = "v$Version"
+}
+
+# Releases before 0.1.2 do not publish all the assets this installer expects,
+# so only 0.1.2 or later is supported.
+if ($Version -ne "latest") {
+    $Release = $Version.TrimStart("v").Split("-")[0]
+    $Parsed = $null
+    if ($Release -cnotmatch '^[0-9]+\.[0-9]+\.[0-9]+$' -or
+        -not [System.Version]::TryParse($Release, [ref]$Parsed)) {
+        Fail "could not parse SYSAND_VERSION '$Version' as major.minor.patch"
+    }
+    if ($Parsed -lt [System.Version]"0.1.2") {
+        Fail "this installer only supports sysand 0.1.2 or later (requested $Version)"
+    }
 }
 
 # Detect the CPU architecture name used by Sysand release assets.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,38 +2,39 @@
 
 # Sysand installer for Linux and macOS.
 #
-# This script is intentionally small and direct so it can be inspected before
-# running. It downloads a release archive, extracts the sysand binary, and copies
-# it into an install directory.
+# This script is intentionally direct so it can be inspected before running.
+# It downloads a release archive, extracts the sysand binary, installs it
+# atomically into $HOME/.local/bin (replacing any existing installation), and
+# ensures that directory is on PATH.
+#
+# Configuration is via environment variables:
+#   SYSAND_VERSION           Release version to install, for example 0.1.0 or
+#                            v0.1.0-rc.1. Default: latest non-prerelease.
+#   SYSAND_INSTALL_BASE_URL  For local tests. It should point at a directory
+#                            containing the release asset files.
 
 set -eu
 
-repo="sensmetry/sysand"
-version="latest"
-install_dir="${HOME}/.local/bin"
-custom_install_dir="false"
-system_install="false"
+# Everything happens in functions and main is the last line of the script, so
+# a partially downloaded "curl | sh" defines functions but executes nothing.
 
 print_usage() {
   cat <<'EOF'
 Sysand installer for Linux and macOS
 
 Usage:
-  sh install.sh [options]
+  sh install.sh [-h|--help]
 
-Options:
-  --version <version>   Install a specific release version, for example 0.1.0
-                        or 0.1.0-rc.1. A leading "v" is also accepted.
-                        Default: latest non-prerelease.
+Installs the sysand binary to $HOME/.local/bin, replacing any existing
+installation, and ensures that directory is on PATH.
 
-  --install-dir <path>  Install into a specific directory.
-                        Default: $HOME/.local/bin
+Configuration via environment variables:
+  SYSAND_VERSION   Release version to install, for example 0.1.0 or
+                   0.1.0-rc.1. A leading "v" is also accepted.
+                   Default: latest non-prerelease.
 
-  --system-install      Install into /usr/local/bin.
-                        If the current user is not root, the install step uses
-                        sudo.
-
-  -h, --help            Print this help text.
+Uninstall by deleting $HOME/.local/bin/sysand and removing the PATH line the
+installer added to your shell profile.
 EOF
 }
 
@@ -46,35 +47,25 @@ need_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
 }
 
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --version)
-      [ "$#" -ge 2 ] || fail "--version requires a value"
-      version="$2"
-      shift 2
-      ;;
-    --install-dir)
-      [ "$#" -ge 2 ] || fail "--install-dir requires a value"
-      [ "$system_install" = "false" ] || fail "--install-dir cannot be used with --system-install"
-      install_dir="$2"
-      custom_install_dir="true"
-      shift 2
-      ;;
-    --system-install)
-      [ "$custom_install_dir" = "false" ] || fail "--system-install cannot be used with --install-dir"
-      install_dir="/usr/local/bin"
-      system_install="true"
-      shift
-      ;;
-    -h|--help)
-      print_usage
-      exit 0
-      ;;
-    *)
-      fail "unknown option: $1"
-      ;;
-  esac
-done
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        print_usage
+        exit 0
+        ;;
+      --version)
+        fail "--version was removed; set SYSAND_VERSION=<version> instead"
+        ;;
+      --install-dir|--system-install)
+        fail "$1 was removed; sysand now always installs to \$HOME/.local/bin"
+        ;;
+      *)
+        fail "unknown option: $1 (configuration is via environment variables, see --help)"
+        ;;
+    esac
+  done
+}
 
 # Accept versions with or without a leading "v". GitHub release tags use "v".
 normalize_version() {
@@ -93,11 +84,9 @@ normalize_version() {
 
 # Keep the version value narrow so it cannot accidentally form a surprising URL.
 validate_version() {
-  [ -n "$version" ] || fail "version must not be empty"
-
   case "$version" in
-    *[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-]*)
-      fail "version may only contain letters, numbers, dots, and dashes"
+    *[!abcdefghijklmnopqrstuvwxyz0123456789.-]*)
+      fail "SYSAND_VERSION may only contain lowercase letters, numbers, dots, and dashes"
       ;;
   esac
 }
@@ -122,6 +111,12 @@ detect_arch() {
   case "$(uname -m)" in
     x86_64|amd64)
       arch="x86_64"
+      # A shell under Rosetta 2 reports x86_64 on Apple Silicon; prefer the
+      # native arm64 build.
+      if [ "$os" = "macos" ] &&
+        [ "$(sysctl -n sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
+        arch="arm64"
+      fi
       ;;
     arm64|aarch64)
       arch="arm64"
@@ -132,16 +127,85 @@ detect_arch() {
   esac
 }
 
+# The macOS release binaries require macOS 11 (Big Sur) on arm64 and
+# macOS 10.12 (Sierra) on x86_64, the Rust toolchain minimums.
+check_macos_version() {
+  macos_version="$(sw_vers -productVersion)"
+  macos_major="${macos_version%%.*}"
+  macos_minor="${macos_version#*.}"
+  macos_minor="${macos_minor%%[!0-9]*}"
+  case "$macos_version" in
+    *.*) ;;
+    *) macos_minor="0" ;;
+  esac
+  case "$macos_major" in
+    ''|*[!0-9]*)
+      fail "could not parse macOS version \`${macos_version}\`"
+      ;;
+  esac
+  [ -n "$macos_minor" ] || macos_minor="0"
+
+  if [ "$arch" = "arm64" ]; then
+    [ "$macos_major" -ge 11 ] ||
+      fail "sysand requires macOS 11 or newer on arm64 (found ${macos_version})"
+  elif [ "$macos_major" -lt 10 ] ||
+    { [ "$macos_major" -eq 10 ] && [ "$macos_minor" -lt 12 ]; }; then
+    fail "sysand requires macOS 10.12 or newer on x86_64 (found ${macos_version})"
+  fi
+}
+
+# Pick the gnu build when glibc 2.35+ is available, the fully static musl
+# build otherwise (older glibc, musl, or undetectable).
+detect_libc() {
+  glibc_version=""
+  if glibc_output="$(getconf GNU_LIBC_VERSION 2>/dev/null)"; then
+    # getconf prints "glibc 2.39". On musl this query fails.
+    glibc_version="${glibc_output#glibc }"
+  else
+    # musl's ldd prints "musl libc (...)" to stderr; glibc's prints a first
+    # line ending in the version.
+    ldd_line="$(ldd --version 2>&1 | head -n 1 || true)"
+    case "$ldd_line" in
+      *musl*) ;;
+      *)
+        glibc_version="$(echo "$ldd_line" | grep -o '[0-9][0-9.]*$' || true)"
+        ;;
+    esac
+  fi
+
+  glibc_major="${glibc_version%%.*}"
+  glibc_minor="${glibc_version#*.}"
+  glibc_minor="${glibc_minor%%[!0-9]*}"
+  case "$glibc_version" in
+    *.*) ;;
+    *) glibc_major="" ;;
+  esac
+  case "$glibc_major" in
+    ''|*[!0-9]*) glibc_major="" ;;
+  esac
+
+  if [ -n "$glibc_major" ] && [ -n "$glibc_minor" ] &&
+    { [ "$glibc_major" -gt 2 ] ||
+      { [ "$glibc_major" -eq 2 ] && [ "$glibc_minor" -ge 35 ]; }; }; then
+    libc="gnu"
+    echo "Detected glibc ${glibc_version}; using the gnu build"
+  elif [ -n "$glibc_major" ]; then
+    libc="musl"
+    echo "Detected glibc ${glibc_version} (older than 2.35); using the static musl build"
+  else
+    libc="musl"
+    echo "Could not detect glibc; using the static musl build"
+  fi
+}
+
 # Build the release asset URL. "latest" means GitHub's latest non-prerelease.
 build_download_url() {
   if [ "$os" = "linux" ]; then
-    asset="sysand-${os}-${arch}-gnu.tar.gz"
+    asset="sysand-${os}-${arch}-${libc}.tar.gz"
   else
     asset="sysand-${os}-${arch}.tar.gz"
   fi
 
-  # SYSAND_INSTALL_BASE_URL is for local tests. It should point at a directory
-  # containing the release asset files.
   if [ -n "${SYSAND_INSTALL_BASE_URL:-}" ]; then
     base_url="${SYSAND_INSTALL_BASE_URL%/}"
     download_url="${base_url}/${asset}"
@@ -152,78 +216,173 @@ build_download_url() {
   fi
 }
 
+download_failed() {
+  if [ "${libc:-}" = "musl" ]; then
+    echo "note: musl assets are only published for sysand releases newer than 0.1.1" >&2
+  fi
+  fail "failed to download \`${asset}\` from \`${download_url}\`"
+}
+
 download_file() {
   url="$1"
   output="$2"
 
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" -o "$output"
+    curl -fsSL "$url" -o "$output" || download_failed
   elif command -v wget >/dev/null 2>&1; then
-    wget -q "$url" -O "$output"
+    wget -q "$url" -O "$output" || download_failed
   else
     fail "curl or wget is required"
   fi
 }
 
-run_system_install() {
-  if [ "$(id -u)" = "0" ]; then
-    "$@"
-  else
-    sudo "$@"
-  fi
-}
-
+# Stage inside the destination directory so the final move is an atomic
+# same-filesystem rename; the destination never holds a partial binary.
 install_binary() {
-  if [ "$system_install" = "true" ]; then
-    run_system_install mkdir -p "$install_dir"
-    run_system_install cp "$extracted_binary" "${install_dir}/sysand"
-  else
-    mkdir -p "$install_dir"
-    cp "$extracted_binary" "${install_dir}/sysand"
-  fi
+  mkdir -p "$install_dir"
+  rm -f "${install_dir}/.sysand."*
+  staging="$(mktemp "${install_dir}/.sysand.XXXXXX")"
+  cp "$extracted_binary" "$staging"
+  chmod 755 "$staging"
+  mv -f "$staging" "${install_dir}/sysand"
+  staging=""
 }
 
-print_path_note() {
-  case ":${PATH:-}:" in
-    *":${install_dir}:"*)
+# Append the install directory to the profile of the user's login shell so
+# future sessions find sysand. Best effort: warns instead of failing.
+persist_path() {
+  shell_name="${SHELL:-}"
+  shell_name="${shell_name##*/}"
+  case "$shell_name" in
+    zsh)
+      profile="${ZDOTDIR:-$HOME}/.zshrc"
+      ;;
+    bash)
+      if [ "$os" = "macos" ]; then
+        profile="${HOME}/.bash_profile"
+      else
+        profile="${HOME}/.bashrc"
+      fi
       ;;
     *)
-      echo
-      echo "Note: ${install_dir} is not currently on PATH."
-      echo "Add it to your shell profile to run sysand by name, for example:"
-      echo "  export PATH=\"${install_dir}:\$PATH\""
+      echo "warning: unsupported shell \`${SHELL:-}\`; add this line to your shell profile yourself:" >&2
+      echo "  ${path_line}" >&2
+      return 0
       ;;
   esac
+
+  if [ -f "$profile" ] && grep -qF "$path_line" "$profile"; then
+    path_already_persisted="true"
+    return 0
+  fi
+
+  if {
+    echo ""
+    echo "# Added by the sysand installer"
+    echo "$path_line"
+  } >> "$profile" 2>/dev/null; then
+    echo "Added ${install_dir} to PATH in ${profile} (takes effect in new shells)"
+  else
+    echo "warning: could not update ${profile}; add this line to it yourself:" >&2
+    echo "  ${path_line}" >&2
+  fi
 }
 
-need_cmd uname
-need_cmd mktemp
-need_cmd tar
+configure_path() {
+  if [ -n "${GITHUB_PATH:-}" ]; then
+    echo "$install_dir" >> "$GITHUB_PATH"
+    echo "Added ${install_dir} to GITHUB_PATH"
+    return 0
+  fi
 
-validate_version
-normalize_version
-detect_os
-detect_arch
-build_download_url
+  case ":${PATH:-}:" in
+    *":${install_dir}:"*)
+      return 0
+      ;;
+  esac
 
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT
+  # In CI the job shell is the only session; a profile edit would be a
+  # pointless write to an ephemeral environment.
+  path_already_persisted="false"
+  if [ -n "${CI:-}" ]; then
+    echo "CI environment detected; not updating any shell profile"
+  else
+    persist_path
+  fi
 
-archive="${tmp_dir}/${asset}"
-extract_dir="${tmp_dir}/extract"
-mkdir -p "$extract_dir"
+  # A profile that already has the line means an earlier run printed the
+  # session instructions; repeating them is noise.
+  if [ "$path_already_persisted" = "false" ]; then
+    echo "To use sysand in this shell, run:"
+    echo "  ${path_line}"
+  fi
+}
 
-echo "Downloading ${download_url}"
-download_file "$download_url" "$archive"
+# An older sysand earlier on PATH (for example a /usr/local/bin system
+# install) would keep being picked up instead of this one.
+warn_shadowed() {
+  case ":${PATH:-}:" in
+    *":${install_dir}:"*) ;;
+    *)
+      return 0
+      ;;
+  esac
+  resolved="$(command -v sysand 2>/dev/null || true)"
+  if [ -n "$resolved" ] && [ "$resolved" != "${install_dir}/sysand" ]; then
+    echo "warning: \`${resolved}\` comes before \`${install_dir}/sysand\` on PATH and will shadow it" >&2
+  fi
+}
 
-echo "Extracting ${asset}"
-tar -xzf "$archive" -C "$extract_dir"
+main() {
+  parse_args "$@"
 
-extracted_binary="${extract_dir}/sysand"
-[ -f "$extracted_binary" ] || fail "archive did not contain a sysand binary at its root"
+  need_cmd uname
+  need_cmd mktemp
+  need_cmd tar
+  [ -n "${HOME:-}" ] || fail "HOME must be set"
 
-echo "Installing sysand to ${install_dir}/sysand"
-install_binary
+  repo="sensmetry/sysand"
+  version="${SYSAND_VERSION:-latest}"
+  install_dir="${HOME}/.local/bin"
+  # Written verbatim to shell profiles; $HOME must stay unexpanded.
+  # shellcheck disable=SC2016
+  path_line='export PATH="$HOME/.local/bin:$PATH"'
 
-echo "Installed $("${install_dir}/sysand" --version)"
-print_path_note
+  validate_version
+  normalize_version
+  detect_os
+  detect_arch
+  if [ "$os" = "macos" ]; then
+    check_macos_version
+  fi
+  if [ "$os" = "linux" ]; then
+    detect_libc
+  fi
+  build_download_url
+
+  tmp_dir="$(mktemp -d)"
+  staging=""
+  trap 'rm -rf "$tmp_dir"; if [ -n "$staging" ]; then rm -f "$staging"; fi' EXIT
+
+  archive="${tmp_dir}/${asset}"
+  extract_dir="${tmp_dir}/extract"
+  mkdir -p "$extract_dir"
+
+  echo "Downloading ${download_url}"
+  download_file "$download_url" "$archive"
+
+  echo "Extracting ${asset}"
+  tar -xzf "$archive" -C "$extract_dir"
+
+  extracted_binary="${extract_dir}/sysand"
+  [ -f "$extracted_binary" ] || fail "archive did not contain a sysand binary at its root"
+
+  echo "Installing sysand to ${install_dir}/sysand"
+  install_binary
+
+  echo "Installed $("${install_dir}/sysand" --version)"
+  configure_path
+  warn_shadowed
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,8 +8,9 @@
 # ensures that directory is on PATH.
 #
 # Configuration is via environment variables:
-#   SYSAND_VERSION           Release version to install, for example 0.1.0 or
-#                            v0.1.0-rc.1. Default: latest non-prerelease.
+#   SYSAND_VERSION           Release version to install, for example 0.1.2 or
+#                            v0.1.2-rc.1. Must be 0.1.2 or later.
+#                            Default: latest non-prerelease.
 #   SYSAND_INSTALL_BASE_URL  For local tests. It should point at a directory
 #                            containing the release asset files.
 
@@ -29,9 +30,9 @@ Installs the sysand binary to $HOME/.local/bin, replacing any existing
 installation, and ensures that directory is on PATH.
 
 Configuration via environment variables:
-  SYSAND_VERSION   Release version to install, for example 0.1.0 or
-                   0.1.0-rc.1. A leading "v" is also accepted.
-                   Default: latest non-prerelease.
+  SYSAND_VERSION   Release version to install, for example 0.1.2 or
+                   0.1.2-dev.1. A leading "v" is also accepted. Must be
+                   0.1.2 or later. Default: latest non-prerelease.
 
 Uninstall by deleting $HOME/.local/bin/sysand and removing the PATH line the
 installer added to your shell profile.
@@ -89,6 +90,36 @@ validate_version() {
       fail "SYSAND_VERSION may only contain lowercase letters, numbers, dots, and dashes"
       ;;
   esac
+}
+
+# Releases before 0.1.2 do not publish all the assets this installer expects
+# (for example the musl builds), so only 0.1.2 or later is supported.
+check_version_supported() {
+  [ "$version" != "latest" ] || return 0
+
+  release="${version#v}"
+  release="${release%%-*}"
+  case "$release" in
+    *.*.*) ;;
+    *)
+      fail "could not parse SYSAND_VERSION \`${version}\` as major.minor.patch"
+      ;;
+  esac
+  major="${release%%.*}"
+  rest="${release#*.}"
+  minor="${rest%%.*}"
+  rest="${rest#*.}"
+  patch="${rest%%.*}"
+  case "${major}~${minor}~${patch}" in
+    *[!0-9~]*|*~~*)
+      fail "could not parse SYSAND_VERSION \`${version}\` as major.minor.patch"
+      ;;
+  esac
+
+  if [ "$major" -eq 0 ] &&
+    { [ "$minor" -lt 1 ] || { [ "$minor" -eq 1 ] && [ "$patch" -lt 2 ]; }; }; then
+    fail "this installer only supports sysand 0.1.2 or later (requested ${version})"
+  fi
 }
 
 # Detect the operating system name used by Sysand release assets.
@@ -216,21 +247,14 @@ build_download_url() {
   fi
 }
 
-download_failed() {
-  if [ "${libc:-}" = "musl" ]; then
-    echo "note: musl assets are only published for sysand releases newer than 0.1.1" >&2
-  fi
-  fail "failed to download \`${asset}\` from \`${download_url}\`"
-}
-
 download_file() {
   url="$1"
   output="$2"
 
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" -o "$output" || download_failed
+    curl -fsSL "$url" -o "$output" || fail "failed to download \`${asset}\` from \`${url}\`"
   elif command -v wget >/dev/null 2>&1; then
-    wget -q "$url" -O "$output" || download_failed
+    wget -q "$url" -O "$output" || fail "failed to download \`${asset}\` from \`${url}\`"
   else
     fail "curl or wget is required"
   fi
@@ -349,6 +373,7 @@ main() {
   path_line='export PATH="$HOME/.local/bin:$PATH"'
 
   validate_version
+  check_version_supported
   normalize_version
   detect_os
   detect_arch


### PR DESCRIPTION
## Breaking changes

- The installation script doesn't accept flags any more, only environment variables.
- The installation is only compatible with the version 0.1.2 and later

---

Configure both installers via SYSAND_VERSION instead of flags so the same
mechanism works for curl|sh and irm|iex; removed flags fail with migration
errors. Installs are user-scoped only: $HOME/.local/bin on Unix and
%LOCALAPPDATA%\Programs\Sensmetry\Sysand\bin on Windows, where the legacy
Programs\Sysand binary and PATH entry are cleaned up.

Install and update atomically: Unix stages in the destination directory and
renames into place; Windows moves a possibly running sysand.exe aside before
renaming the staged binary in, with rollback and leftover cleanup.

Select the Linux artifact by detected glibc (2.35+ gets gnu, anything else
the static musl build), require macOS 11 on arm64 and 10.12 on x86_64 (the
Rust toolchain minimums), prefer the native build under Rosetta 2, and
require Windows 10.

Handle PATH in three tiers: append to GITHUB_PATH when set, skip persistence
in other CI (CI env var) where the job shell is the only session, otherwise
persist idempotently (bash/zsh profiles on Unix, the HKCU Environment Path
registry value on Windows, preserving REG_EXPAND_SZ entries) and print
current-session instructions for sh, PowerShell, and cmd.exe.

The sh installer runs everything from a main function called on the last
line, so a truncated curl|sh download executes nothing.

The test workflow covers the new behavior, adding alpine and debian:11
container jobs for musl selection and a Windows PowerShell 5.1 leg alongside
pwsh.

---

- Fixes https://github.com/sensmetry/sysand/issues/385
- Changes introduced to be removed later tracked by https://github.com/sensmetry/sysand/issues/395
- This PR was developed with Fable 5, I'm happy with its job
