### PR TITLE
feat: perform most of KPAR pre-publish checks before publishing

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.os }}
 
       - name: cargo build ...
         run: cargo build --locked --package sysand-java --release

--- a/.github/workflows/js-wasm.yml
+++ b/.github/workflows/js-wasm.yml
@@ -71,6 +71,8 @@ jobs:
           cache: npm
           cache-dependency-path: bindings/js/package-lock.json
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ubuntu-24.04
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -159,6 +159,8 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.platform.runner }}
 
       - name: cargo test ... (Python bindings)
         run: cargo test --locked --package sysand-py --no-default-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ubuntu-24.04
 
       - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with:
@@ -136,6 +138,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.os }}
 
       - name: (linux musl) Install musl tools
         if: matrix.libc == 'musl'
@@ -200,6 +204,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.os }}
 
       - name: (linux musl) Install musl tools
         if: matrix.libc == 'musl'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,7 +66,7 @@ We generate changelogs from merged PRs using their titles and labels with the
    1. Generate an initial changelog entry.
 
       ```sh
-      github-activity --heading-level=3
+      github-activity --heading-level=2
       ```
 
    2. Revise PR labels.
@@ -92,7 +92,7 @@ We generate changelogs from merged PRs using their titles and labels with the
    4. Generate a final changelog.
 
       ```sh
-      github-activity --heading-level=3
+      github-activity --heading-level=2
       ```
 
 3. Add it to the sysand client changelog maintained in the [sysand-index]

--- a/core/src/commands/build_tests.rs
+++ b/core/src/commands/build_tests.rs
@@ -44,6 +44,8 @@ fn surfaces_non_not_found_io_errors() {
 
 fn stems(expr: &str) -> Vec<String> {
     license_file_stems(&spdx::Expression::parse(expr).unwrap())
+        .into_iter()
+        .collect()
 }
 
 #[test]

--- a/core/src/commands/include.rs
+++ b/core/src/commands/include.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use typed_path::Utf8UnixPath;
 
 use crate::{
-    project::{ProjectMut, ProjectOrIOError, utils::FsIoError},
+    project::{ProjectMut, ProjectOrIOError, ProjectRead, utils::FsIoError},
     symbols::{ExtractError, Language},
 };
 
@@ -52,7 +52,7 @@ pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
     log::info!("{header}{including:>12}{header:#} file `{}`", path.as_ref());
 
     if index_symbols {
-        let new_symbols = extract_symbols(project, &path, force_format)?;
+        let new_symbols = extract_symbols(&project, &path, force_format)?;
         project.replace_index_for_file(new_symbols.into_iter(), &path, true)?;
     }
 
@@ -61,11 +61,11 @@ pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
 }
 
 /// Extract top level symbols from file at `path` belonging to `project`
-pub fn extract_symbols<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
-    project: &mut Pr,
+pub fn extract_symbols<PR: ProjectRead, P: AsRef<Utf8UnixPath>>(
+    project: PR,
     path: &P,
     force_format: Option<Language>,
-) -> Result<Vec<String>, IncludeError<Pr::Error>> {
+) -> Result<Vec<String>, IncludeError<PR::Error>> {
     match force_format.or_else(|| Language::guess_from_path(path)) {
         Some(Language::SysML) => crate::symbols::top_level_sysml(
             project.read_source(path).map_err(IncludeError::Project)?,

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -454,11 +454,6 @@ pub struct PublishPreparation {
 // All of the publish checks will need to be revisited when we start supporting
 // publishing to other indexes, many of them will not apply
 
-// TODO: if sysand starts putting in "produced by: sysand v<version>" into
-// all zips produced, we can skip most of the checks to speed things up;
-// even if the zip was altered or we skip a check we were not supposed to,
-// server will catch it
-
 /// Reads and validates a `.kpar` file, returning the upload payload and
 /// metadata. Does not touch network. Should be called before any network
 /// activity.

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -1,26 +1,39 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    io::{self},
+    sync::Arc,
+};
 
 use bytes::Bytes;
 use camino::Utf8Path;
 use serde::Deserialize;
 use thiserror::Error;
+use typed_path::{Utf8UnixComponent, Utf8UnixPath};
 use url::Url;
+use zip::result::ZipError;
 
 use crate::{
     auth::{ForceBearerAuth, HTTPAuthentication},
     env::discovery::{HttpBaseUrlShapeError, validate_http_base_url_shape},
+    include::{IncludeError, extract_symbols},
+    model::{
+        InterchangeProjectUsageRaw, InterchangeProjectValidationError, KERML_METAMODEL_PREFIX,
+        KerMlChecksumAlg, SYSML_METAMODEL_PREFIX,
+    },
     project::{
-        ProjectRead,
-        local_kpar::{KparInnerPath, LocalKParProject},
+        ProjectRead, hash_reader,
+        local_kpar::{LocalKParError, LocalKParProjectRaw},
+        utils::{FsIoError, wrapfs},
     },
     purl::{
-        PKG_SYSAND_PREFIX, is_valid_unnormalized_name, is_valid_unnormalized_publisher,
-        normalize_field,
+        SysandPurlError, is_valid_unnormalized_name, is_valid_unnormalized_publisher,
+        normalize_field, parse_sysand_purl,
     },
-    utils::sha256_lowercase_hex,
+    symbols::Language,
+    utils::{license_file_stems, lowercase_hex, sha256_lowercase_hex},
 };
 
 /// Defensive upper bound on kpar file size (100 MiB) to catch unexpected uploads by mistake.
@@ -46,12 +59,14 @@ pub fn do_publish(
     // the user configured — the actual upload targets `api_root`.
     let upload_url = build_upload_url(&api_root)?;
     let PublishPreparation {
-        purl_versioned,
+        norm_publisher: publisher,
+        norm_name: name,
+        version,
         metadata,
         kpar_bytes,
     } = prepared;
     log::info!(
-        "{header}{:>12}{header:#} `{purl_versioned}` to {discovery_root}",
+        "{header}{:>12}{header:#} {publisher}/{name} v{version} to {discovery_root}",
         "Publishing",
     );
 
@@ -101,7 +116,7 @@ pub fn do_publish(
 /// message names the spec concept the URL came from.
 #[derive(Debug, Clone, Copy)]
 pub enum EndpointKind {
-    /// User-supplied URL (pre-discovery) — `--index`.
+    /// User-supplied URL (`--index`).
     DiscoveryRoot,
     /// Resolved URL coming back from the discovery document.
     ApiRoot,
@@ -170,13 +185,175 @@ pub struct PublishResponse {
     pub is_new_project: bool,
 }
 
+// TODO: link to https://docs.sysand.com/reference/kpar-archive-validation upon encountering
+// any validation error; maybe from CLI, maybe from here?
 #[derive(Error, Debug)]
 pub enum PublishError {
-    #[error("failed to read kpar file at `{0}`: {1}")]
-    KparRead(Box<str>, std::io::Error),
+    #[error(
+        "archive contains a file with executable permisions `{path}`;
+        archive containing executable files cannot be published for security reasons"
+    )]
+    ExecInArchive { path: Box<str> },
+    #[error("archive is corrupt: it contains overlapping files")]
+    OverlappingFiles,
+    #[error("archive is corrupt: path `{path:?}` contains a NULL character")]
+    NullChar { path: Box<str> },
+    #[error(
+        "archive contains a file `{path}` which uses unsupported\n\
+        {comp} compression; published archives currently must use DEFLATE\n\
+        compression"
+    )]
+    UnsupportedCompression {
+        path: Box<str>,
+        comp: zip::CompressionMethod,
+    },
+    #[error(
+        "archive contains an encrypted file `{path}`;
+        archives with encrypted files cannot be published"
+    )]
+    Encrypted { path: Box<str> },
+    #[error(
+        "archive contains a symbolic link `{path}`; symbolic links
+        are forbidden for security reasons"
+    )]
+    Symlink { path: Box<str> },
+    #[error(
+        "metadata indicates that project file `{path}`\n\
+        exports `{symbol}`, but it does not; it exports:\n\
+        {actual_symbols:?}"
+    )]
+    NonexistentSymbolExported {
+        path: Box<str>,
+        symbol: Box<str>,
+        actual_symbols: Box<[String]>,
+    },
+    #[error(
+        "project metadata has incorrect checksum for source file `{path}`:\n\
+        expected: {expected}\n  actual: {actual}"
+    )]
+    IncorrectFileChecksum {
+        path: Box<str>,
+        expected: Box<str>,
+        actual: Box<str>,
+    },
+    #[error(
+        "archive contains file with invalid path `{path}`\n\
+        relative components . and .. and absolute paths are not allowed
+        for security reasons"
+    )]
+    DisallowedPath { path: Box<str> },
+    #[error(
+        "unsupported checksum algorithm `{alg}` for file `{path}`\n\
+        only SHA256 is currently supported"
+    )]
+    UnsupportedFileChecksumType {
+        path: Box<str>,
+        alg: KerMlChecksumAlg,
+    },
+    #[error(
+        "archive contains unexpected file `{path}`,\n\
+        which is not mentioned in project metadata and is not an expected\n\
+        license/readme/changelog file; remove this file from the archive"
+    )]
+    UnexpectedFile { path: Box<str> },
+    #[error("project does not include `checksum` field in `.meta.json`")]
+    MissingChecksum,
+    #[error(
+        "project doesn't list any source file (empty `checksum` field in\n\
+        `.meta.json`); the project is not useful if it has no files\n\
+        (did you forget to include them?)"
+    )]
+    EmptyChecksum,
+    #[error("failed to index file")]
+    IndexFail {
+        source: IncludeError<LocalKParError>,
+    },
+    #[error(
+        "project does not include source file `{path}`,\n\
+        which is mentioned by `checksum` field of `.meta.json`"
+    )]
+    MissingFile { path: Box<str> },
+    #[error("project metadata does not include a checksum for source file `{path}`")]
+    MissingChecksumForFile { path: Box<str> },
+    #[error("project includes source file `{path}`, which does not have expected\n\
+        file extension `{}`; project metamodel `{metamodel_iri}`\n\
+        requires all source files to be {}", metamodel.file_ext(), metamodel.lang())]
+    IncorrectFileFormat {
+        path: Box<str>,
+        metamodel_iri: Box<str>,
+        metamodel: AllowedMetamodelKind,
+    },
+    #[error(
+        "archive does not include license file `{path}`, required because\n\
+        the project's license is `{license}`, and every license/exception\n\
+        must have its corresponding file; it is recommended to use\n\
+        SPDX license text files from https://spdx.org/licenses/ or\n\
+        https://github.com/spdx/license-list-data/tree/main/text\n\
+        just note that some of them have placeholder copyright\n\
+        holder/dates in the text that should be replaced"
+    )]
+    MissingLicenseFile { path: Box<str>, license: Box<str> },
+    #[error(
+        "metamodel `{metamodel}` cannot be used; only SysML/KerML\n\
+        metamodels are currently allowed in the index"
+    )]
+    UnsupportedMetamodel { metamodel: String },
+    // TODO: add help in CLI that knowns which commands can be used to fix such issues
+    #[error("project does not have a metamodel set")]
+    MissingMetamodel,
+    #[error("project metamodel `{metamodel}` has invalid version `{version}`")]
+    InvalidMetamodelVersion {
+        metamodel: Box<str>,
+        version: Box<str>,
+    },
+    #[error("project usage includes unknown standard library `{name}`")]
+    UnknownStdLib { name: Box<str> },
+    #[error("project usage of standard library `{name}` specifies invalid version `{std_version}`")]
+    InvalidStdLibVersion {
+        name: Box<str>,
+        std_version: Box<str>,
+    },
+    #[error(
+        "standard library usage `{name}`\n\
+        has a version constraint `{vc}`, but it is meaningless for direct URL usages"
+    )]
+    StdWithVersionConstraint { name: Box<str>, vc: Box<str> },
+    #[error("invalid Sysand project identifier `{name}`")]
+    InvalidPurl {
+        name: Box<str>,
+        source: SysandPurlError,
+    },
+    #[error(
+        "project usage includes `{name}`,\n\
+        which is neither in the index nor a SysML/KerML standard library"
+    )]
+    DisallowedUsage { name: Box<str> },
+    #[error("KPAR's `.{name}.json` is invalid")]
+    InfoMetaValidation {
+        name: &'static str,
+        source: InterchangeProjectValidationError,
+    },
+    #[error(transparent)]
+    Io(#[from] Box<FsIoError>),
+    #[error("failed to read KPAR `{0}`")]
+    KparRead(Box<str>, #[source] LocalKParError),
+    #[error("failed to read KPAR `{0}`")]
+    KparReadZip(Box<str>, #[source] ZipError),
 
-    #[error("failed to open kpar project at `{0}`: {1}")]
-    KparOpen(Box<str>, String),
+    #[error("failed to read file `{path}` from the archive")]
+    KparFileRead { path: Box<str>, source: ZipError },
+    #[error("failed to read file `{path}` from the archive")]
+    KparFileReadIo { path: Box<str>, source: io::Error },
+
+    #[error(
+        "archive `{kpar_path}` does not contain a project at its root,\n\
+         the project is at `{root_in_kpar}` within the archive;\n\
+         project must be at the root of the archive for publishing"
+    )]
+    ProjectNotAtRoot {
+        kpar_path: Box<str>,
+        root_in_kpar: Box<str>,
+    },
 
     #[error("missing project info in kpar")]
     MissingInfo,
@@ -184,36 +361,40 @@ pub enum PublishError {
     #[error("missing project metadata in kpar")]
     MissingMeta,
 
-    #[error("missing publisher in project info (required for publishing)")]
+    #[error(
+        "missing publisher in project info; publisher has\n\
+        to be set for publishing"
+    )]
     MissingPublisher,
 
     #[error(
