### PR TITLE
chore: update to Rust 1.96 and use newly stable `assert_matches`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["sysand", "core"]
 [workspace.package]
 version = "0.1.4"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 publish = false
 authors = ["Sensmetry <opensource@sensmetry.com>"]
 license = "MIT OR Apache-2.0"

--- a/core/src/commands/add_tests.rs
+++ b/core/src/commands/add_tests.rs
@@ -6,6 +6,7 @@ use crate::{
     model::InterchangeProjectInfoRaw,
     project::memory::InMemoryProject,
 };
+use std::assert_matches;
 
 fn project() -> InMemoryProject {
     InMemoryProject {
@@ -26,10 +27,10 @@ fn project() -> InMemoryProject {
 
 #[test]
 fn purl_shorthand_expansion_keeps_two_segment_non_purl_resource() {
-    assert!(matches!(
+    assert_matches!(
         expand_sysand_purl_shorthand("ab/proj0"),
         Err(crate::purl::SysandPurlError::InvalidPublisher { .. })
-    ));
+    );
 }
 
 #[test]

--- a/core/src/commands/lock.rs
+++ b/core/src/commands/lock.rs
@@ -104,7 +104,8 @@ pub enum LockError<PD: ProjectRead, R: ResolveRead + Debug + 'static> {
     SelfNameCollision(Box<SelfNameCollisionError>),
 }
 
-pub struct LockOutcome<PD> {
+#[derive(Debug)]
+pub struct LockOutcome<PD: Debug> {
     pub lock: Lock,
     pub dependencies: Vec<(fluent_uri::Iri<String>, PD)>,
 }

--- a/core/src/commands/lock_tests.rs
+++ b/core/src/commands/lock_tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
+use std::assert_matches;
 use std::collections::HashMap;
 
 use crate::{
@@ -46,7 +47,7 @@ fn lock_export_conflict() {
         &Default::default(),
     );
 
-    assert!(matches!(res, Err(LockError::NameCollision(_))));
+    assert_matches!(res, Err(LockError::NameCollision(_)));
 }
 
 #[test]

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -6,6 +6,7 @@ use super::{
     check_usage, error_body_to_string, map_publish_response, validate_endpoint_url_shape,
 };
 use crate::model::InterchangeProjectUsageRaw;
+use std::assert_matches;
 use url::Url;
 
 #[test]
@@ -61,7 +62,7 @@ fn build_upload_url_rejects_upload_endpoint_path() {
         "https://example.org/api/v1/upload/",
     ] {
         let err = build_upload_url(&Url::parse(url).unwrap()).unwrap_err();
-        assert!(matches!(err, PublishError::InvalidApiRoot { .. }));
+        assert_matches!(err, PublishError::InvalidApiRoot { .. });
     }
 }
 
@@ -69,19 +70,19 @@ fn build_upload_url_rejects_upload_endpoint_path() {
 fn build_upload_url_rejects_query_and_fragment() {
     let err =
         build_upload_url(&Url::parse("https://example.org/index?x=1#frag").unwrap()).unwrap_err();
-    assert!(matches!(err, PublishError::InvalidApiRoot { .. }));
+    assert_matches!(err, PublishError::InvalidApiRoot { .. });
 }
 
 #[test]
 fn build_upload_url_rejects_non_http_scheme() {
     let err = build_upload_url(&Url::parse("ftp://example.org").unwrap()).unwrap_err();
-    assert!(matches!(err, PublishError::InvalidApiRoot { .. }));
+    assert_matches!(err, PublishError::InvalidApiRoot { .. });
 }
 
 #[test]
 fn build_upload_url_rejects_non_hierarchical_url() {
     let err = build_upload_url(&Url::parse("mailto:test@example.org").unwrap()).unwrap_err();
-    assert!(matches!(err, PublishError::InvalidApiRoot { .. }));
+    assert_matches!(err, PublishError::InvalidApiRoot { .. });
 }
 
 #[test]
@@ -91,7 +92,7 @@ fn build_upload_url_rejects_userinfo() {
         "https://user:password@example.org/api/",
     ] {
         let err = build_upload_url(&Url::parse(raw).unwrap()).unwrap_err();
-        assert!(matches!(err, PublishError::InvalidApiRoot { .. }));
+        assert_matches!(err, PublishError::InvalidApiRoot { .. });
     }
 }
 
@@ -134,21 +135,21 @@ fn check_metamodel_accepts_valid_kerml() {
 #[test]
 fn check_metamodel_rejects_unsupported_metamodel() {
     let err = check_metamodel("https://example.com/some-meta").unwrap_err();
-    assert!(matches!(err, PublishError::UnsupportedMetamodel { .. }));
+    assert_matches!(err, PublishError::UnsupportedMetamodel { .. });
 }
 
 #[test]
 fn check_metamodel_rejects_invalid_sysml_version() {
     // Valid SysML prefix but non-date version string.
     let err = check_metamodel("https://www.omg.org/spec/SysML/notadate").unwrap_err();
-    assert!(matches!(err, PublishError::InvalidMetamodelVersion { .. }));
+    assert_matches!(err, PublishError::InvalidMetamodelVersion { .. });
 }
 
 #[test]
 fn check_metamodel_rejects_invalid_kerml_version() {
     // Month 13 is not a valid calendar month.
     let err = check_metamodel("https://www.omg.org/spec/KerML/20251301").unwrap_err();
-    assert!(matches!(err, PublishError::InvalidMetamodelVersion { .. }));
+    assert_matches!(err, PublishError::InvalidMetamodelVersion { .. });
 }
 
 // --- check_usage ---
@@ -194,14 +195,14 @@ fn check_usage_accepts_all_known_std_libs() {
 fn check_usage_rejects_disallowed_usage() {
     // Not a pkg:sysand purl and not a std-lib IRI prefix.
     let err = check_usage(&usage("https://example.com/some/library")).unwrap_err();
-    assert!(matches!(err, PublishError::DisallowedUsage { .. }));
+    assert_matches!(err, PublishError::DisallowedUsage { .. });
 }
 
 #[test]
 fn check_usage_rejects_invalid_purl() {
     // pkg:sysand prefix present but name segment is syntactically invalid.
     let err = check_usage(&usage("pkg:sysand/publisher/bad__name")).unwrap_err();
-    assert!(matches!(err, PublishError::InvalidPurl { .. }));
+    assert_matches!(err, PublishError::InvalidPurl { .. });
 }
 
 #[test]
@@ -211,7 +212,7 @@ fn check_usage_rejects_std_lib_with_version_constraint() {
         ">=1.0.0",
     ))
     .unwrap_err();
-    assert!(matches!(err, PublishError::StdWithVersionConstraint { .. }));
+    assert_matches!(err, PublishError::StdWithVersionConstraint { .. });
 }
 
 #[test]
@@ -221,7 +222,7 @@ fn check_usage_rejects_invalid_std_lib_version() {
         "https://www.omg.org/spec/SysML/baddate/Systems-Library.kpar",
     ))
     .unwrap_err();
-    assert!(matches!(err, PublishError::InvalidStdLibVersion { .. }));
+    assert_matches!(err, PublishError::InvalidStdLibVersion { .. });
 }
 
 #[test]
