### PR TITLE
fix: don't hardcode file name in error

### DIFF
--- a/core/src/commands/index/add.rs
+++ b/core/src/commands/index/add.rs
@@ -135,6 +135,15 @@ pub enum IndexAddError {
         "{iri} version {version} is removed so it cannot be added again; removed version can only stay removed"
     )]
     VersionRemoved { iri: Box<str>, version: Version },
+    #[error(
+        "archive `{kpar_path}` does not contain a project at its root,\n\
+         the project is at `{root_in_kpar}` within the archive;\n\
+         project must be at the root of the archive"
+    )]
+    ProjectNotAtRoot {
+        kpar_path: Box<Utf8Path>,
+        root_in_kpar: Box<Utf8Path>,
+    },
 }
 
 pub fn do_index_add<I: AsRef<str>, P: AsRef<Utf8Path>, R: AsRef<Utf8Path>>(
@@ -157,7 +166,15 @@ pub fn do_index_add<I: AsRef<str>, P: AsRef<Utf8Path>, R: AsRef<Utf8Path>>(
 
     let kpar_path = kpar_path.as_ref();
     let kpar_path_abs = wrapfs::absolute(kpar_path)?;
-    let local_project = LocalKParProjectRaw::new_project_at_root(&kpar_path_abs)?;
+    let local_project = LocalKParProjectRaw::new_guess_root(&kpar_path_abs)?;
+    if let Some(p) = local_project.project_root_in_archive()
+        && !p.as_str().is_empty()
+    {
+        return Err(IndexAddError::ProjectNotAtRoot {
+            kpar_path: kpar_path_abs.as_str().into(),
+            root_in_kpar: p.as_str().into(),
+        });
+    }
     let Some(info) = local_project.get_info()? else {
         return Err(IndexAddError::MissingInfo(kpar_path_abs.clone()));
     };

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -517,9 +517,9 @@ impl LocalKParProjectRaw {
         zip: &mut ZipArchive<File>,
         path: P,
     ) -> Result<Option<T>, LocalKParError> {
-        match self.get_relative(zip, path) {
+        match self.get_relative(zip, &path) {
             Ok(f) => Ok(Some(serde_json::from_reader(f).map_err(|e| {
-                ProjectDeserializationError::new("failed to deserialize `.project.json`", e)
+                ProjectDeserializationError::new(path.as_ref().as_str(), e)
             })?)),
             Err((_, ZipError::FileNotFound)) => Ok(None),
             Err((path, err)) => Err(LocalKParError::Zip(ZipArchiveError::NamedFileMeta(

--- a/core/src/project/local_src.rs
+++ b/core/src/project/local_src.rs
@@ -387,9 +387,8 @@ impl ProjectRead for LocalSrcProject {
 
         let info_json = if info_json_path.exists() {
             Some(
-                serde_json::from_reader(wrapfs::File::open(&info_json_path)?).map_err(|e| {
-                    ProjectDeserializationError::new("failed to deserialize `.project.json`", e)
-                })?,
+                serde_json::from_reader(wrapfs::File::open(&info_json_path)?)
+                    .map_err(|e| ProjectDeserializationError::new(".project.json", e))?,
             )
         } else {
             None
@@ -399,9 +398,8 @@ impl ProjectRead for LocalSrcProject {
 
         let meta_json = if meta_json_path.exists() {
             Some(
-                serde_json::from_reader(wrapfs::File::open(&meta_json_path)?).map_err(|e| {
-                    ProjectDeserializationError::new("failed to deserialize `.meta.json`", e)
-                })?,
+                serde_json::from_reader(wrapfs::File::open(&meta_json_path)?)
+                    .map_err(|e| ProjectDeserializationError::new(".meta.json", e))?,
             )
         } else {
             None

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -308,15 +308,18 @@ pub mod wrapfs {
 }
 
 #[derive(Debug, Error)]
-#[error("project deserialization error: {msg}: {err}")]
+#[error("project deserialization error: failed to deserialize `{path}`: {err}")]
 pub struct ProjectDeserializationError {
-    msg: &'static str,
+    path: Box<Utf8Path>,
     err: serde_json::Error,
 }
 
 impl ProjectDeserializationError {
-    pub fn new(msg: &'static str, err: serde_json::Error) -> Self {
-        Self { msg, err }
+    pub fn new(path: impl AsRef<Utf8Path>, err: serde_json::Error) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            err,
+        }
     }
 }
 


### PR DESCRIPTION
Also give nice error if project is not at the root of the kpar in `index add`.