### PR TITLE
maint: consistently format errors

### DIFF
--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -22,6 +22,7 @@ use sysand_core::{
         utils::wrapfs,
     },
     resolve::{net_utils::create_reqwest_client, standard::standard_resolver},
+    utils::format_err,
     workspace::Workspace,
 };
 
@@ -82,37 +83,36 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_init<'local>(
         commands::init::do_init_local_file(name, publisher, version, license, path.into());
     match command_result {
         Ok(_) => {}
-        Err(error) => match error {
-            InitError::SemVerParse(..) => {
-                env.throw_exception(ExceptionKind::InvalidSemanticVersion, error.to_string())
+        Err(error) => {
+            let e = format_err(&error);
+            match error {
+                InitError::SemVerParse(..) => {
+                    env.throw_exception(ExceptionKind::InvalidSemanticVersion, e)
+                }
+                InitError::SPDXLicenseParse(..) => {
+                    env.throw_exception(ExceptionKind::InvalidSPDXLicense, e)
+                }
+                InitError::Project(suberror) => match suberror {
+                    LocalSrcError::AlreadyExists(_) => {
+                        env.throw_exception(ExceptionKind::ProjectAlreadyExists, e)
+                    }
+                    LocalSrcError::Deserialize(_) => {
+                        env.throw_exception(ExceptionKind::InvalidValue, e)
+                    }
+                    LocalSrcError::Io(_) => env.throw_exception(ExceptionKind::IOError, e),
+                    LocalSrcError::Path(_) => env.throw_exception(ExceptionKind::PathError, e),
+                    LocalSrcError::Serialize(_) => {
+                        env.throw_exception(ExceptionKind::SerializationError, e)
+                    }
+                    LocalSrcError::ImpossibleRelativePath(_) => {
+                        env.throw_exception(ExceptionKind::PathError, e)
+                    }
+                    LocalSrcError::MissingMeta | LocalSrcError::MissingInfoMeta => {
+                        env.throw_exception(ExceptionKind::SysandException, e)
+                    }
+                },
             }
-            InitError::SPDXLicenseParse(..) => {
-                env.throw_exception(ExceptionKind::InvalidSPDXLicense, error.to_string())
-            }
-            InitError::Project(suberror) => match suberror {
-                LocalSrcError::AlreadyExists(msg) => {
-                    env.throw_exception(ExceptionKind::ProjectAlreadyExists, msg)
-                }
-                LocalSrcError::Deserialize(subsuberror) => {
-                    env.throw_exception(ExceptionKind::InvalidValue, subsuberror.to_string())
-                }
-                LocalSrcError::Io(subsuberror) => {
-                    env.throw_exception(ExceptionKind::IOError, subsuberror.to_string())
-                }
-                LocalSrcError::Path(subsuberror) => {
-                    env.throw_exception(ExceptionKind::PathError, subsuberror.to_string())
-                }
-                LocalSrcError::Serialize(subsuberror) => {
-                    env.throw_exception(ExceptionKind::SerializationError, subsuberror.to_string())
-                }
-                LocalSrcError::ImpossibleRelativePath(_) => {
-                    env.throw_exception(ExceptionKind::PathError, suberror.to_string())
-                }
-                LocalSrcError::MissingMeta | LocalSrcError::MissingInfoMeta => {
-                    env.throw_exception(ExceptionKind::SysandException, suberror.to_string())
-                }
-            },
-        },
+        }
     }
 }
 
@@ -142,44 +142,39 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_env<'local>(
     let command_result = commands::env::do_env_local_dir(path);
     match command_result {
         Ok(_) => {}
-        Err(error) => match error {
-            commands::env::EnvError::AlreadyExists(path) => env.throw_exception(
-                ExceptionKind::PathError,
-                format!("Path already exists: {}", path),
-            ),
-            commands::env::EnvError::Write(suberror) => match suberror {
-                LocalWriteError::Io(subsuberror) => {
-                    env.throw_exception(ExceptionKind::IOError, subsuberror.to_string())
-                }
-                LocalWriteError::Deserialize(subsuberror) => {
-                    env.throw_exception(ExceptionKind::InvalidValue, subsuberror.to_string())
-                }
-                LocalWriteError::Path(subsuberror) => {
-                    env.throw_exception(ExceptionKind::PathError, subsuberror.to_string())
-                }
-                LocalWriteError::AlreadyExists(msg) => {
-                    env.throw_exception(ExceptionKind::IOError, msg)
-                }
-                LocalWriteError::Serialize(subsuberror) => {
-                    env.throw_exception(ExceptionKind::SerializationError, subsuberror.to_string())
-                }
-                LocalWriteError::TryMove(subsuberror) => {
-                    env.throw_exception(ExceptionKind::IOError, subsuberror.to_string())
-                }
-                LocalWriteError::LocalRead(subsuberror) => {
-                    env.throw_exception(ExceptionKind::IOError, subsuberror.to_string())
-                }
-                LocalWriteError::ImpossibleRelativePath(_) => {
-                    env.throw_exception(ExceptionKind::PathError, suberror.to_string())
-                }
-                LocalWriteError::AddProject(subsuberror) => {
-                    env.throw_exception(ExceptionKind::IOError, subsuberror.to_string())
-                }
-                LocalWriteError::MissingMeta | LocalWriteError::MissingInfoMeta => {
-                    env.throw_exception(ExceptionKind::SysandException, suberror.to_string())
-                }
-            },
-        },
+        Err(error) => {
+            let e = format_err(&error);
+            match error {
+                commands::env::EnvError::AlreadyExists(path) => env.throw_exception(
+                    ExceptionKind::PathError,
+                    format!("Path already exists: {path}"),
+                ),
+                commands::env::EnvError::Write(suberror) => match suberror {
+                    LocalWriteError::Io(_) => env.throw_exception(ExceptionKind::IOError, e),
+                    LocalWriteError::Deserialize(_) => {
+                        env.throw_exception(ExceptionKind::InvalidValue, e)
+                    }
+                    LocalWriteError::Path(_) => env.throw_exception(ExceptionKind::PathError, e),
+                    LocalWriteError::AlreadyExists(_) => {
+                        env.throw_exception(ExceptionKind::IOError, e)
+                    }
+                    LocalWriteError::Serialize(_) => {
+                        env.throw_exception(ExceptionKind::SerializationError, e)
+                    }
+                    LocalWriteError::TryMove(_) => env.throw_exception(ExceptionKind::IOError, e),
+                    LocalWriteError::LocalRead(_) => env.throw_exception(ExceptionKind::IOError, e),
+                    LocalWriteError::ImpossibleRelativePath(_) => {
+                        env.throw_exception(ExceptionKind::PathError, e)
+                    }
+                    LocalWriteError::AddProject(_) => {
+                        env.throw_exception(ExceptionKind::IOError, e)
+                    }
+                    LocalWriteError::MissingMeta | LocalWriteError::MissingInfoMeta => {
+                        env.throw_exception(ExceptionKind::SysandException, e)
+                    }
+                },
+            }
+        }
     }
 }
 
@@ -202,7 +197,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_infoPath<'local>(
     match command_result {
         Ok(info_metadata) => info_metadata.to_jobject(&mut env).unwrap_or_default(),
         Err(e) => {
-            env.throw_exception(ExceptionKind::SysandException, e.to_string());
+            env.throw_exception(ExceptionKind::SysandException, format_err(e));
             JObject::default()
         }
     }
@@ -222,7 +217,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
     let client = match create_reqwest_client() {
         Ok(c) => c,
         Err(e) => {
-            env.throw_exception(ExceptionKind::SysandException, e.to_string());
+            env.throw_exception(ExceptionKind::SysandException, format_err(e));
             return JObject::default();
         }
     };
@@ -279,7 +274,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
         Err(error) => {
             env.throw_exception(
                 ExceptionKind::ResolutionError,
-                format!("Failed to discover index endpoints: {error}"),
+                format!("Failed to discover index endpoints: {}", format_err(error)),
             );
             return JObject::default();
         }
@@ -293,7 +288,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
             | InfoError::UnsupportedIri(..)
             | InfoError::Resolution(_)),
         ) => {
-            env.throw_exception(ExceptionKind::ResolutionError, e.to_string());
+            env.throw_exception(ExceptionKind::ResolutionError, format_err(e));
             return JObject::default();
         }
     };
@@ -313,7 +308,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_workspaceProjectPaths<'l
     let workspace = match Workspace::new(workspace_path.into()) {
         Ok(w) => w,
         Err(e) => {
-            env.throw_exception(ExceptionKind::InvalidWorkspace, e.to_string());
+            env.throw_exception(ExceptionKind::InvalidWorkspace, format_err(e));
             return JObjectArray::default();
         }
     };
