### PR TITLE
bindings: small improvements to Python API

### DIFF
--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -6,6 +6,7 @@ from ._model import (
     InterchangeProjectInfo,
     InterchangeProjectChecksum,
     InterchangeProjectMetadata,
+    Dependencies,
     CompressionMethod,
 )
 
@@ -50,6 +51,7 @@ __all__ = [
     "InterchangeProjectInfo",
     "InterchangeProjectChecksum",
     "InterchangeProjectMetadata",
+    "Dependencies",
     "CompressionMethod",
     ## Add
     "add",

--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
+# SPDX-FileCopyrightText: © 2025-2026 Sysand contributors <opensource@sensmetry.com>
 
 from ._model import (
     InterchangeProjectUsage,
@@ -41,6 +41,10 @@ from ._sources import (
 
 from ._build import build
 
+from ._root import (
+    root,
+)
+
 __all__ = [
     "InterchangeProjectUsage",
     "InterchangeProjectInfo",
@@ -66,4 +70,6 @@ __all__ = [
     "exclude",
     ## Sources
     "sources",
+    ## Root
+    "root",
 ]

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
+# SPDX-FileCopyrightText: © 2025-2026 Sysand contributors <opensource@sensmetry.com>
 
 from enum import Enum, auto
 import typing
@@ -36,6 +36,17 @@ class InterchangeProjectMetadata(typing.TypedDict):
     checksum: typing.Optional[typing.List[InterchangeProjectChecksum]]
 
 
+class Dependencies(Enum):
+    NONE = auto()
+    """Do not list any dependency sources"""
+    DEPS = auto()
+    """List dependency sources, excluding standard libraries"""
+    DEPS_STD = auto()
+    """List dependency sources, including standard libraries"""
+    STD = auto()
+    """List only standard-library dependency sources"""
+
+
 class CompressionMethod(Enum):
     STORED = auto()
     """Store the files as is"""
@@ -56,5 +67,6 @@ __all__ = [
     "InterchangeProjectInfo",
     "InterchangeProjectChecksum",
     "InterchangeProjectMetadata",
+    "Dependencies",
     "CompressionMethod",
 ]

--- a/bindings/py/python/sysand/_root.py
+++ b/bindings/py/python/sysand/_root.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2025-2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sysand._sysand_core as sysand_rs  # type: ignore
+
+
+def root(path: str | Path = ".") -> Path | None:
+    """Find the root directory of the project containing ``path``.
+
+    Args:
+        path: Path to start searching from. Defaults to the current directory.
+
+    Returns:
+        The canonicalized project root as a :class:`~pathlib.Path`, or ``None``
+        if ``path`` is not inside a project.
+    """
+    result = sysand_rs.do_root_py(str(path))  # type: ignore
+    return Path(result) if result is not None else None
+
+
+__all__ = [
+    "root",
+]

--- a/bindings/py/python/sysand/_root.py
+++ b/bindings/py/python/sysand/_root.py
@@ -18,7 +18,7 @@ def root(path: str | Path = ".") -> Path | None:
         The canonicalized project root as a :class:`~pathlib.Path`, or ``None``
         if ``path`` is not inside a project.
     """
-    result = sysand_rs.do_root_py(str(path))  # type: ignore
+    result = sysand_rs.do_root_py(str(path))
     return Path(result) if result is not None else None
 
 

--- a/bindings/py/python/sysand/_sources.py
+++ b/bindings/py/python/sysand/_sources.py
@@ -1,25 +1,43 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
+# SPDX-FileCopyrightText: © 2025-2026 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 from typing import List
 from pathlib import Path
 
+from sysand._model import Dependencies
 import sysand._sysand_core as sysand_rs  # type: ignore
 
 
 def sources(
     path: str | Path,
     *,
-    include_deps: bool = True,
+    no_own: bool = False,
+    dependencies: Dependencies = Dependencies.NONE,
     env_path: str | Path | None = None,
-    include_std: bool = False,
 ) -> List[Path]:
+    """List the source files of the project at ``path``.
+
+    By default only the project's own sources are listed. ``no_own`` excludes
+    them, and ``dependencies`` selects which dependency sources to add. Every
+    combination of ``no_own`` and ``dependencies`` is valid.
+
+    Args:
+        path: Path to the project.
+        no_own: Exclude the project's own sources.
+        dependencies: Which dependency sources to list (see :class:`Dependencies`).
+            Defaults to :attr:`Dependencies.NONE` (no dependencies).
+        env_path: Path to the environment in which dependencies are installed.
+            Required unless ``dependencies`` is :attr:`Dependencies.NONE`.
+
+    Returns:
+        The source file paths as a list of :class:`~pathlib.Path`.
+    """
     if env_path is not None:
         env_path = str(env_path)
 
     return sysand_rs.do_sources_project_py(  # type: ignore
-        str(path), include_deps, env_path, include_std
+        str(path), no_own, dependencies.name, env_path
     )
 
 

--- a/bindings/py/python/sysand/env/_sources.py
+++ b/bindings/py/python/sysand/env/_sources.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
+# SPDX-FileCopyrightText: © 2025-2026 Sysand contributors <opensource@sensmetry.com>
 
 from __future__ import annotations
 from typing import List
 from pathlib import Path
 
+from sysand._model import Dependencies
 import sysand._sysand_core as sysand_rs  # type: ignore
 
 
@@ -13,11 +14,29 @@ def sources(
     iri: str,
     version: str | None = None,
     *,
-    include_deps: bool = True,
-    include_std: bool = False,
+    no_own: bool = False,
+    dependencies: Dependencies = Dependencies.NONE,
 ) -> List[Path]:
+    """List the source files of an (already installed) project in an environment.
+
+    By default only the project's own sources are listed. ``no_own`` excludes
+    them, and ``dependencies`` selects which dependency sources to add. Every
+    combination of ``no_own`` and ``dependencies`` is valid.
+
+    Args:
+        env_path: Path to the environment in which the project is installed.
+        iri: IRI of the installed project to list sources for.
+        version: Version constraint selecting which installed project to use.
+            Defaults to the first matching candidate.
+        no_own: Exclude the project's own sources.
+        dependencies: Which dependency sources to list (see :class:`Dependencies`).
+            Defaults to :attr:`Dependencies.NONE` (no dependencies).
+
+    Returns:
+        The source file paths as a list of :class:`~pathlib.Path`.
+    """
     return sysand_rs.do_sources_env_py(  # type: ignore
-        str(env_path), iri, version, include_deps, include_std
+        str(env_path), iri, version, no_own, dependencies.name
     )
 
 

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::{collections::HashMap, iter, process::ExitCode, sync::Arc};
+use std::{iter, process::ExitCode, sync::Arc};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use pyo3::{
@@ -28,7 +28,7 @@ use sysand_core::{
     include::do_include,
     info::{InfoError, InfoProjectError, do_info, do_info_project},
     init::InitError,
-    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
+    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw, InterchangeProjectUsage},
     project::{
         ProjectRead as _,
         local_kpar::{KparInnerPath, LocalKParProject},
@@ -38,8 +38,7 @@ use sysand_core::{
     remove::do_remove_guess,
     resolve::{net_utils::create_reqwest_client, standard::standard_resolver},
     root::do_root,
-    sources::{do_sources_local_src_project_no_deps, find_project_dependencies},
-    stdlib::known_std_libs,
+    sources::{Dependencies, do_sources_local_src_project_no_deps, resolve_dependencies},
     symbols::Language,
     utils::format_err,
 };
@@ -264,24 +263,41 @@ fn do_build_py(
         })
 }
 
+/// Collects the source files of the dependencies of `usages` selected by
+/// `dependencies` (resolved in `env`).
+fn collect_dependency_sources(
+    env: LocalDirectoryEnvironment,
+    usages: Vec<InterchangeProjectUsage>,
+    dependencies: Dependencies,
+) -> PyResult<Vec<String>> {
+    let mut result = vec![];
+    for dep in resolve_dependencies(usages, env, dependencies)
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
+    {
+        for src_path in do_sources_local_src_project_no_deps(&dep, true)
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
+        {
+            result.push(src_path.into_string());
+        }
+    }
+    Ok(result)
+}
+
 #[pyfunction(name = "do_sources_env_py")]
 #[pyo3(
-    signature = (env_path, iri, version, include_deps, include_std),
+    signature = (env_path, iri, version, no_own, dependencies),
 )]
 pub fn do_sources_env_py(
     env_path: String,
     iri: String,
     version: Option<String>,
-    include_deps: bool,
-    include_std: bool,
+    no_own: bool,
+    dependencies: String,
 ) -> PyResult<Vec<String>> {
     let _ = pyo3_log::try_init();
 
-    let provided_iris = if !include_std {
-        known_std_libs()
-    } else {
-        HashMap::default()
-    };
+    let dependencies = Dependencies::try_from(dependencies.as_str())
+        .map_err(|e| PyValueError::new_err(format_err(e)))?;
 
     let version = match version {
         Some(version) => Some(
@@ -292,7 +308,7 @@ pub fn do_sources_env_py(
 
     let mut result = vec![];
 
-    let env = LocalDirectoryEnvironment::read(env_path).map_err(env_read_to_pyerr)?;
+    let env = LocalDirectoryEnvironment::read(&env_path).map_err(env_read_to_pyerr)?;
 
     fn local_read_to_pyerr(err: LocalReadError) -> PyErr {
         let e = format_err(&err);
@@ -340,13 +356,15 @@ pub fn do_sources_env_py(
         }
     };
 
-    for src_path in do_sources_local_src_project_no_deps(&project, true)
-        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-    {
-        result.push(src_path.into_string());
+    if !no_own {
+        for src_path in do_sources_local_src_project_no_deps(&project, true)
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
+        {
+            result.push(src_path.into_string());
+        }
     }
 
-    if include_deps {
+    if dependencies != Dependencies::None {
         let Some(info) = project
             .get_info()
             .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
@@ -356,21 +374,12 @@ pub fn do_sources_env_py(
             ));
         };
 
-        for dep in find_project_dependencies(
-            info.validate()
-                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-                .usage,
-            env,
-            &provided_iris,
-        )
-        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-        {
-            for src_path in do_sources_local_src_project_no_deps(&dep, true)
-                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-            {
-                result.push(src_path.into_string());
-            }
-        }
+        let usages = info
+            .validate()
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
+            .usage;
+
+        result.extend(collect_dependency_sources(env, usages, dependencies)?);
     }
 
     Ok(result)
@@ -378,15 +387,18 @@ pub fn do_sources_env_py(
 
 #[pyfunction(name = "do_sources_project_py")]
 #[pyo3(
-    signature = (path, include_deps, env_path, include_std),
+    signature = (path, no_own, dependencies, env_path),
 )]
 pub fn do_sources_project_py(
     path: String,
-    include_deps: bool,
+    no_own: bool,
+    dependencies: String,
     env_path: Option<String>,
-    include_std: bool,
 ) -> PyResult<Vec<String>> {
     let _ = pyo3_log::try_init();
+
+    let dependencies = Dependencies::try_from(dependencies.as_str())
+        .map_err(|e| PyValueError::new_err(format_err(e)))?;
 
     let mut result = vec![];
 
@@ -396,13 +408,15 @@ pub fn do_sources_project_py(
         expected_checksum: None,
     };
 
-    for src_path in do_sources_local_src_project_no_deps(&current_project, true)
-        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-    {
-        result.push(src_path.into_string());
+    if !no_own {
+        for src_path in do_sources_local_src_project_no_deps(&current_project, true)
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
+        {
+            result.push(src_path.into_string());
+        }
     }
 
-    if include_deps {
+    if dependencies != Dependencies::None {
         // TODO: Better bail early?
         let Some(info) = current_project
             .get_info()
@@ -419,29 +433,14 @@ pub fn do_sources_project_py(
             ));
         };
 
-        let provided_iris = if !include_std {
-            known_std_libs()
-        } else {
-            HashMap::default()
-        };
+        let env = LocalDirectoryEnvironment::read(&env_path).map_err(env_read_to_pyerr)?;
 
-        let env = LocalDirectoryEnvironment::read(env_path).map_err(env_read_to_pyerr)?;
+        let usages = info
+            .validate()
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
+            .usage;
 
-        for dep in find_project_dependencies(
-            info.validate()
-                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-                .usage,
-            env,
-            &provided_iris,
-        )
-        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-        {
-            for src_path in do_sources_local_src_project_no_deps(&dep, true)
-                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
-            {
-                result.push(src_path.into_string());
-            }
-        }
+        result.extend(collect_dependency_sources(env, usages, dependencies)?);
     }
 
     Ok(result)

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -37,6 +37,7 @@ use sysand_core::{
     },
     remove::do_remove_guess,
     resolve::{net_utils::create_reqwest_client, standard::standard_resolver},
+    root::do_root,
     sources::{do_sources_local_src_project_no_deps, find_project_dependencies},
     stdlib::known_std_libs,
     symbols::Language,
@@ -199,6 +200,17 @@ fn do_info_py(
             ) => Err(PyRuntimeError::new_err(format_err(e))),
         }
     })
+}
+
+#[pyfunction(name = "do_root_py")]
+#[pyo3(
+    signature = (path),
+)]
+fn do_root_py(path: String) -> PyResult<Option<String>> {
+    let _ = pyo3_log::try_init();
+
+    let root = do_root(Utf8PathBuf::from(path)).map_err(|e| PyIOError::new_err(format_err(e)))?;
+    Ok(root.map(Utf8PathBuf::into_string))
 }
 
 #[pyfunction(name = "do_build_py")]
@@ -610,6 +622,7 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_env_py_local_dir, m)?)?;
     m.add_function(wrap_pyfunction!(do_info_py_path, m)?)?;
     m.add_function(wrap_pyfunction!(do_info_py, m)?)?;
+    m.add_function(wrap_pyfunction!(do_root_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_build_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_sources_env_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_sources_project_py, m)?)?;

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -276,6 +276,28 @@ def test_end_to_end_install_sources() -> None:
             )
 
 
+def test_root() -> None:
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmpdirname = Path(tmpdirname).resolve()
+        sysand.init("test_root", "a", "1.2.3", tmpdirname)
+
+        subdir = tmpdirname / "sub" / "nested"
+        subdir.mkdir(parents=True)
+
+        root_from_top = sysand.root(tmpdirname)
+        root_from_sub = sysand.root(subdir)
+
+        assert root_from_top is not None
+        assert root_from_sub is not None
+        assert os.path.samefile(root_from_top, tmpdirname)
+        assert os.path.samefile(root_from_sub, tmpdirname)
+
+
+def test_root_not_in_project() -> None:
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        assert sysand.root(tmpdirname) is None
+
+
 @pytest.mark.parametrize(
     "compression",
     [None, sysand.CompressionMethod.STORED, sysand.CompressionMethod.DEFLATED],

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -211,69 +211,130 @@ def compare_sources(
 
 
 def test_end_to_end_install_sources() -> None:
-    with tempfile.TemporaryDirectory() as tmp_main:
-        with tempfile.TemporaryDirectory() as tmp_dep:
-            tmp_main = Path(tmp_main).resolve()
-            tmp_dep = Path(tmp_dep).resolve()
-            sysand.init("test_end_to_end_install_sources", "a", "1.2.3", tmp_main)
-            sysand.init("test_end_to_end_install_sources_dep", "a", "1.2.3", tmp_dep)
+    # A standard library is identified by its hard-coded IRI; the version must
+    # match the embedded standard library metadata so that every `Dependencies`
+    # mode resolves the same usage.
+    std_iri = "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar"
+    std_version = "1.0.0"
 
-            with open(Path(tmp_main) / "src.sysml", "w") as f:
-                f.write("package Src;")
+    with (
+        tempfile.TemporaryDirectory() as tmp_main,
+        tempfile.TemporaryDirectory() as tmp_dep,
+        tempfile.TemporaryDirectory() as tmp_std,
+    ):
+        tmp_main = Path(tmp_main).resolve()
+        tmp_dep = Path(tmp_dep).resolve()
+        tmp_std = Path(tmp_std).resolve()
+        sysand.init("test_end_to_end_install_sources", "a", "1.2.3", tmp_main)
+        sysand.init("test_end_to_end_install_sources_dep", "a", "1.2.3", tmp_dep)
+        sysand.init("Kernel Function Library", "a", std_version, tmp_std)
 
-            sysand.include(tmp_main, "src.sysml")
+        with open(Path(tmp_main) / "src.sysml", "w") as f:
+            f.write("package Src;")
 
-            with open(Path(tmp_dep) / "src_dep.sysml", "w") as f:
-                f.write("package SrcDep;")
+        sysand.include(tmp_main, "src.sysml")
 
-            sysand.include(tmp_dep, "src_dep.sysml")
+        with open(Path(tmp_dep) / "src_dep.sysml", "w") as f:
+            f.write("package SrcDep;")
 
-            env_path = Path(tmp_main) / sysand.env.DEFAULT_ENV_NAME
+        sysand.include(tmp_dep, "src_dep.sysml")
 
-            sysand.env.env(env_path)
+        with open(Path(tmp_std) / "src_std.sysml", "w") as f:
+            f.write("package SrcStd;")
 
-            sysand.env.install_path(
-                env_path, "urn:kpar:test_end_to_end_install_sources_dep", tmp_dep
-            )
+        sysand.include(tmp_std, "src_std.sysml")
 
-            sysand.add(
-                tmp_main, "urn:kpar:test_end_to_end_install_sources_dep", "1.2.3"
-            )
+        env_path = Path(tmp_main) / sysand.env.DEFAULT_ENV_NAME
 
-            compare_sources(
-                sysand.sources(tmp_main, include_deps=False),
-                [str(Path(tmp_main) / "src.sysml")],
-            )
-            compare_sources(
-                sysand.sources(tmp_dep, include_deps=False),
-                [str(Path(tmp_dep) / "src_dep.sysml")],
-            )
-            compare_sources(
-                sysand.sources(tmp_main, include_deps=True, env_path=env_path),
-                [
-                    str(Path(tmp_main) / "src.sysml"),
-                    str(
-                        env_path
-                        / "lib"
-                        / "kpar.test_end_to_end_install_sources_dep_1.2.3"
-                        / "src_dep.sysml"
-                    ),
-                ],
-            )
+        sysand.env.env(env_path)
 
-            sysand.exclude(tmp_main, "src.sysml")
+        sysand.env.install_path(
+            env_path, "urn:kpar:test_end_to_end_install_sources_dep", tmp_dep
+        )
+        sysand.env.install_path(env_path, std_iri, tmp_std)
 
-            compare_sources(
-                sysand.sources(tmp_main, include_deps=True, env_path=env_path),
-                [
-                    str(
-                        env_path
-                        / "lib"
-                        / "kpar.test_end_to_end_install_sources_dep_1.2.3"
-                        / "src_dep.sysml"
-                    ),
-                ],
-            )
+        sysand.add(tmp_main, "urn:kpar:test_end_to_end_install_sources_dep", "1.2.3")
+        sysand.add(tmp_main, std_iri, std_version)
+
+        dep_src = (
+            env_path
+            / "lib"
+            / "kpar.test_end_to_end_install_sources_dep_1.2.3"
+            / "src_dep.sysml"
+        )
+
+        [std_src] = (env_path / "lib").glob("*/src_std.sysml")
+
+        # By default only the project's own sources are listed.
+        compare_sources(
+            sysand.sources(tmp_main),
+            [str(Path(tmp_main) / "src.sysml")],
+        )
+        compare_sources(
+            sysand.sources(tmp_dep),
+            [str(Path(tmp_dep) / "src_dep.sysml")],
+        )
+        # Own sources together with dependency sources, excluding std libs.
+        compare_sources(
+            sysand.sources(
+                tmp_main, dependencies=sysand.Dependencies.DEPS, env_path=env_path
+            ),
+            [str(Path(tmp_main) / "src.sysml"), str(dep_src)],
+        )
+        # Only dependency sources.
+        compare_sources(
+            sysand.sources(
+                tmp_main,
+                no_own=True,
+                dependencies=sysand.Dependencies.DEPS,
+                env_path=env_path,
+            ),
+            [str(dep_src)],
+        )
+        # no_own without dependencies yields nothing.
+        compare_sources(sysand.sources(tmp_main, no_own=True), [])
+
+        # DEPS_STD includes both the dependency and the std lib.
+        compare_sources(
+            sorted(
+                sysand.sources(
+                    tmp_main,
+                    no_own=True,
+                    dependencies=sysand.Dependencies.DEPS_STD,
+                    env_path=env_path,
+                ),
+                key=lambda p: Path(p).name,
+            ),
+            sorted([str(dep_src), str(std_src)], key=lambda p: Path(p).name),
+        )
+        # STD includes only the std lib.
+        compare_sources(
+            sysand.sources(
+                tmp_main,
+                no_own=True,
+                dependencies=sysand.Dependencies.STD,
+                env_path=env_path,
+            ),
+            [str(std_src)],
+        )
+
+        sysand.exclude(tmp_main, "src.sysml")
+
+        compare_sources(
+            sysand.sources(
+                tmp_main, dependencies=sysand.Dependencies.DEPS, env_path=env_path
+            ),
+            [str(dep_src)],
+        )
+        compare_sources(
+            sysand.sources(
+                tmp_main,
+                no_own=True,
+                dependencies=sysand.Dependencies.DEPS,
+                env_path=env_path,
+            ),
+            [str(dep_src)],
+        )
 
 
 def test_root() -> None:

--- a/core/src/commands/root.rs
+++ b/core/src/commands/root.rs
@@ -3,9 +3,13 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-use crate::{discover::discover_project, project::utils::FsIoError};
+use crate::{
+    discover::discover_project,
+    project::utils::{FsIoError, wrapfs},
+};
 
 pub fn do_root<P: AsRef<Utf8Path>>(path: P) -> Result<Option<Utf8PathBuf>, Box<FsIoError>> {
-    let root = discover_project(path)?.map(|e| e.root_path().to_owned());
-    Ok(root)
+    discover_project(path)?
+        .map(|e| wrapfs::canonicalize(e.root_path()))
+        .transpose()
 }

--- a/core/src/commands/sources.rs
+++ b/core/src/commands/sources.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+};
 
 #[cfg(feature = "filesystem")]
 use camino::Utf8PathBuf;
@@ -21,7 +24,46 @@ use crate::{
         priority::{PriorityProject, PriorityResolver},
     },
     solve::pubgrub::SolverError,
+    stdlib::known_std_libs,
 };
+
+/// Selects which dependency sources a sources enumeration should yield. Whether
+/// the project's own sources are listed is controlled separately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dependencies {
+    /// No dependency sources.
+    None,
+    /// Dependency sources, excluding standard libraries.
+    Deps,
+    /// Dependency sources, including standard libraries.
+    DepsStd,
+    /// Only standard-library dependency sources.
+    Std,
+}
+
+#[derive(Error, Debug)]
+#[error("invalid dependencies mode `{0}`")]
+pub struct DependenciesParseError(String);
+
+impl TryFrom<&str> for Dependencies {
+    type Error = DependenciesParseError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "NONE" => Ok(Dependencies::None),
+            "DEPS" => Ok(Dependencies::Deps),
+            "DEPS_STD" => Ok(Dependencies::DepsStd),
+            "STD" => Ok(Dependencies::Std),
+            _ => Err(DependenciesParseError(value.to_owned())),
+        }
+    }
+}
+
+impl TryFrom<String> for Dependencies {
+    type Error = DependenciesParseError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum SourcesError<ProjectError> {
@@ -100,17 +142,21 @@ pub fn do_sources_local_src_project_no_deps(
     Ok(sources?)
 }
 
-/// Transitively resolve a list of usages (typically the usages of some project)
-/// in an environment and enumerate the resolved projects.
+/// Transitively resolves a list of usages (typically the usages of some project)
+/// in an environment and enumerates the resolved projects together with their IRIs.
 ///
 /// `provided_iris` are assumed to have been satisfied (including their dependencies)
 /// but have to match.
-pub fn find_project_dependencies<Env: ReadEnvironment + Debug + 'static>(
+#[allow(clippy::type_complexity)]
+fn solve_dependencies<Env: ReadEnvironment + Debug + 'static>(
     requested: Vec<InterchangeProjectUsage>,
     env: Env,
     provided_iris: &HashMap<String, Vec<InMemoryProject>>,
 ) -> Result<
-    Vec<<Env as ReadEnvironment>::InterchangeProjectRead>,
+    Vec<(
+        fluent_uri::Iri<String>,
+        <Env as ReadEnvironment>::InterchangeProjectRead,
+    )>,
     SolverError<impl ResolveRead + Debug + use<Env>>,
 > {
     let mut memory_projects = HashMap::default();
@@ -131,9 +177,68 @@ pub fn find_project_dependencies<Env: ReadEnvironment + Debug + 'static>(
 
     Ok(wrapped_result
         .drain()
-        .filter_map(|(_, project)| match project {
+        .filter_map(|(iri, project)| match project {
             PriorityProject::HigherProject(_) => None,
-            PriorityProject::LowerProject(project) => Some(project),
+            PriorityProject::LowerProject(project) => Some((iri, project)),
         })
+        .collect())
+}
+
+/// Transitively resolve a list of usages (typically the usages of some project)
+/// in an environment and enumerate the resolved projects.
+///
+/// `provided_iris` are assumed to have been satisfied (including their dependencies)
+/// but have to match.
+pub fn find_project_dependencies<Env: ReadEnvironment + Debug + 'static>(
+    requested: Vec<InterchangeProjectUsage>,
+    env: Env,
+    provided_iris: &HashMap<String, Vec<InMemoryProject>>,
+) -> Result<
+    Vec<<Env as ReadEnvironment>::InterchangeProjectRead>,
+    SolverError<impl ResolveRead + Debug + use<Env>>,
+> {
+    Ok(solve_dependencies(requested, env, provided_iris)?
+        .into_iter()
+        .map(|(_, project)| project)
+        .collect())
+}
+
+/// Resolves the dependencies of `requested` in `env` and returns the projects
+/// selected by `dependencies`.
+///
+/// Standard libraries are identified via [`known_std_libs`]: [`Dependencies::Deps`]
+/// excludes them, [`Dependencies::Std`] keeps only them and [`Dependencies::DepsStd`]
+/// keeps everything. Returns an empty list for [`Dependencies::None`].
+pub fn resolve_dependencies<Env: ReadEnvironment + Debug + 'static>(
+    requested: Vec<InterchangeProjectUsage>,
+    env: Env,
+    dependencies: Dependencies,
+) -> Result<
+    Vec<<Env as ReadEnvironment>::InterchangeProjectRead>,
+    SolverError<impl ResolveRead + Debug + use<Env>>,
+> {
+    // For `Deps` the standard libraries are treated as already provided so the
+    // solver omits them; otherwise everything is resolved and filtered below.
+    let provided_iris = match dependencies {
+        Dependencies::Deps => known_std_libs(),
+        _ => HashMap::default(),
+    };
+
+    let resolved = solve_dependencies(requested, env, &provided_iris)?;
+
+    let std_iris: HashSet<fluent_uri::Iri<String>> = known_std_libs()
+        .into_keys()
+        .map(|iri| fluent_uri::Iri::parse(iri).expect("BUG: invalid std lib IRI"))
+        .collect();
+
+    Ok(resolved
+        .into_iter()
+        .filter(|(iri, _)| match dependencies {
+            Dependencies::None => false,
+            Dependencies::Std => std_iris.contains(iri),
+            Dependencies::Deps => !std_iris.contains(iri),
+            Dependencies::DepsStd => true,
+        })
+        .map(|(_, project)| project)
         .collect())
 }

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -15,6 +15,7 @@ use sysand_core::{
     add::expand_sysand_purl_shorthand,
     build::KparCompressionMethod,
     model::{KERML_METAMODEL_PREFIX, SYSML_METAMODEL_PREFIX},
+    sources::Dependencies,
 };
 use url::Url;
 
@@ -1616,9 +1617,35 @@ pub struct SourcesOptions {
     /// Do not include sources for dependencies
     #[arg(long, default_value_t = false, conflicts_with = "include_std")]
     pub no_deps: bool,
+    /// Only include sources for dependencies, not the project's own sources
+    #[arg(long, default_value_t = false, conflicts_with = "no_deps")]
+    pub only_deps: bool,
     /// Include (installed) KerML/SysML v2 standard libraries
     #[arg(long, default_value_t = false)]
     pub include_std: bool,
+}
+
+impl SourcesOptions {
+    /// Whether the project's own sources should be excluded (`--only-deps`).
+    pub fn no_own(&self) -> bool {
+        self.only_deps
+    }
+
+    /// Resolve which dependency sources to list from the flags.
+    pub fn dependencies(&self) -> Dependencies {
+        // TODO(0.2.0): the CLI cannot produce `Dependencies::Std` ("only standard
+        // libraries"), which the Python API supports. Exposing it cleanly would
+        // mean reworking the `--no-deps`/`--include-std` flags into an orthogonal
+        // `--no-own` + `--dependencies=<none|deps|deps-std|std>` scheme, which is a
+        // breaking CLI change and is therefore deferred to 0.2.0.
+        if self.no_deps {
+            Dependencies::None
+        } else if self.include_std {
+            Dependencies::DepsStd
+        } else {
+            Dependencies::Deps
+        }
+    }
 }
 
 #[derive(clap::Args, Debug)]

--- a/sysand/src/commands/print_root.rs
+++ b/sysand/src/commands/print_root.rs
@@ -4,14 +4,14 @@
 use anyhow::{Result, anyhow};
 
 use camino::Utf8Path;
-use sysand_core::{project::utils::wrapfs, root::do_root};
+use sysand_core::root::do_root;
 
 use crate::CliError;
 
 pub fn command_print_root<P: AsRef<Utf8Path>>(path: P) -> Result<()> {
     match do_root(path)? {
         Some(root) => {
-            println!("{}", wrapfs::canonicalize(root)?);
+            println!("{root}");
             Ok(())
         }
         None => Err(anyhow!(CliError::InvalidDirectory(

--- a/sysand/src/commands/sources.rs
+++ b/sysand/src/commands/sources.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::collections::HashMap;
-
 use crate::CliError;
 
 use anstream::println;
@@ -11,8 +9,8 @@ use semver::VersionReq;
 use sysand_core::{
     context::ProjectContext,
     env::{local_directory::LocalDirectoryEnvironment, null::NullEnvironment},
-    project::{ProjectRead, memory::InMemoryProject},
-    sources::{do_sources_local_src_project_no_deps, find_project_dependencies},
+    project::ProjectRead,
+    sources::{Dependencies, do_sources_local_src_project_no_deps, resolve_dependencies},
 };
 
 use sysand_core::env::ReadEnvironment;
@@ -20,10 +18,9 @@ use sysand_core::env::ReadEnvironment;
 pub fn command_sources_env<S: AsRef<str>>(
     iri: S,
     version: Option<VersionReq>,
-    include_deps: bool,
+    no_own: bool,
+    dependencies: Dependencies,
     env: Option<LocalDirectoryEnvironment>,
-    provided_iris: &HashMap<String, Vec<InMemoryProject>>,
-    include_std: bool,
 ) -> Result<()> {
     let Some(env) = env else {
         bail!("unable to identify local environment");
@@ -61,19 +58,21 @@ pub fn command_sources_env<S: AsRef<str>>(
         }
     };
 
-    for src_path in do_sources_local_src_project_no_deps(&project, true)? {
-        println!("{}", src_path);
+    if !no_own {
+        for src_path in do_sources_local_src_project_no_deps(&project, true)? {
+            println!("{}", src_path);
+        }
     }
 
-    if include_deps {
+    if dependencies != Dependencies::None {
         let Some(info) = project.get_info()? else {
             bail!("project is missing project information")
         };
 
-        if !include_std {
+        if dependencies == Dependencies::Deps {
             crate::logger::warn_std_deps();
         }
-        for dep in find_project_dependencies(info.validate()?.usage, env, provided_iris)? {
+        for dep in resolve_dependencies(info.validate()?.usage, env, dependencies)? {
             for src_path in do_sources_local_src_project_no_deps(&dep, true)? {
                 println!("{}", src_path);
             }
@@ -84,9 +83,9 @@ pub fn command_sources_env<S: AsRef<str>>(
 }
 
 pub fn command_sources_project(
-    include_deps: bool,
+    no_own: bool,
+    dependencies: Dependencies,
     ctx: ProjectContext,
-    provided_iris: &HashMap<String, Vec<InMemoryProject>>,
 ) -> Result<()> {
     let current_project = ctx
         .current_project
@@ -97,16 +96,18 @@ pub fn command_sources_project(
     };
     let info = info.validate()?;
 
-    for src_path in do_sources_local_src_project_no_deps(&current_project, true)? {
-        println!("{}", src_path);
+    if !no_own {
+        for src_path in do_sources_local_src_project_no_deps(&current_project, true)? {
+            println!("{}", src_path);
+        }
     }
 
-    if include_deps {
+    if dependencies != Dependencies::None {
         let deps = match ctx.env {
-            Some(env) => find_project_dependencies(info.usage, env, provided_iris)?,
+            Some(env) => resolve_dependencies(info.usage, env, dependencies)?,
             None => {
                 let env = NullEnvironment::new();
-                find_project_dependencies(info.usage, env, provided_iris)?
+                resolve_dependencies(info.usage, env, dependencies)?
             }
         };
 

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -41,6 +41,7 @@ use sysand_core::{
         utils::wrapfs,
     },
     resolve::net_utils::create_reqwest_client,
+    sources::Dependencies,
     stdlib::known_std_libs,
     workspace::Workspace,
 };
@@ -351,19 +352,13 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 iri,
                 version,
                 sources_opts,
-            }) => {
-                let cli::SourcesOptions {
-                    no_deps,
-                    include_std,
-                } = sources_opts;
-                let provided_iris = if !include_std {
-                    known_std_libs()
-                } else {
-                    HashMap::default()
-                };
-
-                command_sources_env(iri, version, !no_deps, ctx.env, &provided_iris, include_std)
-            }
+            }) => command_sources_env(
+                iri,
+                version,
+                sources_opts.no_own(),
+                sources_opts.dependencies(),
+                ctx.env,
+            ),
         },
         Command::Index { command } => {
             let root =
@@ -735,18 +730,11 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             runtime,
         ),
         Command::Sources { sources_opts } => {
-            let cli::SourcesOptions {
-                no_deps,
-                include_std,
-            } = sources_opts;
-            let provided_iris = if !include_std {
+            let dependencies = sources_opts.dependencies();
+            if dependencies == Dependencies::Deps {
                 crate::logger::warn_std_omit();
-                known_std_libs()
-            } else {
-                HashMap::default()
-            };
-
-            command_sources_project(!no_deps, ctx, &provided_iris)
+            }
+            command_sources_project(sources_opts.no_own(), dependencies, ctx)
         }
         Command::Clone {
             locator,

--- a/sysand/tests/cli_source.rs
+++ b/sysand/tests/cli_source.rs
@@ -76,6 +76,18 @@ fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     assert_eq!(wrapfs::canonicalize(p)?, expected_path);
 
+    let out = run_sysand_in(&path, ["sources", "--only-deps"], None)?;
+
+    let p = String::from_utf8(
+        out.assert()
+            .success()
+            .get_output()
+            .stdout
+            .trim_ascii_end()
+            .to_owned(),
+    )?;
+    assert_eq!(wrapfs::canonicalize(p)?, dep_expected_path);
+
     let out = run_sysand_in(
         &path,
         ["env", "sources", "urn:kpar:list_sources_dep", "--no-deps"],


### PR DESCRIPTION
This PR contains small Python API improvements that I need for integrating Sysand into Syside ReqIF functionality, namely:
1. The ability to obtain the project root (Sysand CLI already can do this through `print-root`, but not in Python)
2. The ability to obtain a list of dependencies the current project depends on (so I could check if the ReqIF library is imported)

These changes required a bit of changes on the Sysand core / CLI, namely the introduction of "source modes":
- `own`, which represents the "I only want to list the `included` files" and was achievable through CLI as `sysand sources --no-deps` (still possible)
- `own_with_deps`, which is what the default is `sysand sources`
- `deps`, which is new and returns only the dependencies without `included` files

While the CLI only got a new flag `--only-deps` and thus there is no breaking change on the CLI side, the Python API lost the `include_deps` argument and gained `no_deps` and `only_deps` instead to better align with the CLI. Not sure if we should consider this a breaking change, or should I try to keep what was already in the Python API?

For context, this is how I would need to get only the deps with the current API:

```python
all_srcs = sysand.sources(root, env_path=root / ".sysand")
own_srcs = sysand.sources(root, env_path=root / ".sysand", include_deps=False)
dep_srcs = [p for p in all_srcs if p not in set(own_srcs)]
```

While after this PR I will be able to do:

```python
dep_srcs = sysand.sources(root, env_path=root / ".sysand", only_deps=True)
```

P.S.: The commits are pretty atomic and contain nice commit messages. If not a lot of changes after review are required, I'd like NOT to squash the commits on merge.