-        "publisher field `{0}` is invalid for modern project IDs: must be 3-50 characters, use only ASCII letters and numbers, may include single spaces or hyphens between words, and must start and end with a letter or number"
+        "publisher `{0}` cannot be used for publishing;\n\
+        it must be 3-50 characters, use only ASCII letters and\n\
+        numbers, may include single spaces or hyphens between\n\
+        words, and must start and end with a letter or number"
     )]
     InvalidPublisher(Box<str>),
 
     #[error(
-        "name field `{0}` is invalid for modern project IDs: must be 3-50 characters, use only ASCII letters and numbers, may include single spaces, hyphens, or dots between words, and must start and end with a letter or number"
+        "name `{0}` cannot be used for publishing;
+        it must be 3-50 characters, use only ASCII letters and\n\
+        numbers, may include single spaces, hyphens, or dots\n\
+        between words, and must start and end with a letter or number"
     )]
     InvalidName(Box<str>),
 
     #[error(
-        "version field `{version}` is invalid for publishing: must be a valid Semantic Versioning 2.0 version ({source})"
-    )]
-    InvalidVersion {
-        version: Box<str>,
-        source: semver::Error,
-    },
-    #[error(
-        "version field `{version}` is invalid for publishing: build metadata (`+...`) cannot be used for projects in the index"
+        "version `{version}` cannot be used for publishing: build\n\
+        metadata (`+...`) cannot be used for projects in the index"
     )]
     VersionBuildMetadata { version: Box<str> },
 
-    #[error("missing license in project info (required for publishing)")]
+    #[error("missing license in project info; it is required for publishing")]
     MissingLicense,
 
     #[error(
