### PR TITLE
feat: improve performance of include, build and exclude

### DIFF
--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -410,18 +410,6 @@ fn handle_build_error(env: &mut JNIEnv<'_>, error: KParBuildError<LocalSrcError>
                 format!("Project read error: {}", error),
             );
         }
-        KParBuildError::LocalSrc(error) => {
-            env.throw_exception(
-                ExceptionKind::SysandException,
-                format!("Local src error: {}", error),
-            );
-        }
-        KParBuildError::IncompleteSource(error) => {
-            env.throw_exception(
-                ExceptionKind::SysandException,
-                format!("Incomplete source error: {}", error),
-            );
-        }
         KParBuildError::Io(error) => {
             env.throw_exception(
                 ExceptionKind::SysandException,
@@ -454,6 +442,12 @@ fn handle_build_error(env: &mut JNIEnv<'_>, error: KParBuildError<LocalSrcError>
         }
         KParBuildError::MissingMeta => {
             env.throw_exception(ExceptionKind::SysandException, "Missing project metadata");
+        }
+        KParBuildError::MissingInfoMeta => {
+            env.throw_exception(
+                ExceptionKind::SysandException,
+                "Missing project information and metadata",
+            );
         }
         KParBuildError::Zip(error) => {
             env.throw_exception(

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::{collections::HashMap, process::ExitCode, sync::Arc};
+use std::{collections::HashMap, iter, process::ExitCode, sync::Arc};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use pyo3::{
@@ -41,6 +41,7 @@ use sysand_core::{
     stdlib::known_std_libs,
     symbols::Language,
 };
+use typed_path::Utf8UnixPathBuf;
 
 #[pyfunction(name = "_run_cli")]
 fn run_cli(args: Vec<String>) -> PyResult<bool> {
@@ -229,14 +230,13 @@ fn do_build_py(
         .map(|_| ())
         .map_err(|err| match err {
             KParBuildError::ProjectRead(_) => PyRuntimeError::new_err(err.to_string()),
-            KParBuildError::LocalSrc(_) => PyRuntimeError::new_err(err.to_string()),
-            KParBuildError::IncompleteSource(_) => PyRuntimeError::new_err(err.to_string()),
             KParBuildError::Io(_) => PyIOError::new_err(err.to_string()),
             KParBuildError::Validation(_) => PyValueError::new_err(err.to_string()),
             KParBuildError::Extract(_) => PyValueError::new_err(err.to_string()),
             KParBuildError::UnknownFormat(_) => PyValueError::new_err(err.to_string()),
             KParBuildError::MissingInfo => PyValueError::new_err(err.to_string()),
             KParBuildError::MissingMeta => PyValueError::new_err(err.to_string()),
+            KParBuildError::MissingInfoMeta => PyValueError::new_err(err.to_string()),
             KParBuildError::Zip(_) => PyIOError::new_err(err.to_string()),
             KParBuildError::Serialize(..) => PyValueError::new_err(err.to_string()),
             KParBuildError::WorkspaceRead(_) => PyRuntimeError::new_err(err.to_string()),
@@ -468,6 +468,8 @@ fn do_remove_py(path: String, iri: String) -> PyResult<()> {
     Ok(())
 }
 
+/// `src_path` must be relative to project root and use Unix separators.
+/// No normalization will be performed
 #[pyfunction(name = "do_include_py")]
 #[pyo3(
     signature = (path, src_path, compute_checksum, index_symbols, force_format),
@@ -486,7 +488,6 @@ fn do_include_py(
         project_path: path.into(),
         expected_checksum: None,
     };
-
     let force_format = match force_format {
         Some(language_str) => match Language::from_suffix(&language_str) {
             Some(language) => Some(language),
@@ -502,7 +503,7 @@ fn do_include_py(
 
     do_include(
         &mut project,
-        src_path,
+        iter::once(Utf8UnixPathBuf::from(src_path)),
         compute_checksum,
         index_symbols,
         force_format,
@@ -510,6 +511,8 @@ fn do_include_py(
     .map_err(|e| PyRuntimeError::new_err(e.to_string()))
 }
 
+/// `src_path` must be relative to project root and use Unix separators.
+/// No normalization will be performed
 #[pyfunction(name = "do_exclude_py")]
 #[pyo3(
     signature = (path, src_path),
@@ -522,8 +525,9 @@ fn do_exclude_py(path: String, src_path: String) -> PyResult<()> {
         project_path: path.into(),
         expected_checksum: None,
     };
-
-    do_exclude(&mut project, src_path).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    // TODO: print the whole error chain
+    do_exclude(&mut project, iter::once(Utf8UnixPathBuf::from(src_path)))
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
     Ok(())
 }

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -2,29 +2,28 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexMap;
 use thiserror::Error;
 
-use std::collections::HashSet;
+use std::{collections::HashSet, io::Write as _};
 
 use crate::{
-    env::utils::{CloneError, ErrorBound},
-    include::{IncludeError, do_include, extract_symbols},
-    model::InterchangeProjectValidationError,
+    env::utils::ErrorBound,
+    include::{IncludeError, extract_symbols, read_project_file_to_string},
+    model::{InterchangeProjectChecksumRaw, InterchangeProjectValidationError, KerMlChecksumAlg},
     project::{
         ProjectRead,
-        local_kpar::{IntoKparError, LocalKParProjectRaw},
+        local_kpar::LocalKParProjectRaw,
         local_src::{LocalSrcError, LocalSrcProject},
-        utils::{FsIoError, ZipArchiveError},
+        utils::{FsIoError, ZipArchiveError, wrapfs},
     },
-    utils::license_file_stems,
+    utils::{license_file_stems, sha256_lowercase_hex},
     workspace::{Workspace, WorkspaceReadError},
 };
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
 // Currently python interop is done with strings instead
-// in part to have less boilerplate, in part because the old
-// Python we use doesn't have pattern matching which ensures
-// all cases are covered
+// to have less boilerplate
 // #[cfg_attr(feature = "python", pyclass(eq))]
 pub enum KparCompressionMethod {
     /// Store the files as is
@@ -130,10 +129,6 @@ pub enum KParBuildError<ProjectReadError: ErrorBound> {
     #[error(transparent)]
     WorkspaceRead(#[from] WorkspaceReadError),
     #[error(transparent)]
-    LocalSrc(#[from] LocalSrcError),
-    #[error("incomplete project: {0}")]
-    IncompleteSource(&'static str),
-    #[error(transparent)]
     Io(#[from] Box<FsIoError>),
     #[error(transparent)]
     Validation(#[from] InterchangeProjectValidationError),
@@ -143,6 +138,8 @@ pub enum KParBuildError<ProjectReadError: ErrorBound> {
         "unknown file format of `{0}`, only SysML v2 (.sysml) and KerML (.kerml) files are supported"
     )]
     UnknownFormat(Box<str>),
+    #[error("missing project info file `.project.json` and metadata file `.meta.json`")]
+    MissingInfoMeta,
     #[error("missing project info file `.project.json`")]
     MissingInfo,
     #[error("missing project metadata file `.meta.json`")]
@@ -176,43 +173,15 @@ impl<ProjectReadError: ErrorBound> From<FsIoError> for KParBuildError<ProjectRea
     }
 }
 
-impl<ProjectReadError: ErrorBound> From<CloneError<ProjectReadError, LocalSrcError>>
+impl<ProjectReadError: ErrorBound> From<IncludeError<ProjectReadError>>
     for KParBuildError<ProjectReadError>
 {
-    fn from(value: CloneError<ProjectReadError, LocalSrcError>) -> Self {
+    fn from(value: IncludeError<ProjectReadError>) -> Self {
         match value {
-            CloneError::ProjectRead(error) => Self::ProjectRead(error),
-            CloneError::EnvWrite(error) => error.into(),
-            CloneError::IncompleteSource(error) => Self::IncompleteSource(error),
-            CloneError::Io(error) => error.into(),
-        }
-    }
-}
-
-impl<ProjectReadError: ErrorBound> From<IncludeError<LocalSrcError>>
-    for KParBuildError<ProjectReadError>
-{
-    fn from(value: IncludeError<LocalSrcError>) -> Self {
-        match value {
-            IncludeError::Project(error) => error.into(),
+            IncludeError::Project(error) => Self::ProjectRead(error),
             IncludeError::Io(error) => error.into(),
             IncludeError::Extract(..) => Self::Extract(value.to_string()),
-            IncludeError::UnknownFormat(error) => KParBuildError::UnknownFormat(error),
-        }
-    }
-}
-
-impl<ProjectReadError: ErrorBound> From<IntoKparError<LocalSrcError>>
-    for KParBuildError<ProjectReadError>
-{
-    fn from(value: IntoKparError<LocalSrcError>) -> Self {
-        match value {
-            IntoKparError::MissingInfo => KParBuildError::MissingInfo,
-            IntoKparError::MissingMeta => KParBuildError::MissingMeta,
-            IntoKparError::ProjectRead(error) => error.into(),
-            IntoKparError::Zip(zip_error) => zip_error.into(),
-            IntoKparError::Io(error) => error.into(),
-            IntoKparError::Serialize(msg, e) => Self::Serialize(msg, e),
+            IncludeError::UnknownFormat(error) => Self::UnknownFormat(error),
         }
     }
 }
@@ -247,8 +216,8 @@ pub fn default_kpar_file_name<Pr: ProjectRead>(
     ))
 }
 
-/// `update_index_checksum` controls whether to parse symbols from current
-/// file to update index and also update file checksum
+/// `update_index` controls whether to parse symbols from current
+/// file to update index
 pub fn do_build_kpar<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
@@ -256,16 +225,26 @@ pub fn do_build_kpar<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     update_index: bool,
     allow_path_usage: bool,
 ) -> Result<LocalKParProjectRaw, KParBuildError<Pr::Error>> {
-    do_build_kpar_inner(
+    let path = path.as_ref();
+    match do_build_kpar_inner(
         project,
         path,
         compression,
         update_index,
         allow_path_usage,
         None,
-    )
+    ) {
+        Ok(p) => Ok(p),
+        Err(e) => {
+            if let Err(e) = wrapfs::remove_file(path) {
+                log::debug!("cleanup: failed to remove archive file `{path}`: {e}");
+            }
+            Err(e)
+        }
+    }
 }
 
+/// Caller must delete the created archive on error
 fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     project: &Pr,
     path: P,
@@ -278,8 +257,17 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     let header = crate::style::get_style_config().header;
     log::info!("{header}{building:>12}{header:#} kpar `{}`", path.as_ref());
 
-    let (_tmp, mut local_project, info, mut meta) =
-        LocalSrcProject::temporary_from_project(project)?;
+    let (info, mut meta) = match project.get_project() {
+        Ok(im) => match im {
+            (Some(i), Some(m)) => (i, m),
+            (None, Some(_)) => return Err(KParBuildError::MissingInfo),
+            (Some(_), None) => return Err(KParBuildError::MissingMeta),
+            (None, None) => return Err(KParBuildError::MissingInfoMeta),
+        },
+        Err(e) => return Err(KParBuildError::ProjectRead(e)),
+    };
+    meta.validate()?;
+
     match semver::Version::parse(&info.version) {
         Ok(_) => (),
         Err(e) => log::warn!(
@@ -325,29 +313,65 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
             if proj_metamodel != ws_metamodel {
                 return Err(KParBuildError::WorkspaceMetamodelConflict {
                     workspace_metamodel: ws_metamodel.to_string(),
-                    project_metamodel: proj_metamodel.clone(),
+                    project_metamodel: proj_metamodel.into(),
                     project_path: path.as_ref().to_string(),
                 });
             }
         } else {
             meta.metamodel = Some(ws_metamodel.to_string());
-            use crate::project::ProjectMut;
-            local_project
-                .put_meta(&meta, true)
-                .map_err(KParBuildError::from)?;
         }
     }
 
-    let meta = meta.validate()?;
-    // Check whether index symbols are up to date
+    let archive_file = wrapfs::File::create(&path)?;
+    let mut zip = zip::ZipWriter::new(archive_file);
+
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(compression.into())
+        .system(zip::System::Unix)
+        .last_modified_time(zip::DateTime::DEFAULT);
+
+    let source_paths = meta.source_paths(true);
+    let mut checksums = if let Some(mut checksum) = meta.checksum.take() {
+        checksum.clear();
+        checksum
+    } else {
+        IndexMap::new()
+    };
+    let len = source_paths.len();
     if update_index {
-        for p in meta.source_paths(true) {
-            do_include(&mut local_project, p, true, true, None)?
+        meta.index.clear();
+        for (i, p) in source_paths.into_iter().enumerate() {
+            // `log` always appends a newline, so `\r` does not work with it
+            eprint!("\rupdating file metadata ({}/{len})", i + 1);
+
+            let source = read_project_file_to_string(project, &p)?;
+            let checksum = sha256_lowercase_hex(&source);
+            let symbols = extract_symbols(&p, &source, None)?;
+
+            zip.start_file(&p, options)
+                .map_err(|e| ZipArchiveError::Write(Utf8Path::new(&p).into(), e))?;
+            zip.write_all(source.as_bytes())
+                .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
+
+            for s in symbols {
+                meta.index.insert(s, p.clone());
+            }
+            checksums.insert(
+                p,
+                InterchangeProjectChecksumRaw {
+                    value: checksum,
+                    algorithm: KerMlChecksumAlg::Sha256.into(),
+                },
+            );
         }
     } else {
-        for p in meta.source_paths(true) {
-            do_include(&mut local_project, &p, true, false, None)?;
-            let new_symbols = extract_symbols(&mut local_project, &p, None)?;
+        for (i, p) in source_paths.into_iter().enumerate() {
+            eprint!("\rupdating file checksums ({}/{len})", i + 1);
+
+            let source = read_project_file_to_string(project, &p)?;
+            let checksum = sha256_lowercase_hex(&source);
+            let new_symbols = extract_symbols(&p, &source, None)?;
+
             let new_symbols: HashSet<String> = new_symbols.into_iter().collect();
             let old_symbols = meta.file_index_symbols(&p);
             if let Some(only_in_old) = old_symbols.difference(&new_symbols).next() {
@@ -364,8 +388,23 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                     exported symbols, or omit `--keep-index` to do so for all files"
                 );
             }
+
+            zip.start_file(&p, options)
+                .map_err(|e| ZipArchiveError::Write(Utf8Path::new(&p).into(), e))?;
+            zip.write_all(source.as_bytes())
+                .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
+
+            checksums.insert(
+                p,
+                InterchangeProjectChecksumRaw {
+                    value: checksum,
+                    algorithm: KerMlChecksumAlg::Sha256.into(),
+                },
+            );
         }
     }
+    eprintln!();
+    meta.checksum = Some(checksums);
 
     let project_root = project.project_root();
     let mut extra_files: Vec<(String, String)> = Vec::new();
@@ -387,13 +426,35 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
             }
         }
     }
+    for (archive_path, content) in extra_files {
+        zip.start_file(&archive_path, options)
+            .map_err(|e| ZipArchiveError::Write(Utf8Path::new(&archive_path).into(), e))?;
+        zip.write_all(content.as_bytes())
+            .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
+    }
 
-    Ok(LocalKParProjectRaw::from_project(
-        &local_project,
-        path,
-        compression.into(),
-        &extra_files,
-    )?)
+    // KerML Clause 10.3: “In addition, the archive shall contain, at its
+    // top level, exactly one file named .project.json and exactly one file
+    // named .meta.json.”
+
+    let info_content =
+        serde_json::to_string(&info).expect("BUG: failed to serialize .project.json");
+    let meta_content = serde_json::to_string(&meta).expect("BUG: failed to serialize .meta.json");
+
+    zip.start_file(".project.json", options)
+        .map_err(|e| ZipArchiveError::Write(Utf8Path::new(".project.json").into(), e))?;
+    zip.write_all(info_content.as_bytes())
+        .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
+
+    zip.start_file(".meta.json", options)
+        .map_err(|e| ZipArchiveError::Write(Utf8Path::new(".meta.json").into(), e))?;
+    zip.write_all(meta_content.as_bytes())
+        .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
+
+    zip.finish()
+        .map_err(|e| ZipArchiveError::Finish(path.as_ref().into(), e))?;
+
+    Ok(LocalKParProjectRaw::new_project_at_root(&path)?)
 }
 
 fn read_optional_project_file(
@@ -435,14 +496,22 @@ pub fn do_build_workspace_kpars<P: AsRef<Utf8Path>>(
 
         let file_name = default_kpar_file_name(&project)?;
         let output_path = path.as_ref().join(file_name);
-        let kpar_project = do_build_kpar_inner(
+        let kpar_project = match do_build_kpar_inner(
             &project,
             &output_path,
             compression,
             update_index,
             allow_path_usage,
             ws_metamodel,
-        )?;
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                if let Err(e) = wrapfs::remove_file(&output_path) {
+                    log::debug!("cleanup: failed to remove archive file `{output_path}`: {e}");
+                }
+                return Err(e);
+            }
+        };
         result.push(kpar_project);
     }
     Ok(result)

--- a/core/src/commands/exclude.rs
+++ b/core/src/commands/exclude.rs
@@ -4,7 +4,10 @@
 use thiserror::Error;
 use typed_path::Utf8UnixPath;
 
-use crate::project::{ProjectMut, ProjectOrIOError, SourceExclusionOutcome, utils::FsIoError};
+use crate::{
+    model::InterchangeProjectChecksumRaw,
+    project::{ProjectMut, ProjectOrIOError, utils::FsIoError},
+};
 
 #[derive(Error, Debug)]
 pub enum ExcludeError<ProjectError> {
@@ -14,6 +17,8 @@ pub enum ExcludeError<ProjectError> {
     Io(#[from] Box<FsIoError>),
     #[error("could not find file `{0}` in project metadata")]
     SourceNotFound(Box<str>),
+    #[error("project is missing metadata file `.meta.json`")]
+    MissingMeta,
 }
 
 impl<ProjectError> From<ProjectOrIOError<ProjectError>> for ExcludeError<ProjectError> {
@@ -25,21 +30,42 @@ impl<ProjectError> From<ProjectOrIOError<ProjectError>> for ExcludeError<Project
     }
 }
 
-pub fn do_exclude<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
+pub fn do_exclude<Pr: ProjectMut, P: AsRef<Utf8UnixPath>, I: Iterator<Item = P>>(
     project: &mut Pr,
-    path: P,
-) -> Result<SourceExclusionOutcome, ExcludeError<Pr::Error>> {
-    let excluding = "Excluding";
-    let header = crate::style::get_style_config().header;
-    log::info!("{header}{excluding:>12}{header:#} file: {}", path.as_ref(),);
+    paths: I,
+) -> Result<Vec<SourceExclusionOutcome>, ExcludeError<Pr::Error>> {
+    let mut meta = match project.get_meta().map_err(ProjectOrIOError::Project)? {
+        Some(m) => m,
+        None => return Err(ExcludeError::MissingMeta),
+    };
 
-    let outcome = project.exclude_source(&path)?;
+    let mut outcomes = Vec::new();
+    for path in paths {
+        let path = path.as_ref();
+        let excluding = "Excluding";
+        let header = crate::style::get_style_config().header;
+        log::info!("{header}{excluding:>12}{header:#} file: `{path}`");
 
-    if outcome.removed_checksum.is_some() || !outcome.removed_symbols.is_empty() {
-        Ok(outcome)
-    } else {
-        Err(ExcludeError::SourceNotFound(path.as_ref().as_str().into()))
+        let removed_checksum = meta.remove_checksum(&path);
+        let removed_symbols = meta.remove_index(&path);
+        let outcome = SourceExclusionOutcome {
+            removed_checksum,
+            removed_symbols,
+        };
+
+        if outcome.removed_checksum.is_none() && outcome.removed_symbols.is_empty() {
+            return Err(ExcludeError::SourceNotFound(path.as_str().into()));
+        }
+        outcomes.push(outcome);
     }
+    project
+        .put_meta(&meta, true)
+        .map_err(ProjectOrIOError::Project)?;
+    Ok(outcomes)
+}
 
-    // Ok(project.exclude_source(path)?)
+#[derive(Debug)]
+pub struct SourceExclusionOutcome {
+    pub removed_checksum: Option<InterchangeProjectChecksumRaw>,
+    pub removed_symbols: Vec<String>,
 }

--- a/core/src/commands/include.rs
+++ b/core/src/commands/include.rs
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
+use std::io::Read;
+
 use thiserror::Error;
-use typed_path::Utf8UnixPath;
+use typed_path::{Utf8UnixPath, Utf8UnixPathBuf};
 
 use crate::{
+    model::KerMlChecksumAlg,
     project::{ProjectMut, ProjectOrIOError, ProjectRead, utils::FsIoError},
     symbols::{ExtractError, Language},
+    utils::sha256_lowercase_hex,
 };
 
 #[derive(Error, Debug)]
@@ -14,7 +18,7 @@ pub enum IncludeError<ProjectError> {
     #[error(transparent)]
     Project(ProjectError),
     #[error(transparent)]
-    Io(Box<FsIoError>),
+    Io(#[from] Box<FsIoError>),
     #[error("failed to extract symbol names from `{0}`: {1}")]
     Extract(Box<str>, ExtractError),
     #[error(
@@ -40,41 +44,77 @@ impl<ProjectError> From<ProjectOrIOError<ProjectError>> for IncludeError<Project
 
 // TODO: Add a CLI option to make the file format explicit (useful in cases
 // of non-standard file extensions)
-pub fn do_include<Pr: ProjectMut, P: AsRef<Utf8UnixPath>>(
+pub fn do_include<Pr: ProjectMut, I: Iterator<Item = Utf8UnixPathBuf>>(
     project: &mut Pr,
-    path: P,
+    paths: I,
     compute_checksum: bool,
     index_symbols: bool,
     force_format: Option<Language>,
 ) -> Result<(), IncludeError<Pr::Error>> {
-    let including = "Including";
-    let header = crate::style::get_style_config().header;
-    log::info!("{header}{including:>12}{header:#} file `{}`", path.as_ref());
+    // TODO: is `unwrap_or_default()` appropriate here?
+    let mut meta = project
+        .get_meta()
+        .map_err(IncludeError::Project)?
+        .unwrap_or_default();
+    for path in paths {
+        let including = "Including";
+        let header = crate::style::get_style_config().header;
+        log::info!("{header}{including:>12}{header:#} file `{path}`");
 
-    if index_symbols {
-        let new_symbols = extract_symbols(&project, &path, force_format)?;
-        project.replace_index_for_file(new_symbols.into_iter(), &path, true)?;
+        let source = read_project_file_to_string(&project, &path)?;
+        if compute_checksum {
+            let checksum = sha256_lowercase_hex(&source);
+            meta.add_checksum(&path, KerMlChecksumAlg::Sha256, checksum, true);
+        } else {
+            meta.add_checksum(&path, KerMlChecksumAlg::None, "", true);
+        }
+
+        if index_symbols {
+            // Remove if present any existing symbols from the same file
+            meta.index.retain(|s, v| {
+                if *v == path {
+                    log::debug!("meta.index: removing obsolete symbol `{s}` (file `{v}`)");
+                    false
+                } else {
+                    true
+                }
+            });
+
+            for s in extract_symbols(&path, &source, force_format)? {
+                meta.index.insert(s, path.to_string());
+            }
+        }
     }
-
-    project.include_source(&path, compute_checksum, true)?;
+    project
+        .put_meta(&meta, true)
+        .map_err(IncludeError::Project)?;
     Ok(())
 }
 
-/// Extract top level symbols from file at `path` belonging to `project`
-pub fn extract_symbols<PR: ProjectRead, P: AsRef<Utf8UnixPath>>(
-    project: PR,
+/// Extract top level symbols from `source`, using `path` for diagnostics
+/// only
+pub fn extract_symbols<P: AsRef<Utf8UnixPath>, S: AsRef<str>, T>(
     path: &P,
+    source: S,
     force_format: Option<Language>,
-) -> Result<Vec<String>, IncludeError<PR::Error>> {
+) -> Result<Vec<String>, IncludeError<T>> {
     match force_format.or_else(|| Language::guess_from_path(path)) {
-        Some(Language::SysML) => crate::symbols::top_level_sysml(
-            project.read_source(path).map_err(IncludeError::Project)?,
-        )
-        .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
-        Some(Language::KerML) => crate::symbols::top_level_kerml(
-            project.read_source(path).map_err(IncludeError::Project)?,
-        )
-        .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
+        Some(Language::SysML) => crate::symbols::top_level_sysml(&source)
+            .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
+        Some(Language::KerML) => crate::symbols::top_level_kerml(&source)
+            .map_err(|e| IncludeError::Extract(path.as_ref().as_str().into(), e)),
         _ => Err(IncludeError::UnknownFormat(path.as_ref().as_str().into())),
     }
+}
+
+pub fn read_project_file_to_string<Pr: ProjectRead, P: AsRef<Utf8UnixPath>>(
+    project: &Pr,
+    path: &P,
+) -> Result<String, IncludeError<Pr::Error>> {
+    let mut file = project.read_source(path).map_err(IncludeError::Project)?;
+    let mut source = String::new();
+    file.read_to_string(&mut source).map_err(|e| {
+        IncludeError::Io(FsIoError::ReadFile(path.as_ref().as_str().into(), e).into())
+    })?;
+    Ok(source)
 }

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::{HashMap, hash_map::Entry},
-    io::{self},
+    io::{self, Read as _},
     sync::Arc,
 };
 
@@ -23,7 +23,7 @@ use crate::{
         KerMlChecksumAlg, SYSML_METAMODEL_PREFIX,
     },
     project::{
-        ProjectRead, hash_reader,
+        ProjectRead,
         local_kpar::{LocalKParError, LocalKParProjectRaw},
         utils::{FsIoError, wrapfs},
     },
@@ -32,7 +32,7 @@ use crate::{
         normalize_field, parse_sysand_purl,
     },
     symbols::Language,
-    utils::{license_file_stems, lowercase_hex, sha256_lowercase_hex},
+    utils::{license_file_stems, sha256_lowercase_hex},
 };
 
 /// Defensive upper bound on kpar file size (100 MiB) to catch unexpected uploads by mistake.
@@ -723,11 +723,13 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
                             path: src_file.as_str().into(),
                             source: e,
                         })?;
-                let digest = hash_reader(&mut file).map_err(|e| PublishError::KparFileReadIo {
-                    path: src_file.as_str().into(),
-                    source: e,
-                })?;
-                let actual_checksum = lowercase_hex(digest);
+                let mut source = String::new();
+                file.read_to_string(&mut source)
+                    .map_err(|e| PublishError::KparFileReadIo {
+                        path: src_file.as_str().into(),
+                        source: e,
+                    })?;
+                let actual_checksum = sha256_lowercase_hex(&source);
                 if !actual_checksum.eq_ignore_ascii_case(&file_checksum.value) {
                     return Err(PublishError::IncorrectFileChecksum {
                         path: src_file.as_str().into(),
@@ -736,9 +738,8 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
                     });
                 }
 
-                // FIXME: don't read the whole file into memory at once
                 let actual_symbols =
-                    extract_symbols(&kpar_project, &src_file, Some(metamodel_kind.lang_kind()))
+                    extract_symbols(&src_file, &source, Some(metamodel_kind.lang_kind()))
                         .map_err(|e| PublishError::IndexFail { source: e })?;
                 // Actual symbols must be a superset of recorded
                 if let Some(symbols) = symbols_for_files.get(&src_file) {

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -508,22 +508,6 @@ pub enum InterchangeProjectValidationError {
     },
 }
 
-impl InterchangeProjectMetadata {
-    /// Get symbols recorded in `index` for file at `path`
-    pub fn file_index_symbols<P: AsRef<str>>(&self, path: P) -> HashSet<String> {
-        self.index
-            .iter()
-            .filter_map(|(k, v)| {
-                if v == path.as_ref() {
-                    Some(k.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-}
-
 impl Default for InterchangeProjectMetadataRaw {
     fn default() -> Self {
         InterchangeProjectMetadataRaw {
@@ -614,6 +598,20 @@ impl InterchangeProjectMetadataRaw {
             includes_implied: self.includes_implied,
             checksum,
         })
+    }
+
+    /// Get symbols recorded in `index` for file at `path`
+    pub fn file_index_symbols<P: AsRef<str>>(&self, path: P) -> HashSet<String> {
+        self.index
+            .iter()
+            .filter_map(|(k, v)| {
+                if v == path.as_ref() {
+                    Some(k.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     // TODO: Get rid of overwrite

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -4,7 +4,7 @@
 use std::{
     cell::OnceCell,
     fs::{self, File},
-    io::{Read, Seek, Write as _},
+    io::{Read, Seek},
     num::NonZeroU64,
 };
 
@@ -400,70 +400,6 @@ impl LocalKParProjectRaw {
         //       Would simplify a bunch of places which currently must check
         //       both
         self.root.as_deref()
-    }
-
-    /// Build a KPAR archive from `from`.
-    ///
-    /// `extra_files` are added to the archive alongside the project's source
-    /// files. Each entry is `(archive_path, content)`; `archive_path` uses `/`
-    /// as the separator and is interpreted relative to the archive root.
-    pub fn from_project<Pr: ProjectRead, P: AsRef<Utf8Path>>(
-        from: &Pr,
-        path: P,
-        compression: zip::CompressionMethod,
-        extra_files: &[(String, String)],
-    ) -> Result<Self, IntoKparError<Pr::Error>> {
-        let file = wrapfs::File::create(&path)?;
-        let mut zip = zip::ZipWriter::new(file);
-
-        let options = zip::write::SimpleFileOptions::default()
-            .compression_method(compression)
-            .system(zip::System::Unix)
-            .last_modified_time(zip::DateTime::DEFAULT);
-
-        let (info, meta) = from.get_project().map_err(IntoKparError::ProjectRead)?;
-        let info = info.ok_or(IntoKparError::MissingInfo)?;
-        let meta = meta.ok_or(IntoKparError::MissingMeta)?;
-        let info_content = serde_json::to_string(&info)
-            .map_err(|e| IntoKparError::Serialize("failed to serialize project info", e))?;
-        let meta_content = serde_json::to_string(&meta)
-            .map_err(|e| IntoKparError::Serialize("failed to serialize project metadata", e))?;
-
-        // KerML Clause 10.3: “In addition, the archive shall contain, at its
-        // top level, exactly one file named .project.json and exactly one file
-        // named .meta.json.”
-
-        zip.start_file(".project.json", options)
-            .map_err(|e| ZipArchiveError::Write(Utf8Path::new(".project.json").into(), e))?;
-        zip.write(info_content.as_bytes())
-            .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
-
-        zip.start_file(".meta.json", options)
-            .map_err(|e| ZipArchiveError::Write(Utf8Path::new(".meta.json").into(), e))?;
-        zip.write(meta_content.as_bytes())
-            .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
-
-        for source_path in meta.source_paths(true) {
-            let mut reader = from
-                .read_source(&source_path)
-                .map_err(IntoKparError::ProjectRead)?;
-            zip.start_file(&source_path, options)
-                .map_err(|e| ZipArchiveError::Write(Utf8Path::new(&source_path).into(), e))?;
-            std::io::copy(&mut reader, &mut zip)
-                .map_err(|e| FsIoError::CopyFile(source_path.into(), path.to_path_buf(), e))?;
-        }
-
-        for (archive_path, content) in extra_files {
-            zip.start_file(archive_path, options)
-                .map_err(|e| ZipArchiveError::Write(Utf8Path::new(archive_path).into(), e))?;
-            zip.write_all(content.as_bytes())
-                .map_err(|e| FsIoError::WriteFile(path.as_ref().into(), e))?;
-        }
-
-        zip.finish()
-            .map_err(|e| ZipArchiveError::Finish(path.as_ref().into(), e))?;
-
-        Self::new_project_at_root(&path).map_err(IntoKparError::Io)
     }
 
     pub fn file_size(&self) -> Result<u64, LocalKParError> {

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -877,18 +877,6 @@ impl<ProjectError> From<FsIoError> for ProjectOrIOError<ProjectError> {
     }
 }
 
-#[derive(Debug)]
-pub struct IndexMergeOutcome {
-    pub new: Vec<String>,
-    pub existing: Vec<(String, String)>,
-}
-
-#[derive(Debug)]
-pub struct SourceExclusionOutcome {
-    pub removed_checksum: Option<InterchangeProjectChecksumRaw>,
-    pub removed_symbols: Vec<String>,
-}
-
 pub trait ProjectMut: ProjectRead {
     fn put_info(
         &mut self,
@@ -918,116 +906,9 @@ pub trait ProjectMut: ProjectRead {
         source: &mut R,
         overwrite: bool,
     ) -> Result<(), Self::Error>;
-
-    // Utilities
-
-    fn include_source<P: AsRef<Utf8UnixPath>>(
-        &mut self,
-        path: P,
-        compute_checksum: bool,
-        overwrite: bool,
-    ) -> Result<(), ProjectOrIOError<Self::Error>> {
-        let path = path.as_ref();
-        let mut meta = self
-            .get_meta()
-            .map_err(ProjectOrIOError::Project)?
-            .unwrap_or_default();
-
-        {
-            let mut reader = self.read_source(path).map_err(ProjectOrIOError::Project)?;
-
-            if compute_checksum {
-                let sha256_checksum = hash_reader(&mut reader)
-                    .map_err(|e| FsIoError::ReadFile(path.as_str().into(), e))?;
-
-                meta.add_checksum(
-                    path,
-                    KerMlChecksumAlg::Sha256,
-                    lowercase_hex(sha256_checksum),
-                    overwrite,
-                );
-            } else {
-                meta.add_checksum(path, KerMlChecksumAlg::None, "", overwrite);
-            }
-        }
-
-        self.put_meta(&meta, true)
-            .map_err(ProjectOrIOError::Project)
-    }
-
-    fn exclude_source<P: AsRef<Utf8UnixPath>>(
-        &mut self,
-        path: P,
-    ) -> Result<SourceExclusionOutcome, ProjectOrIOError<Self::Error>> {
-        let mut meta = self
-            .get_meta()
-            .map_err(ProjectOrIOError::Project)?
-            .unwrap_or_default();
-
-        let removed_checksum = meta.remove_checksum(&path);
-        let removed_symbols = meta.remove_index(&path);
-
-        self.put_meta(&meta, true)
-            .map_err(ProjectOrIOError::Project)?;
-
-        Ok(SourceExclusionOutcome {
-            removed_checksum,
-            removed_symbols,
-        })
-    }
-
-    /// Replace `index` entries pointing to `path` with `symbols`. If `overwrite == true`,
-    /// also point any pre-existing `symbols` to `path`
-    fn replace_index_for_file<S: AsRef<str>, P: AsRef<Utf8UnixPath>, I: Iterator<Item = S>>(
-        &mut self,
-        symbols: I,
-        path: P,
-        overwrite: bool,
-    ) -> Result<IndexMergeOutcome, ProjectOrIOError<Self::Error>> {
-        let path = path.as_ref();
-        let mut meta = self
-            .get_meta()
-            .map_err(ProjectOrIOError::Project)?
-            .unwrap_or_default();
-
-        // Remove if present any existing symbols from the same file
-        meta.index.retain(|s, v| {
-            if v == path {
-                log::debug!("meta.index: removing obsolete symbol `{s}` (file `{v}`)");
-                false
-            } else {
-                true
-            }
-        });
-
-        let mut new = vec![];
-        let mut existing = vec![];
-
-        for symbol in symbols {
-            let this_symbol = symbol.as_ref().to_string();
-            match meta.index.entry(this_symbol.clone()) {
-                indexmap::map::Entry::Occupied(mut occupied_entry) => {
-                    let current = if overwrite {
-                        occupied_entry.insert(path.to_string())
-                    } else {
-                        occupied_entry.get().clone()
-                    };
-
-                    existing.push((this_symbol, current));
-                }
-                indexmap::map::Entry::Vacant(vacant_entry) => {
-                    vacant_entry.insert(path.to_string());
-                    new.push(this_symbol);
-                }
-            }
-        }
-
-        self.put_meta(&meta, true)
-            .map_err(ProjectOrIOError::Project)?;
-
-        Ok(IndexMergeOutcome { new, existing })
-    }
 }
+
+// ----- Blanket trait impls -----
 
 impl<T: ProjectMut> ProjectMut for &mut T {
     fn put_info(
@@ -1062,31 +943,6 @@ impl<T: ProjectMut> ProjectMut for &mut T {
         overwrite: bool,
     ) -> Result<(), Self::Error> {
         (**self).put_project(info, meta, overwrite)
-    }
-
-    fn include_source<P: AsRef<Utf8UnixPath>>(
-        &mut self,
-        path: P,
-        compute_checksum: bool,
-        overwrite: bool,
-    ) -> Result<(), ProjectOrIOError<Self::Error>> {
-        (**self).include_source(path, compute_checksum, overwrite)
-    }
-
-    fn exclude_source<P: AsRef<Utf8UnixPath>>(
-        &mut self,
-        path: P,
-    ) -> Result<SourceExclusionOutcome, ProjectOrIOError<Self::Error>> {
-        (**self).exclude_source(path)
-    }
-
-    fn replace_index_for_file<S: AsRef<str>, P: AsRef<Utf8UnixPath>, I: Iterator<Item = S>>(
-        &mut self,
-        symbols: I,
-        path: P,
-        overwrite: bool,
-    ) -> Result<IndexMergeOutcome, ProjectOrIOError<Self::Error>> {
-        (**self).replace_index_for_file(symbols, path, overwrite)
     }
 }
 

--- a/core/src/symbols/mod.rs
+++ b/core/src/symbols/mod.rs
@@ -9,7 +9,7 @@
 
 mod lex;
 
-use std::{collections::HashMap, io, iter::Peekable};
+use std::{collections::HashMap, iter::Peekable};
 
 use logos::{Logos, Source};
 use thiserror::Error;
@@ -19,7 +19,7 @@ use typed_path::Utf8UnixPath;
 
 use crate::symbols::lex::LexingError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Language {
     SysML,
     KerML,
@@ -356,10 +356,6 @@ fn parse_entity<'a, I: Iterator<Item = &'a (Token, Box<str>, logos::Span)>>(
 
 #[derive(Debug, Error)]
 pub enum ExtractError {
-    #[error("failed to read file to extract symbols: {0}")]
-    ReadTopLevelSysml(io::Error),
-    #[error("failed to read file to extract symbols: {0}")]
-    ReadTopLevelKerml(io::Error),
     #[error("syntax error at line {0}, byte {1}:\n{2}")]
     Syntax(u32, u32, LexingError),
     #[error(
@@ -370,17 +366,6 @@ pub enum ExtractError {
     TokenRange,
     #[error("error at line {0}, byte {1}:\n`{2}`: {3}")]
     Parse(u32, u32, String, String),
-}
-
-fn read_source<R: io::Read>(
-    mut reader: R,
-    error_constructor: impl FnOnce(io::Error) -> ExtractError,
-) -> Result<String, ExtractError> {
-    let mut source = String::new();
-    reader
-        .read_to_string(&mut source)
-        .map_err(error_constructor)?;
-    Ok(source)
 }
 
 type TokenInfo = (Token, Box<str>, logos::Span);
@@ -498,10 +483,9 @@ fn collect_symbols(
 /// A lexer that extracts top-level symbols from a SysML file.
 ///
 /// It is used for handling `index` field of `.meta.json` files.
-pub fn top_level_sysml<R: io::Read>(reader: R) -> Result<Vec<String>, ExtractError> {
-    let source = read_source(reader, ExtractError::ReadTopLevelSysml)?;
-
-    let all = lex_source(&source)?;
+pub fn top_level_sysml<S: AsRef<str>>(source: S) -> Result<Vec<String>, ExtractError> {
+    let source = source.as_ref();
+    let all = lex_source(source)?;
 
     let keywords = HashMap::from([
         // Simple
@@ -590,13 +574,13 @@ pub fn top_level_sysml<R: io::Read>(reader: R) -> Result<Vec<String>, ExtractErr
         ("then", KeywordType::SkipRest),
     ]);
 
-    collect_symbols(&source, all, &keywords)
+    collect_symbols(source, all, &keywords)
 }
 
-pub fn top_level_kerml<R: io::Read>(reader: R) -> Result<Vec<String>, ExtractError> {
-    let source = read_source(reader, ExtractError::ReadTopLevelKerml)?;
+pub fn top_level_kerml<S: AsRef<str>>(source: S) -> Result<Vec<String>, ExtractError> {
+    let source = source.as_ref();
 
-    let all = lex_source(&source)?;
+    let all = lex_source(source)?;
 
     let keywords = HashMap::from([
         ("public", KeywordType::Simple),
@@ -607,7 +591,7 @@ pub fn top_level_kerml<R: io::Read>(reader: R) -> Result<Vec<String>, ExtractErr
         ("package", KeywordType::Simple),
     ]);
 
-    collect_symbols(&source, all, &keywords)
+    collect_symbols(source, all, &keywords)
 }
 
 // Returns: (line, byte), both 1-indexed

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -164,7 +164,7 @@ pub enum Command {
     Exclude {
         /// File(s) to exclude from the project
         #[arg(num_args = 1..)]
-        paths: Vec<String>,
+        paths: Vec<Utf8PathBuf>,
     },
     /// Build a KerML Project Archive (KPAR). If executed in a workspace
     /// outside of a project, builds all projects in the workspace.

--- a/sysand/src/commands/exclude.rs
+++ b/sysand/src/commands/exclude.rs
@@ -2,20 +2,22 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use anyhow::Result;
+use camino::Utf8PathBuf;
 use sysand_core::{context::ProjectContext, exclude::do_exclude};
 
 use crate::CliError;
 
-pub fn command_exclude(paths: Vec<String>, ctx: ProjectContext) -> Result<()> {
+pub fn command_exclude(paths: Vec<Utf8PathBuf>, ctx: ProjectContext) -> Result<()> {
     let mut current_project = ctx
         .current_project
         .ok_or(CliError::MissingProjectCurrentDir)?;
 
-    for path in paths {
-        let unix_path = current_project.get_unix_path(&path)?;
-
-        do_exclude(&mut current_project, unix_path)?;
+    let mut unix_paths = Vec::with_capacity(paths.len());
+    for f in paths {
+        unix_paths.push(current_project.get_unix_path(f)?);
     }
+
+    do_exclude(&mut current_project, unix_paths.into_iter())?;
 
     Ok(())
 }

--- a/sysand/src/commands/include.rs
+++ b/sysand/src/commands/include.rs
@@ -3,13 +3,12 @@
 
 use anyhow::{Result, bail};
 use camino::Utf8PathBuf;
-// use glob::glob;
 use sysand_core::{context::ProjectContext, include::do_include, project::utils::wrapfs};
 
 use crate::CliError;
 
 pub fn command_include(
-    files: Vec<Utf8PathBuf>,
+    paths: Vec<Utf8PathBuf>,
     compute_checksum: bool,
     index_symbols: bool,
     ctx: ProjectContext,
@@ -18,20 +17,20 @@ pub fn command_include(
         .current_project
         .ok_or(CliError::MissingProjectCurrentDir)?;
 
-    for file in files {
-        if !wrapfs::is_file(file.to_path_buf())? {
-            bail!("`{file}` does not exist or is not a file");
+    let mut unix_paths = Vec::with_capacity(paths.len());
+    for p in paths {
+        if !wrapfs::is_file(&p)? {
+            bail!("`{p}` does not exist or is not a file");
         }
-        let unix_path = current_project.get_unix_path(file)?;
-
-        do_include(
-            &mut current_project,
-            unix_path,
-            compute_checksum,
-            index_symbols,
-            None,
-        )?;
+        unix_paths.push(current_project.get_unix_path(p)?);
     }
+    do_include(
+        &mut current_project,
+        unix_paths.into_iter(),
+        compute_checksum,
+        index_symbols,
+        None,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
`build` times for a large test project went from ~5 min to ~3 s.
Similar results for `include`, they `build` does very similar work to `include`

Also fix `build` producing truncated `.meta.json` files for large projects by using `write_all()` instead of `write()`.

Previously, during build, every file in the project was copied multiple times:
1. make a temporary copy of the whole project (needed to avoid touching original, because `.meta.json` was modified in place)
2. for each source file:
    1. read the file to extract symbols
    2. update (read+write) `.meta.json`
    3. read the file to calculate checksum
    4. update (read+write) `.meta.json`
    5. read the file to put into the kpar

Include performs most of the same stuff, but it does not make a temp copy of the project and obviously does not create a kpar.