### PR TITLE
refactor: turn `InterchangeProjectUsageG` into an enum

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
 //
 // config ref: https://docs.renovatebot.com/configuration-options/
 //
+// validate: renovate-config-validator .github/renovate.json5 --strict --no-global
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
@@ -11,6 +12,7 @@
     "helpers:pinGitHubActionDigestsToSemver",
   ],
   minimumReleaseAge: "7 days",
+  abandonmentThreshold: "3 years",
   packageRules: [
     // Group bumps of all non-major dependencies by using two rules, one for
     // situations like 1.2.3, and one for situations like 0.1.2.

--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SetProjectInfoTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SetProjectInfoTest.java
@@ -9,6 +9,7 @@ import com.sensmetry.sysand.model.InterchangeProjectChecksum;
 import com.sensmetry.sysand.model.InterchangeProjectInfo;
 import com.sensmetry.sysand.model.InterchangeProjectMetadata;
 import com.sensmetry.sysand.model.InterchangeProjectUsage;
+import com.sensmetry.sysand.model.InterchangeProjectUsageResource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -80,8 +81,8 @@ public class SetProjectInfoTest {
         Path dir = initProject();
 
         InterchangeProjectUsage[] usages = new InterchangeProjectUsage[]{
-                new InterchangeProjectUsage("urn:example:dep-a", ">=1.0.0"),
-                new InterchangeProjectUsage("urn:example:dep-b", null),
+                new InterchangeProjectUsageResource("urn:example:dep-a", ">=1.0.0"),
+                new InterchangeProjectUsageResource("urn:example:dep-b", null),
         };
         InterchangeProjectInfo updated = new InterchangeProjectInfo(
                 "original", "pub", null, "1.0.0", null,
@@ -90,10 +91,12 @@ public class SetProjectInfoTest {
 
         com.sensmetry.sysand.model.InterchangeProject project = Sysand.infoPath(dir);
         assertEquals(2, project.info.getUsage().length);
-        assertEquals("urn:example:dep-a", project.info.getUsage()[0].getResource());
-        assertEquals(">=1.0.0", project.info.getUsage()[0].getVersionConstraint());
-        assertEquals("urn:example:dep-b", project.info.getUsage()[1].getResource());
-        assertNull(project.info.getUsage()[1].getVersionConstraint());
+        InterchangeProjectUsageResource u1 = (InterchangeProjectUsageResource)project.info.getUsage()[0];
+        assertEquals("urn:example:dep-a", u1.getResource());
+        assertEquals(">=1.0.0", u1.getVersionConstraint());
+        InterchangeProjectUsageResource u2 = (InterchangeProjectUsageResource)project.info.getUsage()[1];
+        assertEquals("urn:example:dep-b", u2.getResource());
+        assertNull(u2.getVersionConstraint());
     }
 
     @Test

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsage.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsage.java
@@ -3,29 +3,7 @@
 
 package com.sensmetry.sysand.model;
 
-public class InterchangeProjectUsage {
-
-    private String resource;
-    private String versionConstraint;
-
-    public InterchangeProjectUsage(String resource, String versionConstraint) {
-        this.resource = resource;
-        this.versionConstraint = versionConstraint;
-    }
-
-    public String getResource() {
-        return resource;
-    }
-
-    public void setResource(String resource) {
-        this.resource = resource;
-    }
-
-    public String getVersionConstraint() {
-        return versionConstraint;
-    }
-
-    public void setVersionConstraint(String versionConstraint) {
-        this.versionConstraint = versionConstraint;
-    }
-}
+// TODO(Java 17+): use sealed classes and interfaces 
+// This is meant to be a sealed interface and Sysand only supports
+// usage classes from this package.
+public interface InterchangeProjectUsage {}

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsageResource.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsageResource.java
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+package com.sensmetry.sysand.model;
+
+public class InterchangeProjectUsageResource implements InterchangeProjectUsage {
+
+    private String resource;
+    private String versionConstraint;
+
+    public InterchangeProjectUsageResource(String resource, String versionConstraint) {
+        this.resource = resource;
+        this.versionConstraint = versionConstraint;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
+    }
+
+    public String getVersionConstraint() {
+        return versionConstraint;
+    }
+
+    public void setVersionConstraint(String versionConstraint) {
+        this.versionConstraint = versionConstraint;
+    }
+}

--- a/bindings/java/src/conversion.rs
+++ b/bindings/java/src/conversion.rs
@@ -198,12 +198,30 @@ fn get_usage_array_field<'local>(
                 return None;
             }
         };
-        let resource = get_string_field(env, &elem, "resource")?;
-        let version_constraint = get_nullable_string_field(env, &elem, "versionConstraint")?;
-        result.push(InterchangeProjectUsageRaw {
-            resource,
-            version_constraint,
-        });
+        match env.is_instance_of(&elem, INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS) {
+            Ok(true) => {
+                let resource = get_string_field(env, &elem, "resource")?;
+                let version_constraint =
+                    get_nullable_string_field(env, &elem, "versionConstraint")?;
+                result.push(InterchangeProjectUsageRaw::Resource {
+                    resource,
+                    version_constraint,
+                });
+            }
+            Ok(false) => {
+                env.throw_runtime_exception(
+                    "Unknown usage type, only InterchangeProjectUsageResource is supported",
+                );
+                return None;
+            }
+            Err(e) => {
+                env.throw_runtime_exception(format!(
+                    "Failed to check whether `{field_name}[{i}]` is InterchangeProjectUsageResource:\n\
+                    {e}"
+                ));
+                return None;
+            }
+        }
     }
     Some(result)
 }
@@ -335,6 +353,8 @@ pub(crate) fn java_metadata_to_raw<'local>(
     })
 }
 
+pub(crate) const INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS: &str =
+    "com/sensmetry/sysand/model/InterchangeProjectUsageResource";
 pub(crate) const INTERCHANGE_PROJECT_USAGE_CLASS: &str =
     "com/sensmetry/sysand/model/InterchangeProjectUsage";
 pub(crate) const INTERCHANGE_PROJECT_INFO_CLASS: &str =