-        "license field `{license}` is invalid for publishing, it must be a valid SPDX license expression, but failed to parse:\n{err}"
+        "license `{license}` cannot be used for publishing; it must\n\
+        be a valid SPDX license expression, but failed to parse:\n{err}"
     )]
     InvalidLicense {
         license: Box<str>,
@@ -256,66 +437,318 @@ pub enum PublishError {
 // --- Preparation helpers ---
 
 /// Payload ready to POST to the upload endpoint.
+#[derive(Debug)]
 pub struct PublishPreparation {
-    purl_versioned: String,
+    norm_publisher: String,
+    norm_name: String,
+    version: String,
     // Keep upload payload in `Bytes` so request retries clone cheaply.
     kpar_bytes: Bytes,
     metadata: String,
 }
+
+// TODO:
+// - warn if unknown fields present in .project.json/.meta.json - this will require
+//   a large refactoring to keep track of consistently
+//
+// All of the publish checks will need to be revisited when we start supporting
+// publishing to other indexes, many of them will not apply
+
+// TODO: if sysand starts putting in "produced by: sysand v<version>" into
+// all zips produced, we can skip most of the checks to speed things up;
+// even if the zip was altered or we skip a check we were not supposed to,
+// server will catch it
 
 /// Reads and validates a `.kpar` file, returning the upload payload and
 /// metadata. Does not touch network. Should be called before any network
 /// activity.
 pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, PublishError> {
     // Open and validate kpar.
-    let kpar_project = LocalKParProject::new(path, KparInnerPath::Guess, None, None);
+    let kpar_project = LocalKParProjectRaw::new_guess_root(path)
+        .map_err(|e| PublishError::KparRead(path.as_str().into(), e))?;
+    if let Some(p) = kpar_project.project_root_in_archive()
+        && !p.as_str().is_empty()
+    {
+        return Err(PublishError::ProjectNotAtRoot {
+            kpar_path: path.as_str().into(),
+            root_in_kpar: p.as_str().into(),
+        });
+    }
 
     let (info, meta) = kpar_project
         .get_project()
-        .map_err(|e| PublishError::KparOpen(path.as_str().into(), e.to_string()))?;
+        .map_err(|e| PublishError::KparRead(path.as_str().into(), e))?;
 
     let info = info.ok_or(PublishError::MissingInfo)?;
-    // Validate that metadata exists; contents are not used during upload.
-    _ = meta.ok_or(PublishError::MissingMeta)?;
+    let validated_info = info
+        .validate()
+        .map_err(|e| PublishError::InfoMetaValidation {
+            name: "project",
+            source: e,
+        })?;
+    let meta = meta.ok_or(PublishError::MissingMeta)?;
+    // TODO: maybe use parse_sysand_purl() in validate() for usages? This would give better errors
+    // than generic IRI parsing
+    let validated_meta = meta
+        .validate()
+        .map_err(|e| PublishError::InfoMetaValidation {
+            name: "meta",
+            source: e,
+        })?;
 
+    // Usages are only `pkg:sysand/` or std libs
+    for usage in &info.usage {
+        check_usage(usage)?;
+    }
+
+    // Publisher
     let publisher = info
         .publisher
         .as_deref()
         .ok_or(PublishError::MissingPublisher)?;
-    let name = &info.name;
-    let version = &info.version;
-    let license = info
-        .license
-        .as_deref()
-        .ok_or(PublishError::MissingLicense)?;
     if !is_valid_unnormalized_publisher(publisher) {
         return Err(PublishError::InvalidPublisher(publisher.into()));
     }
+    let normalized_publisher = normalize_field(publisher);
+
+    let name = &info.name;
     if !is_valid_unnormalized_name(name) {
         return Err(PublishError::InvalidName(name.as_str().into()));
     }
-    let parsed_version =
-        semver::Version::parse(version).map_err(|source| PublishError::InvalidVersion {
-            version: version.as_str().into(),
-            source,
-        })?;
-    if !parsed_version.build.is_empty() {
+    let normalized_name = normalize_field(name);
+
+    let version = &info.version;
+    if !validated_info.version.build.is_empty() {
         return Err(PublishError::VersionBuildMetadata {
             version: version.as_str().into(),
         });
     }
-    spdx::Expression::parse(license).map_err(|err| PublishError::InvalidLicense {
-        license: license.into(),
-        err,
-    })?;
-    let normalized_publisher = normalize_field(publisher);
-    let normalized_name = normalize_field(name);
-    let purl_versioned =
-        format!("{PKG_SYSAND_PREFIX}{normalized_publisher}/{normalized_name}@{version}");
 
-    let file_size = std::fs::metadata(path)
-        .map_err(|e| PublishError::KparRead(path.as_str().into(), e))?
-        .len();
+    let license = info
+        .license
+        .as_deref()
+        .ok_or(PublishError::MissingLicense)?;
+    let license_expr =
+        spdx::Expression::parse(license).map_err(|err| PublishError::InvalidLicense {
+            license: license.into(),
+            err,
+        })?;
+
+    let (metamodel, metamodel_kind) = if let Some(m) = &meta.metamodel {
+        (m, check_metamodel(m)?)
+    } else {
+        return Err(PublishError::MissingMetamodel);
+    };
+
+    // Get archive file list, all file presence/format checking will be done on that
+    let mut archive = kpar_project
+        .open_archive()
+        .map_err(|e| PublishError::KparRead(path.as_str().into(), e))?;
+    if archive
+        .has_overlapping_files()
+        .map_err(|e| PublishError::KparReadZip(path.as_str().into(), e))?
+    {
+        return Err(PublishError::OverlappingFiles);
+    }
+    // Bools track whether the file is expected by metadata/our conventions
+    let mut kpar_files: HashMap<String, bool> = HashMap::new();
+    for i in 0..archive.len() {
+        let f = archive.by_index_raw(i).unwrap();
+        let name = f.name();
+        if name.contains('\0') {
+            return Err(PublishError::NullChar { path: name.into() });
+        }
+        if f.encrypted() {
+            return Err(PublishError::Encrypted { path: name.into() });
+        }
+        if f.is_symlink() {
+            return Err(PublishError::Symlink { path: name.into() });
+        }
+        if f.compression() != zip::CompressionMethod::Deflated {
+            return Err(PublishError::UnsupportedCompression {
+                path: name.into(),
+                comp: f.compression(),
+            });
+        }
+        // Check all exec bits for files; exec bit for dirs means dir can be opened
+        if !f.is_dir()
+            && let Some(mode) = f.unix_mode()
+            && (mode & 0o111) != 0
+        {
+            return Err(PublishError::ExecInArchive { path: name.into() });
+        }
+
+        for c in Utf8UnixPath::new(name).components() {
+            // TODO: this is likely to fail in ugly ways if zip includes a Windows path,
+            // but Unix paths are required by zip spec
+            // It will also mostly ignore `.` components
+            match c {
+                Utf8UnixComponent::Normal(_) => (),
+                Utf8UnixComponent::RootDir
+                | Utf8UnixComponent::CurDir
+                | Utf8UnixComponent::ParentDir => {
+                    return Err(PublishError::DisallowedPath { path: name.into() });
+                }
+            }
+        }
+
+        kpar_files.insert(name.to_owned(), false);
+    }
+
+    for stem in license_file_stems(&license_expr) {
+        let license_path = format!("LICENSES/{stem}.txt");
+        match kpar_files.get_mut(license_path.as_str()) {
+            Some(v) => *v = true,
+            None => {
+                return Err(PublishError::MissingLicenseFile {
+                    path: license_path.into_boxed_str(),
+                    license: license.into(),
+                });
+            }
+        };
+    }
+
+    let Some(file_checksums) = validated_meta.checksum else {
+        return Err(PublishError::MissingChecksum);
+    };
+    if file_checksums.is_empty() {
+        return Err(PublishError::EmptyChecksum);
+    }
+    if validated_meta.index.is_empty() {
+        log::warn!(
+            "project doesn't list any symbols as exported (empty `index`
+            {0:>8} field in `.meta.json`);\n\
+            {0:>8} it's unlikely to be useful if no symbols are exported\n\
+            {0:>8} (did you forget to include source files?)",
+            ' '
+        );
+    }
+
+    // Reverse of `meta.index`: instead of symbol -> file, this is file -> symbols
+    let mut symbols_for_files: HashMap<_, Vec<String>> = HashMap::new();
+
+    for (symbol, src_file) in validated_meta.index {
+        // `meta.checksum` must reference a superset of files mentioned by `meta.index`
+        // TODO: what about detecting duplicate exports? With our current design this is by
+        // construction impossible.
+        // Should probably change InterchangeProjectMetadataRaw to have Vec for checksum and
+        // index, instead of HashMap, which will silently discard duplicates; and then fail
+        // on `validate()`, as such metadata is always incorrect
+        if !file_checksums.contains_key(&src_file) {
+            return Err(PublishError::MissingChecksumForFile {
+                path: src_file.as_str().into(),
+            });
+        }
+        match symbols_for_files.entry(src_file) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().push(symbol);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(vec![symbol]);
+            }
+        }
+    }
+
+    for (src_file, file_checksum) in file_checksums {
+        if !src_file.as_str().ends_with(metamodel_kind.file_ext()) {
+            return Err(PublishError::IncorrectFileFormat {
+                path: src_file.as_str().into(),
+                metamodel_iri: metamodel.as_str().into(),
+                metamodel: metamodel_kind,
+            });
+        }
+
+        if file_checksum.algorithm != KerMlChecksumAlg::Sha256 {
+            return Err(PublishError::UnsupportedFileChecksumType {
+                path: src_file.as_str().into(),
+                alg: file_checksum.algorithm,
+            });
+        }
+
+        match kpar_files.get_mut(src_file.as_str()) {
+            Some(v) => {
+                *v = true;
+
+                let mut file =
+                    archive
+                        .by_path(src_file.as_str())
+                        .map_err(|e| PublishError::KparFileRead {
+                            path: src_file.as_str().into(),
+                            source: e,
+                        })?;
+                let digest = hash_reader(&mut file).map_err(|e| PublishError::KparFileReadIo {
+                    path: src_file.as_str().into(),
+                    source: e,
+                })?;
+                let actual_checksum = lowercase_hex(digest);
+                if !actual_checksum.eq_ignore_ascii_case(&file_checksum.value) {
+                    return Err(PublishError::IncorrectFileChecksum {
+                        path: src_file.as_str().into(),
+                        expected: file_checksum.value.into_boxed_str(),
+                        actual: actual_checksum.into_boxed_str(),
+                    });
+                }
+
+                // FIXME: don't read the whole file into memory at once
+                let actual_symbols =
+                    extract_symbols(&kpar_project, &src_file, Some(metamodel_kind.lang_kind()))
+                        .map_err(|e| PublishError::IndexFail { source: e })?;
+                // Actual symbols must be a superset of recorded
+                if let Some(symbols) = symbols_for_files.get(&src_file) {
+                    for s in symbols {
+                        if !actual_symbols.contains(s) {
+                            return Err(PublishError::NonexistentSymbolExported {
+                                path: src_file.as_str().into(),
+                                symbol: s.as_str().into(),
+                                actual_symbols: actual_symbols.into_boxed_slice(),
+                            });
+                        }
+                    }
+                } else {
+                    // It is valid for a file to not export any symbols
+                    log::warn!(
+                        "project file `{src_file}` exports symbols {actual_symbols:?},\n\
+                    {0:>8} but they are not mentioned in `.meta.json`; this is valid,\n\
+                    {0:>8} but likely to be an error",
+                        ' '
+                    );
+                }
+            }
+            None => {
+                return Err(PublishError::MissingFile {
+                    path: src_file.as_str().into(),
+                });
+            }
+        };
+    }
+
+    match kpar_files.get_mut("README.md") {
+        Some(v) => *v = true,
+        None => log::warn!(
+            "KPAR does not contain a readme file README.md; it is
+            {0:>8} recommended to provide it to serve as introduction to users",
+            ' '
+        ),
+    }
+    match kpar_files.get_mut("README.md") {
+        Some(v) => *v = true,
+        None => log::warn!(
+            "KPAR does not contain a changelog file CHANGELOG.md;\n\
+            {0:>8} it is recommended to provide it to inform users of\n\
+            {0:>8} the changes between versions",
+            ' '
+        ),
+    }
+    *kpar_files.get_mut(".project.json").unwrap() = true;
+    *kpar_files.get_mut(".meta.json").unwrap() = true;
+
+    for (path, expected) in kpar_files {
+        if !expected {
+            return Err(PublishError::UnexpectedFile { path: path.into() });
+        }
+    }
+
+    let file_size = wrapfs::metadata(path).map_err(PublishError::Io)?.len();
     if file_size > MAX_KPAR_PUBLISH_SIZE {
         return Err(PublishError::KparTooLarge {
             size: file_size,
@@ -323,8 +756,7 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
         });
     }
 
-    let kpar_bytes =
-        std::fs::read(path).map_err(|e| PublishError::KparRead(path.as_str().into(), e))?;
+    let kpar_bytes = wrapfs::read(path).map_err(PublishError::Io)?;
     let sha256_digest = sha256_lowercase_hex(&kpar_bytes);
     let metadata = serde_json::json!({
         "normalized_publisher": normalized_publisher,
@@ -336,9 +768,34 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
     .to_string();
 
     Ok(PublishPreparation {
-        purl_versioned,
+        norm_publisher: normalized_publisher,
+        norm_name: normalized_name,
+        version: version.to_owned(),
         metadata,
         kpar_bytes: Bytes::from(kpar_bytes),
+    })
+}
+
+/// `Ok(_)` - valid SysML/KerML metamodel
+/// `Err` - invalid SysML/KerML or other
+fn check_metamodel(metamodel: &str) -> Result<AllowedMetamodelKind, PublishError> {
+    for (prefix, kind) in [
+        (SYSML_METAMODEL_PREFIX, AllowedMetamodelKind::SysML),
+        (KERML_METAMODEL_PREFIX, AllowedMetamodelKind::KerML),
+    ] {
+        if let Some(metamodel_version) = metamodel.strip_prefix(prefix) {
+            if is_valid_metamodel_version(metamodel_version) {
+                return Ok(kind);
+            } else {
+                return Err(PublishError::InvalidMetamodelVersion {
+                    metamodel: metamodel.into(),
+                    version: metamodel_version.into(),
+                });
+            }
+        }
+    }
+    Err(PublishError::UnsupportedMetamodel {
+        metamodel: metamodel.to_owned(),
     })
 }
 
@@ -395,6 +852,133 @@ fn error_body_to_string(body_bytes: &[u8]) -> String {
     serde_json::from_str::<ErrorResponse>(trimmed)
         .map(|error| error.error)
         .unwrap_or_else(|_| trimmed.to_string())
+}
+
+const KERML_STD_LIB_SUFFIXES: [&str; 3] = [
+    "/Semantic-Library.kpar",
+    "/Data-Type-Library.kpar",
+    "/Function-Library.kpar",
+];
+
+const SYSML_STD_LIB_SUFFIXES: [&str; 7] = [
+    "/Systems-Library.kpar",
+    "/Analysis-Domain-Library.kpar",
+    "/Cause-and-Effect-Domain-Library.kpar",
+    "/Geometry-Domain-Library.kpar",
+    "/Metadata-Domain-Library.kpar",
+    "/Quantities-and-Units-Domain-Library.kpar",
+    "/Requirement-Derivation-Domain-Library.kpar",
+];
+
+/// A usage can be either `pkg:sysand/` or an std lib
+// TODO: be case insensitive
+fn check_usage(usage: &InterchangeProjectUsageRaw) -> Result<(), PublishError> {
+    if check_std_libs(
+        usage,
+        &SYSML_STD_LIB_SUFFIXES,
+        "https://www.omg.org/spec/SysML/",
+    )? || check_std_libs(
+        usage,
+        &KERML_STD_LIB_SUFFIXES,
+        "https://www.omg.org/spec/KerML/",
+    )? {
+        return Ok(());
+    }
+
+    match parse_sysand_purl(&usage.resource) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(PublishError::DisallowedUsage {
+            name: usage.resource.as_str().into(),
+        }),
+        Err(e) => Err(PublishError::InvalidPurl {
+            name: usage.resource.as_str().into(),
+            source: e,
+        }),
+    }
+}
+
+/// `Ok(true)` - matched
+/// `Ok(false)` - not matched
+/// `Err` - matched, but incorrect
+fn check_std_libs(
+    usage: &InterchangeProjectUsageRaw,
+    lib_names: &[&str],
+    prefix: &str,
+) -> Result<bool, PublishError> {
+    if let Some(stripped) = usage.resource.strip_prefix(prefix) {
+        if let Some(vc) = usage.version_constraint.as_deref() {
+            return Err(PublishError::StdWithVersionConstraint {
+                name: usage.resource.as_str().into(),
+                vc: vc.into(),
+            });
+        }
+        for s in lib_names {
+            if let Some(metamodel_version) = stripped.strip_suffix(s) {
+                if is_valid_metamodel_version(metamodel_version) {
+                    return Ok(true);
+                } else {
+                    return Err(PublishError::InvalidStdLibVersion {
+                        name: usage.resource.as_str().into(),
+                        std_version: metamodel_version.into(),
+                    });
+                }
+            }
+        }
+        return Err(PublishError::UnknownStdLib {
+            name: usage.resource.as_str().into(),
+        });
+    }
+    Ok(false)
+}
+
+/// Check that `v` is a number of the form `20yymmxx`, where `yy` and `xx` are pairs
+/// of digits, and `1 <= mm <= 12`
+fn is_valid_metamodel_version(v: &str) -> bool {
+    let first_release = "20250201";
+    if v.len() != first_release.len() || !v.starts_with("20") {
+        return false;
+    }
+
+    let number: u32 = match v.parse() {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+
+    // Year is already constrained to start with 20,
+    // and release format is unspecified number
+    let month = (number / 100) % 100;
+
+    (1..=12).contains(&month)
+}
+
+/// All metamodels allowed by the index
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AllowedMetamodelKind {
+    SysML,
+    KerML,
+}
+
+impl AllowedMetamodelKind {
+    fn file_ext(&self) -> &'static str {
+        match self {
+            AllowedMetamodelKind::SysML => ".sysml",
+            AllowedMetamodelKind::KerML => ".kerml",
+        }
+    }
+
+    fn lang(&self) -> &'static str {
+        match self {
+            AllowedMetamodelKind::SysML => "SysMLv2",
+            AllowedMetamodelKind::KerML => "KerML",
+        }
+    }
+
+    fn lang_kind(&self) -> Language {
+        match self {
+            AllowedMetamodelKind::SysML => Language::SysML,
+            AllowedMetamodelKind::KerML => Language::KerML,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -11,7 +11,6 @@ use bytes::Bytes;
 use camino::Utf8Path;
 use serde::Deserialize;
 use thiserror::Error;
-use typed_path::{Utf8UnixComponent, Utf8UnixPath};
 use url::Url;
 use zip::result::ZipError;
 
@@ -185,8 +184,9 @@ pub struct PublishResponse {
     pub is_new_project: bool,
 }
 
-// TODO: link to https://docs.sysand.com/reference/kpar-archive-validation upon encountering
+// TODO: link to https://docs.sysand.com/index/reference/kpar-archive-validation upon encountering
 // any validation error; maybe from CLI, maybe from here?
+// TODO: add help in CLI that knowns which commands can be used to fix some issues
 #[derive(Error, Debug)]
 pub enum PublishError {
     #[error(
@@ -196,12 +196,36 @@ pub enum PublishError {
     ExecInArchive { path: Box<str> },
     #[error("archive is corrupt: it contains overlapping files")]
     OverlappingFiles,
+    #[error(
+        "archive is corrupt: directory entry for `{path}`
+        is marked as compressed with {comp}, but directory entries\n\
+        cannot have any content to compress"
+    )]
+    CompressedDirEntry {
+        path: Box<str>,
+        comp: zip::CompressionMethod,
+    },
     #[error("archive is corrupt: path `{path:?}` contains a NULL character")]
     NullChar { path: Box<str> },
     #[error(
+        "archive is corrupt: path `{path}`\n\
+        contains two consecutive directory separators `//`"
+    )]
+    DoubleSlash { path: Box<str> },
+    #[error("archive is corrupt: path `{path}` is absolute")]
+    AbsolutePath { path: Box<str> },
+    #[error(
+        "item in archive has path `{path}`\n\
+        that contains a backslash `\\`; backslash is not allowed in paths to\n\
+        preserve consistent interpretation across different operating systems;\n\
+        backslash could be present because the path is Windows path, which is\n\
+        not allowed by the Zip format specification"
+    )]
+    Backslash { path: Box<str> },
+    #[error(
         "archive contains a file `{path}` which uses unsupported\n\
         {comp} compression; published archives currently must use DEFLATE\n\
-        compression"
+        compression for all files"
     )]
     UnsupportedCompression {
         path: Box<str>,
@@ -237,11 +261,11 @@ pub enum PublishError {
         actual: Box<str>,
     },
     #[error(
-        "archive contains file with invalid path `{path}`\n\
+        "archive contains file with invalid path `{path}`;\n\
         relative components . and .. and absolute paths are not allowed
         for security reasons"
     )]