@@ -231,7 +232,7 @@ fn check_usage_rejects_unknown_std_lib() {
         "https://www.omg.org/spec/SysML/20250201/Nonexistent-Library.kpar",
     ))
     .unwrap_err();
-    assert!(matches!(err, PublishError::UnknownStdLib { .. }));
+    assert_matches!(err, PublishError::UnknownStdLib { .. });
 }
 
 // --- map_publish_response ---
@@ -245,7 +246,7 @@ fn map_publish_response_400_maps_to_bad_request() {
         "http://example.org/v1/upload",
     )
     .unwrap_err();
-    assert!(matches!(err, PublishError::BadRequest(_)));
+    assert_matches!(err, PublishError::BadRequest(_));
 }
 
 #[test]
@@ -280,27 +281,28 @@ fn map_publish_response_201_is_ok_new_project() {
 fn validate_discovery_root_rejects_non_http_scheme() {
     let url = Url::parse("ftp://example.org").unwrap();
     let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
-    assert!(matches!(err, PublishError::InvalidDiscoveryRoot { .. }));
+    assert_matches!(err, PublishError::InvalidDiscoveryRoot { .. });
 }
 
 #[test]
 fn validate_discovery_root_rejects_upload_endpoint_path() {
     let url = Url::parse("https://example.org/v1/upload").unwrap();
     let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
-    assert!(matches!(err, PublishError::InvalidDiscoveryRoot { .. }));
+    assert_matches!(err, PublishError::InvalidDiscoveryRoot { .. });
 }
 
 #[test]
 fn validate_discovery_root_rejects_query_and_fragment() {
     let url = Url::parse("https://example.org/index?x=1").unwrap();
     let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
-    assert!(matches!(err, PublishError::InvalidDiscoveryRoot { .. }));
+    assert_matches!(err, PublishError::InvalidDiscoveryRoot { .. });
 }
 
 // --- prepare_publish_payload error cases ---
 
 mod prepare_publish {
     use crate::utils::sha256_lowercase_hex;
+    use std::assert_matches;
 
     use super::super::prepare_publish_payload;
     use super::PublishError;
@@ -390,7 +392,7 @@ mod prepare_publish {
         std::fs::write(tmp.path(), b"this is not a zip file").unwrap();
         let path = Utf8Path::new(tmp.path().to_str().unwrap());
         let err = prepare_publish_payload(path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::KparRead(..)));
+        assert_matches!(err, PublishError::KparRead(..));
     }
 
     #[test]
@@ -398,7 +400,7 @@ mod prepare_publish {
         // A valid ZIP but containing no .project.json — guess_root fails.
         let (_tmp, path) = write_zip(&[("unrelated.txt", b"hello", deflate())]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::KparRead(..)));
+        assert_matches!(err, PublishError::KparRead(..));
     }
 
     // ── ProjectNotAtRoot ─────────────────────────────────────────────────────