@@ -353,7 +348,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_setProjectIndex<'local>(
     };
     let _ = project
         .set_index(rust_index)
-        .inspect_err(|e| env.throw_exception(ExceptionKind::SysandException, e.to_string()));
+        .inspect_err(|e| env.throw_exception(ExceptionKind::SysandException, format_err(e)));
 }
 
 #[unsafe(no_mangle)]
@@ -376,7 +371,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_setProjectInfo<'local>(
     };
     let _ = project
         .put_info(&info_raw, true)
-        .inspect_err(|e| env.throw_exception(ExceptionKind::SysandException, e.to_string()));
+        .inspect_err(|e| env.throw_exception(ExceptionKind::SysandException, format_err(e)));
 }
 
 #[unsafe(no_mangle)]
@@ -399,39 +394,37 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_setProjectMetadata<'loca
     };
     let _ = project
         .put_meta(&metadata_raw, true)
-        .inspect_err(|e| env.throw_exception(ExceptionKind::SysandException, e.to_string()));
+        .inspect_err(|e| env.throw_exception(ExceptionKind::SysandException, format_err(e)));
 }
 
 fn handle_build_error(env: &mut JNIEnv<'_>, error: KParBuildError<LocalSrcError>) {
+    let e = format_err(&error);
     match error {
-        KParBuildError::ProjectRead(error) => {
+        KParBuildError::ProjectRead(_) => {
             env.throw_exception(
                 ExceptionKind::SysandException,
-                format!("Project read error: {}", error),
+                format!("Project read error: {e}"),
             );
         }
-        KParBuildError::Io(error) => {
-            env.throw_exception(
-                ExceptionKind::SysandException,
-                format!("IO error: {}", error),
-            );
+        KParBuildError::Io(_) => {
+            env.throw_exception(ExceptionKind::SysandException, format!("IO error: {e}"));
         }
         KParBuildError::Validation { .. } => {
             env.throw_exception(
                 ExceptionKind::SysandException,
-                format!("Validation error: {}", error),
+                format!("Validation error: {e}"),
             );
         }
-        KParBuildError::Extract(error) => {
+        KParBuildError::Extract(_) => {
             env.throw_exception(
                 ExceptionKind::SysandException,
-                format!("Extract error: {}", error),
+                format!("Extract error: {e}"),
             );
         }
-        KParBuildError::UnknownFormat(error) => {
+        KParBuildError::UnknownFormat(_) => {
             env.throw_exception(
                 ExceptionKind::SysandException,
-                format!("Unknown format error: {}", error),
+                format!("Unknown format error: {e}"),
             );
         }
         KParBuildError::MissingInfo => {
@@ -449,32 +442,32 @@ fn handle_build_error(env: &mut JNIEnv<'_>, error: KParBuildError<LocalSrcError>
                 "Missing project information and metadata",
             );
         }
-        KParBuildError::Zip(error) => {
+        KParBuildError::Zip(_) => {
             env.throw_exception(
                 ExceptionKind::SysandException,
-                format!("Zip write error: {}", error),
+                format!("Zip write error: {e}"),
             );
         }
-        KParBuildError::Serialize(msg, error) => {
+        KParBuildError::Serialize(..) => {
             env.throw_exception(
                 ExceptionKind::SysandException,
-                format!("Project serialization error: {}: {}", msg, error),
+                format!("Project serialization error: {e}"),
             );
         }
-        KParBuildError::WorkspaceRead(error) => {
+        KParBuildError::WorkspaceRead(_) => {
             env.throw_exception(
                 ExceptionKind::SysandException,
-                format!("Workspace read error: {}", error),
+                format!("Workspace read error: {e}"),
             );
         }
         KParBuildError::PathUsage(_) => {
-            env.throw_exception(ExceptionKind::SysandException, error.to_string());
+            env.throw_exception(ExceptionKind::SysandException, e);
         }
         KParBuildError::WorkspaceMetamodelConflict { .. } => {
-            env.throw_exception(ExceptionKind::SysandException, error.to_string());
+            env.throw_exception(ExceptionKind::SysandException, e);
         }
         KParBuildError::MissingIndexSymbol(_, _) => {
-            env.throw_exception(ExceptionKind::InvalidValue, error.to_string())
+            env.throw_exception(ExceptionKind::InvalidValue, e)
         }
     }
 }
@@ -486,7 +479,7 @@ fn compression_from_java_string(
     match KparCompressionMethod::try_from(compression) {
         Ok(compression) => Some(compression),
         Err(err) => {
-            env.throw_exception(ExceptionKind::SysandException, err.to_string());
+            env.throw_exception(ExceptionKind::SysandException, format_err(err));
             None
         }
     }
@@ -550,7 +543,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_buildWorkspace<'local>(
     let workspace = match Workspace::new(workspace_path.into()) {
         Ok(w) => w,
         Err(e) => {
-            env.throw_exception(ExceptionKind::InvalidWorkspace, e.to_string());
+            env.throw_exception(ExceptionKind::InvalidWorkspace, format_err(e));
             return;
         }
     };
@@ -562,8 +555,8 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_buildWorkspace<'local>(
     };
     match wrapfs::create_dir_all(&output_path) {
         Ok(_) => {}
-        Err(error) => {
-            env.throw_exception(ExceptionKind::IOError, error.to_string());
+        Err(e) => {
+            env.throw_exception(ExceptionKind::IOError, format_err(e));
             return;
         }
     }

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -416,7 +416,7 @@ fn handle_build_error(env: &mut JNIEnv<'_>, error: KParBuildError<LocalSrcError>
                 format!("IO error: {}", error),
             );
         }
-        KParBuildError::Validation(error) => {
+        KParBuildError::Validation { .. } => {
             env.throw_exception(
                 ExceptionKind::SysandException,
                 format!("Validation error: {}", error),

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -4,7 +4,7 @@
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "browser")]
-use sysand_core::commands::init::do_init;
+use sysand_core::{commands::init::do_init, utils::format_err};
 
 pub mod env;
 pub mod io;
@@ -27,7 +27,7 @@ pub fn ensure_debug_hook() {
 #[wasm_bindgen(js_name = clear_local_storage)]
 pub fn clear_local_storage(prefix: &str) -> Result<(), JsValue> {
     let local_storage = local_storage_utils::get_local_browser_storage(prefix)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        .map_err(|e| JsValue::from_str(&format_err(e)))?;
     local_storage.local_storage.clear()
 }
 
@@ -50,12 +50,12 @@ pub fn do_init_js_local_storage(
         license,
         &mut io::local_storage::ProjectLocalBrowserStorage {
             vfs: local_storage_utils::get_local_browser_storage(prefix)
-                .map_err(|e| JsValue::from_str(&e.to_string()))?,
+                .map_err(|e| JsValue::from_str(&format_err(e)))?,
             root_path: Utf8UnixPath::new(root_path).to_path_buf(),
             expected_checksum: None,
         },
     )
-    .map_err(|e| JsValue::from_str(&e.to_string()))
+    .map_err(|e| JsValue::from_str(&format_err(e)))
 }
 
 #[cfg(feature = "browser")]
@@ -66,7 +66,7 @@ pub fn do_env_js_local_storage(prefix: &str, root_path: &str) -> Result<(), JsVa
     use typed_path::Utf8UnixPath;
 
     empty_environment_local_storage(prefix, Utf8UnixPath::new(root_path).join(DEFAULT_ENV_NAME))
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        .map_err(|e| JsValue::from_str(&format_err(e)))?;
 
     Ok(())
 }

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -231,7 +231,7 @@ fn do_build_py(
         .map_err(|err| match err {
             KParBuildError::ProjectRead(_) => PyRuntimeError::new_err(err.to_string()),
             KParBuildError::Io(_) => PyIOError::new_err(err.to_string()),
-            KParBuildError::Validation(_) => PyValueError::new_err(err.to_string()),
+            KParBuildError::Validation { .. } => PyValueError::new_err(err.to_string()),
             KParBuildError::Extract(_) => PyValueError::new_err(err.to_string()),
             KParBuildError::UnknownFormat(_) => PyValueError::new_err(err.to_string()),
             KParBuildError::MissingInfo => PyValueError::new_err(err.to_string()),

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -40,6 +40,7 @@ use sysand_core::{
     sources::{do_sources_local_src_project_no_deps, find_project_dependencies},
     stdlib::known_std_libs,
     symbols::Language,
+    utils::format_err,
 };
 use typed_path::Utf8UnixPathBuf;
 
@@ -67,21 +68,22 @@ fn do_init_py_local_file(
     let _ = pyo3_log::try_init();
 
     do_init_local_file(name, publisher, version, license, Utf8PathBuf::from(path)).map_err(
-        |err| match err {
-            InitError::SemVerParse(..) => PyValueError::new_err(err.to_string()),
-            InitError::SPDXLicenseParse(..) => PyValueError::new_err(err.to_string()),
-            InitError::Project(err) => match err {
-                LocalSrcError::AlreadyExists(msg) => PyFileExistsError::new_err(msg),
-                LocalSrcError::Deserialize(error) => PyValueError::new_err(error.to_string()),
-                LocalSrcError::Io(error) => PyIOError::new_err(error.to_string()),
-                LocalSrcError::Path(error) => PyIOError::new_err(error.to_string()),
-                LocalSrcError::Serialize(error) => PyValueError::new_err(error.to_string()),
-                LocalSrcError::ImpossibleRelativePath(error) => {
-                    PyValueError::new_err(error.to_string())
-                }
-                LocalSrcError::MissingMeta => PyFileNotFoundError::new_err(err.to_string()),
-                LocalSrcError::MissingInfoMeta => PyFileNotFoundError::new_err(err.to_string()),
-            },
+        |err| {
+            let e = format_err(&err);
+            match err {
+                InitError::SemVerParse(..) => PyValueError::new_err(e),
+                InitError::SPDXLicenseParse(..) => PyValueError::new_err(e),
+                InitError::Project(err) => match err {
+                    LocalSrcError::AlreadyExists(_) => PyFileExistsError::new_err(e),
+                    LocalSrcError::Deserialize(_) => PyValueError::new_err(e),
+                    LocalSrcError::Io(_) => PyIOError::new_err(e),
+                    LocalSrcError::Path(_) => PyIOError::new_err(e),
+                    LocalSrcError::Serialize(_) => PyValueError::new_err(e),
+                    LocalSrcError::ImpossibleRelativePath(_) => PyValueError::new_err(e),
+                    LocalSrcError::MissingMeta => PyFileNotFoundError::new_err(e),
+                    LocalSrcError::MissingInfoMeta => PyFileNotFoundError::new_err(e),
+                },
+            }
         },
     )?;
 
@@ -95,24 +97,25 @@ fn do_init_py_local_file(
 fn do_env_py_local_dir(path: String) -> PyResult<()> {
     let _ = pyo3_log::try_init();
 
-    do_env_local_dir(Utf8Path::new(&path)).map_err(|err| match err {
-        EnvError::AlreadyExists(path_buf) => PyFileExistsError::new_err(path_buf.into_string()),
-        EnvError::Write(werr) => match werr {
-            LocalWriteError::Io(error) => PyIOError::new_err(error.to_string()),
-            LocalWriteError::Deserialize(error) => PyValueError::new_err(error.to_string()),
-            LocalWriteError::Path(error) => PyValueError::new_err(error.to_string()),
-            LocalWriteError::AlreadyExists(error) => PyFileExistsError::new_err(error.to_string()),
-            LocalWriteError::Serialize(error) => PyValueError::new_err(error.to_string()),
-            LocalWriteError::TryMove(error) => PyIOError::new_err(error.to_string()),
-            LocalWriteError::LocalRead(error) => PyIOError::new_err(error.to_string()),
-            LocalWriteError::ImpossibleRelativePath(error) => {
-                PyValueError::new_err(error.to_string())
-            }
-            LocalWriteError::AddProject(error) => PyIOError::new_err(error.to_string()),
-            LocalWriteError::MissingMeta | LocalWriteError::MissingInfoMeta => {
-                PyFileNotFoundError::new_err(werr.to_string())
-            }
-        },
+    do_env_local_dir(Utf8Path::new(&path)).map_err(|err| {
+        let e = format_err(&err);
+        match err {
+            EnvError::AlreadyExists(_) => PyFileExistsError::new_err(e),
+            EnvError::Write(werr) => match werr {
+                LocalWriteError::Io(_) => PyIOError::new_err(e),
+                LocalWriteError::Deserialize(_) => PyValueError::new_err(e),
+                LocalWriteError::Path(_) => PyValueError::new_err(e),
+                LocalWriteError::AlreadyExists(_) => PyFileExistsError::new_err(e),
+                LocalWriteError::Serialize(_) => PyValueError::new_err(e),
+                LocalWriteError::TryMove(_) => PyIOError::new_err(e),
+                LocalWriteError::LocalRead(_) => PyIOError::new_err(e),
+                LocalWriteError::ImpossibleRelativePath(_) => PyValueError::new_err(e),
+                LocalWriteError::AddProject(_) => PyIOError::new_err(e),
+                LocalWriteError::MissingMeta | LocalWriteError::MissingInfoMeta => {
+                    PyFileNotFoundError::new_err(e)
+                }
+            },
+        }
     })?;
 
     Ok(())
@@ -140,7 +143,7 @@ fn do_info_py_path(
             | InfoProjectError::MissingInfo
             | InfoProjectError::MissingMeta
             | InfoProjectError::InvalidProject(..)),
-        ) => Err(PyRuntimeError::new_err(e.to_string())),
+        ) => Err(PyRuntimeError::new_err(format_err(e))),
     }
 }
 
@@ -157,7 +160,7 @@ fn do_info_py(
     let _ = pyo3_log::try_init();
 
     py.detach(|| {
-        let client = create_reqwest_client().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let client = create_reqwest_client().map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
 
         let runtime = Arc::new(
             tokio::runtime::Builder::new_current_thread()
@@ -173,7 +176,7 @@ fn do_info_py(
                     .collect()
             })
             .transpose()
-            .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            .map_err(|err| PyValueError::new_err(format_err(err)))?;
 
         let combined_resolver = standard_resolver(
             Some(relative_file_root.into()),
@@ -184,7 +187,7 @@ fn do_info_py(
             // FIXME: Add Python support for authentication
             Arc::new(Unauthenticated {}),
         )
-        .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        .map_err(|err| PyValueError::new_err(format_err(err)))?;
 
         match do_info(&uri, &combined_resolver) {
             Ok(info_meta) => Ok(info_meta),
@@ -193,7 +196,7 @@ fn do_info_py(
                 | InfoError::NoResolve(..)
                 | InfoError::UnsupportedIri(..)
                 | InfoError::Resolution(_)),
-            ) => Err(PyRuntimeError::new_err(e.to_string())),
+            ) => Err(PyRuntimeError::new_err(format_err(e))),
         }
     })
 }
@@ -221,30 +224,31 @@ fn do_build_py(
     let compression = match compression {
         Some(compression) => match KparCompressionMethod::try_from(compression) {
             Ok(compression) => compression,
-            Err(err) => return Err(PyValueError::new_err(err.to_string())),
+            Err(err) => return Err(PyValueError::new_err(format_err(err))),
         },
         None => KparCompressionMethod::default(),
     };
 
     do_build_kpar(&project, &output_path, compression, true, true)
         .map(|_| ())
-        .map_err(|err| match err {
-            KParBuildError::ProjectRead(_) => PyRuntimeError::new_err(err.to_string()),
-            KParBuildError::Io(_) => PyIOError::new_err(err.to_string()),
-            KParBuildError::Validation { .. } => PyValueError::new_err(err.to_string()),
-            KParBuildError::Extract(_) => PyValueError::new_err(err.to_string()),
-            KParBuildError::UnknownFormat(_) => PyValueError::new_err(err.to_string()),
-            KParBuildError::MissingInfo => PyValueError::new_err(err.to_string()),
-            KParBuildError::MissingMeta => PyValueError::new_err(err.to_string()),
-            KParBuildError::MissingInfoMeta => PyValueError::new_err(err.to_string()),
-            KParBuildError::Zip(_) => PyIOError::new_err(err.to_string()),
-            KParBuildError::Serialize(..) => PyValueError::new_err(err.to_string()),
-            KParBuildError::WorkspaceRead(_) => PyRuntimeError::new_err(err.to_string()),
-            KParBuildError::PathUsage(_) => PyValueError::new_err(err.to_string()),
-            KParBuildError::WorkspaceMetamodelConflict { .. } => {
-                PyValueError::new_err(err.to_string())
+        .map_err(|err| {
+            let e = format_err(&err);
+            match err {
+                KParBuildError::ProjectRead(_) => PyRuntimeError::new_err(e),
+                KParBuildError::Io(_) => PyIOError::new_err(e),
+                KParBuildError::Validation { .. } => PyValueError::new_err(e),
+                KParBuildError::Extract(_) => PyValueError::new_err(e),
+                KParBuildError::UnknownFormat(_) => PyValueError::new_err(e),
+                KParBuildError::MissingInfo => PyValueError::new_err(e),
+                KParBuildError::MissingMeta => PyValueError::new_err(e),
+                KParBuildError::MissingInfoMeta => PyValueError::new_err(e),
+                KParBuildError::Zip(_) => PyIOError::new_err(e),
+                KParBuildError::Serialize(..) => PyValueError::new_err(e),
+                KParBuildError::WorkspaceRead(_) => PyRuntimeError::new_err(e),
+                KParBuildError::PathUsage(_) => PyValueError::new_err(e),
+                KParBuildError::WorkspaceMetamodelConflict { .. } => PyValueError::new_err(e),
+                KParBuildError::MissingIndexSymbol(_, _) => PyValueError::new_err(e),
             }
-            KParBuildError::MissingIndexSymbol(_, _) => PyValueError::new_err(err.to_string()),
         })
 }
 
@@ -269,7 +273,7 @@ pub fn do_sources_env_py(
 
     let version = match version {
         Some(version) => Some(
-            VersionReq::parse(&version).map_err(|err| PyValueError::new_err(err.to_string()))?,
+            VersionReq::parse(&version).map_err(|err| PyValueError::new_err(format_err(err)))?,
         ),
         None => None,
     };
@@ -278,10 +282,11 @@ pub fn do_sources_env_py(
 
     let env = LocalDirectoryEnvironment::read(env_path).map_err(env_read_to_pyerr)?;
 
-    fn local_read_to_pyerr(e: LocalReadError) -> PyErr {
-        match e {
-            LocalReadError::Io(error) => PyIOError::new_err(error.to_string()),
-            LocalReadError::ProjectNotFound(_) => PyValueError::new_err(e.to_string()),
+    fn local_read_to_pyerr(err: LocalReadError) -> PyErr {
+        let e = format_err(&err);
+        match err {
+            LocalReadError::Io(_) => PyIOError::new_err(e),
+            LocalReadError::ProjectNotFound(_) => PyValueError::new_err(e),
         }
     }
 
@@ -296,7 +301,7 @@ pub fn do_sources_env_py(
             if let Some(candidate) = projects.next() {
                 if let Some(v) = candidate
                     .version()
-                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                    .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
                     .and_then(|x| Version::parse(&x).ok())
                     && vr.matches(&v)
                 {
@@ -324,7 +329,7 @@ pub fn do_sources_env_py(
     };
 
     for src_path in do_sources_local_src_project_no_deps(&project, true)
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
     {
         result.push(src_path.into_string());
     }
@@ -332,7 +337,7 @@ pub fn do_sources_env_py(
     if include_deps {
         let Some(info) = project
             .get_info()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
         else {
             return Err(PyRuntimeError::new_err(
                 "project is missing project information",
@@ -341,15 +346,15 @@ pub fn do_sources_env_py(
 
         for dep in find_project_dependencies(
             info.validate()
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
                 .usage,
             env,
             &provided_iris,
         )
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
         {
             for src_path in do_sources_local_src_project_no_deps(&dep, true)
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
             {
                 result.push(src_path.into_string());
             }
@@ -380,7 +385,7 @@ pub fn do_sources_project_py(
     };
 
     for src_path in do_sources_local_src_project_no_deps(&current_project, true)
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
     {
         result.push(src_path.into_string());
     }
@@ -389,7 +394,7 @@ pub fn do_sources_project_py(
         // TODO: Better bail early?
         let Some(info) = current_project
             .get_info()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
         else {
             return Err(PyRuntimeError::new_err(
                 "project is missing project information",
@@ -412,15 +417,15 @@ pub fn do_sources_project_py(
 
         for dep in find_project_dependencies(
             info.validate()
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
                 .usage,
             env,
             &provided_iris,
         )
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
         {
             for src_path in do_sources_local_src_project_no_deps(&dep, true)
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
             {
                 result.push(src_path.into_string());
             }
@@ -446,7 +451,7 @@ fn do_add_py(path: String, iri: String, version: Option<String>) -> PyResult<()>
     // TODO: do dependency resolution and locking?
     match do_add_guess(&mut project, iri, version) {
         Ok(_added) => Ok(()),
-        Err(e) => Err(PyRuntimeError::new_err(e.to_string())),
+        Err(e) => Err(PyRuntimeError::new_err(format_err(e))),
     }
 }
 
@@ -463,7 +468,7 @@ fn do_remove_py(path: String, iri: String) -> PyResult<()> {
         expected_checksum: None,
     };
 
-    do_remove_guess(&mut project, iri).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    do_remove_guess(&mut project, iri).map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
 
     Ok(())
 }
@@ -508,7 +513,7 @@ fn do_include_py(
         index_symbols,
         force_format,
     )
-    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    .map_err(|e| PyRuntimeError::new_err(format_err(e)))
 }
 
 /// `src_path` must be relative to project root and use Unix separators.
@@ -527,7 +532,7 @@ fn do_exclude_py(path: String, src_path: String) -> PyResult<()> {
     };
     // TODO: print the whole error chain
     do_exclude(&mut project, iter::once(Utf8UnixPathBuf::from(src_path)))
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
 
     Ok(())
 }
@@ -544,13 +549,13 @@ fn do_env_install_path_py(env_path: String, iri: String, location: String) -> Py
     let mut env = LocalDirectoryEnvironment::read(env_path).map_err(env_read_to_pyerr)?;
 
     let metadata =
-        wrapfs::metadata(&location).map_err(|e| PyErr::new::<PyIOError, _>(e.to_string()))?;
+        wrapfs::metadata(&location).map_err(|e| PyErr::new::<PyIOError, _>(format_err(e)))?;
     if metadata.is_file() {
         let project = LocalKParProject::new(&location, KparInnerPath::Guess, None, None);
 
         let Some(version) = project
             .version()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
         else {
             return Err(PyRuntimeError::new_err(format!(
                 "project at `{}` lacks project information",
@@ -560,11 +565,11 @@ fn do_env_install_path_py(env_path: String, iri: String, location: String) -> Py
 
         let checksum = project
             .checksum_canonical_variant()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
         env.put_project(iri, version, Some(checksum), |to| {
             clone_project(&project, to, true).map(|_| ())
         })
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
     } else if metadata.is_dir() {
         let project = LocalSrcProject {
             nominal_path: None,
@@ -574,7 +579,7 @@ fn do_env_install_path_py(env_path: String, iri: String, location: String) -> Py
 
         let Some(version) = project
             .version()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?
         else {
             return Err(PyRuntimeError::new_err(format!(
                 "project at {} lacks project information",
@@ -583,16 +588,15 @@ fn do_env_install_path_py(env_path: String, iri: String, location: String) -> Py
         };
         let checksum = project
             .checksum_canonical_variant()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            .map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
 
         env.put_project(iri, version, Some(checksum), |to| {
             clone_project(&project, to, true).map(|_| ())
         })
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        .map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
     } else {
         return Err(PyRuntimeError::new_err(format!(
-            "unable to find project at `{}`",
-            location
+            "unable to find project at `{location}`"
         )));
     }
 
@@ -622,5 +626,8 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 fn env_read_to_pyerr(err: EnvMetadataError) -> PyErr {
-    PyIOError::new_err(format!("failed to read environment metadata: {err}"))
+    PyIOError::new_err(format!(
+        "failed to read environment metadata: {}",
+        format_err(err)
+    ))
 }

--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -58,7 +58,7 @@ pub fn do_add_guess<P: ProjectMut>(
             Ok(None) => resource,
             Err(source) => {
                 return Err(AddError::Validation(
-                    InterchangeProjectValidationError::MalformedSysandPurl {
+                    InterchangeProjectValidationError::MalformedUsageSysandPurl {
                         iri: resource,
                         source,
                     },

--- a/core/src/commands/add_tests.rs
+++ b/core/src/commands/add_tests.rs
@@ -5,6 +5,7 @@ use crate::{
     add::{do_add_guess, expand_sysand_purl_shorthand},
     model::{InterchangeProjectInfoRaw, InterchangeProjectUsageRaw},
     project::memory::InMemoryProject,
+    utils::format_err,
 };
 use std::assert_matches;
 
@@ -91,7 +92,7 @@ fn add_rejects_non_normalized_sysand_shorthand() {
 
     let err = do_add_guess(&mut project, "Acme Labs/My.Project".to_owned(), None).unwrap_err();
 
-    let err = err.to_string();
+    let err = format_err(err);
     assert!(err.contains("`Acme Labs/My.Project`"), "{err}");
     assert!(err.contains("`pkg:sysand/acme-labs/my.project`"), "{err}");
     assert!(project.info.unwrap().usage.is_empty());

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -133,8 +133,11 @@ pub enum KParBuildError<ProjectReadError: ErrorBound> {
     WorkspaceRead(#[from] WorkspaceReadError),
     #[error(transparent)]
     Io(#[from] Box<FsIoError>),
-    #[error(transparent)]
-    Validation(#[from] InterchangeProjectValidationError),
+    #[error("project's `.{name}.json` is invalid")]
+    Validation {
+        name: &'static str,
+        source: InterchangeProjectValidationError,
+    },
     #[error("{0}")]
     Extract(String),
     #[error(
@@ -269,7 +272,10 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
         },
         Err(e) => return Err(KParBuildError::ProjectRead(e)),
     };
-    meta.validate()?;
+    meta.validate().map_err(|e| KParBuildError::Validation {
+        name: "meta",
+        source: e,
+    })?;
 
     match semver::Version::parse(&info.version) {
         Ok(_) => (),

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -20,7 +20,7 @@ use crate::{
         local_src::{LocalSrcError, LocalSrcProject},
         utils::{FsIoError, ZipArchiveError, wrapfs},
     },
-    utils::{license_file_stems, sha256_lowercase_hex},
+    utils::{format_err, license_file_stems, sha256_lowercase_hex},
     workspace::{Workspace, WorkspaceReadError},
 };
 
@@ -186,7 +186,7 @@ impl<ProjectReadError: ErrorBound> From<IncludeError<ProjectReadError>>
         match value {
             IncludeError::Project(error) => Self::ProjectRead(error),
             IncludeError::Io(error) => error.into(),
-            IncludeError::Extract(..) => Self::Extract(value.to_string()),
+            IncludeError::Extract(..) => Self::Extract(format_err(value)),
             IncludeError::UnknownFormat(error) => Self::UnknownFormat(error),
         }
     }

--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -9,7 +9,7 @@ use crate::{
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::ProjectRead,
     resolve::{ResolutionOutcome, ResolveRead},
-    utils::format_sources,
+    utils::format_err,
 };
 
 #[derive(Error, Debug)]
@@ -93,8 +93,7 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
                             }
                     }
                     Err(err) => {
-                        log::warn!("ignoring a project because: {err}");
-                        log::info!("{}", format_sources(&err));
+                        log::warn!("ignoring a project because: {}", format_err(err));
                     }
                 };
             }

--- a/core/src/commands/lock.rs
+++ b/core/src/commands/lock.rs
@@ -96,8 +96,11 @@ pub enum LockError<PD: ProjectRead, R: ResolveRead + Debug + 'static> {
         /// `canonical digest`.
         field: IncompleteField,
     },
-    #[error(transparent)]
-    Validation(InterchangeProjectValidationError),
+    #[error("project `{identifier}` has invalid metadata")]
+    InvalidUsage {
+        identifier: String,
+        source: InterchangeProjectValidationError,
+    },
     #[error(transparent)]
     Solver(SolverError<R>),
     #[error(transparent)]
@@ -117,6 +120,9 @@ pub struct LockOutcome<PD: Debug> {
 ///
 /// Typically `PI` will be a single `EditableProject` wrapping some local workspace project.
 /// See `do_lock_local_editable`.
+///
+/// `projects` contains `(identifiers, project)` pairs. If `identifiers` is `Some()`,
+/// it must not be an empty list
 ///
 /// `resolver` is used to interpret the usage IRIs.
 ///
@@ -156,6 +162,16 @@ pub fn do_lock_projects<
                     field: IncompleteField::Info,
                 })
             })?;
+        let validated_info = info.validate().map_err(|e| LockError::InvalidUsage {
+            identifier: {
+                if let Some(ids) = &identifiers {
+                    ids[0].as_str().to_owned()
+                } else {
+                    info.name.clone()
+                }
+            },
+            source: e,
+        })?;
         let named_project_label = format!("`{}` {}", info.name, info.version);
         let meta = project
             .get_meta()
@@ -191,11 +207,7 @@ pub fn do_lock_projects<
                 .collect(),
         });
 
-        let usages: Result<Vec<InterchangeProjectUsage>, InterchangeProjectValidationError> =
-            info.usage.iter().map(|p| p.validate()).collect();
-        let usages = usages.map_err(LockError::Validation)?;
-
-        all_deps.extend(usages);
+        all_deps.extend(validated_info.usage);
     }
 
     let lock_outcome = do_lock_extend(lock, all_deps, resolver, provided_iris, ctx)?;

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -415,6 +415,7 @@ pub enum PublishError {
     #[error("missing license in project info; it is required for publishing")]
     MissingLicense,
 
+    // Print `ParseError` directly, since its formatting demands a newline before
     #[error(
         "license `{license}` cannot be used for publishing; it must\n\
         be a valid SPDX license expression, but failed to parse:\n{err}"

--- a/core/src/commands/remove.rs
+++ b/core/src/commands/remove.rs
@@ -32,7 +32,7 @@ pub fn do_remove_guess<P: ProjectMut>(
         Ok(None) => resource,
         Err(source) => {
             return Err(RemoveError::Validation(
-                InterchangeProjectValidationError::MalformedSysandPurl {
+                InterchangeProjectValidationError::MalformedUsageSysandPurl {
                     iri: resource,
                     source,
                 },

--- a/core/src/commands/remove_tests.rs
+++ b/core/src/commands/remove_tests.rs
@@ -5,6 +5,7 @@ use crate::{
     model::{InterchangeProjectInfoRaw, InterchangeProjectUsageRaw},
     project::memory::InMemoryProject,
     remove::do_remove_guess,
+    utils::format_err,
 };
 
 fn project_with_usage(resource: &str) -> InMemoryProject {
@@ -75,7 +76,7 @@ fn remove_rejects_non_normalized_sysand_shorthand() {
 
     let err = do_remove_guess(&mut project, "Acme Labs/My.Project".to_owned()).unwrap_err();
 
-    let err = err.to_string();
+    let err = format_err(err);
     assert!(err.contains("`Acme Labs/My.Project`"), "{err}");
     assert!(err.contains("`pkg:sysand/acme-labs/my.project`"), "{err}");
     assert_eq!(project.info.unwrap().usage.len(), 1);

--- a/core/src/commands/sources.rs
+++ b/core/src/commands/sources.rs
@@ -27,8 +27,11 @@ use crate::{
 pub enum SourcesError<ProjectError> {
     #[error(transparent)]
     Project(ProjectError),
-    #[error(transparent)]
-    Validation(#[from] InterchangeProjectValidationError),
+    #[error("project's `.{name}.json` is invalid")]
+    Validation {
+        name: &'static str,
+        source: InterchangeProjectValidationError,
+    },
 }
 
 /// Enumerates source files in a project (as Unix-paths relative to the project root).
@@ -43,7 +46,11 @@ pub fn do_sources_project_no_deps<Pr: ProjectRead>(
     };
 
     Ok(meta
-        .validate()?
+        .validate()
+        .map_err(|e| SourcesError::Validation {
+            name: "meta",
+            source: e,
+        })?
         .source_paths(include_index)
         .into_iter()
         .collect())
@@ -54,8 +61,11 @@ pub fn do_sources_project_no_deps<Pr: ProjectRead>(
 pub enum LocalSourcesError {
     #[error(transparent)]
     Project(LocalSrcError),
-    #[error(transparent)]
-    Validation(#[from] InterchangeProjectValidationError),
+    #[error("project's `.{name}.json` is invalid")]
+    Validation {
+        name: &'static str,
+        source: InterchangeProjectValidationError,
+    },
     #[error(transparent)]
     Path(#[from] PathError),
 }
@@ -65,7 +75,9 @@ impl From<SourcesError<LocalSrcError>> for LocalSourcesError {
     fn from(value: SourcesError<LocalSrcError>) -> Self {
         match value {
             SourcesError::Project(error) => LocalSourcesError::Project(error),
-            SourcesError::Validation(error) => LocalSourcesError::Validation(error),
+            SourcesError::Validation { name, source } => {
+                LocalSourcesError::Validation { name, source }
+            }
         }
     }
 }

--- a/core/src/commands/sync.rs
+++ b/core/src/commands/sync.rs
@@ -12,6 +12,7 @@ use crate::{
     iri_normalize::canonicalize_iri_tolerant,
     lock::{Lock, Source},
     project::{ProjectChecksum, ProjectRead, memory::InMemoryProject},
+    utils::format_err,
 };
 
 #[derive(Error, Debug)]
@@ -187,7 +188,7 @@ where
                 if let Some(checksum) = source.to_checksum()
                     && env
                         .has_version_verified(iri, &project.version, &checksum)
-                        .map_err(|e| SyncError::ProjectRead(e.to_string()))?
+                        .map_err(|e| SyncError::ProjectRead(format_err(e)))?
                         == ProjectChecksumResult::Match
                 {
                     log::debug!("`{iri}` found in .sysand");
@@ -340,7 +341,7 @@ where
                     do_env_install_project(uri, &project.version, &storage, None, env, true, true)
                         .map_err(|e| SyncError::InstallFail {
                             uri: uri.as_str().into(),
-                            cause: e.to_string(),
+                            cause: format_err(e),
                         })?;
                 }
             }
@@ -379,7 +380,7 @@ fn try_install<
     let uri = uri.as_ref();
     let actual_checksum = storage
         .checksum_canonical_variant()
-        .map_err(|e| SyncError::ProjectRead(e.to_string()))?;
+        .map_err(|e| SyncError::ProjectRead(format_err(e)))?;
     if expected_checksum == &actual_checksum {
         // TODO: Need to decide how to handle existing installations and possible flags to modify behavior
         do_env_install_project(
@@ -393,7 +394,7 @@ fn try_install<
         )
         .map_err(|e| SyncError::InstallFail {
             uri: uri.into(),
-            cause: e.to_string(),
+            cause: format_err(e),
         })?;
     } else {
         return Err(SyncError::BadChecksum {

--- a/core/src/env/index_tests.rs
+++ b/core/src/env/index_tests.rs
@@ -246,7 +246,7 @@ fn mock_json_get_count(
 // }
 
 mod uris {
-    use crate::{index::iri::ParseIriError, utils::format_sources};
+    use crate::{index::iri::ParseIriError, utils::format_err};
     use std::assert_matches;
 
     use super::*;
@@ -348,12 +348,11 @@ mod uris {
         let err = resolved_endpoints(&env)
             .kpar_url(purl("Acme Labs/My.Project"), "1.0.0")
             .expect_err("non-normalized pkg:sysand must be rejected");
-        let err_msg = err.to_string();
-        let sources_msg = format_sources(&err);
+        let err_msg = format_err(&err);
         let proper_purl = &purl("acme-labs/my.project");
         assert!(
-            err_msg.contains(proper_purl) || sources_msg.contains(proper_purl),
-            "error message `{err_msg}` or sources message `{sources_msg}` must surface the suggested normalized IRI"
+            err_msg.contains(proper_purl),
+            "error message `{err_msg}` must surface the suggested normalized IRI"
         );
         Ok(())
     }

--- a/core/src/env/local_directory/utils.rs
+++ b/core/src/env/local_directory/utils.rs
@@ -55,12 +55,10 @@ pub fn clean_dir<P: AsRef<Utf8Path>>(path: P) {
 pub enum TryMoveError {
     #[error("recovered from failure: {0}")]
     RecoveredIO(Box<FsIoError>),
-    #[error(
-        "failed and may have left the directory in inconsistent state:\n{err}\nwhich was caused by:\n{cause}"
-    )]
+    #[error("failed and may have left the directory in inconsistent state:\n{err}")]
     CatastrophicIO {
         err: Box<FsIoError>,
-        cause: Box<FsIoError>,
+        source: Box<FsIoError>,
     },
 }
 
@@ -143,7 +141,7 @@ pub fn try_move_files(paths: &[(&Utf8Path, &Utf8Path)]) -> Result<(), TryMoveErr
             if src_path.exists()
                 && let Err(err) = move_fs_item(src_path, path)
             {
-                return Err(TryMoveError::CatastrophicIO { err, cause });
+                return Err(TryMoveError::CatastrophicIO { err, source: cause });
             }
         }
 
@@ -171,7 +169,7 @@ pub fn try_move_files(paths: &[(&Utf8Path, &Utf8Path)]) -> Result<(), TryMoveErr
             if trg_path.exists()
                 && let Err(err) = move_fs_item(trg_path, path)
             {
-                return Err(TryMoveError::CatastrophicIO { err, cause });
+                return Err(TryMoveError::CatastrophicIO { err, source: cause });
             }
         }
 
@@ -181,7 +179,7 @@ pub fn try_move_files(paths: &[(&Utf8Path, &Utf8Path)]) -> Result<(), TryMoveErr
             if src_path.exists()
                 && let Err(err) = move_fs_item(src_path, path)
             {
-                return Err(TryMoveError::CatastrophicIO { err, cause });
+                return Err(TryMoveError::CatastrophicIO { err, source: cause });
             }
         }
 
@@ -208,7 +206,7 @@ pub fn try_move_files(paths: &[(&Utf8Path, &Utf8Path)]) -> Result<(), TryMoveErr
             if path.exists()
                 && let Err(err) = move_fs_item(path, src_path)
             {
-                return Err(TryMoveError::CatastrophicIO { err, cause });
+                return Err(TryMoveError::CatastrophicIO { err, source: cause });
             }
         }
 
@@ -218,7 +216,7 @@ pub fn try_move_files(paths: &[(&Utf8Path, &Utf8Path)]) -> Result<(), TryMoveErr
             if trg_path.exists()
                 && let Err(err) = move_fs_item(trg_path, path)
             {
-                return Err(TryMoveError::CatastrophicIO { err, cause });
+                return Err(TryMoveError::CatastrophicIO { err, source: cause });
             }
         }
 
@@ -228,7 +226,7 @@ pub fn try_move_files(paths: &[(&Utf8Path, &Utf8Path)]) -> Result<(), TryMoveErr
             if src_path.exists()
                 && let Err(err) = move_fs_item(src_path, path)
             {
-                return Err(TryMoveError::CatastrophicIO { err, cause });
+                return Err(TryMoveError::CatastrophicIO { err, source: cause });
             }
         }
 

--- a/core/src/lock.rs
+++ b/core/src/lock.rs
@@ -191,7 +191,7 @@ impl Lock {
         self.validate_lock_version()?;
         self.check_name_collision()?;
         self.validate_usages()?;
-        self.validate_digest_format()?;
+        self.validate_sources()?;
         Ok(())
     }
 
@@ -257,8 +257,6 @@ impl Lock {
             for iri in &project.identifiers {
                 iri_versions.insert(iri.clone());
             }
-        }
-        for project in &self.projects {
             for usage in &project.usages {
                 if !iri_versions.contains(usage.inner()) {
                     return Err(ValidationError::UnsatisfiedUsage {
@@ -271,7 +269,7 @@ impl Lock {
         Ok(())
     }
 
-    fn validate_digest_format(&self) -> Result<(), ValidationError> {
+    fn validate_sources(&self) -> Result<(), ValidationError> {
         for project in &self.projects {
             for source in &project.sources {
                 let (c, kind) = match source {

--- a/core/src/lock.rs
+++ b/core/src/lock.rs
@@ -257,6 +257,8 @@ impl Lock {
             for iri in &project.identifiers {
                 iri_versions.insert(iri.clone());
             }
+        }
+        for project in &self.projects {
             for usage in &project.usages {
                 if !iri_versions.contains(usage.inner()) {
                     return Err(ValidationError::UnsatisfiedUsage {

--- a/core/src/lock_tests.rs
+++ b/core/src/lock_tests.rs
@@ -7,6 +7,7 @@ use std::{fmt::Display, num::NonZeroU64, slice, str::FromStr};
 use toml_edit::DocumentMut;
 use typed_path::Utf8UnixPathBuf;
 
+use crate::utils::format_err;
 use crate::{
     lock::{
         CURRENT_LOCK_VERSION, LOCKFILE_PREFIX, Lock, Project, Source, Usage, ValidationError,
@@ -36,7 +37,7 @@ fn check_unsupported_lock_version() {
     };
     assert_eq!(s, version);
     assert_eq!(
-        err.to_string(),
+        format_err(err),
         "lockfile version `X` is not supported; regenerate it with a lock operation"
     );
 }
@@ -61,7 +62,7 @@ sources = [{{ registry = "https://example.org" }}]
     };
     assert_eq!(s, "0.3");
     assert_eq!(
-        err.to_string(),
+        format_err(err),
         "lockfile version `0.3` is not supported; regenerate it with a lock operation"
     );
 }
@@ -608,12 +609,12 @@ fn validate_unsupported_lock_version() {
     .validate() else {
         panic!()
     };
-    let ValidationError::UnsupportedVersion(ref s) = err else {
+    let ValidationError::UnsupportedVersion(s) = &err else {
         panic!()
     };
     assert_eq!(s, version);
     assert_eq!(
-        err.to_string(),
+        format_err(err),
         "lockfile version `X` is not supported; regenerate it with a lock operation"
     );
 }

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -44,6 +44,7 @@ pub type InterchangeProjectUsage =
     InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>;
 
 impl InterchangeProjectUsageRaw {
+    /// Caller is responsible for identifying the project when reporting the error
     pub fn validate(&self) -> Result<InterchangeProjectUsage, InterchangeProjectValidationError> {
         match self {
             InterchangeProjectUsageG::Resource {
@@ -57,24 +58,26 @@ impl InterchangeProjectUsageRaw {
                 // error (with a suggested normalized form) instead of a downstream
                 // "not found" — see `crate::purl::parse_sysand_purl`.
                 crate::purl::parse_sysand_purl(resource).map_err(|e| {
-                    InterchangeProjectValidationError::MalformedSysandPurl {
+                    InterchangeProjectValidationError::MalformedUsageSysandPurl {
                         iri: resource.clone(),
                         source: e,
                     }
                 })?;
 
                 Ok(InterchangeProjectUsage::Resource {
-                    resource: fluent_uri::Iri::parse(resource.clone())
-                        .map_err(|(e, val)| InterchangeProjectValidationError::IriParse(val, e))?,
+                    resource: fluent_uri::Iri::parse(resource.clone()).map_err(|(e, val)| {
+                        InterchangeProjectValidationError::InvalidUsageResource(val, e)
+                    })?,
 
                     version_constraint: version_constraint
                         .as_ref()
                         .map(|c| {
                             semver::VersionReq::parse(c).map_err(|e| {
-                                InterchangeProjectValidationError::SemVerConstraintParse(
-                                    c.to_owned(),
-                                    e,
-                                )
+                                InterchangeProjectValidationError::InvalidUsageVersionConstraint {
+                                    resource: resource.to_owned(),
+                                    constraint: c.to_owned(),
+                                    source: e,
+                                }
                             })
                         })
                         .transpose()?,
@@ -114,13 +117,6 @@ impl From<InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>>
     }
 }
 
-impl TryFrom<InterchangeProjectUsageRaw> for InterchangeProjectUsage {
-    type Error = InterchangeProjectValidationError;
-
-    fn try_from(value: InterchangeProjectUsageRaw) -> Result<InterchangeProjectUsage, Self::Error> {
-        value.validate()
-    }
-}
 impl<Iri: Display, VersionReq: Display> Display for InterchangeProjectUsageG<Iri, VersionReq> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -211,12 +207,6 @@ impl<Iri: PartialEq + Clone, Version, VersionReq: Clone>
             usage: vec![],
         }
     }
-    // pub fn push_usage(&mut self, resource: Iri, version_requirement: Option<VersionReq>) {
-    //     self.usage.push(InterchangeProjectUsageG {
-    //         resource: resource,
-    //         version_constraint: version_requirement,
-    //     });
-    // }
 
     /// Remove and return all occurrences of `resource` in project usages.
     /// Note that sysand will never add multiple usages of the same resource
@@ -236,10 +226,11 @@ impl<Iri: PartialEq + Clone, Version, VersionReq: Clone>
 }
 
 impl InterchangeProjectInfoRaw {
+    /// Caller is responsible for identifying the project when reporting the error
     pub fn validate(&self) -> Result<InterchangeProjectInfo, InterchangeProjectValidationError> {
         let mut usage = vec![];
         for a_usage in self.usage.iter() {
-            usage.push(a_usage.to_owned().try_into()?);
+            usage.push(a_usage.to_owned().validate()?);
         }
 
         Ok(InterchangeProjectInfo {
@@ -247,7 +238,10 @@ impl InterchangeProjectInfoRaw {
             publisher: self.publisher.clone(),
             description: self.description.clone(),
             version: semver::Version::parse(&self.version).map_err(|e| {
-                InterchangeProjectValidationError::SemVerParse(self.version.as_str().into(), e)
+                InterchangeProjectValidationError::InvalidProjectVersion(
+                    self.version.as_str().into(),
+                    e,
+                )
             })?,
             license: self.license.clone(),
             maintainer: self.maintainer.clone(),
@@ -256,19 +250,11 @@ impl InterchangeProjectInfoRaw {
                 .clone()
                 .map(fluent_uri::Iri::parse)
                 .transpose()
-                .map_err(|(e, val)| InterchangeProjectValidationError::IriParse(val, e))?,
+                .map_err(|(e, val)| InterchangeProjectValidationError::InvalidWebsite(val, e))?,
 
             topic: self.topic.clone(),
             usage,
         })
-    }
-}
-
-impl TryFrom<InterchangeProjectInfoRaw> for InterchangeProjectInfo {
-    type Error = InterchangeProjectValidationError;
-
-    fn try_from(value: InterchangeProjectInfoRaw) -> Result<Self, Self::Error> {
-        value.validate()
     }
 }
 
@@ -514,14 +500,25 @@ impl From<InterchangeProjectMetadata> for InterchangeProjectMetadataRaw {
 
 #[derive(Error, Debug)]
 pub enum InterchangeProjectValidationError {
-    #[error("failed to parse `{0}` as IRI: {1}")]
-    IriParse(String, fluent_uri::ParseError),
-    #[error("failed to parse `{0}` as a Semantic Version: {1}")]
-    SemVerParse(Box<str>, semver::Error),
-    #[error("failed to parse `{0}` as a Semantic Version constraint: {1}")]
-    SemVerConstraintParse(String, semver::Error),
+    #[error("invalid website (`website` field in `.project.json`) `{0}`")]
+    InvalidWebsite(String, #[source] fluent_uri::ParseError),
+    #[error("invalid usage resource `{0}`")]
+    InvalidUsageResource(String, #[source] fluent_uri::ParseError),
+    #[error("invalid metamodel (`metamodel` field in `.meta.json`) `{0}`")]
+    InvalidMetamodel(String, #[source] fluent_uri::ParseError),
+    #[error("project has an invalid Semantic Version `{0}`")]
+    InvalidProjectVersion(Box<str>, #[source] semver::Error),
+    #[error(
+        "failed to parse version constraint `{constraint}` of usage\n\
+        `{resource}` as a Semantic Version constraint"
+    )]
+    InvalidUsageVersionConstraint {
+        resource: String,
+        constraint: String,
+        source: semver::Error,
+    },
     #[error("failed to parse `{0}` as RFC3339 datetime: {1}")]
-    DatetimeParse(Box<str>, chrono::ParseError),
+    InvalidCreatedTime(Box<str>, chrono::ParseError),
     #[error("file `{0}` is present in symbol index, but absent in file checksums")]
     MissingFileInChecksum(Box<str>),
     #[error(
@@ -530,11 +527,11 @@ pub enum InterchangeProjectValidationError {
         BLAKE2b-256, BLAKE2b-384, BLAKE2b-512, BLAKE3\n\
         MD2, MD4, MD5, MD6, ADLER32"
     )]
-    ChecksumAlg(Box<str>),
+    InvalidChecksumAlg(Box<str>),
     #[error(
         "invalid hex checksum length for {algorithm}: expected {expected} char(s), got {got} char(s)"
     )]
-    ChecksumLen {
+    IncorrectChecksumLen {
         algorithm: KerMlChecksumAlg,
         expected: u8,
         got: usize,
@@ -542,7 +539,7 @@ pub enum InterchangeProjectValidationError {
     #[error("checksum `{cksum}`\ncontains invalid symbols (only `A-Fa-f0-9` are allowed)")]
     NonHexChecksumChars { cksum: Box<str> },
     #[error("malformed `pkg:sysand` IRI `{iri}`: {source}")]
-    MalformedSysandPurl {
+    MalformedUsageSysandPurl {
         iri: String,
         #[source]
         source: crate::purl::SysandPurlError,
@@ -563,6 +560,7 @@ impl Default for InterchangeProjectMetadataRaw {
 }
 
 impl InterchangeProjectMetadataRaw {
+    /// Caller is responsible for identifying the project when reporting the error
     pub fn validate(
         &self,
     ) -> Result<InterchangeProjectMetadata, InterchangeProjectValidationError> {
@@ -582,12 +580,14 @@ impl InterchangeProjectMetadataRaw {
                 let k = Utf8UnixPath::new(k).to_path_buf();
                 let algorithm: KerMlChecksumAlg =
                     v.algorithm.as_str().try_into().map_err(|_| {
-                        InterchangeProjectValidationError::ChecksumAlg(v.algorithm.as_str().into())
+                        InterchangeProjectValidationError::InvalidChecksumAlg(
+                            v.algorithm.as_str().into(),
+                        )
                     })?;
                 let value = {
                     if let Some(expected_len) = algorithm.expected_hex_len() {
                         if v.value.len() != expected_len as usize {
-                            return Err(InterchangeProjectValidationError::ChecksumLen {
+                            return Err(InterchangeProjectValidationError::IncorrectChecksumLen {
                                 algorithm,
                                 expected: expected_len,
                                 got: v.value.len(),
@@ -618,7 +618,7 @@ impl InterchangeProjectMetadataRaw {
             // TODO: this is not strictly correct, as RFC3339 only partially overlaps with ISO8601
             created: chrono::DateTime::parse_from_rfc3339(&self.created)
                 .map_err(|e| {
-                    InterchangeProjectValidationError::DatetimeParse(
+                    InterchangeProjectValidationError::InvalidCreatedTime(
                         self.created.as_str().into(),
                         e,
                     )
@@ -634,7 +634,7 @@ impl InterchangeProjectMetadataRaw {
                     fluent_uri::Iri::parse(m)
                 })
                 .transpose()
-                .map_err(|(e, val)| InterchangeProjectValidationError::IriParse(val, e))?,
+                .map_err(|(e, val)| InterchangeProjectValidationError::InvalidMetamodel(val, e))?,
             includes_derived: self.includes_derived,
             includes_implied: self.includes_implied,
             checksum,
@@ -708,16 +708,6 @@ impl InterchangeProjectMetadataRaw {
             .extract_if(.., |_, v| v == remove_path)
             .map(|x| x.0)
             .collect()
-    }
-}
-
-impl TryFrom<InterchangeProjectMetadataRaw> for InterchangeProjectMetadata {
-    type Error = InterchangeProjectValidationError;
-
-    fn try_from(
-        value: InterchangeProjectMetadataRaw,
-    ) -> Result<InterchangeProjectMetadata, Self::Error> {
-        value.validate()
     }
 }
 

--- a/core/src/purl_tests.rs
+++ b/core/src/purl_tests.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
+use crate::utils::format_err;
+
 use super::*;
 use std::assert_matches;
 
@@ -161,14 +163,12 @@ fn parse_sysand_purl_rejects_non_normalized_with_suggestion() {
 #[test]
 fn parse_sysand_purl_error_messages_include_input_purl() {
     let err = parse_sysand_purl("pkg:sysand/ab/proj0").unwrap_err();
-    assert!(err.to_string().contains("`pkg:sysand/ab/proj0`"), "{err}");
+    let e = format_err(err);
+    assert!(e.contains("`pkg:sysand/ab/proj0`"), "{e}");
 
     let err = parse_sysand_purl("pkg:sysand/Acme Labs/My.Project").unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("`pkg:sysand/Acme Labs/My.Project`"),
-        "{err}"
-    );
+    let e = format_err(err);
+    assert!(e.contains("`pkg:sysand/Acme Labs/My.Project`"), "{e}");
 }
 
 #[test]

--- a/core/src/resolve/combined.rs
+++ b/core/src/resolve/combined.rs
@@ -13,6 +13,7 @@ use crate::{
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::{ProjectRead, cached::CachedProject},
     resolve::{ResolutionOutcome, ResolveRead, null::NullResolver},
+    utils::format_err,
 };
 
 /// Implements "standard" resolution logic given a set of individual resolvers.
@@ -154,7 +155,7 @@ impl<
                             .and_then(|checksum| self.locals.shift_remove(&checksum)),
                         Err(err) => {
                             log::debug!(
-                                "remote-project checksum_canonical_hex failed; skipping local-cache match: {err}"
+                                "remote-project checksum_canonical_hex failed; skipping local-cache match: {}", format_err(err)
                             );
                             None
                         }
@@ -181,7 +182,7 @@ impl<
                             .and_then(|checksum| self.locals.shift_remove(&checksum)),
                         Err(err) => {
                             log::debug!(
-                                "index-project checksum_canonical_hex failed; skipping local-cache match: {err}"
+                                "index-project checksum_canonical_hex failed; skipping local-cache match: {}", format_err(err)
                             );
                             None
                         }
@@ -276,7 +277,8 @@ impl<
                         match res {
                             Err(err) => {
                                 log::debug!(
-                                    "local resolver rejected project with IRI `{uri}`: {err}",
+                                    "local resolver rejected project with IRI `{uri}`: {}",
+                                    format_err(err)
                                 );
                             }
                             Ok(project) => match project.checksum_canonical_hex() {
@@ -290,7 +292,8 @@ impl<
                                 }
                                 Err(err) => {
                                     log::debug!(
-                                        "local resolver rejected project with IRI `{uri}`: {err}",
+                                        "local resolver rejected project with IRI `{uri}`: {}",
+                                        format_err(err)
                                     );
                                 }
                             },
@@ -332,7 +335,8 @@ impl<
                         match remote_projects.peek() {
                             Some(Err(err)) => {
                                 log::debug!(
-                                    "remote resolver skipping project for IRI `{uri}` due to: {err}"
+                                    "remote resolver skipping project for IRI `{uri}` due to: {}",
+                                    format_err(err)
                                 );
                                 remote_projects.next();
                             }
@@ -360,7 +364,8 @@ impl<
                                     }
                                     Err(err) => {
                                         log::debug!(
-                                            "remote resolver skipping project for IRI `{uri}`: {err}"
+                                            "remote resolver skipping project for IRI `{uri}`: {}",
+                                            format_err(err)
                                         );
                                         remote_projects.next();
                                     }

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -371,7 +371,7 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
                     // https://github.com/pubgrub-rs/pubgrub/pull/216
                     // match resolve_candidates(resolver, &usage.resource, cache) {
                     //     Ok(_) => (),
-                    //     Err(err) => return Ok(pubgrub::Dependencies::Unavailable(err.to_string())),
+                    //     Err(err) => return Ok(pubgrub::Dependencies::Unavailable(format_err(err))),
                     // };
 
                     deps.push((

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -25,7 +25,11 @@ pub(crate) mod scheme {
     pub const SCHEME_HTTPS: &Scheme = Scheme::new_or_panic("https");
 }
 
-pub(crate) fn format_sources(mut error: &dyn Error) -> String {
+/// Format an error, together with a chain of its `source()`.
+/// Should be used in all cases where an error is turned into
+/// a string and `source()` is not checked
+pub fn format_err(error: impl Error) -> String {
+    let mut error: &dyn Error = &error;
     let mut message = error.to_string();
     while let Some(source) = error.source() {
         writeln!(&mut message, "  caused by: {source}").unwrap();

--- a/core/tests/index_management.rs
+++ b/core/tests/index_management.rs
@@ -10,8 +10,9 @@ use camino_tempfile::tempdir;
 use serde_json::{Value, json};
 use zip::write::SimpleFileOptions;
 
-use sysand_core::index::{
-    RemoveTarget, do_index_add, do_index_init, do_index_remove, do_index_yank,
+use sysand_core::{
+    index::{RemoveTarget, do_index_add, do_index_init, do_index_remove, do_index_yank},
+    utils::format_err,
 };
 
 #[test]
@@ -285,8 +286,8 @@ fn read_json(path: Utf8PathBuf) -> Value {
     serde_json::from_str::<Value>(&str).unwrap()
 }
 
-fn assert_error_contains<E: std::fmt::Display>(err: E, expected: &str) {
-    let err = err.to_string();
+fn assert_error_contains<E: std::error::Error>(err: E, expected: &str) {
+    let err = format_err(err);
     assert!(
         err.contains(expected),
         "expected error to contain `{expected}`, got `{err}`"

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -22,6 +22,7 @@ use sysand_core::{
         utils::{relativize_path, wrapfs},
     },
     resolve::{ResolutionOutcome, ResolveRead, standard::standard_resolver},
+    utils::format_err,
 };
 
 use crate::{
@@ -104,7 +105,7 @@ pub fn command_add<Policy: HTTPAuthentication>(
                             break;
                         }
                         Err(err) => {
-                            log::debug!("skipping candidate project: {err}");
+                            log::debug!("skipping candidate project: {}", format_err(err));
                         }
                     }
                 }

--- a/sysand/src/commands/sources.rs
+++ b/sysand/src/commands/sources.rs
@@ -91,22 +91,22 @@ pub fn command_sources_project(
     let current_project = ctx
         .current_project
         .ok_or(CliError::MissingProjectCurrentDir)?;
+    // TODO: Better bail early?
+    let Some(info) = current_project.get_info()? else {
+        bail!("project is missing project information")
+    };
+    let info = info.validate()?;
 
     for src_path in do_sources_local_src_project_no_deps(&current_project, true)? {
         println!("{}", src_path);
     }
 
     if include_deps {
-        // TODO: Better bail early?
-        let Some(info) = current_project.get_info()? else {
-            bail!("project is missing project information")
-        };
-
         let deps = match ctx.env {
-            Some(env) => find_project_dependencies(info.validate()?.usage, env, provided_iris)?,
+            Some(env) => find_project_dependencies(info.usage, env, provided_iris)?,
             None => {
                 let env = NullEnvironment::new();
-                find_project_dependencies(info.validate()?.usage, env, provided_iris)?
+                find_project_dependencies(info.usage, env, provided_iris)?
             }
         };
 


### PR DESCRIPTION
We're using `#[source]`/`#[from]` attributes more and more to derive `Error` trait, which means that error sources are sometimes no longer included in `Display`/`{}`/`.to_string()` implementations. Use our own `format_err()`, which prints the whole error sources chain everywhere where we use `.to_string()`/`{}` on an error.

Also provide attribution to a project when its validation fails.
Fixes #415.