### PR TITLE
chore: fix inline comment about default index

### DIFF
--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1505,9 +1505,8 @@ pub struct ResolutionOptions {
     )]
     pub index: Vec<String>,
     /// Comma-delimited list of URLs to use as default index
-    /// URLs. Default indexes are tried before other indexes
+    /// URLs. Default indexes are tried after other indexes
     /// (default `https://sysand.com`)
-    // TODO: verify index use order
     #[arg(
         long,
         num_args = 0..,


### PR DESCRIPTION
The TODO was removed as the order is verified it seems.

AI notes:

core/src/config/mod_tests.rs:48:

  - index_urls_without_default verifies explicit --index URLs come first, then config indexes, then built-in/default URLs.
  - index_urls_with_default verifies config entries marked default = true are sorted after non-default config indexes.
  - index_urls_with_override verifies explicit default override URLs are appended after explicit and non-default config indexes.

  The implementation they exercise is core/src/config/mod.rs:130. index_urls_no_default_override sorts indexes by default, then chains index_urls, config indexes, and default URLs in that order. index_urls_with_default_override
  chains explicit indexes, non-default config indexes, then default override URLs