@@ -409,7 +411,7 @@ mod prepare_publish {
         let (_tmp, path) =
             write_zip(&[("subdir/.project.json", base_project().as_slice(), deflate())]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::ProjectNotAtRoot { .. }));
+        assert_matches!(err, PublishError::ProjectNotAtRoot { .. });
     }
 
     // ── MissingMeta ──────────────────────────────────────────────────────────
@@ -418,7 +420,7 @@ mod prepare_publish {
     fn missing_meta() {
         let (_tmp, path) = write_zip(&[(".project.json", base_project().as_slice(), deflate())]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::MissingMeta));
+        assert_matches!(err, PublishError::MissingMeta);
     }
 
     // ── InfoMetaValidation ───────────────────────────────────────────────────
@@ -431,13 +433,13 @@ mod prepare_publish {
             (".meta.json", meta_json_empty().as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(
+        assert_matches!(
             err,
             PublishError::InfoMetaValidation {
                 name: "project",
                 ..
             }
-        ));
+        );
     }
 
     #[test]
@@ -449,10 +451,7 @@ mod prepare_publish {
             (".meta.json", bad_meta, deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(
-            err,
-            PublishError::InfoMetaValidation { name: "meta", .. }
-        ));
+        assert_matches!(err, PublishError::InfoMetaValidation { name: "meta", .. });
     }
 
     // ── MissingPublisher ─────────────────────────────────────────────────────
@@ -465,7 +464,7 @@ mod prepare_publish {
             (".meta.json", meta_json_empty().as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::MissingPublisher));
+        assert_matches!(err, PublishError::MissingPublisher);
     }
 
     // ── InvalidPublisher ─────────────────────────────────────────────────────
@@ -478,7 +477,7 @@ mod prepare_publish {
             (".meta.json", meta_json_empty().as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::InvalidPublisher(..)));
+        assert_matches!(err, PublishError::InvalidPublisher(..));
     }
 
     // ── InvalidName ──────────────────────────────────────────────────────────
@@ -491,7 +490,7 @@ mod prepare_publish {
             (".meta.json", meta_json_empty().as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::InvalidName(..)));
+        assert_matches!(err, PublishError::InvalidName(..));
     }
 
     // ── VersionBuildMetadata ─────────────────────────────────────────────────
@@ -504,7 +503,7 @@ mod prepare_publish {
             (".meta.json", meta_json_empty().as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::VersionBuildMetadata { .. }));
+        assert_matches!(err, PublishError::VersionBuildMetadata { .. });
     }
 
     // ── MissingLicense ───────────────────────────────────────────────────────
@@ -517,7 +516,7 @@ mod prepare_publish {
             (".meta.json", meta_json_empty().as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::MissingLicense));