@@ -523,17 +543,24 @@ impl ToJObject for InterchangeProjectChecksumRaw {
 
 impl ToJObject for InterchangeProjectUsageRaw {
     fn to_jobject<'local>(&self, env: &mut JNIEnv<'local>) -> Option<JObject<'local>> {
-        let resource = self.resource.to_jobject(env)?;
-        let version_constraint = self.version_constraint.to_jobject(env)?;
-        match env.new_object(
-            INTERCHANGE_PROJECT_USAGE_CLASS,
-            "(Ljava/lang/String;Ljava/lang/String;)V",
-            &[JValue::from(&resource), JValue::from(&version_constraint)],
-        ) {
-            Ok(o) => Some(o),
-            Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create LinkedHashMap: {e}"));
-                None
+        match self {
+            InterchangeProjectUsageRaw::Resource {
+                resource,
+                version_constraint,
+            } => {
+                let resource = resource.to_jobject(env)?;
+                let version_constraint = version_constraint.to_jobject(env)?;
+                match env.new_object(
+                    INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS,
+                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                    &[JValue::from(&resource), JValue::from(&version_constraint)],
+                ) {
+                    Ok(o) => Some(o),
+                    Err(e) => {
+                        env.throw_runtime_exception(format!("Failed to create LinkedHashMap: {e}"));
+                        None
+                    }
+                }
             }
         }
     }

--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -52,7 +52,7 @@ pub fn do_add_guess<P: ProjectMut>(
     resource: String,
     version_constraint: Option<String>,
 ) -> Result<bool, AddError<P::Error>> {
-    let usage_raw = InterchangeProjectUsageRaw {
+    let usage_raw = InterchangeProjectUsageRaw::Resource {
         resource: match expand_sysand_purl_shorthand(&resource) {
             Ok(Some(purl)) => purl,
             Ok(None) => resource,
@@ -80,77 +80,78 @@ pub fn do_add<P: ProjectMut>(
 
     let adding = "Adding";
     let header = crate::style::get_style_config().header;
-    log::info!(
-        "{header}{adding:>12}{header:#} usage: `{}` {}",
-        &usage_raw.resource,
-        usage_raw
-            .version_constraint
-            .as_ref()
-            .map(|vr| vr.to_string())
-            .unwrap_or("".to_string()),
-    );
+    log::info!("{header}{adding:>12}{header:#} usage: {usage_raw}");
 
     if let Some(info) = project.get_info().map_err(AddError::Project)?.as_mut() {
-        if let Some(u) = info.usage.iter_mut().find(|u| u.resource == usage.resource) {
-            match (usage.version_constraint, &mut u.version_constraint) {
-                (None, None) => {
-                    log::warn!(
-                        "ignoring usage `{}`,\n\
-                    {SP:>8} since it is already present",
-                        usage.resource,
-                    );
-                    return Ok(false);
-                }
-                (None, Some(vc)) => {
-                    log::warn!(
-                        "ignoring usage `{}`\n\
-                    {SP:>8} without a version constraint, since it is already present with\n\
-                    {SP:>8} version constraint `{}`",
-                        usage.resource,
-                        vc
-                    );
-                    return Ok(false);
-                }
-                (Some(vc), vc_current @ None) => {
-                    log::warn!(
-                        "usage `{}` is already present,\n\
-                        {SP:>8} but without a version constraint; version constraint\n\
-                        {SP:>8} `{}` will be added to it",
-                        usage.resource,
-                        vc
-                    );
-                    *vc_current = Some(vc);
-                }
-                (Some(vc_new), Some(vc_current)) => {
-                    // TODO: more intelligent merging of constraints
-                    if &vc_new == vc_current {
-                        log::warn!(
-                            "ignoring usage `{}` with version constraint\n\
-                            {SP:>8} `{}`, since it is already present with identical version constraint",
-                            usage.resource,
-                            vc_new
-                        )
-                    } else {
-                        log::warn!(
-                            "usage `{}` is already present, but with version\n\
-                            {SP:>8} constraint `{}`; new version constraint\n\
-                            {SP:>8} `{}` will be added to the existing ones; this may\n\
-                            {SP:>8} result in failed version resolution or conflicting symbol errors",
-                            u.resource,
-                            vc_current,
-                            vc_new
-                        );
-                        vc_current.push_str(", ");
-                        vc_current.push_str(&vc_new);
+        let mut found = false;
+        match &usage {
+            InterchangeProjectUsageRaw::Resource {
+                resource: new_resource,
+                version_constraint: new_vc,
+            } => {
+                for u in info.usage.iter_mut() {
+                    match u {
+                        InterchangeProjectUsageRaw::Resource {
+                            resource,
+                            version_constraint,
+                        } if resource == new_resource => {
+                            match (&new_vc, version_constraint) {
+                                (None, None) => {
+                                    log::warn!(
+                                        "ignoring usage `{new_resource}`,\n\
+                                         {SP:>8} since it is already present"
+                                    );
+                                    return Ok(false);
+                                }
+                                (None, Some(vc)) => {
+                                    log::warn!(
+                                        "ignoring usage `{new_resource}`\n\
+                                         {SP:>8} without a version constraint, since it is already present with\n\
+                                         {SP:>8} version constraint `{vc}`",
+                                    );
+                                    return Ok(false);
+                                }
+                                (Some(vc), vc_current @ None) => {
+                                    log::warn!(
+                                        "usage `{new_resource}` is already present,\n\
+                                         {SP:>8} but without a version constraint; version constraint\n\
+                                         {SP:>8} `{vc}` will be added to it",
+                                    );
+                                    *vc_current = Some(vc.to_owned());
+                                    found = true;
+                                }
+                                (Some(vc_new), Some(vc_current)) => {
+                                    // TODO: more intelligent merging of constraints
+                                    if vc_new == vc_current {
+                                        log::warn!(
+                                            "ignoring usage `{new_resource}` with version constraint\n\
+                                             {SP:>8} `{vc_new}`, since it is already present with identical version constraint",
+                                        );
+                                        return Ok(false);
+                                    } else {
+                                        log::warn!(
+                                            "usage `{new_resource}` is already present, but with version\n\
+                                             {SP:>8} constraint `{vc_current}`; new version constraint\n\
+                                             {SP:>8} `{vc_new}` will be added to the existing ones; this may\n\
+                                             {SP:>8} result in failed version resolution or conflicting symbol errors",
+                                        );
+                                        vc_current.push_str(", ");
+                                        vc_current.push_str(vc_new);
+                                        found = true;
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                        InterchangeProjectUsageRaw::Resource { .. } => (),
                     }
                 }
             }
-        } else {
+        }
+        if !found {
             info.usage.push(usage);
         }
-
         project.put_info(info, true).map_err(AddError::Project)?;
-
         Ok(true)
     } else {
         Err(AddError::MissingInfo(

--- a/core/src/commands/add_tests.rs
+++ b/core/src/commands/add_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     add::{do_add_guess, expand_sysand_purl_shorthand},
-    model::InterchangeProjectInfoRaw,
+    model::{InterchangeProjectInfoRaw, InterchangeProjectUsageRaw},
     project::memory::InMemoryProject,
 };
 use std::assert_matches;
@@ -54,8 +54,13 @@ fn add_accepts_normalized_sysand_shorthand() {
 
     let info = project.info.unwrap();
     assert_eq!(info.usage.len(), 1);
-    assert_eq!(info.usage[0].resource, "pkg:sysand/acme-labs/my.project");
-    assert_eq!(info.usage[0].version_constraint.as_deref(), Some("^1.2.3"));
+    assert_eq!(
+        info.usage[0],
+        InterchangeProjectUsageRaw::Resource {
+            resource: "pkg:sysand/acme-labs/my.project".to_string(),
+            version_constraint: Some("^1.2.3".to_string())
+        }
+    );
 }
 
 #[test]
@@ -72,8 +77,11 @@ fn add_keeps_iri_resource() {
     let info = project.info.unwrap();
     assert_eq!(info.usage.len(), 1);
     assert_eq!(
-        info.usage[0].resource,
-        "https://example.com/acme-labs/my.project"
+        info.usage[0],
+        InterchangeProjectUsageRaw::Resource {
+            resource: "https://example.com/acme-labs/my.project".to_string(),
+            version_constraint: None
+        }
     );
 }
 

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -10,7 +10,10 @@ use std::{collections::HashSet, io::Write as _};
 use crate::{
     env::utils::ErrorBound,
     include::{IncludeError, extract_symbols, read_project_file_to_string},
-    model::{InterchangeProjectChecksumRaw, InterchangeProjectValidationError, KerMlChecksumAlg},
+    model::{
+        InterchangeProjectChecksumRaw, InterchangeProjectUsageRaw,
+        InterchangeProjectValidationError, KerMlChecksumAlg,
+    },
     project::{
         ProjectRead,
         local_kpar::LocalKParProjectRaw,
@@ -288,23 +291,27 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                 }
             });
 
-    if let Some(u) = info.usage.iter().find(|x| {
+    if let Some(resource) = info.usage.iter().find_map(|x| {
         // Case-insensitively match `file:` scheme
-        x.resource.len() >= 5
-            && x.resource
-                .as_bytes()
-                .iter()
-                .zip(b"file:")
-                .all(|(c1, &c2)| c1.to_ascii_lowercase() == c2)
+        match x {
+            InterchangeProjectUsageRaw::Resource { resource, .. } => {
+                if let Some(scheme) = resource.get(..5)
+                    && scheme.eq_ignore_ascii_case("file:")
+                {
+                    Some(resource)
+                } else {
+                    None
+                }
+            }
+        }
     }) {
         if allow_path_usage {
             log::warn!(
-                "project includes a path usage `{}`,\n\
-            which is unlikely to be available on other computers at the same path",
-                u.resource
+                "project includes a path usage `{resource}`,\n\
+                which is unlikely to be available on other computers at the same path"
             );
         } else {
-            return Err(KParBuildError::PathUsage(u.resource.clone()));
+            return Err(KParBuildError::PathUsage(resource.clone()));
         }
     }
 

--- a/core/src/commands/lock.rs
+++ b/core/src/commands/lock.rs
@@ -20,7 +20,9 @@ use crate::project::{editable::EditableProject, local_src::LocalSrcProject};
 use crate::{
     context::ProjectContext,
     lock::{Lock, Project, Usage, hash_str},
-    model::{InterchangeProjectUsage, InterchangeProjectValidationError},
+    model::{
+        InterchangeProjectUsage, InterchangeProjectUsageRaw, InterchangeProjectValidationError,
+    },
     project::{CanonicalizationError, ProjectRead, memory::InMemoryProject, utils::FsIoError},
     resolve::ResolveRead,
     solve::pubgrub::{SolverError, solve},
@@ -181,7 +183,11 @@ pub fn do_lock_projects<
             usages: info
                 .usage
                 .iter()
-                .map(|u| Usage::from(u.resource.clone()))
+                .map(|u| match u {
+                    InterchangeProjectUsageRaw::Resource { resource, .. } => {
+                        Usage::from(resource.to_owned())
+                    }
+                })
                 .collect(),
         });
 
@@ -282,13 +288,14 @@ pub fn do_lock_extend<
             usages: info
                 .usage
                 .into_iter()
-                .map(|u| Usage::from(u.resource))
+                .map(|u| match u {
+                    InterchangeProjectUsageRaw::Resource { resource, .. } => Usage::from(resource),
+                })
                 .collect(),
         };
         if lock_projects.contains(iri.as_str()) {
             log::debug!(
-                "not adding project `{}` ({}) to lock, as lock already contains it",
-                iri,
+                "not adding project `{iri}` ({}) to lock, as lock already contains it",
                 lock_project.version
             );
         } else {

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -925,15 +925,19 @@ fn check_usage(usage: &InterchangeProjectUsageRaw) -> Result<(), PublishError> {
         return Ok(());
     }
 
-    match parse_sysand_purl(&usage.resource) {
-        Ok(Some(_)) => Ok(()),
-        Ok(None) => Err(PublishError::DisallowedUsage {
-            name: usage.resource.as_str().into(),
-        }),
-        Err(e) => Err(PublishError::InvalidPurl {
-            name: usage.resource.as_str().into(),
-            source: e,
-        }),
+    match usage {
+        InterchangeProjectUsageRaw::Resource { resource, .. } => {
+            match parse_sysand_purl(resource) {
+                Ok(Some(_)) => Ok(()),
+                Ok(None) => Err(PublishError::DisallowedUsage {
+                    name: resource.as_str().into(),
+                }),
+                Err(e) => Err(PublishError::InvalidPurl {
+                    name: resource.as_str().into(),
+                    source: e,
+                }),
+            }
+        }
     }
 }
 
@@ -945,30 +949,37 @@ fn check_std_libs(
     lib_names: &[&str],
     prefix: &str,
 ) -> Result<bool, PublishError> {
-    if let Some(stripped) = usage.resource.strip_prefix(prefix) {
-        for s in lib_names {
-            if let Some(metamodel_version) = stripped.strip_suffix(s) {
-                if is_valid_metamodel_version(metamodel_version) {
-                    if let Some(vc) = usage.version_constraint.as_deref() {
-                        return Err(PublishError::StdWithVersionConstraint {
-                            name: usage.resource.as_str().into(),
-                            vc: vc.into(),
-                        });
+    match usage {
+        InterchangeProjectUsageRaw::Resource {
+            resource,
+            version_constraint,
+        } => {
+            if let Some(stripped) = resource.strip_prefix(prefix) {
+                for s in lib_names {
+                    if let Some(metamodel_version) = stripped.strip_suffix(s) {
+                        if is_valid_metamodel_version(metamodel_version) {
+                            if let Some(vc) = version_constraint.as_deref() {
+                                return Err(PublishError::StdWithVersionConstraint {
+                                    name: resource.as_str().into(),
+                                    vc: vc.into(),
+                                });
+                            }
+                            return Ok(true);
+                        } else {
+                            return Err(PublishError::InvalidStdLibVersion {
+                                name: resource.as_str().into(),
+                                std_version: metamodel_version.into(),
+                            });
+                        }
                     }
-                    return Ok(true);
-                } else {
-                    return Err(PublishError::InvalidStdLibVersion {
-                        name: usage.resource.as_str().into(),
-                        std_version: metamodel_version.into(),
-                    });
                 }
+                return Err(PublishError::UnknownStdLib {
+                    name: resource.as_str().into(),
+                });
             }
+            Ok(false)
         }
-        return Err(PublishError::UnknownStdLib {
-            name: usage.resource.as_str().into(),
-        });
     }
-    Ok(false)
 }
 
 /// Check that `v` is a number of the form `20yymmxx`, where `yy` and `xx` are pairs

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -155,14 +155,14 @@ fn check_metamodel_rejects_invalid_kerml_version() {
 // --- check_usage ---
 
 fn usage(resource: &str) -> InterchangeProjectUsageRaw {
-    InterchangeProjectUsageRaw {
+    InterchangeProjectUsageRaw::Resource {
         resource: resource.to_string(),
         version_constraint: None,
     }
 }
 
 fn usage_with_vc(resource: &str, vc: &str) -> InterchangeProjectUsageRaw {
-    InterchangeProjectUsageRaw {
+    InterchangeProjectUsageRaw::Resource {
         resource: resource.to_string(),
         version_constraint: Some(vc.to_string()),
     }

--- a/core/src/commands/remove_tests.rs
+++ b/core/src/commands/remove_tests.rs
@@ -17,7 +17,7 @@ fn project_with_usage(resource: &str) -> InMemoryProject {
             license: None,
             maintainer: vec![],
             topic: vec![],
-            usage: vec![InterchangeProjectUsageRaw {
+            usage: vec![InterchangeProjectUsageRaw::Resource {
                 resource: resource.to_owned(),
                 version_constraint: None,
             }],
@@ -38,7 +38,13 @@ fn remove_accepts_normalized_sysand_shorthand() {
     let removed = do_remove_guess(&mut project, "acme-labs/my.project".to_owned()).unwrap();
 
     assert_eq!(removed.len(), 1);
-    assert_eq!(removed[0].resource, "pkg:sysand/acme-labs/my.project");
+    assert_eq!(
+        removed[0],
+        InterchangeProjectUsageRaw::Resource {
+            resource: "pkg:sysand/acme-labs/my.project".to_string(),
+            version_constraint: None
+        }
+    );
     assert!(project.info.unwrap().usage.is_empty());
 }
 
@@ -54,8 +60,11 @@ fn remove_keeps_iri_resource() {
 
     assert_eq!(removed.len(), 1);
     assert_eq!(
-        removed[0].resource,
-        "https://example.com/acme-labs/my.project"
+        removed[0],
+        InterchangeProjectUsageRaw::Resource {
+            resource: "https://example.com/acme-labs/my.project".to_string(),
+            version_constraint: None
+        }
     );
     assert!(project.info.unwrap().usage.is_empty());
 }

--- a/core/src/env/index_tests.rs
+++ b/core/src/env/index_tests.rs
@@ -1071,6 +1071,8 @@ mod versions {
 /// - A caller-supplied version not listed in `versions.json` surfaces
 ///   as `VersionNotInIndex`; there is no kpar-only fallback.
 mod get_project {
+    use crate::model::InterchangeProjectUsageRaw;
+
     use super::*;
 
     #[test]
@@ -1353,11 +1355,20 @@ mod get_project {
         let info = info.expect("info should be prefetched");
 
         assert_eq!(info.usage.len(), 2);
-        assert_eq!(info.usage[0].resource, purl("admin/dep"));
-        assert_eq!(info.usage[0].version_constraint.as_deref(), Some("<2"));
-        assert_eq!(info.usage[1].resource, purl("admin/other"));
-        assert_eq!(info.usage[1].version_constraint, None);
-
+        assert_eq!(
+            info.usage[0],
+            InterchangeProjectUsageRaw::Resource {
+                resource: purl("admin/dep"),
+                version_constraint: Some("<2".to_string())
+            }
+        );
+        assert_eq!(
+            info.usage[1],
+            InterchangeProjectUsageRaw::Resource {
+                resource: purl("admin/other"),
+                version_constraint: None
+            }
+        );
         versions_mock.assert();
         project_json_mock.assert();
         meta_json_mock.assert();
@@ -1457,9 +1468,13 @@ mod get_project {
         assert_eq!(info.publisher.as_deref(), Some("real_publisher"));
         assert_eq!(info.version, "0.3.0");
         assert_eq!(info.usage.len(), 1);
-        assert_eq!(info.usage[0].resource, purl("x/y"));
-        assert_eq!(info.usage[0].version_constraint.as_deref(), Some(">=1"));
-
+        assert_eq!(
+            info.usage[0],
+            InterchangeProjectUsageRaw::Resource {
+                resource: purl("x/y"),
+                version_constraint: Some(">=1".to_string())
+            }
+        );
         assert_eq!(
             meta.metamodel.as_deref(),
             Some("https://www.omg.org/spec/KerML/20250201")

--- a/core/src/env/local_directory/metadata.rs
+++ b/core/src/env/local_directory/metadata.rs
@@ -11,6 +11,7 @@ use typed_path::{Utf8UnixComponent, Utf8UnixPathBuf};
 
 use crate::{
     env::ProjectChecksum,
+    model::InterchangeProjectUsageRaw,
     project::{
         local_src::{LocalSrcError, LocalSrcProject},
         utils::{FsIoError, deserialize_unix_path, wrapfs},
@@ -224,7 +225,13 @@ impl EnvMetadata {
                 .expect("BUG: no nominal path for project")
                 .to_owned(),
             identifiers,
-            usages: info.usage.into_iter().map(|u| u.resource).collect(),
+            usages: info
+                .usage
+                .into_iter()
+                .map(|u| match u {
+                    InterchangeProjectUsageRaw::Resource { resource, .. } => resource,
+                })
+                .collect(),
             editable,
             workspace,
             checksum: checksum.map(Into::into),

--- a/core/src/env/local_directory/mod.rs
+++ b/core/src/env/local_directory/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     },
     iri_normalize::IriVersionFilename,
     lock::{Lock, Source},
+    model::InterchangeProjectUsageRaw,
     project::{
         local_src::{LocalSrcError, LocalSrcProject, PathError},
         utils::{
@@ -118,7 +119,7 @@ impl LocalDirectoryEnvironment {
                 let usages = project
                     .usages
                     .iter()
-                    .map(|usage| usage.resource.clone())
+                    .map(|usage| usage.inner().clone())
                     .collect();
 
                 let workspace_member = ws
@@ -463,7 +464,13 @@ impl WriteEnvironment for LocalDirectoryEnvironment {
             existing.publisher = info.publisher;
             existing.name = info.name;
             existing.version = info.version;
-            existing.usages = info.usage.into_iter().map(|u| u.resource).collect();
+            existing.usages = info
+                .usage
+                .into_iter()
+                .map(|u| match u {
+                    InterchangeProjectUsageRaw::Resource { resource, .. } => resource,
+                })
+                .collect();
             existing.checksum = checksum.map(Into::into);
 
             self.write().map_err(LocalWriteError::from)?;

--- a/core/src/lock.rs
+++ b/core/src/lock.rs
@@ -7,6 +7,7 @@ use std::{
     fmt::Display,
     hash::{DefaultHasher, Hash, Hasher},
     num::NonZeroU64,
+    ops::Deref,
     str::FromStr,
 };
 
@@ -259,9 +260,9 @@ impl Lock {
         }
         for project in &self.projects {
             for usage in &project.usages {
-                if !iri_versions.contains(&usage.resource) {
+                if !iri_versions.contains(usage.inner()) {
                     return Err(ValidationError::UnsatisfiedUsage {
-                        usage: usage.resource.clone(),
+                        usage: usage.inner().to_owned(),
                         name: project.name.clone(),
                     });
                 }
@@ -620,27 +621,39 @@ impl Source {
 }
 
 #[derive(Clone, Eq, Debug, Ord, PartialEq, PartialOrd)]
-pub struct Usage {
-    pub resource: String,
+pub struct Usage(String);
+
+impl Deref for Usage {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<String> for Usage {
     fn from(resource: String) -> Self {
-        Self { resource }
+        Self(resource)
     }
 }
 
 impl From<Iri<String>> for Usage {
     fn from(resource: Iri<String>) -> Self {
-        Self {
-            resource: resource.into_string(),
-        }
+        Self(resource.into_string())
     }
 }
 
 impl Usage {
+    pub fn inner(&self) -> &String {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
     fn to_toml(&self) -> Value {
-        Value::from(&self.resource)
+        Value::from(&self.0)
     }
 }
 
@@ -650,7 +663,7 @@ impl<'de> Deserialize<'de> for Usage {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Ok(Usage { resource: s })
+        Ok(Self(s))
     }
 }
 

--- a/core/src/lock_tests.rs
+++ b/core/src/lock_tests.rs
@@ -379,9 +379,7 @@ fn one_usage_to_toml() {
             version: "0.5.1".to_string(),
             exports: vec![],
             identifiers: vec![],
-            usages: vec![Usage {
-                resource: "urn:kpar:usage".to_string(),
-            }],
+            usages: vec![Usage::from("urn:kpar:usage".to_string())],
             sources: vec![],
         }],
         r#"
@@ -405,15 +403,9 @@ fn many_usage_to_toml() {
             exports: vec![],
             identifiers: vec![],
             usages: vec![
-                Usage {
-                    resource: "urn:kpar:first".to_string(),
-                },
-                Usage {
-                    resource: "urn:kpar:second".to_string(),
-                },
-                Usage {
-                    resource: "urn:kpar:third".to_string(),
-                },
+                Usage::from("urn:kpar:first".to_string()),
+                Usage::from("urn:kpar:second".to_string()),
+                Usage::from("urn:kpar:third".to_string()),
             ],
             sources: vec![],
         }],
@@ -544,9 +536,7 @@ fn validate_single_usage() {
                 "0.0.1",
                 &[],
                 &[],
-                &[Usage {
-                    resource: iri.to_string(),
-                }],
+                &[Usage::from(iri.to_string())],
             ),
             make_project("b", None, "0.0.1", &[], &[iri], &[]),
         ],
@@ -568,14 +558,7 @@ fn validate_multiple_usage() {
                 "0.0.1",
                 &[],
                 &[],
-                &[
-                    Usage {
-                        resource: iri1.to_string(),
-                    },
-                    Usage {
-                        resource: iri2.to_string(),
-                    },
-                ],
+                &[Usage::from(iri1.to_string()), Usage::from(iri2.to_string())],
             ),
             make_project("b", None, "0.0.1", &[], &[iri1], &[]),
             make_project("c", None, "0.0.1", &[], &[iri2], &[]),
@@ -598,9 +581,7 @@ fn validate_chained_usages() {
                 "0.0.1",
                 &[],
                 &[],
-                &[Usage {
-                    resource: iri1.to_string(),
-                }],
+                &[Usage::from(iri1.to_string())],
             ),
             make_project(
                 "b",
@@ -608,9 +589,7 @@ fn validate_chained_usages() {
                 "0.0.1",
                 &[],
                 &[iri1],
-                &[Usage {
-                    resource: iri2.to_string(),
-                }],
+                &[Usage::from(iri2.to_string())],
             ),
             make_project("c", None, "0.0.1", &[], &[iri2], &[]),
         ],
@@ -652,9 +631,7 @@ fn validate_single_name_collision() {
                 "0.0.1",
                 &[name],
                 &[],
-                &[Usage {
-                    resource: iri.to_string(),
-                }],
+                &[Usage::from(iri.to_string())],
             ),
             make_project("b", None, "0.0.1", &[name], &[iri], &[]),
         ],
@@ -684,9 +661,7 @@ fn validate_multiple_name_collision() {
                 "0.0.1",
                 &[name1, name2, name3],
                 &[],
-                &[Usage {
-                    resource: iri.to_string(),
-                }],
+                &[Usage::from(iri.to_string())],
             ),
             make_project("b", None, "0.0.1", &[name2, name3, name4], &[iri], &[]),
         ],
@@ -701,9 +676,7 @@ fn validate_multiple_name_collision() {
 
 #[test]
 fn validate_unsatisfied_usage() {
-    let usage_in = Usage {
-        resource: "urn:kpar:test".to_string(),
-    };
+    let usage_in = Usage::from("urn:kpar:test".to_string());
     let Err(err) = Lock {
         lock_version: CURRENT_LOCK_VERSION.to_string(),
         projects: vec![make_project(
@@ -721,7 +694,7 @@ fn validate_unsatisfied_usage() {
     let ValidationError::UnsatisfiedUsage { usage, name } = err else {
         panic!()
     };
-    assert_eq!(usage, usage_in.resource);
+    assert_eq!(usage, *usage_in);
     assert_eq!(name, "a");
 }
 
@@ -876,12 +849,8 @@ fn sort_identifiers() {
 
 #[test]
 fn sort_sources() {
-    let usage1 = Usage {
-        resource: "urn:kpar:a".to_string(),
-    };
-    let usage2 = Usage {
-        resource: "urn:kpar:b".to_string(),
-    };
+    let usage1 = Usage::from("urn:kpar:a".to_string());
+    let usage2 = Usage::from("urn:kpar:b".to_string());
     let project1 = make_project(
         "a",
         None,
@@ -902,12 +871,8 @@ fn sort_sources() {
 
 #[test]
 fn sort_sources_with_constraints() {
-    let usage1 = Usage {
-        resource: "urn:kpar:a".to_string(),
-    };
-    let usage2 = Usage {
-        resource: "urn:kpar:a".to_string(),
-    };
+    let usage1 = Usage::from("urn:kpar:a".to_string());
+    let usage2 = Usage::from("urn:kpar:a".to_string());
     let project1 = make_project(
         "a",
         None,

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -27,53 +27,73 @@ pub const KERML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/KerML/";
 
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Hash, Debug)]
 #[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
-#[serde(rename_all = "camelCase")]
-pub struct InterchangeProjectUsageG<Iri, VersionReq> {
-    pub resource: Iri, // TODO: We should have a fallback for invalid IRIs
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version_constraint: Option<VersionReq>, // TODO: We should have a fallback for invalid semvers
+#[serde(untagged)]
+pub enum InterchangeProjectUsageG<Iri, VersionReq> {
+    // `rename_all` does not apply to enum variant fields if applied on
+    // the whole enum
+    #[serde(rename_all = "camelCase")]
+    Resource {
+        resource: Iri, // TODO: We should have a fallback for invalid IRIs
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version_constraint: Option<VersionReq>, // TODO: We should have a fallback for invalid semvers
+    },
 }
+
 pub type InterchangeProjectUsageRaw = InterchangeProjectUsageG<String, String>;
 pub type InterchangeProjectUsage =
     InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>;
 
 impl InterchangeProjectUsageRaw {
     pub fn validate(&self) -> Result<InterchangeProjectUsage, InterchangeProjectValidationError> {
-        // `pkg:sysand/<publisher>/<name>` is the canonical sysand project
-        // identifier; the index protocol routes it directly under
-        // `<publisher>/<name>/`. Reject malformed or non-normalized
-        // `pkg:sysand` IRIs at validation time so users get an actionable
-        // error (with a suggested normalized form) instead of a downstream
-        // "not found" — see `crate::purl::parse_sysand_purl`.
-        crate::purl::parse_sysand_purl(&self.resource).map_err(|e| {
-            InterchangeProjectValidationError::MalformedSysandPurl {
-                iri: self.resource.clone(),
-                source: e,
-            }
-        })?;
+        match self {
+            InterchangeProjectUsageG::Resource {
+                resource,
+                version_constraint,
+            } => {
+                // `pkg:sysand/<publisher>/<name>` is the canonical sysand project
+                // identifier; the index protocol routes it directly under
+                // `<publisher>/<name>/`. Reject malformed or non-normalized
+                // `pkg:sysand` IRIs at validation time so users get an actionable
+                // error (with a suggested normalized form) instead of a downstream
+                // "not found" — see `crate::purl::parse_sysand_purl`.
+                crate::purl::parse_sysand_purl(resource).map_err(|e| {
+                    InterchangeProjectValidationError::MalformedSysandPurl {
+                        iri: resource.clone(),
+                        source: e,
+                    }
+                })?;
 
-        Ok(InterchangeProjectUsage {
-            resource: fluent_uri::Iri::parse(self.resource.clone())
-                .map_err(|(e, val)| InterchangeProjectValidationError::IriParse(val, e))?,
+                Ok(InterchangeProjectUsage::Resource {
+                    resource: fluent_uri::Iri::parse(resource.clone())
+                        .map_err(|(e, val)| InterchangeProjectValidationError::IriParse(val, e))?,
 
-            version_constraint: self
-                .version_constraint
-                .as_ref()
-                .map(|c| {
-                    semver::VersionReq::parse(c).map_err(|e| {
-                        InterchangeProjectValidationError::SemVerConstraintParse(c.to_owned(), e)
-                    })
+                    version_constraint: version_constraint
+                        .as_ref()
+                        .map(|c| {
+                            semver::VersionReq::parse(c).map_err(|e| {
+                                InterchangeProjectValidationError::SemVerConstraintParse(
+                                    c.to_owned(),
+                                    e,
+                                )
+                            })
+                        })
+                        .transpose()?,
                 })
-                .transpose()?,
-        })
+            }
+        }
     }
 }
 
 impl From<InterchangeProjectUsage> for InterchangeProjectUsageRaw {
     fn from(value: InterchangeProjectUsage) -> InterchangeProjectUsageRaw {
-        InterchangeProjectUsageRaw {
-            resource: value.resource.to_string(),
-            version_constraint: value.version_constraint.map(|x| x.to_string()),
+        match value {
+            InterchangeProjectUsageG::Resource {
+                resource,
+                version_constraint,
+            } => InterchangeProjectUsageRaw::Resource {
+                resource: resource.into_string(),
+                version_constraint: version_constraint.map(|x| x.to_string()),
+            },
         }
     }
 }
@@ -82,9 +102,14 @@ impl From<InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>>
     for InterchangeProjectUsageG<String, semver::VersionReq>
 {
     fn from(value: InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>) -> Self {
-        InterchangeProjectUsageG {
-            resource: value.resource.to_string(),
-            version_constraint: value.version_constraint,
+        match value {
+            InterchangeProjectUsageG::Resource {
+                resource,
+                version_constraint,
+            } => InterchangeProjectUsageG::Resource {
+                resource: resource.into_string(),
+                version_constraint,
+            },
         }
     }
 }
@@ -94,6 +119,22 @@ impl TryFrom<InterchangeProjectUsageRaw> for InterchangeProjectUsage {
 
     fn try_from(value: InterchangeProjectUsageRaw) -> Result<InterchangeProjectUsage, Self::Error> {
         value.validate()
+    }
+}
+impl<Iri: Display, VersionReq: Display> Display for InterchangeProjectUsageG<Iri, VersionReq> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InterchangeProjectUsageG::Resource {
+                resource,
+                version_constraint,
+            } => {
+                write!(f, "IRI `{resource}`")?;
+                if let Some(vc) = version_constraint {
+                    write!(f, " ({vc})")?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -185,7 +226,7 @@ impl<Iri: PartialEq + Clone, Version, VersionReq: Clone>
         self.usage
             .extract_if(
                 ..,
-                |InterchangeProjectUsageG {
+                |InterchangeProjectUsageG::Resource {
                      resource: this_resource,
                      ..
                  }| this_resource == resource,

--- a/core/src/project/index_entry_tests.rs
+++ b/core/src/project/index_entry_tests.rs
@@ -42,7 +42,7 @@ fn make_fixture() -> IndexEntryProject<Unauthenticated> {
 
     let advertised = AdvertisedVersion {
         version: semver::Version::parse("1.2.3").unwrap(),
-        usage: vec![InterchangeProjectUsageRaw {
+        usage: vec![InterchangeProjectUsageRaw::Resource {
             resource: format!("{PKG_SYSAND_PREFIX}acme/widget"),
             version_constraint: Some("^1.0".to_string()),
         }],
@@ -94,7 +94,13 @@ fn usage_async_returns_advertised_without_fetch() {
         .unwrap()
         .expect("advertised usage is Some");
     assert_eq!(usage.len(), 1);
-    assert_eq!(usage[0].resource, format!("{PKG_SYSAND_PREFIX}acme/widget"));
+    assert_eq!(
+        usage[0],
+        InterchangeProjectUsageRaw::Resource {
+            resource: format!("{PKG_SYSAND_PREFIX}acme/widget"),
+            version_constraint: Some("^1.0".to_string())
+        }
+    );
     assert!(!project.archive.is_downloaded_and_verified());
 }
 

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -327,53 +327,59 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
     let mut deps: Vec<(DependencyIdentifier, DiscreteHashSet)> = Vec::new();
 
     for usage in usages {
-        if let Some(constraint) = &usage.version_constraint {
-            let mut valid_candidates = HashSet::new();
+        match usage {
+            InterchangeProjectUsage::Resource {
+                resource,
+                version_constraint,
+            } => {
+                if let Some(constraint) = version_constraint {
+                    let mut valid_candidates = HashSet::new();
 
-            let mut found_versions = Vec::new();
-            for (i, candidate_info) in resolve_candidates(resolver, &usage.resource, cache)?
-                .iter()
-                .enumerate()
-            {
-                found_versions.push(candidate_info.version.clone());
-                if constraint.matches(&candidate_info.version) {
-                    valid_candidates.insert(i);
+                    let mut found_versions = Vec::new();
+                    for (i, candidate_info) in resolve_candidates(resolver, resource, cache)?
+                        .iter()
+                        .enumerate()
+                    {
+                        found_versions.push(candidate_info.version.clone());
+                        if constraint.matches(&candidate_info.version) {
+                            valid_candidates.insert(i);
+                        }
+                    }
+                    if valid_candidates.is_empty() {
+                        let mut versions = String::new();
+                        // `found_versions` must contain at least one element
+                        write!(versions, "`{}`", found_versions[0]).unwrap();
+                        for v in &found_versions[1..] {
+                            write!(versions, ", `{}`", v).unwrap();
+                        }
+                        return Err(InternalSolverError::VersionNotAvailable(format!(
+                            "project `{resource}`\n\
+                            was found, but the requested version constraint `{constraint}`\n\
+                            was not satisfied by any of the found versions:\n\
+                            {versions}"
+                        )));
+                    }
+
+                    deps.push((
+                        DependencyIdentifier::Remote(resource.clone()),
+                        DiscreteHashSet::Finite(valid_candidates),
+                    ));
+                } else {
+                    // Check that the project can be found
+                    resolve_candidates(resolver, resource, cache)?;
+                    // TODO: reenable this when it's fixed to give better error messages
+                    // https://github.com/pubgrub-rs/pubgrub/pull/216
+                    // match resolve_candidates(resolver, &usage.resource, cache) {
+                    //     Ok(_) => (),
+                    //     Err(err) => return Ok(pubgrub::Dependencies::Unavailable(err.to_string())),
+                    // };
+
+                    deps.push((
+                        DependencyIdentifier::Remote(resource.clone()),
+                        DiscreteHashSet::empty().complement(),
+                    ));
                 }
             }
-            if valid_candidates.is_empty() {
-                let mut versions = String::new();
-                // `found_versions` must contain at least one element
-                write!(versions, "`{}`", found_versions[0]).unwrap();
-                for v in &found_versions[1..] {
-                    write!(versions, ", `{}`", v).unwrap();
-                }
-                return Err(InternalSolverError::VersionNotAvailable(format!(
-                    "project `{}`\n\
-                    was found, but the requested version constraint `{}`\n\
-                    was not satisfied by any of the found versions:\n\
-                    {}",
-                    usage.resource, constraint, versions
-                )));
-            }
-
-            deps.push((
-                DependencyIdentifier::Remote(usage.resource.clone()),
-                DiscreteHashSet::Finite(valid_candidates),
-            ));
-        } else {
-            // Check that the project can be found
-            resolve_candidates(resolver, &usage.resource, cache)?;
-            // TODO: reenable this when it's fixed to give better error messages
-            // https://github.com/pubgrub-rs/pubgrub/pull/216
-            // match resolve_candidates(resolver, &usage.resource, cache) {
-            //     Ok(_) => (),
-            //     Err(err) => return Ok(pubgrub::Dependencies::Unavailable(err.to_string())),
-            // };
-
-            deps.push((
-                DependencyIdentifier::Remote(usage.resource.clone()),
-                DiscreteHashSet::empty().complement(),
-            ));
         }
     }
 

--- a/core/src/solve/pubgrub_tests.rs
+++ b/core/src/solve/pubgrub_tests.rs
@@ -33,7 +33,7 @@ fn trivial_memory_project(
             topic: vec![],
             usage: usage
                 .into_iter()
-                .map(|(d, dv)| InterchangeProjectUsageRaw {
+                .map(|(d, dv)| InterchangeProjectUsageRaw::Resource {
                     resource: d.to_string(),
                     version_constraint: dv.map(|x| x.to_string()),
                 })
@@ -93,7 +93,7 @@ fn version_selection() -> Result<(), Box<dyn std::error::Error>> {
         simple_resolver_environment(&[("urn:kpar:version_selection", &[project_v1, project_v2])]);
 
     let solution = super::solve(
-        vec![InterchangeProjectUsage {
+        vec![InterchangeProjectUsage::Resource {
             resource: fluent_uri::Iri::parse("urn:kpar:version_selection")?.into(),
             version_constraint: Some(semver::VersionReq::parse(">=2.0.0")?),
         }],
@@ -151,11 +151,11 @@ fn diamond_selection() -> Result<(), Box<dyn std::error::Error>> {
 
     let solution = super::solve(
         vec![
-            InterchangeProjectUsage {
+            InterchangeProjectUsage::Resource {
                 resource: fluent_uri::Iri::parse("urn:kpar:diamond_selection_a")?.into(),
                 version_constraint: Some(semver::VersionReq::parse(">=0.1.0")?),
             },
-            InterchangeProjectUsage {
+            InterchangeProjectUsage::Resource {
                 resource: fluent_uri::Iri::parse("urn:kpar:diamond_selection_b")?.into(),
                 version_constraint: None,
             },

--- a/core/src/symbols/mod.rs
+++ b/core/src/symbols/mod.rs
@@ -27,10 +27,13 @@ pub enum Language {
 
 impl Language {
     pub fn from_suffix<S: AsRef<str>>(suffix: S) -> Option<Language> {
-        match suffix.as_ref().to_ascii_lowercase().as_str() {
-            "sysml" => Some(Language::SysML),
-            "kerml" => Some(Language::KerML),
-            _ => None,
+        let suffix = suffix.as_ref();
+        if suffix.eq_ignore_ascii_case("sysml") {
+            Some(Language::SysML)
+        } else if suffix.eq_ignore_ascii_case("kerml") {
+            Some(Language::KerML)
+        } else {
+            None
         }
     }
 

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -193,7 +193,7 @@ pub fn command_add<Policy: HTTPAuthentication>(
         HashMap::default()
     };
 
-    let usage_raw = InterchangeProjectUsageRaw {
+    let usage_raw = InterchangeProjectUsageRaw::Resource {
         resource: iri.to_owned(),
         version_constraint,
     };

--- a/sysand/src/commands/env.rs
+++ b/sysand/src/commands/env.rs
@@ -144,7 +144,7 @@ pub fn command_env_install<Policy: HTTPAuthentication>(
             allow_multiple,
         )?;
     } else {
-        let usages = vec![InterchangeProjectUsage {
+        let usages = vec![InterchangeProjectUsage::Resource {
             resource: fluent_uri::Iri::from_str(iri.as_ref())?,
             version_constraint: version.map(|v| semver::VersionReq::parse(&v)).transpose()?,
         }];

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -14,6 +14,7 @@ use sysand_core::{
     context::ProjectContext,
     model::{
         InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw,
+        InterchangeProjectUsageRaw,
     },
     project::{ProjectMut, ProjectRead, any::OverrideProject, local_kpar::KparInnerPath},
     resolve::{
@@ -66,25 +67,37 @@ pub fn pprint_interchange_project(
     if info.usage.is_empty() {
         println!("No usages.");
     } else {
-        let has_ignored_usages = info
-            .usage
-            .iter()
-            .any(|u| excluded_iris.contains(&u.resource));
+        let has_ignored_usages = info.usage.iter().any(|u| match u {
+            InterchangeProjectUsageRaw::Resource { resource, .. } => {
+                excluded_iris.contains(resource)
+            }
+        });
         let usages_to_print: Vec<_> = info
             .usage
             .iter()
-            .filter(|u| !excluded_iris.contains(&u.resource))
+            .filter(|u| match u {
+                InterchangeProjectUsageRaw::Resource { resource, .. } => {
+                    !excluded_iris.contains(resource)
+                }
+            })
             .collect();
         if has_ignored_usages && usages_to_print.is_empty() {
             println!("All usages are ignored");
         } else {
             println!("{header}Usages:{header:#}");
             for usage in usages_to_print.iter() {
-                print!("    {}", usage.resource);
-                if let Some(ref v) = usage.version_constraint {
-                    println!(" ({})", v);
-                } else {
-                    println!();
+                match usage {
+                    InterchangeProjectUsageRaw::Resource {
+                        resource,
+                        version_constraint,
+                    } => {
+                        print!("    {resource}");
+                        if let Some(v) = version_constraint {
+                            println!(" ({v})");
+                        } else {
+                            println!();
+                        }
+                    }
                 }
             }
             if has_ignored_usages {
@@ -346,11 +359,16 @@ fn apply_get_info(
             Some(
                 info.usage
                     .into_iter()
-                    .map(|usage| {
-                        if let Some(version_constraint) = usage.version_constraint {
-                            format!("{} ({})", usage.resource, version_constraint)
-                        } else {
-                            usage.resource.clone()
+                    .map(|usage| match usage {
+                        InterchangeProjectUsageRaw::Resource {
+                            resource,
+                            version_constraint,
+                        } => {
+                            if let Some(version_constraint) = version_constraint {
+                                format!("{resource} ({version_constraint})")
+                            } else {
+                                resource.clone()
+                            }
                         }
                     })
                     .collect(),

--- a/sysand/src/commands/remove.rs
+++ b/sysand/src/commands/remove.rs
@@ -8,6 +8,7 @@ use fluent_uri::Iri;
 use sysand_core::{
     config::local_fs::{CONFIG_FILE, remove_project_source_from_config},
     context::ProjectContext,
+    model::InterchangeProjectUsageRaw,
     remove::do_remove,
 };
 
@@ -36,33 +37,36 @@ pub fn command_remove(
     let removed = "Removed";
     let header = sysand_core::style::get_style_config().header;
     if let [usage] = usages.as_slice() {
-        match usage.version_constraint {
-            Some(ref vc) => {
-                log::info!(
-                    "{header}{removed:>12}{header:#} `{}` with version constraints `{}`",
-                    &usage.resource,
-                    vc
-                );
-            }
-            None => {
-                log::info!("{header}{removed:>12}{header:#} `{}`", &usage.resource,);
-            }
+        match usage {
+            InterchangeProjectUsageRaw::Resource {
+                resource,
+                version_constraint,
+            } => match version_constraint {
+                Some(vc) => {
+                    log::info!(
+                        "{header}{removed:>12}{header:#} `{resource}` with version constraints `{vc}`"
+                    );
+                }
+                None => {
+                    log::info!("{header}{removed:>12}{header:#} `{resource}`");
+                }
+            },
         }
     } else {
         log::info!("{header}{removed:>12}{header:#}:");
         for usage in usages {
-            match usage.version_constraint {
-                Some(vc) => {
-                    log::info!(
-                        "{:>13} `{}` with version constraints `{}`",
-                        ' ',
-                        &usage.resource,
-                        vc
-                    );
-                }
-                None => {
-                    log::info!("{:>13} `{}`", ' ', &usage.resource,);
-                }
+            match usage {
+                InterchangeProjectUsageRaw::Resource {
+                    resource,
+                    version_constraint,
+                } => match version_constraint {
+                    Some(vc) => {
+                        log::info!("{:>13} `{resource}` with version constraints `{vc}`", ' ');
+                    }
+                    None => {
+                        log::info!("{:>13} `{resource}`", ' ');
+                    }
+                },
             }
         }
     }

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -19,9 +19,9 @@ fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
 
     let out = run_sysand_in(&cwd, ["add", "--no-lock", "urn:kpar:test"], None)?;
 
-    out.assert()
-        .success()
-        .stderr(predicate::str::contains("Adding usage: `urn:kpar:test`"));
+    out.assert().success().stderr(predicate::str::contains(
+        "Adding usage: IRI `urn:kpar:test`",
+    ));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
 
@@ -74,7 +74,7 @@ fn add_accepts_sysand_shorthand_without_lock() -> Result<(), Box<dyn std::error:
     let out = run_sysand_in(&cwd, ["add", "--no-lock", "acme-labs/my.project"], None)?;
 
     out.assert().success().stderr(predicate::str::contains(
-        "Adding usage: `pkg:sysand/acme-labs/my.project`",
+        "Adding usage: IRI `pkg:sysand/acme-labs/my.project`",
     ));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -277,7 +277,7 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
     out.assert()
         .success()
         .stderr(predicate::str::contains(format!(
-            "Adding usage: `{file_url}`",
+            "Adding usage: IRI `{file_url}`",
         )));
 
     let info_json = std::fs::read_to_string(cwd1.join(".project.json"))?;
@@ -353,7 +353,7 @@ fn add_and_remove_as_editable() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:test` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test`"#
+      Adding usage: IRI `urn:kpar:test`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -447,7 +447,7 @@ fn add_and_remove_as_local_src() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:test` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test`"#
+      Adding usage: IRI `urn:kpar:test`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -541,7 +541,7 @@ fn add_and_remove_as_local_kpar() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:test` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test`"#
+      Adding usage: IRI `urn:kpar:test`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -635,7 +635,7 @@ fn add_and_remove_as_remote_src() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:test` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test`"#
+      Adding usage: IRI `urn:kpar:test`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -729,7 +729,7 @@ fn add_and_remove_as_remote_kpar() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:test` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test`"#
+      Adding usage: IRI `urn:kpar:test`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -823,7 +823,7 @@ fn add_and_remove_as_remote_git() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:test` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test`"#
+      Adding usage: IRI `urn:kpar:test`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -919,7 +919,7 @@ fn add_and_remove_from_path() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:test-src` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test-src`"#
+      Adding usage: IRI `urn:kpar:test-src`"#
         )));
 
     std::fs::File::create_new(cwd.join("local/test.kpar"))?;
@@ -940,7 +940,7 @@ fn add_and_remove_from_path() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stderr(predicate::str::contains(format!(
             r#"Adding source for `urn:kpar:test-kpar` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:test-kpar`"#
+      Adding usage: IRI `urn:kpar:test-kpar`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -1069,7 +1069,7 @@ fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
         .stderr(predicate::str::contains(format!(
             r#"Creating configuration file at `{config_path}`
       Adding source for `urn:kpar:add-from-url-dep` to configuration file at `{config_path}`
-      Adding usage: `urn:kpar:add-from-url-dep`"#
+      Adding usage: IRI `urn:kpar:add-from-url-dep`"#
         )));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -1145,7 +1145,7 @@ fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::err
     )?;
 
     out.assert().success().stderr(predicate::str::contains(
-        "Adding usage: `pkg:sysand/acme-labs/my.project`",
+        "Adding usage: IRI `pkg:sysand/acme-labs/my.project`",
     ));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -1206,7 +1206,7 @@ fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dy
     )?;
 
     out.assert().success().stderr(predicate::str::contains(
-        "Adding usage: `urn:kpar:acme-labs/my.project`",
+        "Adding usage: IRI `urn:kpar:acme-labs/my.project`",
     ));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
@@ -1384,7 +1384,7 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
     .assert()
     .success()
     .stderr(predicate::str::contains(
-        "Adding usage: `urn:kpar:add_and_remove_with_lock_preinstall_dep`",
+        "Adding usage: IRI `urn:kpar:add_and_remove_with_lock_preinstall_dep`",
     ));
 
     let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -119,7 +119,7 @@ fn lock_std_lib() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     out.assert().success().stderr(predicate::str::contains(
-        "Adding usage: `https://www.omg.org/spec/KerML/20250201/Function-Library.kpar`",
+        "Adding usage: IRI `https://www.omg.org/spec/KerML/20250201/Function-Library.kpar`",
     ));
 
     let cfg = toml::to_string(&sysand_core::config::Config {
@@ -243,7 +243,7 @@ fn inject_usages_versions<
     )?;
 
     for (usage, version_req) in usages {
-        info.usage.push(InterchangeProjectUsageRaw {
+        info.usage.push(InterchangeProjectUsageRaw::Resource {
             resource: usage.as_ref().to_string(),
             version_constraint: version_req.map(|x| x.as_ref().to_string()),
         });


### PR DESCRIPTION
No behavior changes. This is a preparation for adding more dependency types, which will be variants of the enum. Current plan is something like this:

```rust
pub enum InterchangeProjectUsageG<Iri, VersionReq, Path> {
    /// Legacy, kept for compatibility only
    Resource {
        resource: Iri,
        version_constraint: Option<VersionReq>,
    },
    Url {
        url: Iri,
        publisher: String,
        name: String,
    },
    Path {
        path: Path,
        publisher: String,
        name: String,
    },
    Git {
        git: Iri,
        id: GitId,
        publisher: String,
        name: String,
    },
    Index {
        publisher: String,
        name: String,
        version_constraint: VersionReq,
    },
}

pub enum GitId {
    Rev(String),
    Tag(String),
    Branch(String),
}
```