-    DisallowedPath { path: Box<str> },
+    RelativePathComponents { path: Box<str> },
     #[error(
         "unsupported checksum algorithm `{alg}` for file `{path}`\n\
         only SHA256 is currently supported"
@@ -259,7 +283,7 @@ pub enum PublishError {
     #[error("project does not include `checksum` field in `.meta.json`")]
     MissingChecksum,
     #[error(
-        "project doesn't list any source file (empty `checksum` field in\n\
+        "project doesn't list any source files (empty `checksum` field in\n\
         `.meta.json`); the project is not useful if it has no files\n\
         (did you forget to include them?)"
     )]
@@ -298,7 +322,6 @@ pub enum PublishError {
         metamodels are currently allowed in the index"
     )]
     UnsupportedMetamodel { metamodel: String },
-    // TODO: add help in CLI that knowns which commands can be used to fix such issues
     #[error("project does not have a metamodel set")]
     MissingMetamodel,
     #[error("project metamodel `{metamodel}` has invalid version `{version}`")]
@@ -458,6 +481,14 @@ pub struct PublishPreparation {
 /// metadata. Does not touch network. Should be called before any network
 /// activity.
 pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, PublishError> {
+    let file_size = wrapfs::metadata(path).map_err(PublishError::Io)?.len();
+    if file_size > MAX_KPAR_PUBLISH_SIZE {
+        return Err(PublishError::KparTooLarge {
+            size: file_size,
+            limit: MAX_KPAR_PUBLISH_SIZE,
+        });
+    }
+
     // Open and validate kpar.
     let kpar_project = LocalKParProjectRaw::new_guess_root(path)
         .map_err(|e| PublishError::KparRead(path.as_str().into(), e))?;
@@ -539,6 +570,7 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
     let mut archive = kpar_project
         .open_archive()
         .map_err(|e| PublishError::KparRead(path.as_str().into(), e))?;
+    // Check for one kind of zip bomb. Other kinds are difficult to check for.
     if archive
         .has_overlapping_files()
         .map_err(|e| PublishError::KparReadZip(path.as_str().into(), e))?
@@ -548,46 +580,66 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
     // Bools track whether the file is expected by metadata/our conventions
     let mut kpar_files: HashMap<String, bool> = HashMap::new();
     for i in 0..archive.len() {
-        let f = archive.by_index_raw(i).unwrap();
+        let f = archive
+            .by_index_raw(i)
+            .map_err(|e| PublishError::KparReadZip(path.as_str().into(), e))?;
+
         let name = f.name();
-        if name.contains('\0') {
-            return Err(PublishError::NullChar { path: name.into() });
-        }
-        if f.encrypted() {
-            return Err(PublishError::Encrypted { path: name.into() });
+        for c in name.bytes() {
+            if c == b'\0' {
+                return Err(PublishError::NullChar { path: name.into() });
+            } else if c == b'\\' {
+                return Err(PublishError::Backslash { path: name.into() });
+            }
         }
         if f.is_symlink() {
             return Err(PublishError::Symlink { path: name.into() });
         }
-        if f.compression() != zip::CompressionMethod::Deflated {
-            return Err(PublishError::UnsupportedCompression {
+
+        if name.starts_with('/') {
+            return Err(PublishError::AbsolutePath { path: name.into() });
+        }
+        // Manually split into componenets, `Utf8UnixPath::components()` does
+        // some normalization, which is undesirable here
+        for c in name.split_terminator('/') {
+            if c.is_empty() {
+                // `split_terminator()` ignores trailing slash, and the path is
+                // not absolute, so the only way for it to contain an empty
+                // component is to have two consecutive slashes
+                return Err(PublishError::DoubleSlash { path: name.into() });
+            } else if c == "." || c == ".." {
+                return Err(PublishError::RelativePathComponents { path: name.into() });
+            }
+        }
+
+        // Directory entries don't contain any contents, so encryption
+        // or compression doesn't matter, but extraction can still fail
+        // if such metadata is set
+        if f.encrypted() {
+            return Err(PublishError::Encrypted { path: name.into() });
+        }
+        if !f.is_dir() {
+            if f.compression() != zip::CompressionMethod::Deflated {
+                return Err(PublishError::UnsupportedCompression {
+                    path: name.into(),
+                    comp: f.compression(),
+                });
+            }
+            // Check all exec bits for files; exec bit for dirs means dir can be opened
+            if let Some(mode) = f.unix_mode()
+                && (mode & 0o111) != 0
+            {
+                return Err(PublishError::ExecInArchive { path: name.into() });
+            }
+
+            // Ignore directory entries, as we don't have any use for them
+            kpar_files.insert(name.to_owned(), false);
+        } else if f.compression() != zip::CompressionMethod::Stored {
+            return Err(PublishError::CompressedDirEntry {
                 path: name.into(),
                 comp: f.compression(),
             });
         }
-        // Check all exec bits for files; exec bit for dirs means dir can be opened
-        if !f.is_dir()
-            && let Some(mode) = f.unix_mode()
-            && (mode & 0o111) != 0
-        {
-            return Err(PublishError::ExecInArchive { path: name.into() });
-        }
-
-        for c in Utf8UnixPath::new(name).components() {
-            // TODO: this is likely to fail in ugly ways if zip includes a Windows path,
-            // but Unix paths are required by zip spec
-            // It will also mostly ignore `.` components
-            match c {
-                Utf8UnixComponent::Normal(_) => (),
-                Utf8UnixComponent::RootDir
-                | Utf8UnixComponent::CurDir
-                | Utf8UnixComponent::ParentDir => {
-                    return Err(PublishError::DisallowedPath { path: name.into() });
-                }
-            }
-        }
-
-        kpar_files.insert(name.to_owned(), false);
     }
 
     for stem in license_file_stems(&license_expr) {
@@ -699,7 +751,7 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
                             });
                         }
                     }
-                } else {
+                } else if !actual_symbols.is_empty() {
                     // It is valid for a file to not export any symbols
                     log::warn!(
                         "project file `{src_file}` exports symbols {actual_symbols:?},\n\
@@ -725,7 +777,7 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
             ' '
         ),
     }
-    match kpar_files.get_mut("README.md") {
+    match kpar_files.get_mut("CHANGELOG.md") {
         Some(v) => *v = true,
         None => log::warn!(
             "KPAR does not contain a changelog file CHANGELOG.md;\n\
@@ -734,21 +786,13 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
             ' '
         ),
     }
-    *kpar_files.get_mut(".project.json").unwrap() = true;
-    *kpar_files.get_mut(".meta.json").unwrap() = true;
+    kpar_files.remove_entry(".project.json").unwrap();
+    kpar_files.remove_entry(".meta.json").unwrap();
 
     for (path, expected) in kpar_files {
         if !expected {
             return Err(PublishError::UnexpectedFile { path: path.into() });
         }
-    }
-
-    let file_size = wrapfs::metadata(path).map_err(PublishError::Io)?.len();
-    if file_size > MAX_KPAR_PUBLISH_SIZE {
-        return Err(PublishError::KparTooLarge {
-            size: file_size,
-            limit: MAX_KPAR_PUBLISH_SIZE,
-        });
     }
 
     let kpar_bytes = wrapfs::read(path).map_err(PublishError::Io)?;
@@ -901,15 +945,15 @@ fn check_std_libs(
     prefix: &str,
 ) -> Result<bool, PublishError> {
     if let Some(stripped) = usage.resource.strip_prefix(prefix) {
-        if let Some(vc) = usage.version_constraint.as_deref() {
-            return Err(PublishError::StdWithVersionConstraint {
-                name: usage.resource.as_str().into(),
-                vc: vc.into(),
-            });
-        }
         for s in lib_names {
             if let Some(metamodel_version) = stripped.strip_suffix(s) {
                 if is_valid_metamodel_version(metamodel_version) {
+                    if let Some(vc) = usage.version_constraint.as_deref() {
+                        return Err(PublishError::StdWithVersionConstraint {
+                            name: usage.resource.as_str().into(),
+                            vc: vc.into(),
+                        });
+                    }
                     return Ok(true);
                 } else {
                     return Err(PublishError::InvalidStdLibVersion {

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use super::{PublishError, build_upload_url, error_body_to_string};
+use super::{
+    AllowedMetamodelKind, EndpointKind, PublishError, build_upload_url, check_metamodel,
+    check_usage, error_body_to_string, map_publish_response, validate_endpoint_url_shape,
+};
+use crate::model::InterchangeProjectUsageRaw;
 use url::Url;
 
 #[test]
@@ -107,4 +111,714 @@ fn error_body_to_string_extracts_error_from_json() {
 #[test]
 fn error_body_to_string_reports_empty_body() {
     assert_eq!(error_body_to_string(b" \n\t "), "no error details provided");
+}
+
+// --- check_metamodel ---
+
+#[test]
+fn check_metamodel_accepts_valid_sysml() {
+    assert_eq!(
+        check_metamodel("https://www.omg.org/spec/SysML/20250201").unwrap(),
+        AllowedMetamodelKind::SysML,
+    );
+}
+
+#[test]
+fn check_metamodel_accepts_valid_kerml() {
+    assert_eq!(
+        check_metamodel("https://www.omg.org/spec/KerML/20250201").unwrap(),
+        AllowedMetamodelKind::KerML,
+    );
+}
+
+#[test]
+fn check_metamodel_rejects_unsupported_metamodel() {
+    let err = check_metamodel("https://example.com/some-meta").unwrap_err();
+    assert!(matches!(err, PublishError::UnsupportedMetamodel { .. }));
+}
+
+#[test]
+fn check_metamodel_rejects_invalid_sysml_version() {
+    // Valid SysML prefix but non-date version string.
+    let err = check_metamodel("https://www.omg.org/spec/SysML/notadate").unwrap_err();
+    assert!(matches!(err, PublishError::InvalidMetamodelVersion { .. }));
+}
+
+#[test]
+fn check_metamodel_rejects_invalid_kerml_version() {
+    // Month 13 is not a valid calendar month.
+    let err = check_metamodel("https://www.omg.org/spec/KerML/20251301").unwrap_err();
+    assert!(matches!(err, PublishError::InvalidMetamodelVersion { .. }));
+}
+
+// --- check_usage ---
+
+fn usage(resource: &str) -> InterchangeProjectUsageRaw {
+    InterchangeProjectUsageRaw {
+        resource: resource.to_string(),
+        version_constraint: None,
+    }
+}
+
+fn usage_with_vc(resource: &str, vc: &str) -> InterchangeProjectUsageRaw {
+    InterchangeProjectUsageRaw {
+        resource: resource.to_string(),
+        version_constraint: Some(vc.to_string()),
+    }
+}
+
+#[test]
+fn check_usage_accepts_valid_sysand_purl() {
+    check_usage(&usage("pkg:sysand/acme/widget")).unwrap();
+}
+
+#[test]
+fn check_usage_accepts_all_known_std_libs() {
+    for resource in [
+        "https://www.omg.org/spec/KerML/20250201/Data-Type-Library.kpar",
+        "https://www.omg.org/spec/KerML/20250201/Semantic-Library.kpar",
+        "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
+        "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
+        "https://www.omg.org/spec/SysML/20250201/Analysis-Domain-Library.kpar",
+        "https://www.omg.org/spec/SysML/20250201/Cause-and-Effect-Domain-Library.kpar",
+        "https://www.omg.org/spec/SysML/20250201/Geometry-Domain-Library.kpar",
+        "https://www.omg.org/spec/SysML/20250201/Metadata-Domain-Library.kpar",
+        "https://www.omg.org/spec/SysML/20250201/Quantities-and-Units-Domain-Library.kpar",
+        "https://www.omg.org/spec/SysML/20250201/Requirement-Derivation-Domain-Library.kpar",
+    ] {
+        check_usage(&usage(resource)).unwrap_or_else(|e| panic!("{resource}: {e}"));
+    }
+}
+
+#[test]
+fn check_usage_rejects_disallowed_usage() {
+    // Not a pkg:sysand purl and not a std-lib IRI prefix.
+    let err = check_usage(&usage("https://example.com/some/library")).unwrap_err();
+    assert!(matches!(err, PublishError::DisallowedUsage { .. }));
+}
+
+#[test]
+fn check_usage_rejects_invalid_purl() {
+    // pkg:sysand prefix present but name segment is syntactically invalid.
+    let err = check_usage(&usage("pkg:sysand/publisher/bad__name")).unwrap_err();
+    assert!(matches!(err, PublishError::InvalidPurl { .. }));
+}
+
+#[test]
+fn check_usage_rejects_std_lib_with_version_constraint() {
+    let err = check_usage(&usage_with_vc(
+        "https://www.omg.org/spec/SysML/20250201/Systems-Library.kpar",
+        ">=1.0.0",
+    ))
+    .unwrap_err();
+    assert!(matches!(err, PublishError::StdWithVersionConstraint { .. }));
+}
+
+#[test]
+fn check_usage_rejects_invalid_std_lib_version() {
+    // Valid SysML prefix + known suffix, but invalid date portion.
+    let err = check_usage(&usage(
+        "https://www.omg.org/spec/SysML/baddate/Systems-Library.kpar",
+    ))
+    .unwrap_err();
+    assert!(matches!(err, PublishError::InvalidStdLibVersion { .. }));
+}
+
+#[test]
+fn check_usage_rejects_unknown_std_lib() {
+    // Valid SysML prefix, no version constraint, but the suffix is not a known library.
+    let err = check_usage(&usage(
+        "https://www.omg.org/spec/SysML/20250201/Nonexistent-Library.kpar",
+    ))
+    .unwrap_err();
+    assert!(matches!(err, PublishError::UnknownStdLib { .. }));
+}
+
+// --- map_publish_response ---
+
+#[test]
+fn map_publish_response_400_maps_to_bad_request() {
+    let err = map_publish_response(
+        400,
+        b"bad field",
+        "http://example.org/v1/upload",
+        "http://example.org/v1/upload",
+    )
+    .unwrap_err();
+    assert!(matches!(err, PublishError::BadRequest(_)));
+}
+
+#[test]
+fn map_publish_response_200_is_ok_not_new_project() {
+    let resp = map_publish_response(
+        200,
+        b"ok",
+        "http://example.org/v1/upload",
+        "http://example.org/v1/upload",
+    )
+    .unwrap();
+    assert!(!resp.is_new_project);
+    assert_eq!(resp.status, 200);
+}
+
+#[test]
+fn map_publish_response_201_is_ok_new_project() {
+    let resp = map_publish_response(
+        201,
+        b"created",
+        "http://example.org/v1/upload",
+        "http://example.org/v1/upload",
+    )
+    .unwrap();
+    assert!(resp.is_new_project);
+    assert_eq!(resp.status, 201);
+}
+
+// --- validate_endpoint_url_shape with DiscoveryRoot ---
+
+#[test]
+fn validate_discovery_root_rejects_non_http_scheme() {
+    let url = Url::parse("ftp://example.org").unwrap();
+    let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
+    assert!(matches!(err, PublishError::InvalidDiscoveryRoot { .. }));
+}
+
+#[test]
+fn validate_discovery_root_rejects_upload_endpoint_path() {
+    let url = Url::parse("https://example.org/v1/upload").unwrap();
+    let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
+    assert!(matches!(err, PublishError::InvalidDiscoveryRoot { .. }));
+}
+
+#[test]
+fn validate_discovery_root_rejects_query_and_fragment() {
+    let url = Url::parse("https://example.org/index?x=1").unwrap();
+    let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
+    assert!(matches!(err, PublishError::InvalidDiscoveryRoot { .. }));
+}
+
+// --- prepare_publish_payload error cases ---
+
+mod prepare_publish {
+    use crate::utils::sha256_lowercase_hex;
+
+    use super::super::prepare_publish_payload;
+    use super::PublishError;
+    use camino::Utf8Path;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    fn deflate() -> SimpleFileOptions {
+        SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated)
+            .last_modified_time(zip::DateTime::DEFAULT)
+    }
+
+    fn stored() -> SimpleFileOptions {
+        SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .last_modified_time(zip::DateTime::DEFAULT)
+    }
+
+    /// Write a ZIP with the given entries to a NamedTempFile; keep the file
+    /// alive by returning it alongside the path.
+    fn write_zip(
+        entries: &[(&str, &[u8], SimpleFileOptions)],
+    ) -> (tempfile::NamedTempFile, camino::Utf8PathBuf) {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = camino::Utf8PathBuf::from(tmp.path().to_str().unwrap());
+        {
+            let f = std::fs::File::create(tmp.path()).unwrap();
+            let mut zip = zip::ZipWriter::new(f);
+            for (name, content, opts) in entries {
+                zip.start_file(*name, *opts).unwrap();
+                zip.write_all(content).unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        (tmp, path)
+    }
+
+    /// Minimal `.project.json` that passes all info-level checks up to the
+    /// archive loop. Caller can override individual fields in the JSON.
+    fn project_json(publisher: &str, name: &str, version: &str, license: &str) -> Vec<u8> {
+        format!(
+            r#"{{"name":"{name}","publisher":"{publisher}","version":"{version}","license":"{license}"}}"#
+        )
+        .into_bytes()
+    }
+
+    fn base_project() -> Vec<u8> {
+        project_json("test-pub", "test-pkg", "1.0.0", "MIT")
+    }
+
+    /// `.meta.json` with a single source file, correct checksum, and valid
+    /// SysML metamodel. `file_content` is the bytes that will be written to
+    /// the archive for `file_name`.
+    fn meta_json_with_file(file_name: &str, file_content: &[u8], symbol: &str) -> Vec<u8> {
+        let cksum = sha256_lowercase_hex(file_content);
+        format!(
+            r#"{{"index":{{"{symbol}":"{file_name}"}},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{{"{file_name}":{{"value":"{cksum}","algorithm":"SHA256"}}}}}}"#
+        )
+        .into_bytes()
+    }
+
+    /// `.meta.json` with no source files (empty index, no checksum).
+    fn meta_json_empty() -> Vec<u8> {
+        br#"{"index":{},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201"}"#.to_vec()
+    }
+
+    /// Base entries that pass every check up to (but not including) the
+    /// archive-file loop. Archive loop errors can be triggered by appending
+    /// one more "bad" entry.
+    fn pre_loop_entries() -> (Vec<u8>, Vec<u8>) {
+        (base_project(), meta_json_empty())
+    }
+
+    /// Complete set of archive entries for a fully-valid kpar with one source
+    /// file `test.sysml` containing `content`.
+    fn valid_entries(sysml_content: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        let meta = meta_json_with_file("test.sysml", sysml_content, "Test");
+        (base_project(), meta)
+    }
+
+    // ── KparRead ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn kpar_read_rejects_non_zip_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"this is not a zip file").unwrap();
+        let path = Utf8Path::new(tmp.path().to_str().unwrap());
+        let err = prepare_publish_payload(path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::KparRead(..)));
+    }
+
+    #[test]
+    fn kpar_read_rejects_zip_without_project_json() {
+        // A valid ZIP but containing no .project.json — guess_root fails.
+        let (_tmp, path) = write_zip(&[("unrelated.txt", b"hello", deflate())]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::KparRead(..)));
+    }
+
+    // ── ProjectNotAtRoot ─────────────────────────────────────────────────────
+
+    #[test]
+    fn project_not_at_root() {
+        // .project.json is inside a subdirectory; publish requires root placement.
+        let (_tmp, path) =
+            write_zip(&[("subdir/.project.json", base_project().as_slice(), deflate())]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::ProjectNotAtRoot { .. }));
+    }
+
+    // ── MissingMeta ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_meta() {
+        let (_tmp, path) = write_zip(&[(".project.json", base_project().as_slice(), deflate())]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::MissingMeta));
+    }
+
+    // ── InfoMetaValidation ───────────────────────────────────────────────────
+
+    #[test]
+    fn info_meta_validation_project_bad_semver() {
+        let bad_project = project_json("test-pub", "test-pkg", "not-semver", "MIT");
+        let (_tmp, path) = write_zip(&[
+            (".project.json", bad_project.as_slice(), deflate()),
+            (".meta.json", meta_json_empty().as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(
+            err,
+            PublishError::InfoMetaValidation {
+                name: "project",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn info_meta_validation_meta_bad_checksum_alg() {
+        // Algorithm field is not one of the recognised values.
+        let bad_meta = br#"{"index":{"Sym":"f.sysml"},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{"f.sysml":{"value":"aa","algorithm":"NOTAKNOWNALG"}}}"#;
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", bad_meta, deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(
+            err,
+            PublishError::InfoMetaValidation { name: "meta", .. }
+        ));
+    }
+
+    // ── MissingPublisher ─────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_publisher() {
+        let no_pub = br#"{"name":"test-pkg","version":"1.0.0","license":"MIT"}"#;
+        let (_tmp, path) = write_zip(&[
+            (".project.json", no_pub, deflate()),
+            (".meta.json", meta_json_empty().as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::MissingPublisher));
+    }
+
+    // ── InvalidPublisher ─────────────────────────────────────────────────────
+
+    #[test]
+    fn invalid_publisher() {
+        let bad = project_json("bad__pub", "test-pkg", "1.0.0", "MIT");
+        let (_tmp, path) = write_zip(&[
+            (".project.json", bad.as_slice(), deflate()),
+            (".meta.json", meta_json_empty().as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::InvalidPublisher(..)));
+    }
+
+    // ── InvalidName ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn invalid_name() {
+        let bad = project_json("test-pub", "bad__name", "1.0.0", "MIT");
+        let (_tmp, path) = write_zip(&[
+            (".project.json", bad.as_slice(), deflate()),
+            (".meta.json", meta_json_empty().as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::InvalidName(..)));
+    }
+
+    // ── VersionBuildMetadata ─────────────────────────────────────────────────
+
+    #[test]
+    fn version_build_metadata() {
+        let bad = project_json("test-pub", "test-pkg", "1.0.0+build", "MIT");
+        let (_tmp, path) = write_zip(&[
+            (".project.json", bad.as_slice(), deflate()),
+            (".meta.json", meta_json_empty().as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::VersionBuildMetadata { .. }));
+    }
+
+    // ── MissingLicense ───────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_license() {
+        let no_lic = br#"{"name":"test-pkg","publisher":"test-pub","version":"1.0.0"}"#;
+        let (_tmp, path) = write_zip(&[
+            (".project.json", no_lic, deflate()),
+            (".meta.json", meta_json_empty().as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::MissingLicense));
+    }
+
+    // ── InvalidLicense ───────────────────────────────────────────────────────
+
+    #[test]
+    fn invalid_license() {
+        let bad = project_json("test-pub", "test-pkg", "1.0.0", "NOT-A-LICENSE!!!");
+        let (_tmp, path) = write_zip(&[
+            (".project.json", bad.as_slice(), deflate()),
+            (".meta.json", meta_json_empty().as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::InvalidLicense { .. }));
+    }
+
+    // ── MissingMetamodel ─────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_metamodel() {
+        let no_meta = br#"{"index":{},"created":"2025-01-01T00:00:00Z"}"#;
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", no_meta, deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::MissingMetamodel));
+    }
+
+    // ── Archive-loop errors (ExecInArchive, UnsupportedCompression, Encrypted)
+
+    // Each test below uses valid .project.json + .meta.json and appends one
+    // "bad" file entry; the archive loop fires before any checksum check.
+
+    #[test]
+    fn exec_in_archive() {
+        let (proj, meta) = pre_loop_entries();
+        let exec = deflate().unix_permissions(0o100755);
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("test.sysml", b"package Test;", exec),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::ExecInArchive { .. }));
+    }
+
+    #[test]
+    fn unsupported_compression() {
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("test.sysml", b"package Test;", stored()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(
+            matches!(err, PublishError::UnsupportedCompression { .. }),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn symlink_in_archive() {
+        let (proj, meta) = pre_loop_entries();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = camino::Utf8PathBuf::from(tmp.path().to_str().unwrap());
+        {
+            let f = std::fs::File::create(tmp.path()).unwrap();
+            let mut zip = zip::ZipWriter::new(f);
+            zip.start_file(".project.json", deflate()).unwrap();
+            zip.write_all(proj.as_slice()).unwrap();
+            zip.start_file(".meta.json", deflate()).unwrap();
+            zip.write_all(meta.as_slice()).unwrap();
+            zip.add_symlink("test.sysml", "target-path", deflate())
+                .unwrap();
+            zip.finish().unwrap();
+        }
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::Symlink { .. }));
+    }
+
+    #[test]
+    fn encrypted_entry() {
+        use zip::unstable::write::FileOptionsExt;
+        let (proj, meta) = pre_loop_entries();
+        let enc_opts = deflate().with_deprecated_encryption(b"secret").unwrap();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = camino::Utf8PathBuf::from(tmp.path().to_str().unwrap());
+        {
+            let f = std::fs::File::create(tmp.path()).unwrap();
+            let mut zip = zip::ZipWriter::new(f);
+            zip.start_file(".project.json", deflate()).unwrap();
+            zip.write_all(proj.as_slice()).unwrap();
+            zip.start_file(".meta.json", deflate()).unwrap();
+            zip.write_all(meta.as_slice()).unwrap();
+            zip.start_file("test.sysml", enc_opts).unwrap();
+            zip.write_all(b"package Test;").unwrap();
+            zip.finish().unwrap();
+        }
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::Encrypted { .. }));
+    }
+
+    // ── DisallowedPath ───────────────────────────────────────────────────────
+
+    #[test]
+    fn disallowed_path_current_dir_prefix() {
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("./test.sysml", b"package Test;", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::DisallowedPath { .. }));
+    }
+
+    // ── MissingLicenseFile ───────────────────────────────────────────────────
+
+    #[test]
+    fn missing_license_file() {
+        // Valid project + meta, archive passes file loop, but LICENSES/MIT.txt
+        // is absent.
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::MissingLicenseFile { .. }));
+    }
+
+    // ── MissingChecksum ──────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_checksum() {
+        // meta.json has no checksum field at all.
+        let meta_no_cksum =
+            br#"{"index":{},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201"}"#;
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta_no_cksum, deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::MissingChecksum));
+    }
+
+    // ── EmptyChecksum ────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_checksum() {
+        // checksum is present but empty.
+        let meta_empty_cksum =
+            br#"{"index":{},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{}}"#;
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta_empty_cksum, deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::EmptyChecksum));
+    }
+
+    // ── IncorrectFileFormat ──────────────────────────────────────────────────
+
+    #[test]
+    fn incorrect_file_format() {
+        // checksum references a .kerml file but metamodel is SysML.
+        let cksum = sha256_lowercase_hex(b"content");
+        let meta = format!(
+            r#"{{"index":{{"Sym":"f.sysml"}},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{{"f.kerml":{{"value":"{cksum}","algorithm":"SHA256"}},"f.sysml":{{"value":"{cksum}","algorithm":"SHA256"}}}}}}"#
+        );
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta.as_bytes(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("f.sysml", b"content", deflate()),
+            ("f.kerml", b"content", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::IncorrectFileFormat { .. }));
+    }
+
+    // ── UnsupportedFileChecksumType ──────────────────────────────────────────
+
+    #[test]
+    fn unsupported_file_checksum_type() {
+        // SHA1 is a valid algorithm but not SHA256.
+        let sha1_val = "a".repeat(40); // 40 hex chars = valid SHA1 length
+        let meta = format!(
+            r#"{{"index":{{"Sym":"f.sysml"}},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{{"f.sysml":{{"value":"{sha1_val}","algorithm":"SHA1"}}}}}}"#
+        );
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta.as_bytes(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(
+            err,
+            PublishError::UnsupportedFileChecksumType { .. }
+        ));
+    }
+
+    // ── MissingFile ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_file() {
+        // checksum mentions test.sysml but the archive does not contain it.
+        let cksum = sha256_lowercase_hex(b"package Test;");
+        let meta = format!(
+            r#"{{"index":{{"Test":"test.sysml"}},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{{"test.sysml":{{"value":"{cksum}","algorithm":"SHA256"}}}}}}"#
+        );
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta.as_bytes(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            // test.sysml intentionally omitted
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::MissingFile { .. }));
+    }
+
+    // ── IncorrectFileChecksum ────────────────────────────────────────────────
+
+    #[test]
+    fn incorrect_file_checksum() {
+        let wrong_cksum = "f".repeat(64); // valid hex length but wrong value
+        let meta = format!(
+            r#"{{"index":{{"Test":"test.sysml"}},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{{"test.sysml":{{"value":"{wrong_cksum}","algorithm":"SHA256"}}}}}}"#
+        );
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta.as_bytes(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("test.sysml", b"package Test;", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::IncorrectFileChecksum { .. }));
+    }
+
+    // ── NonexistentSymbolExported ────────────────────────────────────────────
+
+    #[test]
+    fn nonexistent_symbol_exported() {
+        // index claims "Ghost" is defined in test.sysml, but the file only
+        // defines the package "Test".
+        let content = b"package Test;";
+        let cksum = sha256_lowercase_hex(content);
+        let meta = format!(
+            r#"{{"index":{{"Ghost":"test.sysml"}},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{{"test.sysml":{{"value":"{cksum}","algorithm":"SHA256"}}}}}}"#
+        );
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta.as_bytes(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("test.sysml", content, deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(
+            err,
+            PublishError::NonexistentSymbolExported { .. }
+        ));
+    }
+
+    // ── IndexFail ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn index_fail() {
+        // Garbage content in a .sysml file causes extract_symbols to fail.
+        let content = b"@@@NOT VALID SYSML@@@";
+        let cksum = sha256_lowercase_hex(content);
+        let meta = format!(
+            r#"{{"index":{{"Sym":"test.sysml"}},"created":"2025-01-01T00:00:00Z","metamodel":"https://www.omg.org/spec/SysML/20250201","checksum":{{"test.sysml":{{"value":"{cksum}","algorithm":"SHA256"}}}}}}"#
+        );
+        let (_tmp, path) = write_zip(&[
+            (".project.json", base_project().as_slice(), deflate()),
+            (".meta.json", meta.as_bytes(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("test.sysml", content, deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::IndexFail { .. }));
+    }
+
+    // ── UnexpectedFile ───────────────────────────────────────────────────────
+
+    #[test]
+    fn unexpected_file() {
+        // A file that is neither in checksum nor a recognised ancillary file.
+        let content = b"package Test;";
+        let (proj, meta) = valid_entries(content);
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("test.sysml", content, deflate()),
+            ("extra.txt", b"surprise", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::UnexpectedFile { .. }));
+    }
 }

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -632,7 +632,7 @@ mod prepare_publish {
             ("./test.sysml", b"package Test;", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::DisallowedPath { .. }));
+        assert!(matches!(err, PublishError::RelativePathComponents { .. }));
     }
 
     // ── MissingLicenseFile ───────────────────────────────────────────────────