+        assert_matches!(err, PublishError::MissingLicense);
     }
 
     // ── InvalidLicense ───────────────────────────────────────────────────────
@@ -530,7 +529,7 @@ mod prepare_publish {
             (".meta.json", meta_json_empty().as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::InvalidLicense { .. }));
+        assert_matches!(err, PublishError::InvalidLicense { .. });
     }
 
     // ── MissingMetamodel ─────────────────────────────────────────────────────
@@ -543,7 +542,7 @@ mod prepare_publish {
             (".meta.json", no_meta, deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::MissingMetamodel));
+        assert_matches!(err, PublishError::MissingMetamodel);
     }
 
     // ── Archive-loop errors (ExecInArchive, UnsupportedCompression, Encrypted)
@@ -561,7 +560,7 @@ mod prepare_publish {
             ("test.sysml", b"package Test;", exec),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::ExecInArchive { .. }));
+        assert_matches!(err, PublishError::ExecInArchive { .. });
     }
 
     #[test]
@@ -573,8 +572,9 @@ mod prepare_publish {
             ("test.sysml", b"package Test;", stored()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(
-            matches!(err, PublishError::UnsupportedCompression { .. }),
+        assert_matches!(
+            err,
+            PublishError::UnsupportedCompression { .. },
             "got: {err}"
         );
     }
@@ -596,7 +596,7 @@ mod prepare_publish {
             zip.finish().unwrap();
         }
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::Symlink { .. }));
+        assert_matches!(err, PublishError::Symlink { .. });
     }
 
     #[test]
@@ -618,7 +618,7 @@ mod prepare_publish {
             zip.finish().unwrap();
         }
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::Encrypted { .. }));
+        assert_matches!(err, PublishError::Encrypted { .. });
     }
 
     // ── DisallowedPath ───────────────────────────────────────────────────────
@@ -632,7 +632,7 @@ mod prepare_publish {
             ("./test.sysml", b"package Test;", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::RelativePathComponents { .. }));
+        assert_matches!(err, PublishError::RelativePathComponents { .. });
     }
 
     // ── MissingLicenseFile ───────────────────────────────────────────────────
@@ -647,7 +647,7 @@ mod prepare_publish {
             (".meta.json", meta.as_slice(), deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::MissingLicenseFile { .. }));
+        assert_matches!(err, PublishError::MissingLicenseFile { .. });
     }
 
     // ── MissingChecksum ──────────────────────────────────────────────────────
@@ -663,7 +663,7 @@ mod prepare_publish {
             ("LICENSES/MIT.txt", b"MIT License", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::MissingChecksum));
+        assert_matches!(err, PublishError::MissingChecksum);
     }
 
     // ── EmptyChecksum ────────────────────────────────────────────────────────
@@ -679,7 +679,7 @@ mod prepare_publish {
             ("LICENSES/MIT.txt", b"MIT License", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::EmptyChecksum));
+        assert_matches!(err, PublishError::EmptyChecksum);
     }
 
     // ── IncorrectFileFormat ──────────────────────────────────────────────────
@@ -699,7 +699,7 @@ mod prepare_publish {
             ("f.kerml", b"content", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::IncorrectFileFormat { .. }));
+        assert_matches!(err, PublishError::IncorrectFileFormat { .. });
     }
 
     // ── UnsupportedFileChecksumType ──────────────────────────────────────────
@@ -717,10 +717,7 @@ mod prepare_publish {
             ("LICENSES/MIT.txt", b"MIT License", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(
-            err,
-            PublishError::UnsupportedFileChecksumType { .. }
-        ));
+        assert_matches!(err, PublishError::UnsupportedFileChecksumType { .. });
     }
 
     // ── MissingFile ──────────────────────────────────────────────────────────
@@ -739,7 +736,7 @@ mod prepare_publish {
             // test.sysml intentionally omitted
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::MissingFile { .. }));
+        assert_matches!(err, PublishError::MissingFile { .. });
     }
 
     // ── IncorrectFileChecksum ────────────────────────────────────────────────
@@ -757,7 +754,7 @@ mod prepare_publish {
             ("test.sysml", b"package Test;", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::IncorrectFileChecksum { .. }));
+        assert_matches!(err, PublishError::IncorrectFileChecksum { .. });
     }
 
     // ── NonexistentSymbolExported ────────────────────────────────────────────
