### PR TITLE
feat: sign and attest provenance of published container images

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -16,6 +16,9 @@ on:
 
 permissions:
   contents: read
+  id-token: write # for cosign and actions/attest-build-provenance
+  attestations: write # for actions/attest-build-provenance
+  artifact-metadata: write # for actions/attest-build-provenance
   packages: write
 
 jobs:
@@ -124,23 +127,57 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build and push image
+        id: build-image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: mode=max
+          sbom: true
           tags: ${{ join(fromJson(steps.tags.outputs.tags)) }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: Build and push alpine image
+        id: build-alpine-image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile.alpine
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: mode=max
+          sbom: true
           tags: ${{ join(fromJson(steps.tags-alpine.outputs.tags)) }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.1
+
+      - name: Sign images
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          IMAGE_DIGEST: ${{ steps.build-image.outputs.digest }}
+          ALPINE_IMAGE_DIGEST: ${{ steps.build-alpine-image.outputs.digest }}
+        run: |
+          cosign sign --yes "$IMAGE@$IMAGE_DIGEST"
+          cosign sign --yes "$IMAGE@$ALPINE_IMAGE_DIGEST"
+
+      - name: Generate image provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build-image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate alpine image provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build-alpine-image.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -16,9 +16,9 @@ on:
 
 permissions:
   contents: read
-  id-token: write # for cosign and actions/attest-build-provenance
-  attestations: write # for actions/attest-build-provenance
-  artifact-metadata: write # for actions/attest-build-provenance
+  id-token: write # for cosign and actions/attest
+  attestations: write # for actions/attest
+  artifact-metadata: write # for actions/attest
   packages: write
 
 jobs:
@@ -169,14 +169,14 @@ jobs:
           cosign sign --yes "$IMAGE@$ALPINE_IMAGE_DIGEST"
 
       - name: Generate image provenance attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build-image.outputs.digest }}
           push-to-registry: true
 
       - name: Generate alpine image provenance attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build-alpine-image.outputs.digest }}


### PR DESCRIPTION
Published container images did not have Sigstore signatures or
registry-pushed provenance attestations. Add Docker-native SBOM and
provenance output, then sign and attest each pushed image digest.

Signed-off-by: Erik Sundell <erik.sundell+2025@sensmetry.com>

---

- fixes #421
- verified to work in my fork: https://github.com/consideRatio/sysand/actions/runs/28227467649