@@ -820,5 +820,160 @@ mod prepare_publish {
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
         assert!(matches!(err, PublishError::UnexpectedFile { .. }));
+    }
+
+    // ── Backslash ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn backslash_in_path() {
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("subdir\\file.sysml", b"package Test;", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(matches!(err, PublishError::Backslash { .. }), "got: {err}");
+    }
+
+    // ── AbsolutePath ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn absolute_path() {
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("/absolute/file.sysml", b"package Test;", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(
+            matches!(err, PublishError::AbsolutePath { .. }),
+            "got: {err}"
+        );
+    }
+
+    // ── DoubleSlash ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn double_slash_in_path() {
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("foo//bar.sysml", b"package Test;", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(
+            matches!(err, PublishError::DoubleSlash { .. }),
+            "got: {err}"
+        );
+    }
+
+    // ── RelativePathComponents with .. ────────────────────────────────────────
+
+    #[test]
+    fn relative_path_parent_dir() {
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("../escape.sysml", b"package Test;", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(
+            matches!(err, PublishError::RelativePathComponents { .. }),
+            "got: {err}"
+        );
+    }
+
+    // ── CompressedDirEntry ────────────────────────────────────────────────────
+
+    #[test]
+    fn compressed_dir_entry() {
+        // A directory entry (name ends with '/') must use Stored compression.
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("subdir/", b"", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(
+            matches!(err, PublishError::CompressedDirEntry { .. }),
+            "got: {err}"
+        );
+    }
+
+    // ── Directory entry with Stored compression is accepted ───────────────────
+
+    #[test]
+    fn dir_entry_with_stored_passes_archive_loop() {
+        // A Stored-compression directory entry must not trigger UnsupportedCompression
+        // or CompressedDirEntry; the function should proceed past the archive loop.
+        let (proj, meta) = pre_loop_entries();
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("LICENSES/", b"", stored()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+        ]);
+        let err = prepare_publish_payload(&path).expect_err("expected Err");
+        assert!(
+            matches!(err, PublishError::MissingChecksum),
+            "expected MissingChecksum (past archive loop), got: {err}"
+        );
+    }
+
+    // ── CHANGELOG.md is accepted ──────────────────────────────────────────────
+
+    #[test]
+    fn changelog_md_accepted() {
+        let content = b"package Test;";
+        let (proj, meta) = valid_entries(content);
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("test.sysml", content, deflate()),
+            (
+                "CHANGELOG.md",
+                b"# Changelog\n\n## 1.0.0\n- initial release",
+                deflate(),
+            ),
+        ]);
+        prepare_publish_payload(&path)
+            .expect("CHANGELOG.md must not be rejected as UnexpectedFile");
+    }
+
+    // ── README.md is accepted ─────────────────────────────────────────────────
+
+    #[test]
+    fn readme_md_accepted() {
+        let content = b"package Test;";
+        let (proj, meta) = valid_entries(content);
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("test.sysml", content, deflate()),
+            ("README.md", b"# My Package", deflate()),
+        ]);
+        prepare_publish_payload(&path).expect("README.md must not be rejected as UnexpectedFile");
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_kpar_succeeds() {
+        let content = b"package Test;";
+        let (proj, meta) = valid_entries(content);
+        let (_tmp, path) = write_zip(&[
+            (".project.json", proj.as_slice(), deflate()),
+            (".meta.json", meta.as_slice(), deflate()),
+            ("LICENSES/MIT.txt", b"MIT License", deflate()),
+            ("test.sysml", content, deflate()),
+        ]);
+        prepare_publish_payload(&path).expect("fully valid kpar should succeed");
     }
 }

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -22,6 +22,9 @@ pub const KNOWN_METAMODELS: [&str; 2] = [
     "https://www.omg.org/spec/KerML/20250201",
 ];
 