@@ -778,10 +775,7 @@ mod prepare_publish {
             ("test.sysml", content, deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(
-            err,
-            PublishError::NonexistentSymbolExported { .. }
-        ));
+        assert_matches!(err, PublishError::NonexistentSymbolExported { .. });
     }
 
     // ── IndexFail ────────────────────────────────────────────────────────────
@@ -801,7 +795,7 @@ mod prepare_publish {
             ("test.sysml", content, deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::IndexFail { .. }));
+        assert_matches!(err, PublishError::IndexFail { .. });
     }
 
     // ── UnexpectedFile ───────────────────────────────────────────────────────
@@ -819,7 +813,7 @@ mod prepare_publish {
             ("extra.txt", b"surprise", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::UnexpectedFile { .. }));
+        assert_matches!(err, PublishError::UnexpectedFile { .. });
     }
 
     // ── Backslash ────────────────────────────────────────────────────────────
@@ -833,7 +827,7 @@ mod prepare_publish {
             ("subdir\\file.sysml", b"package Test;", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(matches!(err, PublishError::Backslash { .. }), "got: {err}");
+        assert_matches!(err, PublishError::Backslash { .. }, "got: {err}");
     }
 
     // ── AbsolutePath ─────────────────────────────────────────────────────────
@@ -847,10 +841,7 @@ mod prepare_publish {
             ("/absolute/file.sysml", b"package Test;", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(
-            matches!(err, PublishError::AbsolutePath { .. }),
-            "got: {err}"
-        );
+        assert_matches!(err, PublishError::AbsolutePath { .. }, "got: {err}");
     }
 
     // ── DoubleSlash ───────────────────────────────────────────────────────────
@@ -864,10 +855,7 @@ mod prepare_publish {
             ("foo//bar.sysml", b"package Test;", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(
-            matches!(err, PublishError::DoubleSlash { .. }),
-            "got: {err}"
-        );
+        assert_matches!(err, PublishError::DoubleSlash { .. }, "got: {err}");
     }
 
     // ── RelativePathComponents with .. ────────────────────────────────────────
@@ -881,8 +869,9 @@ mod prepare_publish {
             ("../escape.sysml", b"package Test;", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(
-            matches!(err, PublishError::RelativePathComponents { .. }),
+        assert_matches!(
+            err,
+            PublishError::RelativePathComponents { .. },
             "got: {err}"
         );
     }
@@ -899,10 +888,7 @@ mod prepare_publish {
             ("subdir/", b"", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(
-            matches!(err, PublishError::CompressedDirEntry { .. }),
-            "got: {err}"
-        );
+        assert_matches!(err, PublishError::CompressedDirEntry { .. }, "got: {err}");
     }
 
     // ── Directory entry with Stored compression is accepted ───────────────────
@@ -919,8 +905,9 @@ mod prepare_publish {
             ("LICENSES/MIT.txt", b"MIT License", deflate()),
         ]);
         let err = prepare_publish_payload(&path).expect_err("expected Err");
-        assert!(
-            matches!(err, PublishError::MissingChecksum),
+        assert_matches!(
+            err,
+            PublishError::MissingChecksum,
             "expected MissingChecksum (past archive loop), got: {err}"
         );
     }

--- a/core/src/env/index_tests.rs
+++ b/core/src/env/index_tests.rs
@@ -247,6 +247,7 @@ fn mock_json_get_count(
 
 mod uris {
     use crate::{index::iri::ParseIriError, utils::format_sources};
+    use std::assert_matches;
 
     use super::*;
 
@@ -325,12 +326,10 @@ mod uris {
                 .expect_err(&format!(
                     "expected `{iri}` to be rejected as malformed pkg:sysand"
                 ));
-            assert!(
-                matches!(
-                    err,
-                    super::IndexEnvironmentError::MalformedIri(
-                        ParseIriError::MalformedSysandPurl { .. }
-                    )
+            assert_matches!(
+                err,
+                super::IndexEnvironmentError::MalformedIri(
+                    ParseIriError::MalformedSysandPurl { .. }
                 ),
                 "expected MalformedSysandPurl for `{iri}`, got {err:?}"
             );
@@ -591,6 +590,7 @@ mod uris {
 ///   appearing before its release) rejects the whole document.
 mod versions {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn versions_from_versions_json() -> Result<(), Box<dyn std::error::Error>> {
@@ -914,11 +914,9 @@ mod versions {
         let err = env
             .versions(purl("admin/proj0"))
             .expect_err("missing required field must reject the document");
-        assert!(
-            matches!(
-                err,
-                super::IndexEnvironmentError::Fetch(super::HttpFetchError::JsonParse { .. })
-            ),
+        assert_matches!(
+            err,
+            super::IndexEnvironmentError::Fetch(super::HttpFetchError::JsonParse { .. }),
             "expected Fetch(JsonParse), got {err:?}"
         );
 

--- a/core/src/env/local_directory/metadata_tests.rs
+++ b/core/src/env/local_directory/metadata_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::*;
+use std::assert_matches;
 
 fn minimal_toml(path: &str, editable: bool) -> String {
     format!(
@@ -20,8 +21,9 @@ editable = {editable}
 fn non_editable_parent_dir_component_is_rejected() {
     let toml = minimal_toml("../escape", false);
     let err = EnvMetadata::from_str(&toml).unwrap_err();
-    assert!(
-        matches!(err, ParseError::NonNormalizedProjectPath(_)),
+    assert_matches!(
+        err,
+        ParseError::NonNormalizedProjectPath(_),
         "unexpected error: {err}"
     );
 }
@@ -30,8 +32,9 @@ fn non_editable_parent_dir_component_is_rejected() {
 fn non_editable_cur_dir_component_is_rejected() {
     let toml = minimal_toml("./subdir", false);
     let err = EnvMetadata::from_str(&toml).unwrap_err();
-    assert!(
-        matches!(err, ParseError::NonNormalizedProjectPath(_)),
+    assert_matches!(
+        err,
+        ParseError::NonNormalizedProjectPath(_),
         "unexpected error: {err}"
     );
 }
@@ -40,8 +43,9 @@ fn non_editable_cur_dir_component_is_rejected() {
 fn non_editable_absolute_path_is_rejected() {
     let toml = minimal_toml("/absolute/path", false);
     let err = EnvMetadata::from_str(&toml).unwrap_err();
-    assert!(
-        matches!(err, ParseError::AbsoluteProjectPath(_)),
+    assert_matches!(
+        err,
+        ParseError::AbsoluteProjectPath(_),
         "unexpected error: {err}"
     );
 }
@@ -62,8 +66,9 @@ fn editable_project_with_parent_dir_is_accepted() {
 fn unsupported_version_is_rejected() {
     let toml = r#"version = "99.0""#;
     let err = EnvMetadata::from_str(toml).unwrap_err();
-    assert!(
-        matches!(err, ParseError::UnsupportedVersion(_)),
+    assert_matches!(
+        err,
+        ParseError::UnsupportedVersion(_),
         "unexpected error: {err}"
     );
 }

--- a/core/src/lock_tests.rs
+++ b/core/src/lock_tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
+use std::assert_matches;
 use std::{fmt::Display, num::NonZeroU64, slice, str::FromStr};
 
 use toml_edit::DocumentMut;
@@ -791,7 +792,7 @@ fn validate_checksum_invalid_digest_all_source_types() {
         };
         assert_eq!(digest, INVALID, "{label}");
         assert_eq!(name, "a", "{label}");
-        assert!(matches!(kind, "kpar" | "project canonical"), "{label}");
+        assert_matches!(kind, "kpar" | "project canonical", "{label}");
     }
 }
 
@@ -1057,8 +1058,8 @@ fn canonicalize_checksums() {
 
     // Editable and RemoteGit carry no checksum; their presence here confirms
     // canonicalize_checksums does not panic on them.
-    assert!(matches!(&project.sources[5], Source::Editable { .. }));
-    assert!(matches!(&project.sources[6], Source::RemoteGit { .. }));
+    assert_matches!(&project.sources[5], Source::Editable { .. });
+    assert_matches!(&project.sources[6], Source::RemoteGit { .. });
 }
 
 #[test]

--- a/core/src/purl_tests.rs
+++ b/core/src/purl_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::*;
+use std::assert_matches;
 
 #[test]
 fn publisher_field_validation() {
@@ -102,26 +103,26 @@ fn parse_sysand_purl_rejects_wrong_segment_count() {
     );
     // Trailing-slash form parses to two segments (`["a", ""]`); the publisher
     // is too short, so we reject on InvalidPublisher rather than WrongShape.
-    assert!(matches!(
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/a/"),
         Err(SysandPurlError::InvalidPublisher { .. })
-    ));
+    );
 }
 
 #[test]
 fn parse_sysand_purl_rejects_traversal_and_dot_publishers() {
-    assert!(matches!(
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/../attacker"),
         Err(SysandPurlError::WrongShape { .. } | SysandPurlError::InvalidPublisher { .. })
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/.hidden/proj"),
         Err(SysandPurlError::InvalidPublisher { .. })
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/pub/.hidden"),
         Err(SysandPurlError::InvalidName { .. })
-    ));
+    );
 }
 
 #[test]
@@ -172,20 +173,20 @@ fn parse_sysand_purl_error_messages_include_input_purl() {
 
 #[test]
 fn parse_sysand_purl_rejects_non_ascii_and_invalid_chars() {
-    assert!(matches!(
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/Åcme/proj"),
         Err(SysandPurlError::InvalidPublisher { .. })
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/pub\t/proj"),
         Err(SysandPurlError::InvalidPublisher { .. })
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/ab/proj0"),
         Err(SysandPurlError::InvalidPublisher { .. })
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         parse_sysand_purl("pkg:sysand/aąčb/oroūj0"),
         Err(SysandPurlError::InvalidPublisher { .. })
-    ));
+    );
 }

--- a/core/src/resolve/combined_tests.rs
+++ b/core/src/resolve/combined_tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
+use std::assert_matches;
 use std::collections::HashMap;
 
 use fluent_uri::Iri;
@@ -328,10 +329,5 @@ fn no_semantic_versions_error_test() {
 
     let info_meta = do_info(example_uri, &resolver);
 
-    // Would like to use assert_matches, but that's not yet stable, see
-    // https://github.com/rust-lang/rust/issues/82775
-    assert!(matches!(
-        info_meta,
-        Err(InfoError::NoSemanticVersionsFound(_))
-    ));
+    assert_matches!(info_meta, Err(InfoError::NoSemanticVersionsFound(_)));
 }

--- a/core/src/symbols/mod_tests.rs
+++ b/core/src/symbols/mod_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::*;
+use std::assert_matches;
 
 fn tokens_match(src: &str, tokens: &[Token]) -> Result<(), Box<dyn std::error::Error>> {
     let tokenized: Result<Vec<Token>, _> = Token::lexer(src).collect();
@@ -12,10 +13,7 @@ fn tokens_match(src: &str, tokens: &[Token]) -> Result<(), Box<dyn std::error::E
 
 fn unclosed_comment_doesnt_parse(src: &str) {
     let tokens: Result<Vec<Token>, _> = Token::lexer(src).collect();
-    assert!(
-        matches!(tokens, Err(LexingError::Unterminated("/*"))),
-        "src: {src:?}"
-    );
+    assert_matches!(tokens, Err(LexingError::Unterminated("/*")), "src: {src:?}");
 }
 
 #[test]

--- a/core/src/workspace_tests.rs
+++ b/core/src/workspace_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::*;
+use std::assert_matches;
 
 #[test]
 fn deserialize_with_meta_metamodel() {
@@ -46,5 +47,5 @@ fn deserialize_invalid_metamodel_iri() {
     let result = WorkspaceInfo::try_from(raw);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(matches!(err, WorkspaceValidationError::InvalidIri(..)));
+    assert_matches!(err, WorkspaceValidationError::InvalidIri(..));
 }

--- a/core/tests/memory_init.rs
+++ b/core/tests/memory_init.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use semver::Version;
+use std::assert_matches;
 use sysand_core::{commands::init::do_init, init::do_init_memory, model::InterchangeProjectInfo};
 
 /// `sysand init` should create valid, minimal, .project.json
@@ -78,12 +79,12 @@ fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
         &mut memory_storage,
     );
 
-    assert!(matches!(
+    assert_matches!(
         second_result,
         Err(sysand_core::commands::init::InitError::Project(
             sysand_core::project::memory::InMemoryError::AlreadyExists(_)
         ))
-    ));
+    );
 
     assert_eq!(memory_storage.info, original_info,);
 


### PR DESCRIPTION
`assert_matches` was stabilized (i.e. made generally available) in Rust 1.96: https://doc.rust-lang.org/core/macro.assert_matches.html