+pub const SYSML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/SysML/";
+pub const KERML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/KerML/";
+
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Hash, Debug)]
 #[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
 #[serde(rename_all = "camelCase")]

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -460,10 +460,6 @@ impl LocalKParProjectRaw {
                 .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
         }
 
-        // This can only fail if the comment is too long
-        zip.set_comment(concat!("produced by: sysand v", env!("CARGO_PKG_VERSION")))
-            .unwrap();
-
         zip.finish()
             .map_err(|e| ZipArchiveError::Finish(path.as_ref().into(), e))?;
 

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -460,6 +460,10 @@ impl LocalKParProjectRaw {
                 .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
         }
 
+        // This can only fail if the comment is too long
+        zip.set_comment(concat!("produced by: sysand v", env!("CARGO_PKG_VERSION")))
+            .unwrap();
+
         zip.finish()
             .map_err(|e| ZipArchiveError::Finish(path.as_ref().into(), e))?;
 
@@ -491,7 +495,7 @@ impl LocalKParProjectRaw {
         Ok(wrapfs::File::open(&self.archive_path)?)
     }
 
-    fn open_archive(&self) -> Result<ZipArchive<fs::File>, LocalKParError> {
+    pub(crate) fn open_archive(&self) -> Result<ZipArchive<fs::File>, LocalKParError> {
         Ok(zip::ZipArchive::new(self.open_archive_file()?)
             .map_err(|e| ZipArchiveError::ReadArchive(self.archive_path.as_path().into(), e))?)
     }

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use camino::Utf8Path;
+use digest::{array::Array, typenum};
 use futures::io::{AsyncBufReadExt as _, AsyncRead};
 use indexmap::IndexMap;
 use sha2::{Digest, Sha256};
@@ -65,7 +66,7 @@ pub struct KparMeta {
 }
 
 /// Produce a SHA-256 digest by hashing all the contents of `reader`
-pub(crate) fn hash_reader<R: Read>(reader: &mut R) -> Result<ProjectHash, io::Error> {
+pub(crate) fn hash_reader<R: Read>(reader: &mut R) -> Result<Array<u8, typenum::U32>, io::Error> {
     let mut hasher = Sha256::new();
     let mut buffered = BufReader::new(reader);
 

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -216,6 +216,10 @@ pub mod wrapfs {
             .map_err(|e| Box::new(FsIoError::ReadFile(path.as_ref().into(), e)))
     }
 
+    pub fn read<P: AsRef<Utf8Path>>(path: P) -> Result<Vec<u8>, Box<FsIoError>> {
+        fs::read(path.as_ref()).map_err(|e| Box::new(FsIoError::ReadFile(path.as_ref().into(), e)))
+    }
+
     pub fn metadata<P: AsRef<Utf8Path>>(path: P) -> Result<fs::Metadata, Box<FsIoError>> {
         fs::metadata(path.as_ref())
             .map_err(|e| Box::new(FsIoError::Metadata(path.as_ref().into(), e)))

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -4,6 +4,7 @@
 use std::{error::Error, fmt::Write as _};
 
 use digest::{array::Array, typenum};
+use indexmap::IndexSet;
 use sha2::{Digest, Sha256};
 
 pub(crate) mod scheme {
@@ -61,8 +62,8 @@ pub fn lowercase_hex(bytes: Array<u8, typenum::U32>) -> String {
 /// any `WITH` exceptions) named in `expression`. Each identifier maps to a
 /// `LICENSES/<id>.txt` file under REUSE conventions; the `+` "or later"
 /// modifier does not affect the filename.
-pub(crate) fn license_file_stems(expression: &spdx::Expression) -> Vec<String> {
-    let mut stems: indexmap::IndexSet<String> = indexmap::IndexSet::new();
+pub(crate) fn license_file_stems(expression: &spdx::Expression) -> IndexSet<String> {
+    let mut stems: IndexSet<String> = IndexSet::new();
     for req in expression.requirements() {
         let license_name = match &req.req.license {
             spdx::LicenseItem::Spdx { id, .. } => id.name.to_string(),
@@ -78,5 +79,5 @@ pub(crate) fn license_file_stems(expression: &spdx::Expression) -> Vec<String> {
             stems.insert(addition_name);
         }
     }
-    stems.into_iter().collect()
+    stems
 }

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -11,7 +11,11 @@ use camino::Utf8PathBuf;
 use clap::{ValueEnum, builder::StyledStr, crate_authors};
 use fluent_uri::Iri;
 use semver::VersionReq;
-use sysand_core::{add::expand_sysand_purl_shorthand, build::KparCompressionMethod};
+use sysand_core::{
+    add::expand_sysand_purl_shorthand,
+    build::KparCompressionMethod,
+    model::{KERML_METAMODEL_PREFIX, SYSML_METAMODEL_PREFIX},
+};
 use url::Url;
 
 use crate::env_vars;
@@ -142,6 +146,7 @@ pub enum Command {
     /// Include model interchange files in project metadata. This can
     /// be used multiple times for the same file to update its metadata,
     /// as the metadata will not be updated automatically
+    #[clap(verbatim_doc_comment)]
     Include {
         /// File(s) to include in the project.
         #[arg(num_args = 1..)]
@@ -1643,16 +1648,11 @@ pub enum MetamodelKind {
     KerML,
 }
 
-impl MetamodelKind {
-    pub const SYSML: &str = "https://www.omg.org/spec/SysML/";
-    pub const KERML: &str = "https://www.omg.org/spec/KerML/";
-}
-
 impl From<&MetamodelKind> for &'static str {
     fn from(value: &MetamodelKind) -> Self {
         match value {
-            MetamodelKind::SysML => MetamodelKind::SYSML,
-            MetamodelKind::KerML => MetamodelKind::KERML,
+            MetamodelKind::SysML => SYSML_METAMODEL_PREFIX,
+            MetamodelKind::KerML => KERML_METAMODEL_PREFIX,
         }
     }
 }

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -441,6 +441,15 @@ fn set_info(
         }
         SetInfoVerb::SetLicense(value) => {
             info.license = Some(value.clone());
+            log::info!(
+                "Note: every license/exception should have its corresponding\n\
+                file in LICENSES/ directory, and for publishing this is required.\n\
+                It is recommended to use SPDX license text files from\n\
+                https://spdx.org/licenses/ or\n\
+                https://github.com/spdx/license-list-data/tree/main/text\n\
+                just note that some of them have placeholder copyright\n\
+                holder/dates in the text that should be replaced"
+            )
         }
         SetInfoVerb::SetMaintainer(value) => {
             info.maintainer = value.clone();

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -492,6 +492,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 // Only print std warning when command is to print all info
                 // or just usages.
                 // These are the only cases where stdlib usages affect output
+                // TODO: be more precise, this warning is annoying
                 match subcommand {
                     None
                     | Some(InfoCommand::Usage {

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
+use std::fs;
+
 use assert_cmd::prelude::*;
 use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::Utf8TempDir;
@@ -28,6 +30,10 @@ fn init_project(name: &str) -> Result<(Utf8TempDir, Utf8PathBuf), Box<dyn std::e
         None,
     )?;
     out.assert().success();
+    let mut licenses = cwd.join("LICENSES");
+    fs::create_dir(&licenses)?;
+    licenses.push("MIT.txt");
+    fs::File::create(licenses)?;
     Ok((temp_dir, cwd))
 }
 
@@ -39,7 +45,8 @@ fn run_sysand_ok(cwd: &Utf8Path, args: &[&str], cfg: Option<&str>) -> TestResult
 
 fn include_basic_model(cwd: &Utf8Path) -> TestResult {
     std::fs::write(cwd.join("test.sysml"), "package P;\n")?;
-    run_sysand_ok(cwd, &["include", "--no-index-symbols", "test.sysml"], None)
+    run_sysand_ok(cwd, &["include", "--no-index-symbols", "test.sysml"], None)?;
+    run_sysand_ok(cwd, &["info", "metamodel", "--set", "sysml"], None)
 }
 
 fn build_default_kpar(cwd: &Utf8Path) -> TestResult {
@@ -374,8 +381,8 @@ fn publish_rejects_invalid_semver_version() -> TestResult {
 
     out.assert()
         .failure()
-        .stderr(predicate::str::contains("version field"))
-        .stderr(predicate::str::contains("Semantic Versioning 2.0 version"))
+        .stderr(predicate::str::contains("`not-semver`"))
+        .stderr(predicate::str::contains("Semantic Version"))
         .stderr(predicate::str::contains("HTTP request failed").not());
 
     Ok(())
@@ -385,6 +392,7 @@ fn publish_rejects_invalid_semver_version() -> TestResult {
 fn publish_rejects_version_build_metadata() -> TestResult {
     let (_temp_dir, cwd) = init_project("version-build-metadata")?;
 
+    // Manually set the field, since set_project_field runs the CLI
     let project_file = cwd.join(".project.json");
     let project_json = std::fs::read_to_string(&project_file)?;
     let project_json =
@@ -404,8 +412,8 @@ fn publish_rejects_version_build_metadata() -> TestResult {
 
     out.assert()
         .failure()
-        .stderr(predicate::str::contains("version field"))
-        .stderr(predicate::str::contains("build metadata"))
+        .stderr(predicate::str::contains("version `1.2.3+build`"))
+        .stderr(predicate::str::contains("metadata"))
         .stderr(predicate::str::contains("HTTP request failed").not());
 
     Ok(())
@@ -428,7 +436,7 @@ fn publish_rejects_noncanonicalizable_publisher() -> TestResult {
 
     out.assert()
         .failure()
-        .stderr(predicate::str::contains("publisher field"))
+        .stderr(predicate::str::contains("publisher `bad__publisher`"))
         .stderr(predicate::str::contains("must be 3-50 characters"))
         .stderr(predicate::str::contains("HTTP request failed").not());
 
@@ -452,7 +460,7 @@ fn publish_rejects_noncanonicalizable_name() -> TestResult {
 
     out.assert()
         .failure()
-        .stderr(predicate::str::contains("name field"))
+        .stderr(predicate::str::contains("name `bad__name`"))
         .stderr(predicate::str::contains("must be 3-50 characters"))
         .stderr(predicate::str::contains("HTTP request failed").not());
 


### PR DESCRIPTION
- checks may be a bit more/less strict than on the server
- errors are currently descriptive, but most are not actionable. Not sure where to provide suggestions (this also applies to many other errors in core that are user-fixable):
  - core should not mention CLI flags, since it's also used by bindings
  - unclear how to provide them in CLI either: matching each error variant and adding more details to some of them is tedious and very verbose
- fix publish tests to now produce kpars that pass our checks

Closes #389 - I decided against compiling in all license texts, since that would add a few extra MB to the binary, which is not justifiable for such a rarely needed feature. Instead a detailed help message has been added when failing due to missing license in publish, and a similar one is printed when setting the license with `sysand info license --set`