### PR TITLE
feat: relative directory usage type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ homepage = "https://sysand.com"
 camino = { version = "1.2", features = ["serde1"] }
 sha2 = { version = "0.11", default-features = false }
 hex = "0.4.3"
+fluent-uri = { version = "0.4.1", features = ["serde", "net"] }
+log = { version = "0.4.29", default-features = false }

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -24,7 +24,7 @@ kpar-ppmd = ["sysand-core/kpar-ppmd"]
 [dependencies]
 sysand-core = { path = "../../core", features = ["std", "filesystem", "networking"] }
 camino.workspace = true
-fluent-uri = { version = "0.4.1", features = ["serde", "net"] }
+fluent-uri.workspace = true
 jni = "0.21.1"
 reqwest-middleware = { version = "0.5.1" }
 indexmap = { version = "2.13.0", default-features = false, features = ["serde"] }

--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SetProjectInfoTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SetProjectInfoTest.java
@@ -9,6 +9,7 @@ import com.sensmetry.sysand.model.InterchangeProjectChecksum;
 import com.sensmetry.sysand.model.InterchangeProjectInfo;
 import com.sensmetry.sysand.model.InterchangeProjectMetadata;
 import com.sensmetry.sysand.model.InterchangeProjectUsage;
+import com.sensmetry.sysand.model.InterchangeProjectUsageDirectory;
 import com.sensmetry.sysand.model.InterchangeProjectUsageResource;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -157,6 +158,29 @@ public class SetProjectInfoTest {
         assertEquals("9.9.9", project.info.getVersion());
         assertEquals(1, project.metadata.getIndex().size());
         assertEquals("src/Foo.sysml", project.metadata.getIndex().get("Foo"));
+    }
+
+    @Test
+    public void testSetProjectInfoWithDirectoryUsage() throws Exception {
+        Path dir = initProject();
+
+        InterchangeProjectUsageDirectory usage = new InterchangeProjectUsageDirectory(
+                "../some-dep", "acme", "lib");
+        InterchangeProjectInfo updated = new InterchangeProjectInfo(
+                "original", "pub", null, "1.0.0", null,
+                new String[]{}, null, new String[]{},
+                new InterchangeProjectUsage[]{usage});
+
+        Sysand.setProjectInfo(dir, updated);
+
+        com.sensmetry.sysand.model.InterchangeProject project = Sysand.infoPath(dir);
+        assertEquals(1, project.info.getUsage().length);
+        assertInstanceOf(InterchangeProjectUsageDirectory.class, project.info.getUsage()[0]);
+        InterchangeProjectUsageDirectory d =
+                (InterchangeProjectUsageDirectory) project.info.getUsage()[0];
+        assertEquals("../some-dep", d.getDirectory());
+        assertEquals("acme", d.getPublisher());
+        assertEquals("lib", d.getName());
     }
 
     // --- setProjectMetadata ---

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
@@ -85,7 +85,7 @@ public class Sysand {
     /**
      * Get the project information and metadata at the given URI.
      *
-     * @param uri              The URI of the project.
+     * @param uri The URI of the project.
      * @return The project information and metadata.
      */
     public static native com.sensmetry.sysand.model.InterchangeProject info(
@@ -96,7 +96,7 @@ public class Sysand {
     /**
      * Get the project information and metadata at the given URI.
      *
-     * @param uri              The URI of the project.
+     * @param uri The URI of the project.
      * @return The project information and metadata.
      */
     public static com.sensmetry.sysand.model.InterchangeProject info(

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsageDirectory.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsageDirectory.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+package com.sensmetry.sysand.model;
+
+public class InterchangeProjectUsageDirectory implements InterchangeProjectUsage {
+
+    private String directory;
+    private String publisher;
+    private String name;
+
+    public InterchangeProjectUsageDirectory(String directory, String publisher, String name) {
+        this.directory = directory;
+        this.publisher = publisher;
+        this.name = name;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+
+    public String getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(String publisher) {
+        this.publisher = publisher;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+

--- a/bindings/java/src/conversion.rs
+++ b/bindings/java/src/conversion.rs
@@ -200,6 +200,22 @@ fn get_nullable_boolean_field<'local>(
     }
 }
 
+fn try_instance_of<'local>(
+    env: &mut JNIEnv<'local>,
+    elem: &JObject<'local>,
+    class: &str,
+    label: &str,
+) -> Option<bool> {
+    env.is_instance_of(elem, class)
+        .map_err(|e| {
+            env.throw_runtime_exception(format!(
+                "Failed to check type of `{label}`: {}",
+                format_err(e)
+            ))
+        })
+        .ok()
+}
+
 fn get_usage_array_field<'local>(
     env: &mut JNIEnv<'local>,
     obj: &JObject<'local>,
@@ -248,30 +264,31 @@ fn get_usage_array_field<'local>(
                 return None;
             }
         };
-        match env.is_instance_of(&elem, INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS) {
-            Ok(true) => {
-                let resource = get_string_field(env, &elem, "resource")?;
-                let version_constraint =
-                    get_nullable_string_field(env, &elem, "versionConstraint")?;
-                result.push(InterchangeProjectUsageRaw::Resource {
-                    resource,
-                    version_constraint,
-                });
-            }
-            Ok(false) => {
-                env.throw_runtime_exception(
-                    "Unknown usage type, only InterchangeProjectUsageResource is supported",
-                );
-                return None;
-            }
-            Err(e) => {
-                env.throw_runtime_exception(format!(
-                    "Failed to check whether `{field_name}[{i}]` is InterchangeProjectUsageResource:\n\
-                    {}",
-                    format_err(e)
-                ));
-                return None;
-            }
+        let label = format!("{field_name}[{i}]");
+        if try_instance_of(env, &elem, INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS, &label)? {
+            let resource = get_string_field(env, &elem, "resource")?;
+            let version_constraint = get_nullable_string_field(env, &elem, "versionConstraint")?;
+            result.push(InterchangeProjectUsageRaw::Resource {
+                resource,
+                version_constraint,
+            });
+        } else if try_instance_of(
+            env,
+            &elem,
+            INTERCHANGE_PROJECT_USAGE_DIRECTORY_CLASS,
+            &label,
+        )? {
+            let dir = get_string_field(env, &elem, "directory")?;
+            let publisher = get_string_field(env, &elem, "publisher")?;
+            let name = get_string_field(env, &elem, "name")?;
+            result.push(InterchangeProjectUsageRaw::Directory {
+                dir,
+                publisher,
+                name,
+            });
+        } else {
+            env.throw_runtime_exception(format!("Unknown usage type for `{label}`"));
+            return None;
         }
     }
     Some(result)
@@ -425,6 +442,8 @@ pub(crate) fn java_metadata_to_raw<'local>(
 
 pub(crate) const INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS: &str =
     "com/sensmetry/sysand/model/InterchangeProjectUsageResource";
+pub(crate) const INTERCHANGE_PROJECT_USAGE_DIRECTORY_CLASS: &str =
+    "com/sensmetry/sysand/model/InterchangeProjectUsageDirectory";
 pub(crate) const INTERCHANGE_PROJECT_USAGE_CLASS: &str =
     "com/sensmetry/sysand/model/InterchangeProjectUsage";
 pub(crate) const INTERCHANGE_PROJECT_INFO_CLASS: &str =
@@ -643,6 +662,33 @@ impl ToJObject for InterchangeProjectUsageRaw {
                     Err(e) => {
                         env.throw_runtime_exception(format!(
                             "Failed to create InterchangeProjectUsageResource: {}",
+                            format_err(e)
+                        ));
+                        None
+                    }
+                }
+            }
+            InterchangeProjectUsageRaw::Directory {
+                dir,
+                publisher,
+                name,
+            } => {
+                let dir = dir.to_jobject(env)?;
+                let publisher = publisher.to_jobject(env)?;
+                let name = name.to_jobject(env)?;
+                match env.new_object(
+                    INTERCHANGE_PROJECT_USAGE_DIRECTORY_CLASS,
+                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                    &[
+                        JValue::from(&dir),
+                        JValue::from(&publisher),
+                        JValue::from(&name),
+                    ],
+                ) {
+                    Ok(o) => Some(o),
+                    Err(e) => {
+                        env.throw_runtime_exception(format!(
+                            "Failed to create InterchangeProjectUsageDirectory: {}",
                             format_err(e)
                         ));
                         None

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -282,7 +282,6 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
             return JObject::default();
         }
     };
-
     let info_meta = match commands::info::do_info(&uri, &combined_resolver) {
         Ok(info_meta) => info_meta,
         Err(e) => {

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -23,7 +23,7 @@ wasm-bindgen = "0.2.114"
 web-sys = { version = "0.3.91", default-features = false, optional = true, features = ["Window", "Storage"] }
 serde = { version = "1.0.228", default-features = false }
 console_log = "1.0.0"
-log = { version = "0.4.29", default-features = false }
+log.workspace = true
 typed-path = { version = "0.12.3", default-features = false }
 
 [dev-dependencies]

--- a/bindings/py/Cargo.toml
+++ b/bindings/py/Cargo.toml
@@ -24,10 +24,10 @@ kpar-ppmd = ["sysand-core/kpar-ppmd", "sysand/kpar-ppmd"]
 sysand-core = { path = "../../core", features = ["python", "filesystem", "networking"] }
 sysand = { path = "../../sysand" }
 camino.workspace = true
-fluent-uri = { version = "0.4.1", features = ["serde", "net"] }
-log = { version = "0.4.29", default-features = false }
+fluent-uri.workspace = true
 pyo3 = { version = "0.29.0", default-features = false, features = ["macros"] }
 pyo3-log = "0.13.3"
+log.workspace = true
 semver = { version = "1.0.27", default-features = false }
 typed-path = { version = "0.12.3", default-features = false, features= ["std"] }
 url = { version = "2.5.8", default-features = false }

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -191,7 +191,6 @@ fn do_info_py(
 
         let uri = Iri::parse(uri)
             .map_err(|(e, input)| PyValueError::new_err(format!("invalid IRI `{input}`: {e}")))?;
-
         match do_info(&uri, &combined_resolver) {
             Ok(info_meta) => Ok(info_meta),
             Err(e) => Err(PyRuntimeError::new_err(format_err(e))),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,10 +40,10 @@ digest = { version = "0.11", default-features = false }
 sha2.workspace = true
 hex.workspace = true
 dirs = { version = "6.0.0", optional = true}
-fluent-uri = { version = "0.4.1", features = ["serde", "net"] }
+fluent-uri.workspace = true
 idna = { version = "1.1.0", default-features = false, features = ["compiled_data"] }
 indexmap = { version = "2.13.0", default-features = false, features = ["serde"] }
-log = { version = "0.4.29", default-features = false }
+log.workspace = true
 pubgrub = { version = "0.4.0", default-features = false }
 # partialzip = { version = "5.0.0", default-features = false, optional = true }
 pyo3 = { version = "0.29.0", default-features = false, features = ["macros", "chrono", "indexmap"], optional = true }

--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -75,79 +75,111 @@ pub fn do_add<P: ProjectMut>(
     project: &mut P,
     usage_raw: &InterchangeProjectUsageRaw,
 ) -> Result<bool, AddError<P::Error>> {
-    let usage: InterchangeProjectUsageG<String, String> = usage_raw.validate()?.into();
+    let usage: InterchangeProjectUsageG<String, String, String> = usage_raw.validate()?.into();
 
     let adding = "Adding";
     let header = crate::style::get_style_config().header;
     log::info!("{header}{adding:>12}{header:#} usage: {usage_raw}");
 
     if let Some(info) = project.get_info().map_err(AddError::Project)?.as_mut() {
-        let mut found = false;
+        let mut dont_add = false;
         match &usage {
             InterchangeProjectUsageRaw::Resource {
                 resource: new_resource,
                 version_constraint: new_vc,
             } => {
                 for u in info.usage.iter_mut() {
-                    match u {
-                        InterchangeProjectUsageRaw::Resource {
-                            resource,
-                            version_constraint,
-                        } if resource == new_resource => {
-                            match (&new_vc, version_constraint) {
-                                (None, None) => {
-                                    log::warn!(
-                                        "ignoring usage `{new_resource}`,\n\
+                    if let InterchangeProjectUsageRaw::Resource {
+                        resource,
+                        version_constraint,
+                    } = u
+                        && resource == new_resource
+                    {
+                        match (&new_vc, version_constraint) {
+                            (None, None) => {
+                                log::warn!(
+                                    "ignoring usage `{new_resource}`,\n\
                                          {SP:>8} since it is already present"
-                                    );
-                                    return Ok(false);
-                                }
-                                (None, Some(vc)) => {
-                                    log::warn!(
-                                        "ignoring usage `{new_resource}`\n\
+                                );
+                                return Ok(false);
+                            }
+                            (None, Some(vc)) => {
+                                log::warn!(
+                                    "ignoring usage `{new_resource}`\n\
                                          {SP:>8} without a version constraint, since it is already present with\n\
                                          {SP:>8} version constraint `{vc}`",
-                                    );
-                                    return Ok(false);
-                                }
-                                (Some(vc), vc_current @ None) => {
-                                    log::warn!(
-                                        "usage `{new_resource}` is already present,\n\
+                                );
+                                return Ok(false);
+                            }
+                            (Some(vc), vc_current @ None) => {
+                                log::warn!(
+                                    "usage `{new_resource}` is already present,\n\
                                          {SP:>8} but without a version constraint; version constraint\n\
                                          {SP:>8} `{vc}` will be added to it",
-                                    );
-                                    *vc_current = Some(vc.to_owned());
-                                    found = true;
-                                }
-                                (Some(vc_new), Some(vc_current)) => {
-                                    // TODO: more intelligent merging of constraints
-                                    if vc_new == vc_current {
-                                        log::warn!(
-                                            "ignoring usage `{new_resource}` with version constraint\n\
+                                );
+                                *vc_current = Some(vc.to_owned());
+                                dont_add = true;
+                            }
+                            (Some(vc_new), Some(vc_current)) => {
+                                // TODO: more intelligent merging of constraints
+                                if vc_new == vc_current {
+                                    log::warn!(
+                                        "ignoring usage `{new_resource}` with version constraint\n\
                                              {SP:>8} `{vc_new}`, since it is already present with identical version constraint",
-                                        );
-                                        return Ok(false);
-                                    } else {
-                                        log::warn!(
-                                            "usage `{new_resource}` is already present, but with version\n\
+                                    );
+                                    return Ok(false);
+                                } else {
+                                    log::warn!(
+                                        "usage `{new_resource}` is already present, but with version\n\
                                              {SP:>8} constraint `{vc_current}`; new version constraint\n\
                                              {SP:>8} `{vc_new}` will be added to the existing ones; this may\n\
                                              {SP:>8} result in failed version resolution or conflicting symbol errors",
-                                        );
-                                        vc_current.push_str(", ");
-                                        vc_current.push_str(vc_new);
-                                        found = true;
-                                    }
+                                    );
+                                    vc_current.push_str(", ");
+                                    vc_current.push_str(vc_new);
+                                    dont_add = true;
                                 }
                             }
+                        }
+                        break;
+                    }
+                }
+            }
+            InterchangeProjectUsageRaw::Directory {
+                dir: new_dir,
+                publisher: new_publisher,
+                name: new_name,
+            } => {
+                for u in info.usage.iter_mut() {
+                    if let InterchangeProjectUsageRaw::Directory {
+                        dir,
+                        publisher,
+                        name,
+                    } = u
+                    {
+                        if publisher == new_publisher && name == new_name {
+                            log::warn!(
+                                "usage `{publisher}`/`{name}` is already present;\n\
+                                {SP:>8} it will be updated to point to `{new_dir}`"
+                            );
+                            *dir = new_dir.to_owned();
+                            dont_add = true;
+                            break;
+                        } else if dir == new_dir {
+                            log::warn!(
+                                "existing usage `{publisher}`/`{name}` already points to path
+                                {SP:>8} `{dir}`; existing usage will be overwritten"
+                            );
+                            *publisher = new_publisher.to_owned();
+                            *name = new_name.to_owned();
+                            dont_add = true;
                             break;
                         }
-                        InterchangeProjectUsageRaw::Resource { .. } => (),
                     }
                 }
             }
         }
-        if !found {
+        if !dont_add {
             info.usage.push(usage);
         }
         project.put_info(info, true).map_err(AddError::Project)?;

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -297,10 +297,10 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                 }
             });
 
-    if let Some(resource) = info.usage.iter().find_map(|x| {
-        // Case-insensitively match `file:` scheme
+    if let Some(path_usage) = info.usage.iter().find_map(|x| {
         match x {
             InterchangeProjectUsageRaw::Resource { resource, .. } => {
+                // Case-insensitively match `file:` scheme
                 if let Some(scheme) = resource.get(..5)
                     && scheme.eq_ignore_ascii_case("file:")
                 {
@@ -309,15 +309,20 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                     None
                 }
             }
+            InterchangeProjectUsageRaw::Directory {
+                dir,
+                publisher: _,
+                name: _,
+            } => Some(dir),
         }
     }) {
         if allow_path_usage {
             log::warn!(
-                "project includes a path usage `{resource}`,\n\
+                "project includes a path usage of `{path_usage}`,\n\
                 which is unlikely to be available on other computers at the same path"
             );
         } else {
-            return Err(KParBuildError::PathUsage(resource.clone()));
+            return Err(KParBuildError::PathUsage(path_usage.clone()));
         }
     }
 

--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -85,7 +85,7 @@ pub fn do_info<R: ResolveRead>(
                     Err(e) => {
                         // These errors may be ugly, as `resolved` includes all
                         // possible candidates, with expectation that only some
-                        // of them will work. So we don't show these by default
+                        // of them will work. So we don't show them by default
                         log::debug!("skipping candidate project: {}", format_err(e));
                         continue;
                     }

--- a/core/src/commands/lock.rs
+++ b/core/src/commands/lock.rs
@@ -20,10 +20,11 @@ use crate::project::{editable::EditableProject, local_src::LocalSrcProject, util
 use crate::{
     context::ProjectContext,
     lock::{Lock, Project, Usage, hash_str},
-    model::{
-        InterchangeProjectUsage, InterchangeProjectUsageRaw, InterchangeProjectValidationError,
+    model::{InterchangeProjectUsage, InterchangeProjectValidationError},
+    project::{
+        CanonicalizationError, ProjectRead,
+        utils::{FsIoError, Identifier},
     },
-    project::{CanonicalizationError, ProjectRead, utils::FsIoError},
     resolve::ResolveRead,
     solve::pubgrub::{SolverError, solve},
     utils::ProvidedProjects,
@@ -113,7 +114,7 @@ pub enum LockError<PD: ProjectRead, R: ResolveRead + Debug + 'static> {
 #[derive(Debug)]
 pub struct LockOutcome<PD: Debug> {
     pub lock: Lock,
-    pub dependencies: Vec<(fluent_uri::Iri<String>, PD)>,
+    pub dependencies: Vec<(Identifier, PD)>,
 }
 
 /// Generates a lockfile by solving for a (compatible) set of interchange projects
@@ -133,6 +134,7 @@ pub fn do_lock_projects<
     'a,
     PI: ProjectRead + Debug + 'a,
     PD: ProjectRead + Debug,
+    // TODO: maybe take Vec<Iri<String>>, since empty vec is tolerated
     I: IntoIterator<Item = (Option<Vec<Iri<String>>>, &'a PI)>,
     R: ResolveRead<ProjectStorage = PD> + Debug,
 >(
@@ -146,9 +148,6 @@ pub fn do_lock_projects<
     let mut all_deps = vec![];
 
     for (identifiers, project) in projects {
-        // Before `info` is known: prefer a caller-supplied IRI, else a
-        // placeholder. After `info` is available (meta/canonical paths),
-        // the name+version is a strictly better label.
         let input_project_label = || match identifiers.as_ref().and_then(|ids| ids.first()) {
             Some(iri) => format!("`{iri}`"),
             None => "<unknown input project>".to_string(),
@@ -163,17 +162,11 @@ pub fn do_lock_projects<
                     field: IncompleteField::Info,
                 })
             })?;
+        let named_project_label = format!("`{}` {}", info.name, info.version);
         let validated_info = info.validate().map_err(|e| LockError::InvalidProject {
-            identifier: {
-                if let Some(ids) = &identifiers {
-                    ids[0].as_str().to_owned()
-                } else {
-                    info.name.clone()
-                }
-            },
+            identifier: named_project_label.clone(),
             source: e,
         })?;
-        let named_project_label = format!("`{}` {}", info.name, info.version);
         let meta = project
             .get_meta()
             .map_err(LockProjectError::InputProjectError)?
@@ -194,18 +187,10 @@ pub fn do_lock_projects<
             version: info.version,
             exports: meta.index.into_keys().collect(),
             identifiers: identifiers
-                .map(|ids| ids.into_iter().map(|id| id.into_string()).collect())
+                .map(|ids| ids.into_iter().map(Into::into).collect())
                 .unwrap_or_default(),
             sources,
-            usages: info
-                .usage
-                .iter()
-                .map(|u| match u {
-                    InterchangeProjectUsageRaw::Resource { resource, .. } => {
-                        Usage::from(resource.to_owned())
-                    }
-                })
-                .collect(),
+            usages: validated_info.usage.iter().map(Usage::from).collect(),
         });
 
         all_deps.extend(validated_info.usage);
@@ -239,17 +224,21 @@ pub fn do_lock_extend<
 ) -> Result<LockOutcome<PD>, LockError<PD, R>> {
     let inputs: Vec<_> = usages.into_iter().collect();
     let mut dependencies = vec![];
-    let solution = solve(inputs, resolver).map_err(LockError::Solver)?;
+    #[cfg(feature = "filesystem")]
+    let base_path = ctx.workspace_or_project_root();
+    #[cfg(not(feature = "filesystem"))]
+    let base_path = None;
+    let solution = solve(inputs, base_path, resolver).map_err(LockError::Solver)?;
     let mut lock_projects = HashSet::new();
     let mut lock_symbols = HashMap::new();
     for (i, p) in lock.projects.iter().enumerate() {
-        if let Some(iri) = p.identifiers.first() {
+        if let Some(id) = p.identifiers.first() {
             // FIXME: better deduplication. What to consider? Previously this was
             // done based on canonical checksum, but such rigor is not necessary,
             // since if symbols of any two projects overlap the lock will fail anyway.
             // Current way may produce a lockfile that does not satisfy all version
             // constraints.
-            lock_projects.insert(iri.clone());
+            lock_projects.insert(id.clone());
         }
         for s in p.exports.iter() {
             if let Some(conflict_idx) = lock_symbols.insert(hash_str(s), i) {
@@ -265,30 +254,28 @@ pub fn do_lock_extend<
         }
     }
 
-    for (iri, project) in solution {
-        let iri_str = iri.as_str().to_owned();
+    for (identifier, project) in solution {
         // TODO: use get_info, that can be more efficient
         let info = project
             .get_info()
             .map_err(LockError::DependencyProject)?
             .ok_or_else(|| LockError::IncompleteProject {
-                project_label: iri_str.clone(),
+                project_label: identifier.to_string(),
                 field: IncompleteField::Info,
             })?;
-        // Validate dependency projects too, not just the top-level ones.
-        info.validate().map_err(|e| LockError::InvalidProject {
-            identifier: iri_str.clone(),
+        let validated_info = info.validate().map_err(|e| LockError::InvalidProject {
+            identifier: identifier.to_string(),
             source: e,
         })?;
         let meta = project
             .get_meta()
             .map_err(LockError::DependencyProject)?
             .ok_or_else(|| LockError::IncompleteProject {
-                project_label: iri_str.clone(),
+                project_label: identifier.to_string(),
                 field: IncompleteField::Meta,
             })?;
 
-        let sources = if !provided_usages.contains_key(iri.as_str()) {
+        let sources = if !provided_usages.contains_key(&identifier) {
             let sources = project.sources(ctx).map_err(LockError::DependencyProject)?;
             debug_assert!(!sources.is_empty());
             sources
@@ -301,19 +288,14 @@ pub fn do_lock_extend<
             publisher: info.publisher,
             version: info.version.to_string(),
             exports: meta.index.into_keys().collect(),
-            identifiers: vec![iri.to_string()],
+            identifiers: vec![identifier.to_string()],
             sources,
-            usages: info
-                .usage
-                .into_iter()
-                .map(|u| match u {
-                    InterchangeProjectUsageRaw::Resource { resource, .. } => Usage::from(resource),
-                })
-                .collect(),
+            // TODO: into_iter
+            usages: validated_info.usage.iter().map(Usage::from).collect(),
         };
-        if lock_projects.contains(iri.as_str()) {
+        if lock_projects.contains(identifier.as_str()) {
             log::debug!(
-                "not adding project `{iri}` ({}) to lock, as lock already contains it",
+                "not adding project `{identifier}` ({}) to lock, as lock already contains it",
                 lock_project.version
             );
         } else {
@@ -349,7 +331,7 @@ pub fn do_lock_extend<
             lock.projects.push(lock_project);
         }
 
-        dependencies.push((iri, project));
+        dependencies.push((identifier, project));
     }
 
     Ok(LockOutcome { lock, dependencies })

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -637,6 +637,12 @@ pub enum PublishError {
         which is neither in the index nor a SysML/KerML standard library"
     )]
     DisallowedUsage { name: Box<str> },
+    #[error(
+        "project uses local project at `{path}`\n\
+        and therefore cannot be published; if the project being published
+        uses projects that are not yet in the index, publish them first"
+    )]
+    PathUsage { path: Box<str> },
     #[error("KPAR's `.{name}.json` is invalid")]
     InfoMetaValidation {
         name: &'static str,
@@ -1279,6 +1285,9 @@ fn check_usage(usage: &InterchangeProjectUsageRaw) -> Result<(), PublishError> {
                 }),
             }
         }
+        InterchangeProjectUsageRaw::Directory { dir, .. } => Err(PublishError::PathUsage {
+            path: dir.as_str().into(),
+        }),
     }
 }
 
@@ -1320,6 +1329,7 @@ fn check_std_libs(
             }
             Ok(false)
         }
+        InterchangeProjectUsageRaw::Directory { .. } => Ok(false),
     }
 }
 

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -531,6 +531,33 @@ fn check_usage_rejects_unknown_std_lib() {
     assert_matches!(err, PublishError::UnknownStdLib { .. });
 }
 
+fn directory_usage(dir: &str) -> InterchangeProjectUsageRaw {
+    InterchangeProjectUsageRaw::Directory {
+        dir: dir.to_string(),
+        publisher: "acme".to_string(),
+        name: "lib".to_string(),
+    }
+}
+
+#[test]
+fn check_usage_rejects_directory_usage() {
+    let err = check_usage(&directory_usage("../local-dep")).unwrap_err();
+    assert_matches!(err, PublishError::PathUsage { path } if path.as_ref() == "../local-dep");
+}
+
+#[test]
+fn check_usage_rejects_directory_usage_with_version_constraint() {
+    // Directory usages have no version_constraint field, but verify the error
+    // is PathUsage regardless of publisher/name values.
+    let err = check_usage(&InterchangeProjectUsageRaw::Directory {
+        dir: "libs/sub".to_string(),
+        publisher: "org".to_string(),
+        name: "thing".to_string(),
+    })
+    .unwrap_err();
+    assert_matches!(err, PublishError::PathUsage { path } if path.as_ref() == "libs/sub");
+}
+
 // --- map_publish_response ---
 
 #[test]

--- a/core/src/commands/remove.rs
+++ b/core/src/commands/remove.rs
@@ -17,6 +17,8 @@ pub enum RemoveError<ProjectError> {
     Validation(#[from] InterchangeProjectValidationError),
     #[error("could not find usage for `{0}`")]
     UsageNotFound(Box<str>),
+    #[error("could not find usage for `{publisher}/{name}`")]
+    ExpUsageNotFound { publisher: String, name: String },
     #[error("project is missing project information")]
     MissingInfo,
 }
@@ -55,6 +57,34 @@ pub fn do_remove<P: ProjectMut>(
 
         if popped.is_empty() {
             Err(RemoveError::UsageNotFound(iri.into_boxed_str()))
+        } else {
+            project
+                .put_info(&info, true)
+                .map_err(RemoveError::Project)?;
+            Ok(popped)
+        }
+    } else {
+        Err(RemoveError::MissingInfo)
+    }
+}
+
+pub fn exp_do_remove<P: ProjectMut>(
+    project: &mut P,
+    publisher: &str,
+    name: &str,
+) -> Result<Vec<InterchangeProjectUsageRaw>, RemoveError<P::Error>> {
+    let removing = "Removing";
+    let header = crate::style::get_style_config().header;
+    log::info!("{header}{removing:>12}{header:#} `{publisher}/{name}` from usages");
+
+    if let Some(mut info) = project.get_info().map_err(RemoveError::Project)? {
+        let popped = info.exp_pop_usage(publisher, name);
+
+        if popped.is_empty() {
+            Err(RemoveError::ExpUsageNotFound {
+                publisher: publisher.to_owned(),
+                name: name.to_owned(),
+            })
         } else {
             project
                 .put_info(&info, true)

--- a/core/src/commands/sources.rs
+++ b/core/src/commands/sources.rs
@@ -13,7 +13,7 @@ use crate::project::local_src::{LocalSrcError, LocalSrcProject, PathError};
 use crate::{
     env::ReadEnvironment,
     model::{InterchangeProjectUsage, InterchangeProjectValidationError},
-    project::ProjectRead,
+    project::{ProjectRead, utils::Identifier},
     resolve::{
         ResolveRead,
         env::EnvResolver,
@@ -144,36 +144,28 @@ pub fn do_sources_local_src_project_no_deps(
 /// in an environment and enumerates the resolved projects together with their IRIs.
 ///
 /// `provided_usages` are assumed to have been satisfied (including their dependencies)
-/// but have to match.
+/// and are not included in the returned list
 #[allow(clippy::type_complexity)]
 fn solve_dependencies<Env: ReadEnvironment + Debug + 'static>(
     requested: Vec<InterchangeProjectUsage>,
     env: Env,
     provided_usages: &ProvidedProjects,
 ) -> Result<
-    Vec<(
-        fluent_uri::Iri<String>,
-        <Env as ReadEnvironment>::InterchangeProjectRead,
-    )>,
+    Vec<(Identifier, <Env as ReadEnvironment>::InterchangeProjectRead)>,
     SolverError<impl ResolveRead + Debug + use<Env>>,
 > {
-    let mut memory_projects = HashMap::default();
-
-    for (k, v) in provided_usages {
-        memory_projects.insert(k.clone(), v.to_vec());
-    }
-
-    let wrapped_resolver = PriorityResolver::new(
+    let resolver = PriorityResolver::new(
         MemoryResolver {
             iri_predicate: AcceptAll {},
-            projects: memory_projects,
+            projects: provided_usages.to_owned(),
         },
         EnvResolver { env },
     );
 
-    let mut wrapped_result = crate::solve::pubgrub::solve(requested, wrapped_resolver)?;
+    // `base_path` does not matter here, since the resolver only looks in env
+    let mut resolved = crate::solve::pubgrub::solve(requested, None, resolver)?;
 
-    Ok(wrapped_result
+    Ok(resolved
         .drain()
         .filter_map(|(iri, project)| match project {
             PriorityProject::HigherProject(_) => None,
@@ -186,7 +178,7 @@ fn solve_dependencies<Env: ReadEnvironment + Debug + 'static>(
 /// in an environment and enumerate the resolved projects.
 ///
 /// `provided_usages` are assumed to have been satisfied (including their dependencies)
-/// but have to match.
+/// and are not included in the returned list
 pub fn find_project_dependencies<Env: ReadEnvironment + Debug + 'static>(
     requested: Vec<InterchangeProjectUsage>,
     env: Env,
@@ -215,27 +207,26 @@ pub fn resolve_dependencies<Env: ReadEnvironment + Debug + 'static>(
     Vec<<Env as ReadEnvironment>::InterchangeProjectRead>,
     SolverError<impl ResolveRead + Debug + use<Env>>,
 > {
-    // No need to resolve dependencies if they are not gonna be used.
+    // No need to resolve dependencies if they are not gonna be used
     if dependencies == Dependencies::None {
         return Ok(Vec::new());
     }
-
     let std_libs = known_std_libs();
 
     // For `Deps` the standard libraries are treated as already provided so the
     // solver omits them; otherwise everything is resolved and filtered below.
     let empty = HashMap::default();
-    let provided_usages = match dependencies {
+    let provided_iris = match dependencies {
         Dependencies::Deps => &std_libs,
         _ => &empty,
     };
 
-    let resolved = solve_dependencies(requested, env, provided_usages)?;
+    let resolved = solve_dependencies(requested, env, provided_iris)?;
 
     Ok(resolved
         .into_iter()
         .filter(|(iri, _)| match dependencies {
-            Dependencies::Std => std_libs.contains_key(iri.as_str()),
+            Dependencies::Std => std_libs.contains_key(iri),
             // std_libs are already filtered out by `solve_dependencies`
             Dependencies::Deps | Dependencies::DepsStd => true,
             Dependencies::None => false,

--- a/core/src/commands/sync.rs
+++ b/core/src/commands/sync.rs
@@ -17,18 +17,18 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum SyncError<UrlParseError: ErrorBound, GitError: ErrorBound> {
     #[error(
-        "incorrect checksum for project with IRI `{iri}` in lockfile:\n\
+        "incorrect checksum for project with `{id}` in lockfile:\n\
         expected `{expected}`, but the actual is\n\
         `{actual}`"
     )]
     BadChecksum {
-        iri: String,
+        id: String,
         expected: ProjectChecksum,
         actual: ProjectChecksum,
     },
     #[error("project with IRI `{0}` is missing `.project.json` or `.meta.json`")]
     BadProject(String),
-    #[error("project with IRI(s) {0:?} has no known sources in lockfile")]
+    #[error("project with identifiers {0:?} has no known sources in lockfile")]
     MissingSource(Box<[String]>),
     #[error("no IRI given for project with src_path = `{0}` in lockfile")]
     MissingIriSrcPath(Box<str>),
@@ -68,10 +68,10 @@ pub enum SyncError<UrlParseError: ErrorBound, GitError: ErrorBound> {
     GitDownload(Box<str>, GitError),
     #[error("invalid remote source URL `{0}`:\n{1}")]
     InvalidRemoteSource(Box<str>, UrlParseError),
-    #[error("no supported sources for project with IRI `{0}`")]
+    #[error("no supported sources for project {0}")]
     UnsupportedSources(String),
-    #[error("failed to install project `{uri}`:\n{cause}")]
-    InstallFail { uri: Box<str>, cause: String },
+    #[error("failed to install project `{id}`:\n{cause}")]
+    InstallFail { id: String, cause: String },
     #[error(
         "tried to install a non-provided version {version} of `{iri}`, which is\n\
         an IRI marked as being provided by your tooling; provided versions are:\n\
@@ -145,9 +145,9 @@ where
         // TODO: We need a proper way to treat multiple IRIs here
         let main_uri = project.identifiers.first();
 
-        for iri in &project.identifiers {
-            // TODO: maybe canonicalize on lock read, or don't canonicalize at all?
-            let excluded_versions = provided_usages.get(iri.as_str());
+        // TODO: maybe canonicalize on lock read, or don't canonicalize at all?
+        for id in &project.identifiers {
+            let excluded_versions = provided_usages.get(id.as_str());
 
             if let Some(versions) = excluded_versions {
                 let mut provided_versions = vec![];
@@ -156,7 +156,7 @@ where
                     // Provided projects must have complete metadata
                     let version = project_version.version().unwrap().unwrap();
                     if project.version == version {
-                        log::debug!("`{iri}` is marked as provided, skipping installation");
+                        log::debug!("`{id}` is marked as provided, skipping installation");
                         continue 'main_loop;
                     }
 
@@ -164,7 +164,7 @@ where
                 }
 
                 return Err(SyncError::InvalidProvidedVersion {
-                    iri: iri.as_str().into(),
+                    iri: id.as_str().into(),
                     version: project.version.as_str().into(),
                     provided_versions,
                 });
@@ -338,7 +338,7 @@ where
                     log::debug!("trying to install `{uri}` from remote_git: {remote_git}");
                     do_env_install_project(uri, &project.version, &storage, None, env, true, true)
                         .map_err(|e| SyncError::InstallFail {
-                            uri: uri.as_str().into(),
+                            id: uri.to_owned(),
                             cause: format_err(e),
                         })?;
                 }
@@ -359,20 +359,20 @@ fn try_install<
     G: ErrorBound,
     S: AsRef<str>,
 >(
-    uri: S,
+    id: S,
     version: &str,
     expected_checksum: &ProjectChecksum,
     storage: P,
     env: &mut E,
 ) -> Result<(), SyncError<U, G>> {
-    let uri = uri.as_ref();
+    let id = id.as_ref();
     let actual_checksum = storage
         .checksum_canonical_variant()
         .map_err(|e| SyncError::ProjectRead(format_err(e)))?;
     if expected_checksum == &actual_checksum {
         // TODO: Need to decide how to handle existing installations and possible flags to modify behavior
         do_env_install_project(
-            uri,
+            id,
             version,
             &storage,
             Some(actual_checksum),
@@ -381,12 +381,12 @@ fn try_install<
             true,
         )
         .map_err(|e| SyncError::InstallFail {
-            uri: uri.into(),
+            id: id.to_owned(),
             cause: format_err(e),
         })?;
     } else {
         return Err(SyncError::BadChecksum {
-            iri: uri.into(),
+            id: id.to_owned(),
             expected: expected_checksum.to_owned(),
             actual: actual_checksum,
         });

--- a/core/src/commands/sync_tests.rs
+++ b/core/src/commands/sync_tests.rs
@@ -130,7 +130,7 @@ fn try_install_fails_to_install_wrong_checksum() {
     let mut env = new_env();
 
     let SyncError::BadChecksum {
-        iri,
+        id: iri,
         expected,
         actual,
     } = try_install::<_, _, Infallible, Infallible, _>(

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -27,3 +27,24 @@ pub struct ProjectContext {
     #[cfg(feature = "filesystem")]
     pub env: Option<LocalDirectoryEnvironment>,
 }
+
+impl ProjectContext {
+    #[cfg(feature = "filesystem")]
+    pub fn project_root(&self) -> Option<Utf8PathBuf> {
+        self.current_project
+            .as_ref()
+            .map(|p| p.root_path().to_owned())
+    }
+
+    #[cfg(feature = "filesystem")]
+    pub fn workspace_root(&self) -> Option<Utf8PathBuf> {
+        self.current_workspace
+            .as_ref()
+            .map(|p| p.root_path().to_owned())
+    }
+
+    #[cfg(feature = "filesystem")]
+    pub fn workspace_or_project_root(&self) -> Option<Utf8PathBuf> {
+        self.workspace_root().or_else(|| self.project_root())
+    }
+}

--- a/core/src/env/local_directory/metadata.rs
+++ b/core/src/env/local_directory/metadata.rs
@@ -11,10 +11,9 @@ use typed_path::{Utf8UnixComponent, Utf8UnixPathBuf};
 
 use crate::{
     env::ProjectChecksum,
-    model::InterchangeProjectUsageRaw,
     project::{
         local_src::{LocalSrcError, LocalSrcProject},
-        utils::{FsIoError, deserialize_unix_path, wrapfs},
+        utils::{FsIoError, Identifier, deserialize_unix_path, wrapfs},
     },
     utils::multiline_array,
 };
@@ -226,10 +225,8 @@ impl EnvMetadata {
             identifiers,
             usages: info
                 .usage
-                .into_iter()
-                .map(|u| match u {
-                    InterchangeProjectUsageRaw::Resource { resource, .. } => resource,
-                })
+                .iter()
+                .map(|u| Identifier::from_interchange_usage_unchecked(u).into_string())
                 .collect(),
             editable,
             workspace,

--- a/core/src/env/local_directory/metadata_tests.rs
+++ b/core/src/env/local_directory/metadata_tests.rs
@@ -72,3 +72,79 @@ fn unsupported_version_is_rejected() {
         "unexpected error: {err}"
     );
 }
+
+// --- Env identifiers ---
+
+#[test]
+fn env_project_with_urn_kpar_identifier_is_found() {
+    let toml = r#"version = "0.1"
+
+[[project]]
+name = "my-dep"
+version = "1.0.0"
+path = "projects/my-dep"
+identifiers = [
+    "urn:kpar:my-dep",
+]
+"#;
+    let meta = EnvMetadata::from_str(toml).unwrap();
+    let found = meta.find_project_version("urn:kpar:my-dep", "1.0.0");
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().name, "my-dep");
+}
+
+#[test]
+fn env_project_with_urn_sysand_identifier_is_found() {
+    // urn:sysand: is the non-PURL, non-URL form produced by Directory usages
+    // with publishers/names that cannot be represented as a PURL (e.g. too short)
+    let toml = r#"version = "0.1"
+
+[[project]]
+publisher = "ab"
+name = "my-lib"
+version = "1.0.0"
+path = "projects/my-lib"
+identifiers = [
+    "urn:sysand:ab/my-lib",
+]
+"#;
+    let meta = EnvMetadata::from_str(toml).unwrap();
+    let found = meta.find_project_version("urn:sysand:ab/my-lib", "1.0.0");
+    assert!(found.is_some());
+    let project = found.unwrap();
+    assert_eq!(project.name, "my-lib");
+    assert_eq!(project.publisher.as_deref(), Some("ab"));
+}
+
+#[test]
+fn env_project_with_urn_sysand_identifier_has_correct_usages() {
+    let toml = r#"version = "0.1"
+
+[[project]]
+name = "consumer"
+version = "2.0.0"
+path = "projects/consumer"
+usages = [
+    "urn:sysand:ab/my-lib",
+]
+
+[[project]]
+publisher = "ab"
+name = "my-lib"
+version = "1.0.0"
+path = "projects/my-lib"
+identifiers = [
+    "urn:sysand:ab/my-lib",
+]
+"#;
+    let meta = EnvMetadata::from_str(toml).unwrap();
+
+    // consumer has no identifiers, look it up by name
+    let consumer = meta.projects.iter().find(|p| p.name == "consumer").unwrap();
+    assert_eq!(consumer.usages, vec!["urn:sysand:ab/my-lib"]);
+
+    let dep = meta
+        .find_project_version("urn:sysand:ab/my-lib", "1.0.0")
+        .unwrap();
+    assert_eq!(dep.name, "my-lib");
+}

--- a/core/src/env/local_directory/mod.rs
+++ b/core/src/env/local_directory/mod.rs
@@ -25,12 +25,11 @@ use crate::{
     },
     iri_normalize::IriVersionFilename,
     lock::{Lock, Source},
-    model::InterchangeProjectUsageRaw,
     project::{
         local_src::{LocalSrcError, LocalSrcProject, PathError},
         utils::{
-            FsIoError, ProjectDeserializationError, ProjectSerializationError, RelativizePathError,
-            wrapfs,
+            FsIoError, Identifier, ProjectDeserializationError, ProjectSerializationError,
+            RelativizePathError, wrapfs,
         },
     },
     workspace::Workspace,
@@ -120,7 +119,7 @@ impl LocalDirectoryEnvironment {
                 let usages = project
                     .usages
                     .iter()
-                    .map(|usage| usage.inner().clone())
+                    .map(|usage| usage.to_string())
                     .collect();
 
                 let workspace_member = ws
@@ -132,7 +131,7 @@ impl LocalDirectoryEnvironment {
                     name: project.name.to_owned(),
                     version: project.version.to_owned(),
                     path: editable.as_str().into(),
-                    identifiers: project.identifiers.to_owned(),
+                    identifiers: project.identifiers.iter().map(|i| i.to_string()).collect(),
                     usages,
                     editable: true,
                     workspace: workspace_member,
@@ -287,9 +286,7 @@ impl ReadEnvironment for LocalDirectoryEnvironment {
             .metadata
             .projects
             .iter()
-            .flat_map(|p| p.identifiers.iter())
-            .cloned()
-            .map(Ok)
+            .flat_map(|p| p.identifiers.iter().map(|i| Ok(i.to_string())))
             .collect())
     }
 
@@ -475,9 +472,7 @@ impl WriteEnvironment for LocalDirectoryEnvironment {
             existing.usages = info
                 .usage
                 .into_iter()
-                .map(|u| match u {
-                    InterchangeProjectUsageRaw::Resource { resource, .. } => resource,
-                })
+                .map(|u| Identifier::from_interchange_usage_unchecked(&u).into_string())
                 .collect();
             existing.checksum = checksum.map(Into::into);
 

--- a/core/src/env/mod.rs
+++ b/core/src/env/mod.rs
@@ -149,7 +149,6 @@ pub trait ReadEnvironmentAsync {
     ) -> impl Future<Output = Result<bool, Self::ReadError>> {
         async move {
             let needle = uri.as_ref();
-
             let uris = self.uris_async().await?;
             uris.try_any(|u| async move { u == needle }).await
         }
@@ -162,7 +161,6 @@ pub trait ReadEnvironmentAsync {
     ) -> impl Future<Output = Result<bool, Self::ReadError>> {
         async move {
             let needle = version.as_ref();
-
             let versions = self.versions_async(&uri).await?;
             versions.try_any(|v| async move { v == needle }).await
         }

--- a/core/src/iri_normalize.rs
+++ b/core/src/iri_normalize.rs
@@ -111,6 +111,7 @@ pub enum IriNormalizeError {
     #[cfg(feature = "filesystem")]
     #[error("IRI is not a well-formed RFC 3987 IRI: {0}")]
     Parse(fluent_uri::ParseError),
+    // `idna::Errors` is an empty type, so not needed here
     #[error("host `{host}` is not a valid IDN and cannot be converted to Punycode")]
     IdnConversion { host: String },
 }

--- a/core/src/lock.rs
+++ b/core/src/lock.rs
@@ -21,9 +21,10 @@ use typed_path::Utf8UnixPathBuf;
 use crate::{
     config::OverrideSource,
     env::ReadEnvironment,
+    model::InterchangeProjectUsage,
     project::{
         ProjectChecksum,
-        utils::{deserialize_unix_path, serialize_unix_path},
+        utils::{Identifier, deserialize_unix_path, serialize_unix_path},
     },
     utils::{RelativePathKind, RelativeUnixPathError, multiline_array, parse_relative_unix_path},
 };
@@ -240,7 +241,7 @@ impl Lock {
                         return Err(ValidationError::ProjectWithoutId(project.name.clone()));
                     }
                 };
-                return Err(ValidationError::ProjectIdCollision(id.to_string()));
+                return Err(ValidationError::ProjectIdCollision(id.to_owned()));
             }
             for name in &project.exports {
                 if !seen_exports.insert(name) {
@@ -252,7 +253,7 @@ impl Lock {
     }
 
     fn validate_usages(&self) -> Result<(), ValidationError> {
-        let mut iri_versions = HashSet::new();
+        let mut identifier_versions = HashSet::new();
         for project in &self.projects {
             let _ = Version::parse(&project.version).inspect_err(|err| {
                 log::warn!(
@@ -264,13 +265,13 @@ impl Lock {
                     err
                 );
             });
-            for iri in &project.identifiers {
-                iri_versions.insert(iri.clone());
+            for id in &project.identifiers {
+                identifier_versions.insert(id.clone());
             }
         }
         for project in &self.projects {
             for usage in &project.usages {
-                if !iri_versions.contains(usage.inner()) {
+                if !identifier_versions.contains(usage.inner()) {
                     return Err(ValidationError::UnsatisfiedUsage {
                         usage: usage.inner().to_owned(),
                         name: project.name.clone(),
@@ -401,6 +402,48 @@ pub const PROJECT_ENTRIES: &[&str] = &[
     "usages",
     "sources",
 ];
+
+// TODO: decide whether to change lockfile project identifier.
+// Ideally, we would require publisher to be present, then
+// `identifiers` could be removed entirely, and
+// projects would refer to each other by publisher and name only:
+// - usages in .project.json
+// - usages in lockfile
+// - standard libraries (can hardcode them to be treated as
+//   having a publisher `OMG` or similar)
+// Not having to deal with identifiers would be nice,
+// but would require an extremely large refactoring
+//
+// For:
+// - project identity becomes clearly defined for all projects,
+//   useful for deduplication, especially during locking
+// - clear how to communicate to the user about a project (errors, logs)
+// - less stuff in lockfile
+// - less identity information to keep track of
+// - easy dependency replacements (publisher+name is much simpler for the
+//   user than IRIs with their normalization etc.)
+//
+// Against:
+// - can't drop support for projects without a publisher, but
+//   publisher becomes load-bearing and necessary for correctness.
+//   TBD how to resolve this, maybe use a placeholder for all such
+//   projects, like `<unspecified-publisher>`.
+// - requires special treatment for std libs (not a big deal, they're
+//   already specially treated)
+// - populating a lockfile will always require pulling the project
+//   info for index projects, since we need non-normalized publisher
+//   and name for identification (or maybe it would be fine to use
+//   normalized variants in lockfile? they still allow checking
+//   if deps are satisfied. Alternatively, add them to versions.json,
+//   it's backwards compatible)
+//
+// Alternatively, use my previous design here that has a separate
+// `Identifier` type, which is constructed:
+// - `Resource`: just the IRI
+// - `Directory/Kpar`: URL-encoded publisher+name
+// - `Index`: pkg:sysand where possible, else URL-encoded publisher+name
+// - `Git`: TBD (maybe URL, maybe URL-encoded publisher+name)
+// - `Url`: TBD (maybe URL, maybe URL-encoded publisher+name)
 
 /// Fields that might not be set for every project are `Option`
 #[derive(Clone, Eq, Debug, Deserialize, PartialEq)]
@@ -690,25 +733,30 @@ impl Deref for Usage {
     }
 }
 
-impl From<String> for Usage {
-    fn from(resource: String) -> Self {
-        Self(resource)
+impl From<&InterchangeProjectUsage> for Usage {
+    fn from(value: &InterchangeProjectUsage) -> Self {
+        Self(Identifier::from(value).into_string())
     }
 }
 
-impl From<Iri<String>> for Usage {
-    fn from(resource: Iri<String>) -> Self {
-        Self(resource.into_string())
+impl From<InterchangeProjectUsage> for Usage {
+    fn from(value: InterchangeProjectUsage) -> Self {
+        Self(Identifier::from(value).into_string())
     }
 }
 
 impl Usage {
-    pub fn inner(&self) -> &String {
+    pub fn inner(&self) -> &str {
         &self.0
     }
 
-    pub fn into_string(self) -> String {
+    pub fn into_inner(self) -> String {
         self.0
+    }
+
+    /// This should not be used where possible
+    pub fn from_str_unchecked(u: &str) -> Usage {
+        Self(u.to_owned())
     }
 
     fn to_toml(&self) -> Value {
@@ -716,6 +764,7 @@ impl Usage {
     }
 }
 
+// TODO: proper validation must be done _somewhere_
 impl<'de> Deserialize<'de> for Usage {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/core/src/lock_tests.rs
+++ b/core/src/lock_tests.rs
@@ -4,6 +4,9 @@
 use std::assert_matches;
 use std::{fmt::Display, num::NonZeroU64, slice, str::FromStr};
 
+use crate::model::InterchangeProjectUsage;
+use fluent_uri::Iri;
+
 use toml_edit::DocumentMut;
 use typed_path::Utf8UnixPathBuf;
 
@@ -380,7 +383,7 @@ fn one_usage_to_toml() {
             version: "0.5.1".to_string(),
             exports: vec![],
             identifiers: vec![],
-            usages: vec![Usage::from("urn:kpar:usage".to_string())],
+            usages: vec![Usage::from_str_unchecked("urn:kpar:usage")],
             sources: vec![],
         }],
         r#"
@@ -404,9 +407,9 @@ fn many_usage_to_toml() {
             exports: vec![],
             identifiers: vec![],
             usages: vec![
-                Usage::from("urn:kpar:first".to_string()),
-                Usage::from("urn:kpar:second".to_string()),
-                Usage::from("urn:kpar:third".to_string()),
+                Usage::from_str_unchecked("urn:kpar:first"),
+                Usage::from_str_unchecked("urn:kpar:second"),
+                Usage::from_str_unchecked("urn:kpar:third"),
             ],
             sources: vec![],
         }],
@@ -537,7 +540,7 @@ fn validate_single_usage() {
                 "0.0.1",
                 &[],
                 &[],
-                &[Usage::from(iri.to_string())],
+                &[Usage::from_str_unchecked(iri)],
             ),
             make_project("b", None, "0.0.1", &[], &[iri], &[]),
         ],
@@ -559,7 +562,10 @@ fn validate_multiple_usage() {
                 "0.0.1",
                 &[],
                 &[],
-                &[Usage::from(iri1.to_string()), Usage::from(iri2.to_string())],
+                &[
+                    Usage::from_str_unchecked(iri1),
+                    Usage::from_str_unchecked(iri2),
+                ],
             ),
             make_project("b", None, "0.0.1", &[], &[iri1], &[]),
             make_project("c", None, "0.0.1", &[], &[iri2], &[]),
@@ -582,7 +588,7 @@ fn validate_chained_usages() {
                 "0.0.1",
                 &[],
                 &[],
-                &[Usage::from(iri1.to_string())],
+                &[Usage::from_str_unchecked(iri1)],
             ),
             make_project(
                 "b",
@@ -590,7 +596,7 @@ fn validate_chained_usages() {
                 "0.0.1",
                 &[],
                 &[iri1],
-                &[Usage::from(iri2.to_string())],
+                &[Usage::from_str_unchecked(iri2)],
             ),
             make_project("c", None, "0.0.1", &[], &[iri2], &[]),
         ],
@@ -632,7 +638,7 @@ fn validate_single_name_collision() {
                 "0.0.1",
                 &[name],
                 &[],
-                &[Usage::from(iri.to_string())],
+                &[Usage::from_str_unchecked(iri)],
             ),
             make_project("b", None, "0.0.1", &[name], &[iri], &[]),
         ],
@@ -662,7 +668,7 @@ fn validate_multiple_name_collision() {
                 "0.0.1",
                 &[name1, name2, name3],
                 &[],
-                &[Usage::from(iri.to_string())],
+                &[Usage::from_str_unchecked(iri)],
             ),
             make_project("b", None, "0.0.1", &[name2, name3, name4], &[iri], &[]),
         ],
@@ -677,7 +683,7 @@ fn validate_multiple_name_collision() {
 
 #[test]
 fn validate_unsatisfied_usage() {
-    let usage_in = Usage::from("urn:kpar:test".to_string());
+    let usage_in = Usage::from_str_unchecked("urn:kpar:test");
     let Err(err) = Lock {
         lock_version: CURRENT_LOCK_VERSION.to_string(),
         projects: vec![make_project(
@@ -850,8 +856,8 @@ fn sort_identifiers() {
 
 #[test]
 fn sort_sources() {
-    let usage1 = Usage::from("urn:kpar:a".to_string());
-    let usage2 = Usage::from("urn:kpar:b".to_string());
+    let usage1 = Usage::from_str_unchecked("urn:kpar:a");
+    let usage2 = Usage::from_str_unchecked("urn:kpar:b");
     let project1 = make_project(
         "a",
         None,
@@ -872,8 +878,8 @@ fn sort_sources() {
 
 #[test]
 fn sort_sources_with_constraints() {
-    let usage1 = Usage::from("urn:kpar:a".to_string());
-    let usage2 = Usage::from("urn:kpar:a".to_string());
+    let usage1 = Usage::from_str_unchecked("urn:kpar:a");
+    let usage2 = Usage::from_str_unchecked("urn:kpar:a");
     let project1 = make_project(
         "a",
         None,
@@ -1026,6 +1032,117 @@ fn canonicalize_checksums() {
     // canonicalize_checksums does not panic on them.
     assert_matches!(&project.sources[5], Source::Editable { .. });
     assert_matches!(&project.sources[6], Source::RemoteGit { .. });
+}
+
+// --- Lock identifiers ---
+
+#[test]
+fn usage_from_resource_usage_is_its_iri() {
+    let iri = Iri::parse("urn:kpar:my-dep".to_owned()).unwrap();
+    let interchange = InterchangeProjectUsage::Resource {
+        resource: iri,
+        version_constraint: None,
+    };
+    let usage = Usage::from(&interchange);
+    assert_eq!(usage.inner(), "urn:kpar:my-dep");
+}
+
+#[test]
+fn usage_from_directory_usage_is_sysand_purl() {
+    let interchange = InterchangeProjectUsage::Directory {
+        dir: Utf8UnixPathBuf::from("dep"),
+        publisher: "acme-corp".to_owned(),
+        name: "my-lib".to_owned(),
+    };
+    let usage = Usage::from(&interchange);
+    assert_eq!(usage.inner(), "pkg:sysand/acme-corp/my-lib");
+}
+
+#[test]
+fn usage_from_directory_usage_with_short_publisher_is_urn_sysand() {
+    // Short publisher → Arbitrary form → urn:sysand: (non-PURL, non-URL)
+    let interchange = InterchangeProjectUsage::Directory {
+        dir: Utf8UnixPathBuf::from("dep"),
+        publisher: "ab".to_owned(),
+        name: "my-lib".to_owned(),
+    };
+    let usage = Usage::from(&interchange);
+    assert_eq!(usage.inner(), "urn:sysand:ab/my-lib");
+}
+
+#[test]
+fn lock_project_with_urn_sysand_identifier_to_toml() {
+    to_toml_matches_expected(
+        vec![Project {
+            name: "my-lib".to_string(),
+            publisher: Some("ab".to_string()),
+            version: "1.0.0".to_string(),
+            exports: vec![],
+            identifiers: vec!["urn:sysand:ab/my-lib".to_string()],
+            usages: vec![],
+            sources: vec![],
+        }],
+        r#"
+[[project]]
+publisher = "ab"
+name = "my-lib"
+version = "1.0.0"
+identifiers = [
+    "urn:sysand:ab/my-lib",
+]
+"#,
+    );
+}
+
+#[test]
+fn lock_project_with_urn_sysand_identifier_roundtrip() {
+    roundtrip_makes_no_changes(
+        r#"
+[[project]]
+publisher = "ab"
+name = "my-lib"
+version = "1.0.0"
+identifiers = [
+    "urn:sysand:ab/my-lib",
+]
+
+[[project]]
+name = "consumer"
+version = "2.0.0"
+usages = [
+    "urn:sysand:ab/my-lib",
+]
+"#,
+    );
+}
+
+#[test]
+fn validate_usage_of_directory_derived_identifier() {
+    // A project identified by urn:sysand: can be depended on via its identifier
+    let dep_id = "urn:sysand:ab/my-lib";
+    Lock {
+        lock_version: CURRENT_LOCK_VERSION.to_string(),
+        projects: vec![
+            make_project(
+                "consumer",
+                None,
+                "2.0.0",
+                &[],
+                &[],
+                &[Usage::from_str_unchecked(dep_id)],
+            ),
+            make_project(
+                "my-lib",
+                Some("ab".to_string()),
+                "1.0.0",
+                &[],
+                &[dep_id],
+                &[],
+            ),
+        ],
+    }
+    .validate()
+    .unwrap();
 }
 
 #[test]

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -27,10 +27,24 @@ pub const KNOWN_METAMODELS: [&str; 2] = [
 pub const SYSML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/SysML/";
 pub const KERML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/KerML/";
 
+/// A dependency on another interchange project. In the dependency solver,
+/// usages are treated as referring to the same project iff they derive the
+/// same `Identifier`. A solution contains one instance per identifier, which
+/// all usages of that identifier accept (in particular, it satisfies
+/// all version constraints)
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Hash, Debug)]
 #[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
 #[serde(untagged)]
-pub enum InterchangeProjectUsageG<Iri, VersionReq> {
+pub enum InterchangeProjectUsageG<Iri, VersionReq, Path> {
+    /// Untyped usage, the only shape KerML 1.0 specifies. Kept for
+    /// compatibility with the spec. `resource` serves two roles at once: it is
+    /// the project's identity (i.e. directly used as its `Identifier`), and,
+    /// depending on its scheme, possibly also a location to fetch from (e.g.
+    /// `pkg:sysand` vs `https`).
+    /// Resolution is not defined, so it's implementation-specific.
+    /// We generally treat the same project referenced via different IRIs as
+    /// different projects. Typed usages (all other shapes) separate the two roles:
+    /// identity is always publisher+name, and the source is explicit.
     // `rename_all` does not apply to enum variant fields if applied on
     // the whole enum
     #[serde(rename_all = "camelCase")]
@@ -39,11 +53,21 @@ pub enum InterchangeProjectUsageG<Iri, VersionReq> {
         #[serde(skip_serializing_if = "Option::is_none")]
         version_constraint: Option<VersionReq>, // TODO: We should have a fallback for invalid semvers
     },
+    /// The project in the directory `dir`, relative to the root
+    /// of the project declaring the usage. `publisher` and `name` must match the
+    /// actual values found at `dir`, without any normalization.
+    /// No version constraint, as the directory contains a single version
+    // TODO: should absolute paths also be supported (like Cargo)?
+    Directory {
+        dir: Path,
+        publisher: String,
+        name: String,
+    },
 }
 
-pub type InterchangeProjectUsageRaw = InterchangeProjectUsageG<String, String>;
+pub type InterchangeProjectUsageRaw = InterchangeProjectUsageG<String, String, String>;
 pub type InterchangeProjectUsage =
-    InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>;
+    InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq, Utf8UnixPathBuf>;
 
 impl InterchangeProjectUsageRaw {
     /// Caller is responsible for identifying the project when reporting the error
@@ -85,6 +109,33 @@ impl InterchangeProjectUsageRaw {
                         .transpose()?,
                 })
             }
+            InterchangeProjectUsageG::Directory {
+                dir: path,
+                publisher,
+                name,
+            } => match parse_relative_unix_path(path, RelativePathKind::Directory) {
+                Ok(p) => Ok(InterchangeProjectUsageG::Directory {
+                    dir: p.to_owned(),
+                    publisher: publisher.clone(),
+                    name: name.clone(),
+                }),
+                Err(e) => Err(InterchangeProjectValidationError::InvalidUsagePath {
+                    publisher: publisher.clone(),
+                    name: name.clone(),
+                    source: e,
+                }),
+            },
+        }
+    }
+}
+
+impl<Iri, VersionReq, Path> InterchangeProjectUsageG<Iri, VersionReq, Path> {
+    /// Typed usages (all non-`Resource`) are treated specially in some places,
+    /// as e.g. if they resolve to invalid projects, it can't be ignored
+    pub fn is_typed(&self) -> bool {
+        match self {
+            InterchangeProjectUsageG::Resource { .. } => false,
+            InterchangeProjectUsageG::Directory { .. } => true,
         }
     }
 }
@@ -92,21 +143,36 @@ impl InterchangeProjectUsageRaw {
 impl From<InterchangeProjectUsage> for InterchangeProjectUsageRaw {
     fn from(value: InterchangeProjectUsage) -> InterchangeProjectUsageRaw {
         match value {
-            InterchangeProjectUsageG::Resource {
+            InterchangeProjectUsage::Resource {
                 resource,
                 version_constraint,
             } => InterchangeProjectUsageRaw::Resource {
                 resource: resource.into_string(),
                 version_constraint: version_constraint.map(|x| x.to_string()),
             },
+            InterchangeProjectUsage::Directory {
+                dir,
+                publisher,
+                name,
+            } => InterchangeProjectUsageRaw::Directory {
+                dir: dir.into_string(),
+                publisher,
+                name,
+            },
         }
     }
 }
 
-impl From<InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>>
-    for InterchangeProjectUsageG<String, semver::VersionReq>
+impl From<InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq, Utf8UnixPathBuf>>
+    for InterchangeProjectUsageG<String, semver::VersionReq, Utf8UnixPathBuf>
 {
-    fn from(value: InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>) -> Self {
+    fn from(
+        value: InterchangeProjectUsageG<
+            fluent_uri::Iri<String>,
+            semver::VersionReq,
+            Utf8UnixPathBuf,
+        >,
+    ) -> Self {
         match value {
             InterchangeProjectUsageG::Resource {
                 resource,
@@ -115,11 +181,22 @@ impl From<InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq>>
                 resource: resource.into_string(),
                 version_constraint,
             },
+            InterchangeProjectUsage::Directory {
+                dir,
+                publisher,
+                name,
+            } => InterchangeProjectUsageG::Directory {
+                dir,
+                publisher,
+                name,
+            },
         }
     }
 }
 
-impl<Iri: Display, VersionReq: Display> Display for InterchangeProjectUsageG<Iri, VersionReq> {
+impl<Iri: Display, VersionReq: Display, Path: Display> Display
+    for InterchangeProjectUsageG<Iri, VersionReq, Path>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             InterchangeProjectUsageG::Resource {
@@ -131,6 +208,13 @@ impl<Iri: Display, VersionReq: Display> Display for InterchangeProjectUsageG<Iri
                     write!(f, " ({vc})")?;
                 }
             }
+            InterchangeProjectUsageG::Directory {
+                dir,
+                publisher,
+                name,
+            } => {
+                write!(f, "`{publisher}/{name}` from `{dir}`")?;
+            }
         }
         Ok(())
     }
@@ -139,7 +223,7 @@ impl<Iri: Display, VersionReq: Display> Display for InterchangeProjectUsageG<Iri
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
 #[serde(rename_all = "camelCase")]
-pub struct InterchangeProjectInfoG<Iri, Version, VersionReq> {
+pub struct InterchangeProjectInfoG<Iri, Version, VersionReq, Path> {
     pub name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -166,12 +250,16 @@ pub struct InterchangeProjectInfoG<Iri, Version, VersionReq> {
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
-    pub usage: Vec<InterchangeProjectUsageG<Iri, VersionReq>>,
+    pub usage: Vec<InterchangeProjectUsageG<Iri, VersionReq, Path>>,
 }
 
-pub type InterchangeProjectInfoRaw = InterchangeProjectInfoG<String, String, String>;
-pub type InterchangeProjectInfo =
-    InterchangeProjectInfoG<fluent_uri::Iri<String>, semver::Version, semver::VersionReq>;
+pub type InterchangeProjectInfoRaw = InterchangeProjectInfoG<String, String, String, String>;
+pub type InterchangeProjectInfo = InterchangeProjectInfoG<
+    fluent_uri::Iri<String>,
+    semver::Version,
+    semver::VersionReq,
+    Utf8UnixPathBuf,
+>;
 
 impl From<InterchangeProjectInfo> for InterchangeProjectInfoRaw {
     fn from(value: InterchangeProjectInfo) -> Self {
@@ -193,8 +281,8 @@ impl From<InterchangeProjectInfo> for InterchangeProjectInfoRaw {
     }
 }
 
-impl<Iri: PartialEq + Clone, Version, VersionReq: Clone>
-    InterchangeProjectInfoG<Iri, Version, VersionReq>
+impl<Iri: PartialEq + Clone, Version, VersionReq: Clone, Path>
+    InterchangeProjectInfoG<Iri, Version, VersionReq, Path>
 {
     pub fn minimal(name: String, version: Version) -> Self {
         InterchangeProjectInfoG {
@@ -214,15 +302,32 @@ impl<Iri: PartialEq + Clone, Version, VersionReq: Clone>
     /// Note that sysand will never add multiple usages of the same resource
     /// to the project, but it does tolerate such usages.
     // TODO: the spec does not say anything about this and should be clarified
-    pub fn pop_usage(&mut self, resource: &Iri) -> Vec<InterchangeProjectUsageG<Iri, VersionReq>> {
+    pub fn pop_usage(
+        &mut self,
+        resource: &Iri,
+    ) -> Vec<InterchangeProjectUsageG<Iri, VersionReq, Path>> {
         self.usage
-            .extract_if(
-                ..,
-                |InterchangeProjectUsageG::Resource {
-                     resource: this_resource,
-                     ..
-                 }| this_resource == resource,
-            )
+            .extract_if(.., |u| match u {
+                InterchangeProjectUsageG::Resource { resource: r, .. } => r == resource,
+                _ => false,
+            })
+            .collect()
+    }
+
+    pub fn exp_pop_usage(
+        &mut self,
+        publisher: &str,
+        name: &str,
+    ) -> Vec<InterchangeProjectUsageG<Iri, VersionReq, Path>> {
+        self.usage
+            .extract_if(.., |u| match u {
+                InterchangeProjectUsageG::Resource { .. } => false,
+                InterchangeProjectUsageG::Directory {
+                    dir: _,
+                    publisher: p,
+                    name: n,
+                } => p == publisher && n == name,
+            })
             .collect()
     }
 }
@@ -523,6 +628,12 @@ pub enum InterchangeProjectValidationError {
     InvalidPathInIndex(#[source] RelativeUnixPathError),
     #[error("source file checksum (`checksum` field in `.meta.json`) references an invalid path")]
     InvalidPathInChecksum(#[source] RelativeUnixPathError),
+    #[error("path usage for `{publisher}`/`{name}` references an invalid path")]
+    InvalidUsagePath {
+        publisher: String,
+        name: String,
+        source: RelativeUnixPathError,
+    },
     #[error("failed to parse `{0}` as RFC3339 datetime: {1}")]
     InvalidCreatedTime(Box<str>, chrono::ParseError),
     #[error(

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -205,6 +205,8 @@ pub trait ProjectRead {
     // Optional and helpers
 
     /// Returns the local filesystem root path of this project, if available.
+    /// It is used, among other things, to resolve relative path usages. Such
+    /// usages will fail resolution if `None` is returned here
     fn project_root(&self) -> Option<&Utf8Path>;
 
     fn get_info(&self) -> Result<Option<InterchangeProjectInfoRaw>, Self::Error> {

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -259,6 +259,7 @@ pub mod wrapfs {
     pub fn canonicalize_raw<P: AsRef<Utf8Path>>(path: P) -> Result<Utf8PathBuf, io::Error> {
         dunce::canonicalize(path.as_ref()).and_then(|path| {
             Utf8PathBuf::from_path_buf(path)
+                // error is just original `path`
                 .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))
         })
     }
@@ -275,6 +276,7 @@ pub mod wrapfs {
         std::env::current_dir()
             .and_then(|d| {
                 Utf8PathBuf::from_path_buf(d)
+                    // error is just original `path`
                     .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))
             })
             .map_err(|e| Box::new(FsIoError::CurrentDir(e)))
@@ -543,19 +545,49 @@ impl Borrow<String> for Identifier {
 
 impl From<&InterchangeProjectUsage> for Identifier {
     fn from(value: &InterchangeProjectUsage) -> Self {
-        let InterchangeProjectUsage::Resource { resource, .. } = value;
-        Self(resource.to_string())
+        let (publisher, name) = match value {
+            InterchangeProjectUsage::Resource { resource, .. } => {
+                return Self(resource.to_string());
+            }
+            InterchangeProjectUsage::Directory {
+                publisher, name, ..
+            } => (publisher, name),
+        };
+        Self::make_identifier_iri(publisher, name)
     }
 }
 
 impl From<InterchangeProjectUsage> for Identifier {
     fn from(value: InterchangeProjectUsage) -> Self {
-        let InterchangeProjectUsage::Resource { resource, .. } = value;
-        Self(resource.into_string())
+        let (publisher, name) = match value {
+            InterchangeProjectUsage::Resource { resource, .. } => {
+                return Self(resource.into_string());
+            }
+            InterchangeProjectUsage::Directory {
+                publisher, name, ..
+            } => (publisher, name),
+        };
+        Self::make_identifier_iri(publisher, name)
     }
 }
 
 impl Identifier {
+    pub fn from_pub_name(publisher: &str, name: &str) -> Identifier {
+        Self::make_identifier_iri(publisher, name)
+    }
+
+    pub fn from_interchange_usage_unchecked(usage: &InterchangeProjectUsageRaw) -> Identifier {
+        let (publisher, name) = match usage {
+            InterchangeProjectUsageRaw::Resource { resource, .. } => {
+                return Self(resource.to_string());
+            }
+            InterchangeProjectUsageRaw::Directory {
+                publisher, name, ..
+            } => (publisher, name),
+        };
+        Self::make_identifier_iri(publisher, name)
+    }
+
     pub fn from_iri_owned(iri: Iri<String>) -> Identifier {
         Self(iri.into_string())
     }
@@ -580,15 +612,6 @@ impl Identifier {
     /// Construct `Identifier` from `&str`, assuming it's a valid IRI
     pub fn from_iri_unchecked_str(iri: &str) -> Identifier {
         Self(iri.to_owned())
-    }
-
-    pub fn from_pub_name(publisher: &str, name: &str) -> Identifier {
-        Self::make_identifier_iri(publisher, name)
-    }
-
-    pub fn from_interchange_usage_unchecked(usage: &InterchangeProjectUsageRaw) -> Identifier {
-        let InterchangeProjectUsageRaw::Resource { resource, .. } = usage;
-        Self(resource.to_string())
     }
 
     fn make_identifier_iri(publisher: impl AsRef<str>, name: impl AsRef<str>) -> Identifier {

--- a/core/src/project/utils_tests.rs
+++ b/core/src/project/utils_tests.rs
@@ -5,9 +5,10 @@ use std::error::Error;
 
 use camino::Utf8Path;
 use fluent_uri::Iri;
+use typed_path::Utf8UnixPathBuf;
 
 use crate::{
-    model::InterchangeProjectUsage,
+    model::{InterchangeProjectUsage, InterchangeProjectUsageRaw},
     project::utils::{Identifier, relativize_path},
 };
 
@@ -146,6 +147,59 @@ fn relativize_path_error_non_common_prefix() -> Result<(), Box<dyn Error>> {
 // --- Identifier constructors ---
 
 #[test]
+fn identifier_from_pub_name_purl_safe() {
+    assert_eq!(
+        Identifier::from_pub_name("acme-corp", "my-lib").as_str(),
+        "pkg:sysand/acme-corp/my-lib"
+    );
+}
+
+#[test]
+fn identifier_from_pub_name_publisher_normalized() {
+    // Uppercase + space in publisher → lowercased, spaces become dashes
+    assert_eq!(
+        Identifier::from_pub_name("ACME Corp", "my-lib").as_str(),
+        "pkg:sysand/acme-corp/my-lib"
+    );
+}
+
+#[test]
+fn identifier_from_pub_name_name_normalized() {
+    // Uppercase + dot in name → lowercased
+    assert_eq!(
+        Identifier::from_pub_name("acme-corp", "My.Lib").as_str(),
+        "pkg:sysand/acme-corp/my.lib"
+    );
+}
+
+#[test]
+fn identifier_from_pub_name_both_normalized() {
+    // Both publisher and name need normalization
+    assert_eq!(
+        Identifier::from_pub_name("ACME Corp", "My Lib").as_str(),
+        "pkg:sysand/acme-corp/my-lib"
+    );
+}
+
+#[test]
+fn identifier_from_pub_name_arbitrary_publisher_gives_urn() {
+    // Publisher too short (< 3 chars) → falls through to urn:sysand: form
+    assert_eq!(
+        Identifier::from_pub_name("ab", "my-lib").as_str(),
+        "urn:sysand:ab/my-lib"
+    );
+}
+
+#[test]
+fn identifier_from_pub_name_arbitrary_name_gives_urn() {
+    // Name too short (< 3 chars) → falls through to urn:sysand: form
+    assert_eq!(
+        Identifier::from_pub_name("acme-corp", "ab").as_str(),
+        "urn:sysand:acme-corp/ab"
+    );
+}
+
+#[test]
 fn identifier_from_resource_usage_returns_iri_as_is() {
     let resource = Iri::parse("urn:kpar:test".to_owned()).unwrap();
     let usage = InterchangeProjectUsage::Resource {
@@ -153,6 +207,55 @@ fn identifier_from_resource_usage_returns_iri_as_is() {
         version_constraint: None,
     };
     assert_eq!(Identifier::from(usage).as_str(), "urn:kpar:test");
+}
+
+#[test]
+fn identifier_from_directory_usage_purl_safe() {
+    let usage = InterchangeProjectUsage::Directory {
+        dir: Utf8UnixPathBuf::from("dep"),
+        publisher: "acme-corp".to_owned(),
+        name: "my-lib".to_owned(),
+    };
+    assert_eq!(
+        Identifier::from(usage).as_str(),
+        "pkg:sysand/acme-corp/my-lib"
+    );
+}
+
+#[test]
+fn identifier_from_directory_usage_arbitrary_publisher_gives_urn() {
+    // Short publisher → Arbitrary form → urn:sysand: (non-PURL, non-URL)
+    let usage = InterchangeProjectUsage::Directory {
+        dir: Utf8UnixPathBuf::from("dep"),
+        publisher: "ab".to_owned(),
+        name: "my-lib".to_owned(),
+    };
+    assert_eq!(Identifier::from(usage).as_str(), "urn:sysand:ab/my-lib");
+}
+
+#[test]
+fn identifier_from_interchange_usage_unchecked_resource() {
+    let usage = InterchangeProjectUsageRaw::Resource {
+        resource: "urn:kpar:test".to_owned(),
+        version_constraint: None,
+    };
+    assert_eq!(
+        Identifier::from_interchange_usage_unchecked(&usage).as_str(),
+        "urn:kpar:test"
+    );
+}
+
+#[test]
+fn identifier_from_interchange_usage_unchecked_directory() {
+    let usage = InterchangeProjectUsageRaw::Directory {
+        dir: "dep".to_owned(),
+        publisher: "acme-corp".to_owned(),
+        name: "my-lib".to_owned(),
+    };
+    assert_eq!(
+        Identifier::from_interchange_usage_unchecked(&usage).as_str(),
+        "pkg:sysand/acme-corp/my-lib"
+    );
 }
 
 #[test]

--- a/core/src/resolve/combined_tests.rs
+++ b/core/src/resolve/combined_tests.rs
@@ -103,6 +103,35 @@ fn prefer_file_resolver_when_successful() {
     assert_eq!(info.name, "a");
 }
 
+// TODO: decide and document the resolution policy, in this case: when should
+// fallbacks be allowed (relevant for all explicit usages, like http/git/file urls
+// and relative paths) and which one should be prioritized? If this test passes
+// (by changing CombinedResolver's file resolver NotFound return to abort the resolution),
+// then transitive env relative path usages will not get resolved, because
+// FileResolver will get the wrong absolute path (due to current env read design,
+// base_path will be the env-internal project path, not the original
+// source of it), and return NotFound, which will abort the resolution.
+// See lock_directory_usage_env_installed_dependency and
+// directory_usage_missing_path_falls_back_to_env_resolver
+// which conflict with this test
+//
+// #[test]
+// fn prefer_file_resolver_even_when_unresolved() {
+//     let example_uri = iri("http://example.com");
+
+//     let project_a = minimal_project("a", "1.2.3");
+
+//     let resolver = CombinedResolver {
+//         file_resolver: empty_any_resolver(),
+//         remote_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+//         local_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+//         index_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+//     };
+
+//     let xs = do_info(&example_uri, &resolver);
+//     assert!(xs.is_err())
+// }
+
 #[test]
 fn skip_file_resolver_if_unsupported_iri() {
     let example_uri = iri("http://example.com");
@@ -279,6 +308,70 @@ fn skip_non_semantic_versions() {
     let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "a");
+}
+
+/// A dependency obtained from an environment (or an index/kpar copy) may
+/// declare a `Directory` usage whose relative path only exists in its
+/// original source tree. When the file resolver cannot find that path on
+/// disk, resolution must fall through to the remaining resolvers, which
+/// resolve the usage by the identifier derived from its publisher/name —
+/// the behaviour established by
+/// `solve::pubgrub_tests::directory_usage_env_transitive`. A typed usage
+/// that hard-fails here would abort the whole solve even though the project
+/// is installed in the environment.
+#[cfg(feature = "filesystem")]
+#[test]
+fn directory_usage_missing_path_falls_back_to_env_resolver() {
+    use crate::{
+        env::memory::MemoryStorageEnvironment, model::InterchangeProjectUsage,
+        project::ProjectRead, resolve::env::EnvResolver, resolve::file::FileResolver,
+    };
+
+    let mut widget = minimal_project("widget", "1.0.0");
+    widget.info.as_mut().unwrap().publisher = Some("acme".to_string());
+
+    let env = MemoryStorageEnvironment::from([(
+        "pkg:sysand/acme/widget".to_string(),
+        "1.0.0".to_string(),
+        widget,
+    )]);
+
+    let resolver = CombinedResolver {
+        file_resolver: Some(FileResolver {
+            sandbox_roots: None,
+        }),
+        local_resolver: Some(EnvResolver { env }),
+        remote_resolver: NO_RESOLVER,
+        index_resolver: NO_RESOLVER,
+    };
+
+    // The base path exists (as an env-internal project root would), but
+    // `../widget` relative to it does not.
+    let tmp = camino_tempfile::tempdir().unwrap();
+    let base = tmp.path().join("app");
+    std::fs::create_dir(&base).unwrap();
+
+    let usage = InterchangeProjectUsage::Directory {
+        dir: "../widget".into(),
+        publisher: "acme".to_string(),
+        name: "widget".to_string(),
+    };
+    let resolution = ResolutionInfo::new(usage, Some(base));
+
+    let projects = match resolver.resolve_read(&resolution).unwrap() {
+        ResolutionOutcome::Resolved(projects) => projects,
+        ResolutionOutcome::UnsupportedUsageType { reason }
+        | ResolutionOutcome::NotFound { reason }
+        | ResolutionOutcome::Unresolvable { reason } => {
+            panic!("directory usage should have been resolved from the environment: {reason}")
+        }
+    };
+
+    let projects: Vec<_> = projects.into_iter().collect::<Result<Vec<_>, _>>().unwrap();
+    assert_eq!(projects.len(), 1);
+    let info = projects[0].get_info().unwrap().unwrap();
+    assert_eq!(info.name, "widget");
+    assert_eq!(info.version, "1.0.0");
 }
 
 #[test]

--- a/core/src/resolve/file.rs
+++ b/core/src/resolve/file.rs
@@ -4,7 +4,7 @@
 // Resolver for file:// URLs
 
 use std::{
-    io::{self, Read},
+    io::{self, ErrorKind, Read},
     path::PathBuf,
 };
 
@@ -299,25 +299,70 @@ impl ResolveRead for FileResolver {
         &self,
         resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
-        let InterchangeProjectUsage::Resource { resource: url, .. } = resolve.usage();
-
-        match try_file_uri_to_path(url)? {
-            Some(path) => {
-                let res = self.check_sandbox(path)?;
-                Ok(res.map(|path| {
-                    vec![
-                        Ok(FileResolverProject::LocalSrcProject(
-                            LocalSrcProject::new_access(path.clone(), None),
-                        )),
-                        Ok(FileResolverProject::LocalKParProject(
-                            LocalKParProject::new(path, KparInnerPath::Guess, None, None),
-                        )),
-                    ]
-                }))
+        match resolve.usage() {
+            InterchangeProjectUsage::Resource {
+                resource: url,
+                // TODO: check that the project version satisfies this
+                version_constraint: _,
+            } => match try_file_uri_to_path(url)? {
+                Some(path) => {
+                    let res = self.check_sandbox(path)?;
+                    Ok(res.map(|path| {
+                        vec![
+                            Ok(FileResolverProject::LocalSrcProject(
+                                LocalSrcProject::new_access(path.clone(), None),
+                            )),
+                            Ok(FileResolverProject::LocalKParProject(
+                                LocalKParProject::new(path, KparInnerPath::Guess, None, None),
+                            )),
+                        ]
+                    }))
+                }
+                None => Ok(ResolutionOutcome::UnsupportedUsageType {
+                    reason: String::from("resource is not a file URL"),
+                }),
+            },
+            InterchangeProjectUsage::Directory {
+                publisher,
+                name,
+                dir,
+            } => {
+                // TODO: should absolute paths be supported here? Cargo does.
+                if let Some(base) = resolve.base_path() {
+                    let abs_path = base.join(dir.as_str());
+                    let canonical = match wrapfs::canonicalize_raw(&abs_path) {
+                        Ok(p) => p,
+                        Err(e) if e.kind() == ErrorKind::NotFound => {
+                            return Ok(ResolutionOutcome::NotFound {
+                                reason: format!("path `{abs_path}` does not exist"),
+                            });
+                        }
+                        Err(e) => {
+                            return Err(FileResolverError::Io(
+                                FsIoError::Canonicalize(abs_path, e).into(),
+                            ));
+                        }
+                    };
+                    let res = self.check_sandbox(canonical)?;
+                    Ok(res.map(|path| {
+                        vec![Ok(FileResolverProject::LocalSrcProject(
+                            LocalSrcProject::new_for_solve(
+                                path,
+                                None,
+                                Some(publisher.clone()),
+                                name.clone(),
+                            ),
+                        ))]
+                    }))
+                } else {
+                    // TODO: return Err?
+                    Ok(ResolutionOutcome::Unresolvable {
+                        reason: String::from(
+                            "cannot resolve relative path usage without a base path",
+                        ),
+                    })
+                }
             }
-            None => Ok(ResolutionOutcome::UnsupportedUsageType {
-                reason: String::from("resource is not a file URL"),
-            }),
         }
     }
 }

--- a/core/src/resolve/gix_git.rs
+++ b/core/src/resolve/gix_git.rs
@@ -70,6 +70,11 @@ impl ResolveRead for GitResolver {
                     .map_err(|e| e.into()),
                 )))
             }
+            InterchangeProjectUsage::Directory { .. } => {
+                Ok(ResolutionOutcome::UnsupportedUsageType {
+                    reason: String::from("not a git usage"),
+                })
+            }
         }
     }
 }

--- a/core/src/resolve/memory.rs
+++ b/core/src/resolve/memory.rs
@@ -64,11 +64,13 @@ pub struct AcceptScheme<'a> {
 
 impl IRIPredicate for AcceptScheme<'_> {
     fn accept(&self, usage: &ResolutionInfo) -> bool {
-        let InterchangeProjectUsage::Resource {
-            resource,
-            version_constraint: _,
-        } = usage.usage();
-        resource.scheme() == self.scheme
+        match usage.usage() {
+            InterchangeProjectUsage::Resource {
+                resource,
+                version_constraint: _,
+            } => resource.scheme() == self.scheme,
+            InterchangeProjectUsage::Directory { .. } => false,
+        }
     }
 }
 

--- a/core/src/resolve/mod.rs
+++ b/core/src/resolve/mod.rs
@@ -10,7 +10,8 @@ use crate::{
     env::{SyncStreamIter, utils::ErrorBound},
     model::InterchangeProjectUsage,
     project::{
-        AsAsyncProject, AsSyncProjectTokio, ProjectRead, ProjectReadAsync, utils::Identifier,
+        AsAsyncProject, AsSyncProjectTokio, ProjectRead, ProjectReadAsync,
+        utils::{Identifier, wrapfs},
     },
 };
 
@@ -184,6 +185,19 @@ impl Display for ResolutionInfo {
                 write!(f, "IRI `{resource}`")?;
                 if let Some(vc) = version_constraint {
                     write!(f, " ({vc})")?;
+                }
+            }
+            InterchangeProjectUsage::Directory {
+                dir,
+                publisher,
+                name,
+            } => {
+                if let Some(bp) = &self.base_path {
+                    let abs_path = bp.join(dir.as_str());
+                    let abs_path = wrapfs::absolute(&abs_path).unwrap_or(abs_path);
+                    write!(f, "`{publisher}/{name}` from `{abs_path}`")?;
+                } else {
+                    write!(f, "`{publisher}/{name}` from `{dir}` (full path unknown)")?;
                 }
             }
         }

--- a/core/src/resolve/reqwest_http.rs
+++ b/core/src/resolve/reqwest_http.rs
@@ -361,28 +361,35 @@ impl<Policy: HTTPAuthentication> ResolveReadAsync for HTTPResolverAsync<Policy> 
         &self,
         resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
-        let InterchangeProjectUsage::Resource { resource: iri, .. } = resolve.usage();
-
         // Try to resolve as a HTTP src project.
-        let outcome = if iri.scheme() == SCHEME_HTTP || iri.scheme() == SCHEME_HTTPS {
-            match reqwest::Url::parse(iri.as_str()) {
-                Ok(url) => ResolutionOutcome::Resolved(futures::stream::iter(HTTPProjects {
-                    client: self.client.clone(),
-                    url,
-                    src_done: false,
-                    kpar_done: false,
-                    lax: self.lax,
-                    auth_policy: self.auth_policy.clone(),
-                    // prefer_ranged: self.prefer_ranged,
-                })),
-                Err(e) => ResolutionOutcome::Unresolvable {
-                    reason: format!("invalid http(s) URL: {e}"),
-                },
+        let outcome = match resolve.usage() {
+            InterchangeProjectUsage::Resource { resource: iri, .. } => {
+                if iri.scheme() == SCHEME_HTTP || iri.scheme() == SCHEME_HTTPS {
+                    match reqwest::Url::parse(iri.as_str()) {
+                        Ok(url) => {
+                            ResolutionOutcome::Resolved(futures::stream::iter(HTTPProjects {
+                                client: self.client.clone(),
+                                url,
+                                src_done: false,
+                                kpar_done: false,
+                                lax: self.lax,
+                                auth_policy: self.auth_policy.clone(),
+                                // prefer_ranged: self.prefer_ranged,
+                            }))
+                        }
+                        Err(e) => ResolutionOutcome::Unresolvable {
+                            reason: format!("invalid http(s) URL: {e}"),
+                        },
+                    }
+                } else {
+                    ResolutionOutcome::UnsupportedUsageType {
+                        reason: String::from("not an http(s) URL"),
+                    }
+                }
             }
-        } else {
-            ResolutionOutcome::UnsupportedUsageType {
-                reason: String::from("not an http(s) URL"),
-            }
+            _ => ResolutionOutcome::UnsupportedUsageType {
+                reason: String::from("not a url/resource usage"),
+            },
         };
         Ok(outcome)
     }

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use fluent_uri::Iri;
+use camino::Utf8PathBuf;
 use pubgrub::{
     DefaultStringReporter, DependencyConstraints, DependencyProvider, Reporter, VersionSet,
 };
@@ -16,18 +16,19 @@ use std::{
 use thiserror::Error;
 
 use crate::{
-    model::InterchangeProjectUsage,
-    project::ProjectRead,
-    resolve::{ResolutionInfo, ResolveRead},
+    model::{InterchangeProjectUsage, InterchangeProjectValidationError},
+    project::{ProjectRead, utils::Identifier},
+    resolve::{CoalescingUsage, ResolutionInfo, ResolutionOutcome, ResolveRead},
+    utils::format_err,
 };
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum DependencyIdentifier {
     /// Dependencies that are to be resolved.
-    Requested(Vec<InterchangeProjectUsage>),
+    Requested(Vec<CoalescingUsage>),
     /// Found dependencies. Note that this does not mean that the
-    /// required version was found, just that the IRI was resolved.
-    Remote(fluent_uri::Iri<String>),
+    /// required version was found, just that the usage was resolved.
+    Remote(CoalescingUsage),
 }
 
 impl Display for DependencyIdentifier {
@@ -178,30 +179,23 @@ impl VersionSet for DiscreteHashSet {
     }
 }
 
-type CandidateMap<ProjectStorage> =
-    HashMap<fluent_uri::Iri<String>, Vec<Candidate<ProjectStorage>>>;
+type CandidateMap<ProjectStorage> = HashMap<Identifier, Vec<Candidate<ProjectStorage>>>;
 
 /// One resolved alternative for a given IRI: the summary the solver scores
-/// against and the `ProjectStorage` we hand back at extraction time. Keeping
-/// the pair in a named record prevents the two Vecs from drifting apart —
-/// every `CandidateSummary` retained in the cache has its paired `project`
-/// right next to it, so "index i" has one meaning instead of two.
+/// against and the `ProjectStorage` we hand back at extraction time.
 #[derive(Clone, Debug)]
 struct Candidate<ProjectStorage> {
     summary: CandidateSummary,
     project: ProjectStorage,
 }
 
-/// The fields of a candidate project that the solver actually consults —
-/// `version` (for range matching) and `usage` (for recursive dependency
-/// discovery). Populated via `ProjectRead::version` + `ProjectRead::usage`,
-/// which leaf backends like `IndexEntryProject` answer from prefetched
-/// metadata so the solver never triggers a kpar download just to score a
-/// candidate.
+/// The fields of a candidate project that the solver needs:
+/// - `version` (for range matching)
+/// - `usage` (for recursive dependency discovery)
 #[derive(Clone, Debug)]
 struct CandidateSummary {
     version: semver::Version,
-    usage: Vec<InterchangeProjectUsage>,
+    usage: Vec<CoalescingUsage>,
 }
 
 pub struct ProjectSolver<R: ResolveRead> {
@@ -215,11 +209,19 @@ pub struct ProjectSolver<R: ResolveRead> {
 #[expect(clippy::result_large_err)]
 fn resolve_candidates<R: ResolveRead>(
     resolver: &R,
-    uri: &fluent_uri::Iri<String>,
+    resolve: &CoalescingUsage,
     cache: &mut CandidateMap<R::ProjectStorage>,
 ) -> Result<Vec<CandidateSummary>, InternalSolverError<R>> {
-    let entry = cache.entry(uri.clone());
+    let entry = cache.entry(resolve.to_id());
 
+    // TODO: decide on a resolution policy. Currently the cache is keyed by Identifier,
+    // which may be encountered multiple times with different sources in the dependency
+    // graph; only the first such encounter will be cached, all others will reuse the cached
+    // one. SysML spec does not allow multiple instances of the same project to be present
+    // in the dependency graph (AFAIK), so they should be coalesced to a single one (like is
+    // currently done), but how exactly? Most specific (Directory > Resource)? Priority to
+    // direct dependencies of the root project? Either way, the policy has to be explicitly
+    // documented
     match entry {
         Entry::Occupied(occupied_entry) => Ok(occupied_entry
             .get()
@@ -229,30 +231,44 @@ fn resolve_candidates<R: ResolveRead>(
         Entry::Vacant(vacant_entry) => {
             let mut found = vec![];
 
-            let resolve_info = ResolutionInfo::iri(uri.clone());
             match resolver
-                .resolve_read(&resolve_info)
+                .resolve_read(resolve.usage())
                 .map_err(InternalSolverError::Resolution)?
             {
-                crate::resolve::ResolutionOutcome::UnsupportedUsageType { reason } => {
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
                     return Err(InternalSolverError::UnsupportedUsageType {
-                        usage: resolve_info,
+                        usage: resolve.to_usage(),
                         reason,
                     });
                 }
-                crate::resolve::ResolutionOutcome::NotFound { reason } => {
-                    return Err(InternalSolverError::NotFound(resolve_info, reason));
+                ResolutionOutcome::Unresolvable { reason } => {
+                    return Err(InternalSolverError::Unresolvable {
+                        usage: resolve.to_usage(),
+                        reason,
+                    });
                 }
-                crate::resolve::ResolutionOutcome::Unresolvable { reason } => {
-                    return Err(InternalSolverError::NotFound(resolve_info, reason));
-                }
-                crate::resolve::ResolutionOutcome::Resolved(alternatives) => {
+                ResolutionOutcome::Resolved(alternatives) => {
+                    // Treat `Resource` usages leniently, as they may produce invalid candidates that should
+                    // not fail the whole resolution (e.g. both src and kpar variants for paths and http)
+                    // Typed usages in contrast are required to be present and valid projects, so missing
+                    // or invalid ones will fail resolution
+                    let typed = resolve.usage().usage().is_typed();
                     for alternative in alternatives {
                         let project = match alternative {
                             Ok(project) => project,
                             Err(e) => {
-                                log::debug!("candidate project for `{uri}` is error: {e}");
-                                continue;
+                                if typed {
+                                    return Err(InternalSolverError::ResolvedError {
+                                        usage: resolve.to_usage(),
+                                        source: e,
+                                    });
+                                } else {
+                                    log::debug!(
+                                        "candidate project for {resolve} is error: {}",
+                                        format_err(e)
+                                    );
+                                    continue;
+                                }
                             }
                         };
 
@@ -260,51 +276,102 @@ fn resolve_candidates<R: ResolveRead>(
                             Ok(Some(version)) => match semver::Version::parse(&version) {
                                 Ok(version) => version,
                                 Err(e) => {
-                                    log::debug!(
-                                        "candidate project for `{uri}` has invalid version `{version}`: {e}"
-                                    );
-                                    continue;
-                                }
-                            },
-                            Ok(None) => {
-                                log::debug!(
-                                    "candidate project for `{uri}` did not expose a version"
-                                );
-                                continue;
-                            }
-                            Err(e) => {
-                                log::debug!(
-                                    "candidate project for `{uri}` failed to get version: {e}"
-                                );
-                                continue;
-                            }
-                        };
-
-                        let usage = match project.usage() {
-                            Ok(Some(usage)) => {
-                                let validated: Result<Vec<InterchangeProjectUsage>, _> =
-                                    usage.into_iter().map(|usage| usage.validate()).collect();
-                                match validated {
-                                    Ok(usage) => usage,
-                                    Err(e) => {
+                                    if typed {
+                                        return Err(InternalSolverError::InvalidResolvedVersion {
+                                            usage: resolve.to_usage(),
+                                            source: e,
+                                        });
+                                    } else {
                                         log::debug!(
-                                            "candidate project for `{uri}` has invalid usage: {e}"
+                                            "candidate project for {resolve} has invalid version `{version}`: {}",
+                                            format_err(e)
                                         );
                                         continue;
                                     }
                                 }
-                            }
+                            },
                             Ok(None) => {
-                                log::debug!("candidate project for `{uri}` did not expose usages");
-                                continue;
+                                if typed {
+                                    return Err(InternalSolverError::MissingVersion {
+                                        usage: resolve.to_usage(),
+                                    });
+                                } else {
+                                    log::debug!(
+                                        "candidate project for {resolve} did not expose a version"
+                                    );
+                                    continue;
+                                }
                             }
                             Err(e) => {
-                                log::debug!(
-                                    "candidate project for `{uri}` failed to get usages: {e}"
-                                );
-                                continue;
+                                if typed {
+                                    return Err(InternalSolverError::VersionObtain {
+                                        usage: resolve.to_usage(),
+                                        source: e,
+                                    });
+                                } else {
+                                    log::debug!(
+                                        "candidate project for {resolve} failed to get version: {}",
+                                        format_err(e)
+                                    );
+                                    continue;
+                                }
                             }
                         };
+
+                        let usage = match project.usage() {
+                            Ok(Some(usages)) => {
+                                let validated: Result<Vec<InterchangeProjectUsage>, _> =
+                                    usages.into_iter().map(|usage| usage.validate()).collect();
+                                match validated {
+                                    Ok(usage) => usage,
+                                    Err(e) => {
+                                        if typed {
+                                            return Err(InternalSolverError::InvalidProject {
+                                                usage: resolve.to_usage(),
+                                                source: e,
+                                            });
+                                        } else {
+                                            log::debug!(
+                                                "candidate project for {resolve} has invalid usage: {}",
+                                                format_err(e)
+                                            );
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                if typed {
+                                    return Err(InternalSolverError::MissingUsage {
+                                        usage: resolve.to_usage(),
+                                    });
+                                } else {
+                                    log::debug!(
+                                        "candidate project for {resolve} did not expose usages"
+                                    );
+                                    continue;
+                                }
+                            }
+                            Err(e) => {
+                                if typed {
+                                    return Err(InternalSolverError::UsageObtain {
+                                        usage: resolve.to_usage(),
+                                        source: e,
+                                    });
+                                } else {
+                                    log::debug!(
+                                        "candidate project for {resolve} failed to get usages: {}",
+                                        format_err(e)
+                                    );
+                                    continue;
+                                }
+                            }
+                        };
+                        let relative_root = project.project_root().map(|p| p.to_path_buf());
+                        let usage = usage
+                            .into_iter()
+                            .map(|u| CoalescingUsage::new_usage(u, relative_root.to_owned()))
+                            .collect();
 
                         found.push(Candidate {
                             summary: CandidateSummary { version, usage },
@@ -312,8 +379,11 @@ fn resolve_candidates<R: ResolveRead>(
                         });
                     }
                     if found.is_empty() {
-                        return Err(InternalSolverError::NoValidCandidates(resolve_info));
+                        return Err(InternalSolverError::NoValidCandidates(resolve.to_usage()));
                     }
+                }
+                ResolutionOutcome::NotFound { reason } => {
+                    return Err(InternalSolverError::NotFound(resolve.to_usage(), reason));
                 }
             }
 
@@ -329,7 +399,7 @@ fn resolve_candidates<R: ResolveRead>(
 #[expect(clippy::result_large_err)]
 fn compute_deps<R: ResolveRead + fmt::Debug>(
     resolver: &R,
-    usages: &Vec<InterchangeProjectUsage>,
+    usages: &[CoalescingUsage],
     cache: &mut CandidateMap<R::ProjectStorage>,
 ) -> Result<
     pubgrub::Dependencies<DependencyIdentifier, DiscreteHashSet, String>,
@@ -338,7 +408,15 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
     let mut deps: Vec<(DependencyIdentifier, DiscreteHashSet)> = Vec::new();
 
     for usage in usages {
-        match usage {
+        let candidates = resolve_candidates(resolver, usage, cache)?;
+        // TODO: reenable this when it's fixed to give better error messages
+        // https://github.com/pubgrub-rs/pubgrub/pull/216
+        // match resolve_candidates(resolver, &usage.resource, cache) {
+        //     Ok(_) => (),
+        //     Err(err) => return Ok(pubgrub::Dependencies::Unavailable(format_err(err))),
+        // };
+
+        match usage.usage().usage() {
             InterchangeProjectUsage::Resource {
                 resource,
                 version_constraint,
@@ -347,10 +425,7 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
                     let mut valid_candidates = HashSet::new();
 
                     let mut found_versions = Vec::new();
-                    for (i, candidate_info) in resolve_candidates(resolver, resource, cache)?
-                        .iter()
-                        .enumerate()
-                    {
+                    for (i, candidate_info) in candidates.iter().enumerate() {
                         found_versions.push(candidate_info.version.clone());
                         if constraint.matches(&candidate_info.version) {
                             valid_candidates.insert(i);
@@ -372,24 +447,28 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
                     }
 
                     deps.push((
-                        DependencyIdentifier::Remote(resource.clone()),
+                        DependencyIdentifier::Remote(usage.to_owned()),
                         DiscreteHashSet::Finite(valid_candidates),
                     ));
                 } else {
-                    // Check that the project can be found
-                    resolve_candidates(resolver, resource, cache)?;
-                    // TODO: reenable this when it's fixed to give better error messages
-                    // https://github.com/pubgrub-rs/pubgrub/pull/216
-                    // match resolve_candidates(resolver, &usage.resource, cache) {
-                    //     Ok(_) => (),
-                    //     Err(err) => return Ok(pubgrub::Dependencies::Unavailable(format_err(err))),
-                    // };
-
                     deps.push((
-                        DependencyIdentifier::Remote(resource.clone()),
+                        DependencyIdentifier::Remote(usage.to_owned()),
                         DiscreteHashSet::empty().complement(),
                     ));
                 }
+            }
+            InterchangeProjectUsage::Directory {
+                dir: _,
+                publisher: _,
+                name: _,
+            } => {
+                // Usually `candidates` will contain a single candidate for this type,
+                // but e.g. environment may have multiple project versions, and will
+                // return all of them based on the identifier
+                deps.push((
+                    DependencyIdentifier::Remote(usage.to_owned()),
+                    DiscreteHashSet::empty().complement(),
+                ));
             }
         }
     }
@@ -461,12 +540,15 @@ impl<R: ResolveRead + fmt::Debug + 'static> Display for SolverError<R> {
 
 impl<R: ResolveRead + fmt::Debug + 'static> std::error::Error for SolverError<R> {}
 
+/// Error of `R`'s resolved project storage. Also hides the nested projection
+/// from `derive(Debug)`, which would otherwise emit an unsatisfiable
+/// `R::ProjectStorage: Debug` bound.
+type StorageError<R> = <<R as ResolveRead>::ProjectStorage as ProjectRead>::Error;
+
 #[derive(Error, Debug)]
 pub enum InternalSolverError<R: ResolveRead> {
     #[error("resolution error: {0}")]
     Resolution(R::Error),
-    // #[error("invalid project requested")]
-    // InvalidProject,
     /// Project not found by current resolver
     /// Value is the formatted error message
     #[error("project {0} not found: {1}")]
@@ -487,6 +569,41 @@ pub enum InternalSolverError<R: ResolveRead> {
     /// Value is the formatted error message
     #[error("requested version unavailable: {0}")]
     VersionNotAvailable(String),
+    /// Resolution failed due to an invalid usage that is in principle supported
+    #[error("usage {usage} is not resolvable: {reason}")]
+    Unresolvable {
+        usage: ResolutionInfo,
+        reason: String,
+    },
+    #[error("usage {usage} resolved to an error")]
+    ResolvedError {
+        usage: ResolutionInfo,
+        source: R::Error,
+    },
+    #[error("usage {usage} resolved to an error")]
+    InvalidProject {
+        usage: ResolutionInfo,
+        source: InterchangeProjectValidationError,
+    },
+    #[error("usage {usage} resolved to a project that does not expose its version")]
+    MissingVersion { usage: ResolutionInfo },
+    #[error("usage {usage} resolved to a project that does not expose its usages")]
+    MissingUsage { usage: ResolutionInfo },
+    #[error("usage {usage} resolved to a project that has an invalid version")]
+    InvalidResolvedVersion {
+        usage: ResolutionInfo,
+        source: semver::Error,
+    },
+    #[error("failed to obtain version of resolved usage {usage}")]
+    VersionObtain {
+        usage: ResolutionInfo,
+        source: StorageError<R>,
+    },
+    #[error("failed to obtain usage of resolved usage {usage}")]
+    UsageObtain {
+        usage: ResolutionInfo,
+        source: StorageError<R>,
+    },
 }
 
 impl<R: ResolveRead> ProjectSolver<R> {
@@ -534,7 +651,7 @@ impl<R: ResolveRead + fmt::Debug + 'static> DependencyProvider for ProjectSolver
         match range {
             DiscreteHashSet::Finite(hash_set) => {
                 let res = hash_set.iter().min().cloned();
-                log::debug!("choosing version for request ({:?})", res);
+                log::debug!("choosing version for request ({res:?})");
                 Ok(res)
             }
             DiscreteHashSet::CoFinite(hash_set) => {
@@ -543,10 +660,10 @@ impl<R: ResolveRead + fmt::Debug + 'static> DependencyProvider for ProjectSolver
                         log::debug!("unknown version for request");
                         Ok(None)
                     }
-                    DependencyIdentifier::Remote(iri) => {
+                    DependencyIdentifier::Remote(usage) => {
                         let candidate_versions = resolve_candidates(
                             &self.resolver,
-                            iri,
+                            usage,
                             &mut self.resolved_candidates.borrow_mut(),
                         )?;
                         let mut versions_indexes: Vec<(usize, semver::Version)> =
@@ -563,15 +680,13 @@ impl<R: ResolveRead + fmt::Debug + 'static> DependencyProvider for ProjectSolver
                         for (i, v) in versions_indexes.iter() {
                             if !hash_set.contains(i) {
                                 found = Some(*i);
-                                log::debug!("chose version for `{}`: {}", iri.as_str(), v);
+                                log::debug!("chose version for {usage}: {v}");
                                 break;
                             }
                         }
                         if found.is_none() {
                             log::debug!(
-                                "no allowed versions for `{}`, considered: {:?}",
-                                iri.as_str(),
-                                versions_indexes
+                                "no allowed versions for {usage}, considered: {versions_indexes:?}",
                             );
                         }
 
@@ -621,30 +736,35 @@ impl<R: ResolveRead + fmt::Debug + 'static> DependencyProvider for ProjectSolver
     }
 }
 
-type Solution<ProjectStorage> = HashMap<Iri<String>, ProjectStorage>;
+type Solution<ProjectStorage> = HashMap<Identifier, ProjectStorage>;
 
 pub fn solve<R: ResolveRead + fmt::Debug + 'static>(
     requested: Vec<InterchangeProjectUsage>,
+    base_path: Option<Utf8PathBuf>,
     resolver: R,
 ) -> Result<Solution<R::ProjectStorage>, SolverError<R>> {
     let solver = ProjectSolver::new(resolver);
 
+    let requested = requested
+        .into_iter()
+        .map(|u| CoalescingUsage::new_usage(u, base_path.clone()))
+        .collect();
     let package = DependencyIdentifier::Requested(requested);
 
     let version: usize = 0;
 
     let solution = pubgrub::resolve(&solver, package, version)?;
 
-    let mut map = solver.resolved_candidates.replace(HashMap::default());
+    let mut map = solver.resolved_candidates.take();
 
-    let mut result: HashMap<fluent_uri::Iri<String>, <R as ResolveRead>::ProjectStorage, _> =
-        HashMap::default();
+    let mut result = HashMap::default();
 
     for (k, idx) in solution {
-        if let DependencyIdentifier::Remote(uri) = k {
-            let mut extracted = map.remove(&uri).expect("internal solver error");
+        if let DependencyIdentifier::Remote(usage) = k {
+            let (_, id) = usage.into_parts();
+            let mut extracted = map.remove(&id).expect("internal solver error");
 
-            result.insert(uri, extracted.swap_remove(idx).project);
+            result.insert(id, extracted.swap_remove(idx).project);
         }
     }
 

--- a/core/src/solve/pubgrub_tests.rs
+++ b/core/src/solve/pubgrub_tests.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use std::{collections::HashMap, slice};
+use core::slice;
+use std::{collections::HashMap, fmt::Debug};
 
 use fluent_uri::Iri;
 use indexmap::IndexMap;
+use semver::VersionReq;
 
 use crate::{
     env::memory::MemoryStorageEnvironment,
@@ -14,16 +16,35 @@ use crate::{
     },
     project::{ProjectRead, memory::InMemoryProject, utils::Identifier},
     resolve::{
+        ResolutionInfo, ResolutionOutcome, ResolveRead,
         env::EnvResolver,
-        memory::{AcceptAll, MemoryResolver},
+        memory::{AcceptAll, IRIPredicate, MemoryResolver},
         sequential::SequentialResolver,
     },
 };
 
-fn trivial_memory_project(
+fn trivial_memory_project<'a>(
     name: &str,
     version: &str,
-    usage: Vec<(&str, Option<&str>)>,
+    usage: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+) -> InMemoryProject {
+    memory_project(
+        name,
+        version,
+        usage
+            .into_iter()
+            .map(|(d, dv)| InterchangeProjectUsageRaw::Resource {
+                resource: d.to_string(),
+                version_constraint: dv.map(|x| x.to_string()),
+            })
+            .collect(),
+    )
+}
+
+fn memory_project(
+    name: &str,
+    version: &str,
+    usage: Vec<InterchangeProjectUsageRaw>,
 ) -> InMemoryProject {
     InMemoryProject {
         info: Some(InterchangeProjectInfoRaw {
@@ -35,13 +56,7 @@ fn trivial_memory_project(
             maintainer: vec![],
             website: None,
             topic: vec![],
-            usage: usage
-                .into_iter()
-                .map(|(d, dv)| InterchangeProjectUsageRaw::Resource {
-                    resource: d.to_string(),
-                    version_constraint: dv.map(|x| x.to_string()),
-                })
-                .collect(),
+            usage,
         }),
         meta: Some(InterchangeProjectMetadataRaw {
             index: IndexMap::default(),
@@ -63,18 +78,45 @@ fn memory_resolver(
         iri_predicate: AcceptAll {},
         projects: structure
             .iter()
-            .map(|(id, projs)| {
-                (
-                    Identifier::from(Iri::parse(id.to_string()).unwrap()),
-                    projs.to_vec(),
-                )
-            })
+            .map(|(id, projs)| (Identifier::from_iri_unchecked_str(id), projs.to_vec()))
+            .collect(),
+    }
+}
+
+/// Which usage forms a storage can serve: a local-path-like storage serves
+/// directory usages, a remote-index-like storage serves resource IRIs
+#[derive(Debug)]
+enum Serves {
+    DirectoryUsages,
+    ResourceUsages,
+}
+
+impl IRIPredicate for Serves {
+    fn accept(&self, usage: &ResolutionInfo) -> bool {
+        #[expect(clippy::match_like_matches_macro)]
+        match (self, usage.usage()) {
+            (Serves::DirectoryUsages, InterchangeProjectUsage::Directory { .. }) => true,
+            (Serves::ResourceUsages, InterchangeProjectUsage::Resource { .. }) => true,
+            _ => false,
+        }
+    }
+}
+
+fn memory_resolver_serving(
+    serves: Serves,
+    structure: &[(&str, &[InMemoryProject])],
+) -> MemoryResolver<Serves, InMemoryProject> {
+    MemoryResolver {
+        iri_predicate: serves,
+        projects: structure
+            .iter()
+            .map(|(id, projs)| (Identifier::from_iri_unchecked_str(id), projs.to_vec()))
             .collect(),
     }
 }
 
 /// The `(name, version)` pairs of all projects in a solution
-fn solution_projects<P: ProjectRead>(solution: &HashMap<Iri<String>, P>) -> Vec<(String, String)> {
+fn solution_projects<P: ProjectRead>(solution: &HashMap<Identifier, P>) -> Vec<(String, String)> {
     solution
         .values()
         .map(|p| {
@@ -109,7 +151,7 @@ fn simple_resolver_environment(
 fn trivial_resolution() -> Result<(), Box<dyn std::error::Error>> {
     let resolver = simple_resolver_environment(&[]);
 
-    let solution = super::solve(vec![], resolver)?;
+    let solution = super::solve(vec![], None, resolver)?;
 
     assert!(solution.is_empty());
 
@@ -126,16 +168,19 @@ fn version_selection() -> Result<(), Box<dyn std::error::Error>> {
 
     let solution = super::solve(
         vec![InterchangeProjectUsage::Resource {
-            resource: fluent_uri::Iri::parse("urn:kpar:version_selection")?.into(),
-            version_constraint: Some(semver::VersionReq::parse(">=2.0.0")?),
+            resource: Iri::parse("urn:kpar:version_selection")?.into(),
+            version_constraint: Some(VersionReq::parse(">=2.0.0")?),
         }],
+        None,
         resolver,
     )?;
 
     assert_eq!(solution.len(), 1);
 
     let install = solution
-        .get(Iri::parse("urn:kpar:version_selection")?.into())
+        .get(&Identifier::from_iri_unchecked_str(
+            "urn:kpar:version_selection",
+        ))
         .unwrap();
 
     assert_eq!(install.version()?.unwrap(), "2.0.1");
@@ -148,9 +193,156 @@ fn version_constraint_default() -> Result<(), Box<dyn std::error::Error>> {
     // `semver` by default prepends `^` if a version requirement does not
     // have a comparator. This is not documented, but is also extremely
     // unlikely to change, as it's the behavior relied on by cargo
-    let v_no_caret = semver::VersionReq::parse("2.0.0")?;
-    let v_caret = semver::VersionReq::parse("^2.0.0")?;
+    let v_no_caret = VersionReq::parse("2.0.0")?;
+    let v_caret = VersionReq::parse("^2.0.0")?;
     assert_eq!(v_no_caret, v_caret);
+
+    Ok(())
+}
+
+/// A directory usage is resolved in an environment by the identifier
+/// derived from its publisher and name; the path is not relevant
+#[test]
+fn directory_usage_env_single_version() -> Result<(), Box<dyn std::error::Error>> {
+    let widget = trivial_memory_project("widget", "1.0.0", vec![]);
+
+    let resolver = simple_resolver_environment(&[("pkg:sysand/acme/widget", &[widget])]);
+
+    let solution = super::solve(
+        vec![InterchangeProjectUsage::Directory {
+            dir: "some/dir".into(),
+            publisher: "acme".to_string(),
+            name: "widget".to_string(),
+        }],
+        None,
+        resolver,
+    )?;
+
+    assert_eq!(solution.len(), 1);
+
+    let install = solution
+        .get(&Identifier::from_pub_name("acme", "widget"))
+        .unwrap();
+    assert_eq!(install.version()?.unwrap(), "1.0.0");
+
+    Ok(())
+}
+
+/// A directory usage carries no version constraint, so when the environment
+/// contains several versions of the project, the highest one is selected
+#[test]
+fn directory_usage_env_multiple_versions_selects_highest() -> Result<(), Box<dyn std::error::Error>>
+{
+    let widget_v1 = trivial_memory_project("widget", "1.0.0", vec![]);
+    let widget_v2 = trivial_memory_project("widget", "2.0.0", vec![]);
+
+    let resolver =
+        simple_resolver_environment(&[("pkg:sysand/acme/widget", &[widget_v1, widget_v2])]);
+
+    let solution = super::solve(
+        vec![InterchangeProjectUsage::Directory {
+            dir: "some/dir".into(),
+            publisher: "acme".to_string(),
+            name: "widget".to_string(),
+        }],
+        None,
+        resolver,
+    )?;
+
+    assert_eq!(solution.len(), 1);
+
+    let install = solution
+        .get(&Identifier::from_pub_name("acme", "widget"))
+        .unwrap();
+    assert_eq!(install.version()?.unwrap(), "2.0.0");
+
+    Ok(())
+}
+
+/// A project installed in an environment can itself have a directory usage
+/// (e.g. `resolve_dependencies` encounters these when enumerating sources);
+/// it is resolved in the environment like any other usage
+#[test]
+fn directory_usage_env_transitive() -> Result<(), Box<dyn std::error::Error>> {
+    let app = memory_project(
+        "app",
+        "1.0.0",
+        vec![InterchangeProjectUsageRaw::Directory {
+            dir: "../widget".to_string(),
+            publisher: "acme".to_string(),
+            name: "widget".to_string(),
+        }],
+    );
+    let widget_v1 = trivial_memory_project("widget", "1.0.0", vec![]);
+    let widget_v2 = trivial_memory_project("widget", "2.0.0", vec![]);
+
+    let resolver = simple_resolver_environment(&[
+        ("pkg:sysand/acme/app", &[app]),
+        ("pkg:sysand/acme/widget", &[widget_v1, widget_v2]),
+    ]);
+
+    let solution = super::solve(
+        vec![InterchangeProjectUsage::Resource {
+            resource: Iri::parse("pkg:sysand/acme/app")?.into(),
+            version_constraint: None,
+        }],
+        None,
+        resolver,
+    )?;
+
+    assert_eq!(solution.len(), 2);
+
+    let install = solution
+        .get(&Identifier::from_pub_name("acme", "widget"))
+        .unwrap();
+    assert_eq!(install.version()?.unwrap(), "2.0.0");
+
+    Ok(())
+}
+
+/// The same project can be used both by its resource IRI and as a directory
+/// usage with the matching publisher and name; both must be satisfied by
+/// the same single project in the solution
+#[test]
+fn directory_and_resource_usage_same_project() -> Result<(), Box<dyn std::error::Error>> {
+    let app = memory_project(
+        "app",
+        "1.0.0",
+        vec![InterchangeProjectUsageRaw::Resource {
+            resource: "pkg:sysand/acme/widget".to_string(),
+            version_constraint: None,
+        }],
+    );
+    let widget = trivial_memory_project("widget", "1.0.0", vec![]);
+
+    let resolver = simple_resolver_environment(&[
+        ("pkg:sysand/acme/app", &[app]),
+        ("pkg:sysand/acme/widget", &[widget]),
+    ]);
+
+    let solution = super::solve(
+        vec![
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("pkg:sysand/acme/app")?.into(),
+                version_constraint: None,
+            },
+            // Same project as `app` uses via its resource IRI
+            InterchangeProjectUsage::Directory {
+                dir: "some/dir".into(),
+                publisher: "acme".to_string(),
+                name: "widget".to_string(),
+            },
+        ],
+        None,
+        resolver,
+    )?;
+
+    assert_eq!(solution.len(), 2);
+
+    let install = solution
+        .get(&Identifier::from_pub_name("acme", "widget"))
+        .unwrap();
+    assert_eq!(install.version()?.unwrap(), "1.0.0");
 
     Ok(())
 }
@@ -184,31 +376,38 @@ fn diamond_selection() -> Result<(), Box<dyn std::error::Error>> {
     let solution = super::solve(
         vec![
             InterchangeProjectUsage::Resource {
-                resource: fluent_uri::Iri::parse("urn:kpar:diamond_selection_a")?.into(),
+                resource: Iri::parse("urn:kpar:diamond_selection_a")?.into(),
                 version_constraint: Some(semver::VersionReq::parse(">=0.1.0")?),
             },
             InterchangeProjectUsage::Resource {
-                resource: fluent_uri::Iri::parse("urn:kpar:diamond_selection_b")?.into(),
+                resource: Iri::parse("urn:kpar:diamond_selection_b")?.into(),
                 version_constraint: None,
             },
         ],
+        None,
         resolver,
     )?;
 
     assert_eq!(solution.len(), 3);
 
     let install_a = solution
-        .get(Iri::parse("urn:kpar:diamond_selection_a")?.into())
+        .get(&Identifier::from_iri_unchecked_str(
+            "urn:kpar:diamond_selection_a",
+        ))
         .unwrap();
     assert_eq!(install_a.version()?.unwrap(), "1.0.1");
 
     let install_b = solution
-        .get(Iri::parse("urn:kpar:diamond_selection_b")?.into())
+        .get(&Identifier::from_iri_unchecked_str(
+            "urn:kpar:diamond_selection_b",
+        ))
         .unwrap();
     assert_eq!(install_b.version()?.unwrap(), "1.0.2");
 
     let install_c = solution
-        .get(Iri::parse("urn:kpar:diamond_selection_c")?.into())
+        .get(&Identifier::from_iri_unchecked_str(
+            "urn:kpar:diamond_selection_c",
+        ))
         .unwrap();
     assert_eq!(install_c.version()?.unwrap(), "2.0.3");
 
@@ -234,6 +433,7 @@ fn incompatible_versions_fail() {
                 version_constraint: Some(semver::VersionReq::parse("=2.0.0").unwrap()),
             },
         ],
+        None,
         resolver,
     )
     .unwrap_err();
@@ -264,6 +464,7 @@ fn incompatible_versions_fail_transitive() {
                 version_constraint: None,
             },
         ],
+        None,
         resolver,
     )
     .unwrap_err();
@@ -284,6 +485,396 @@ fn single_version_single_project() -> Result<(), Box<dyn std::error::Error>> {
             resource: Iri::parse("urn:kpar:widget")?.into(),
             version_constraint: None,
         }],
+        None,
+        resolver,
+    )?;
+
+    assert_eq!(
+        solution_projects(&solution),
+        vec![("widget".to_string(), "1.0.0".to_string())]
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{0}")]
+struct StubError(String);
+
+/// A project whose `version()`/`usage()` results are fully controlled, to
+/// exercise the error paths of `resolve_candidates` for typed usages
+#[derive(Clone, Debug)]
+struct StubProject {
+    version: Result<Option<String>, String>,
+    usage: Result<Option<Vec<InterchangeProjectUsageRaw>>, String>,
+}
+
+impl ProjectRead for StubProject {
+    type Error = StubError;
+
+    fn get_project(
+        &self,
+    ) -> Result<
+        (
+            Option<InterchangeProjectInfoRaw>,
+            Option<InterchangeProjectMetadataRaw>,
+        ),
+        Self::Error,
+    > {
+        unimplemented!("not used by the solver")
+    }
+
+    fn sources(
+        &self,
+        _ctx: &crate::context::ProjectContext,
+    ) -> Result<Vec<crate::lock::Source>, Self::Error> {
+        unimplemented!("not used by the solver")
+    }
+
+    type SourceReader<'a> = std::io::Empty;
+
+    fn read_source<P: AsRef<crate::project::Utf8UnixPath>>(
+        &self,
+        _path: P,
+    ) -> Result<Self::SourceReader<'_>, Self::Error> {
+        unimplemented!("not used by the solver")
+    }
+
+    fn checksum_canonical_variant(&self) -> Result<crate::project::ProjectChecksum, Self::Error> {
+        unimplemented!("not used by the solver")
+    }
+
+    fn version(&self) -> Result<Option<String>, Self::Error> {
+        self.version.clone().map_err(StubError)
+    }
+
+    fn usage(&self) -> Result<Option<Vec<InterchangeProjectUsageRaw>>, Self::Error> {
+        self.usage.clone().map_err(StubError)
+    }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
+    }
+}
+
+/// A resolver whose only candidate for any usage is an error
+#[derive(Debug)]
+struct ErrorCandidateResolver;
+
+impl ResolveRead for ErrorCandidateResolver {
+    type Error = StubError;
+    type ProjectStorage = StubProject;
+    type ResolvedStorages = Vec<Result<StubProject, StubError>>;
+
+    fn resolve_read(
+        &self,
+        _resolve: &ResolutionInfo,
+    ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
+        Ok(ResolutionOutcome::Resolved(vec![Err(StubError(
+            "candidate exploded".to_string(),
+        ))]))
+    }
+}
+
+/// Solve a single `acme/widget` directory usage with the given resolver and
+/// return the Debug rendering of the resolution error it must produce
+fn directory_usage_solve_err<R>(resolver: R) -> String
+where
+    R: ResolveRead + Debug + 'static,
+    R::ProjectStorage: Debug,
+{
+    let result = super::solve(
+        vec![InterchangeProjectUsage::Directory {
+            dir: "some/dir".into(),
+            publisher: "acme".to_string(),
+            name: "widget".to_string(),
+        }],
+        None,
+        resolver,
+    );
+    format!(
+        "{:?}",
+        result.expect_err("typed usage must fail resolution")
+    )
+}
+
+fn stub_resolver(stub: StubProject) -> MemoryResolver<AcceptAll, StubProject> {
+    MemoryResolver {
+        iri_predicate: AcceptAll {},
+        projects: [(Identifier::from_pub_name("acme", "widget"), vec![stub])].into(),
+    }
+}
+
+/// Typed usage resolving to an error candidate fails resolution
+/// (an untyped usage would skip the candidate)
+#[test]
+fn typed_usage_error_candidate_fails_resolution() {
+    let msg = directory_usage_solve_err(ErrorCandidateResolver);
+    assert!(msg.contains("ResolvedError"), "got: {msg}");
+    assert!(msg.contains("candidate exploded"), "got: {msg}");
+}
+
+/// Typed usage resolving to a project whose version is not valid semver
+/// fails resolution
+#[test]
+fn typed_usage_invalid_version_fails_resolution() {
+    let widget = trivial_memory_project("widget", "not-a-semver", vec![]);
+    let resolver = memory_resolver(&[("pkg:sysand/acme/widget", &[widget])]);
+
+    let msg = directory_usage_solve_err(resolver);
+    assert!(msg.contains("InvalidResolvedVersion"), "got: {msg}");
+}
+
+/// Typed usage resolving to a project that does not expose a version
+/// fails resolution
+#[test]
+fn typed_usage_missing_version_fails_resolution() {
+    let msg = directory_usage_solve_err(stub_resolver(StubProject {
+        version: Ok(None),
+        usage: Ok(Some(vec![])),
+    }));
+    assert!(msg.contains("MissingVersion"), "got: {msg}");
+}
+
+/// Typed usage resolving to a project whose version cannot be read
+/// fails resolution
+#[test]
+fn typed_usage_version_read_error_fails_resolution() {
+    let msg = directory_usage_solve_err(stub_resolver(StubProject {
+        version: Err("cannot read version".to_string()),
+        usage: Ok(Some(vec![])),
+    }));
+    assert!(msg.contains("VersionObtain"), "got: {msg}");
+    assert!(msg.contains("cannot read version"), "got: {msg}");
+}
+
+/// Typed usage resolving to a project whose own usage list is invalid
+/// fails resolution
+#[test]
+fn typed_usage_invalid_usages_fail_resolution() {
+    let widget = memory_project(
+        "widget",
+        "1.0.0",
+        vec![InterchangeProjectUsageRaw::Resource {
+            resource: "not a valid iri".to_string(),
+            version_constraint: None,
+        }],
+    );
+    let resolver = memory_resolver(&[("pkg:sysand/acme/widget", &[widget])]);
+
+    let msg = directory_usage_solve_err(resolver);
+    assert!(msg.contains("InvalidProject"), "got: {msg}");
+}
+
+/// Typed usage resolving to a project that does not expose its usages
+/// fails resolution
+#[test]
+fn typed_usage_missing_usages_fails_resolution() {
+    let msg = directory_usage_solve_err(stub_resolver(StubProject {
+        version: Ok(Some("1.0.0".to_string())),
+        usage: Ok(None),
+    }));
+    assert!(msg.contains("MissingUsage"), "got: {msg}");
+}
+
+/// Typed usage resolving to a project whose usages cannot be read
+/// fails resolution
+#[test]
+fn typed_usage_usages_read_error_fails_resolution() {
+    let msg = directory_usage_solve_err(stub_resolver(StubProject {
+        version: Ok(Some("1.0.0".to_string())),
+        usage: Err("cannot read usages".to_string()),
+    }));
+    assert!(msg.contains("UsageObtain"), "got: {msg}");
+    assert!(msg.contains("cannot read usages"), "got: {msg}");
+}
+
+/// When the project at a directory usage's path is rejected (e.g. its
+/// declared publisher does not match the usage), the rejection reason must
+/// surface in the solver error. A typed usage has exactly one place its
+/// project can come from, so silently skipping the candidate and reporting
+/// only "no valid candidates" hides the actual problem
+#[cfg(feature = "filesystem")]
+#[test]
+fn directory_usage_candidate_rejection_reason_is_reported() -> Result<(), Box<dyn std::error::Error>>
+{
+    use crate::project::local_src::LocalSrcProject;
+
+    // A real project on disk that declares a different publisher than
+    // the usage expects
+    let tmp = camino_tempfile::tempdir()?;
+    let mut info = memory_project("widget", "1.0.0", vec![]).info.unwrap();
+    info.publisher = Some("someone-else".to_string());
+    std::fs::write(
+        tmp.path().join(".project.json"),
+        serde_json::to_string(&info)?,
+    )?;
+
+    let project = LocalSrcProject::new_for_solve(
+        tmp.path().to_owned(),
+        None,
+        Some("acme".to_string()),
+        "widget".to_string(),
+    );
+
+    let resolver = MemoryResolver {
+        iri_predicate: AcceptAll {},
+        projects: [(Identifier::from_pub_name("acme", "widget"), vec![project])].into(),
+    };
+
+    let result = super::solve(
+        vec![InterchangeProjectUsage::Directory {
+            dir: "widget".into(),
+            publisher: "acme".to_string(),
+            name: "widget".to_string(),
+        }],
+        None,
+        resolver,
+    );
+
+    let err = result.expect_err("the only candidate declares the wrong publisher");
+    // The rejection reason (`someone-else` does not match `acme`) must be part
+    // of the reported error, not only visible in debug logs
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("someone-else"),
+        "solver error should carry the candidate's rejection reason, got: {msg}"
+    );
+
+    Ok(())
+}
+
+/// A directory usage pins the project to the copy at that path. Version
+/// constraints that other dependents place on the same project are checked
+/// against that pinned copy, and the pinned copy is the one installed,
+/// even when another source offers a higher version that would also satisfy
+/// the constraints
+#[test]
+fn directory_usage_copy_satisfies_constraints_of_other_dependents()
+-> Result<(), Box<dyn std::error::Error>> {
+    let widget_local = trivial_memory_project("widget", "1.3.0", vec![]);
+    let widget_index = trivial_memory_project("widget", "1.5.0", vec![]);
+    let app = trivial_memory_project("app", "1.0.0", [("pkg:sysand/acme/widget", Some("^1.0"))]);
+
+    let local_paths = memory_resolver_serving(
+        Serves::DirectoryUsages,
+        &[("pkg:sysand/acme/widget", &[widget_local])],
+    );
+    let index = memory_resolver_serving(
+        Serves::ResourceUsages,
+        &[
+            ("pkg:sysand/acme/app", &[app]),
+            ("pkg:sysand/acme/widget", &[widget_index]),
+        ],
+    );
+    let resolver = SequentialResolver::new([local_paths, index]);
+
+    let solution = super::solve(
+        vec![
+            InterchangeProjectUsage::Directory {
+                dir: "some/dir".into(),
+                publisher: "acme".to_string(),
+                name: "widget".to_string(),
+            },
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("pkg:sysand/acme/app")?.into(),
+                version_constraint: None,
+            },
+        ],
+        None,
+        resolver,
+    )?;
+
+    // `app`'s `^1.0` is satisfied by the pinned local copy 1.3.0; the
+    // index copy 1.5.0 must not be selected over it
+    let widget_versions: Vec<String> = solution_projects(&solution)
+        .into_iter()
+        .filter(|(name, _)| name == "widget")
+        .map(|(_, version)| version)
+        .collect();
+    assert_eq!(widget_versions, vec!["1.3.0".to_string()]);
+
+    Ok(())
+}
+
+/// When the copy pinned by a directory usage cannot satisfy another
+/// dependent's version constraint, resolution must fail — not silently
+/// fall back to a satisfying copy of the project from another source
+#[test]
+fn directory_usage_copy_violating_constraints_is_an_error() -> Result<(), Box<dyn std::error::Error>>
+{
+    let widget_local = trivial_memory_project("widget", "1.3.0", vec![]);
+    let widget_index = trivial_memory_project("widget", "2.1.0", vec![]);
+    let app = trivial_memory_project(
+        "app",
+        "1.0.0",
+        [("pkg:sysand/acme/widget", Some(">=2.0.0"))],
+    );
+
+    let local_paths = memory_resolver_serving(
+        Serves::DirectoryUsages,
+        &[("pkg:sysand/acme/widget", &[widget_local])],
+    );
+    let index = memory_resolver_serving(
+        Serves::ResourceUsages,
+        &[
+            ("pkg:sysand/acme/app", &[app]),
+            ("pkg:sysand/acme/widget", &[widget_index]),
+        ],
+    );
+    let resolver = SequentialResolver::new([local_paths, index]);
+
+    let result = super::solve(
+        vec![
+            InterchangeProjectUsage::Directory {
+                dir: "some/dir".into(),
+                publisher: "acme".to_string(),
+                name: "widget".to_string(),
+            },
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("pkg:sysand/acme/app")?.into(),
+                version_constraint: None,
+            },
+        ],
+        None,
+        resolver,
+    );
+
+    assert!(
+        result.is_err(),
+        "expected resolution to fail because the directory copy (1.3.0) \
+         violates `app`'s `>=2.0.0`; it must not fall back to the index copy"
+    );
+
+    Ok(())
+}
+
+/// A project reachable both by its resource IRI (available in one storage)
+/// and via a directory usage (available in another storage) is still one
+/// project; the resolved dependency tree contains exactly one instance of it
+#[test]
+fn same_project_version_from_different_storages_and_usage_forms_installs_once()
+-> Result<(), Box<dyn std::error::Error>> {
+    let widget = trivial_memory_project("widget", "1.0.0", vec![]);
+
+    let storage_a = memory_resolver(&[("pkg:sysand/acme/widget", slice::from_ref(&widget))]);
+    let storage_b = memory_resolver(&[("pkg:sysand/acme/widget", &[widget])]);
+    let resolver = SequentialResolver::new([storage_a, storage_b]);
+
+    let solution = super::solve(
+        vec![
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("pkg:sysand/acme/widget")?.into(),
+                version_constraint: None,
+            },
+            // The same project, used via a directory usage
+            InterchangeProjectUsage::Directory {
+                dir: "some/dir".into(),
+                publisher: "acme".to_string(),
+                name: "widget".to_string(),
+            },
+        ],
+        None,
         resolver,
     )?;
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -19,20 +19,20 @@ use crate::project::{memory::InMemoryProject, utils::Identifier};
 pub type ProvidedProjects = HashMap<Identifier, Vec<InMemoryProject>>;
 pub type ProvidedIdentifiers = HashSet<Identifier>;
 
+#[cfg(feature = "filesystem")]
 pub(crate) mod scheme {
     #[cfg(feature = "filesystem")]
     use fluent_uri::component::Scheme;
-    #[cfg(feature = "filesystem")]
     pub const SCHEME_FILE: &Scheme = Scheme::new_or_panic("file");
-    #[cfg(all(feature = "filesystem", feature = "networking"))]
+    #[cfg(feature = "networking")]
     pub const SCHEME_SSH: &Scheme = Scheme::new_or_panic("ssh");
-    #[cfg(all(feature = "filesystem", feature = "networking"))]
+    #[cfg(feature = "networking")]
     pub const SCHEME_GIT_SSH: &Scheme = Scheme::new_or_panic("git+ssh");
-    #[cfg(all(feature = "filesystem", feature = "networking"))]
+    #[cfg(feature = "networking")]
     pub const SCHEME_GIT_FILE: &Scheme = Scheme::new_or_panic("git+file");
-    #[cfg(all(feature = "filesystem", feature = "networking"))]
+    #[cfg(feature = "networking")]
     pub const SCHEME_GIT_HTTP: &Scheme = Scheme::new_or_panic("git+http");
-    #[cfg(all(feature = "filesystem", feature = "networking"))]
+    #[cfg(feature = "networking")]
     pub const SCHEME_GIT_HTTPS: &Scheme = Scheme::new_or_panic("git+https");
     #[cfg(feature = "filesystem")]
     pub const SCHEME_HTTP: &Scheme = Scheme::new_or_panic("http");

--- a/core/tests/filesystem_env.rs
+++ b/core/tests/filesystem_env.rs
@@ -289,11 +289,11 @@ version = \"0.1\"
         source_project.write_source(source_path, &mut Cursor::new(source_code), true)?;
         let checksum = source_project.checksum_canonical_variant()?;
 
-        directory_environment.put_project("urn:sysand_test:1", "1.2.3", Some(checksum), |p| {
+        directory_environment.put_project(iri.as_str(), "1.2.3", Some(checksum), |p| {
             clone_project(&source_project, p, true).map(|_| ())
         })?;
 
-        let target_project = directory_environment.get_project("urn:sysand_test:1", "1.2.3")?;
+        let target_project = directory_environment.get_project(iri.as_str(), "1.2.3")?;
         let (read_info, read_meta) = target_project.get_project()?;
 
         assert_eq!(read_info, Some(info.clone()));
@@ -309,17 +309,17 @@ version = \"0.1\"
 
         assert_eq!(
             directory_environment
-                .versions("urn:sysand_test:1")?
+                .versions(iri.as_str())?
                 .into_iter()
                 .collect::<Result<Vec<String>, _>>()?,
-            vec!["1.2.3"]
+            &["1.2.3"]
         );
         assert_eq!(
             directory_environment
                 .uris()?
                 .into_iter()
                 .collect::<Result<Vec<String>, _>>()?,
-            vec!["urn:sysand_test:1"]
+            vec![iri.as_str()]
         );
 
         assert_eq!(ls_dir(cwd.path()), vec![".sysand"]);

--- a/core/tests/memory_env.rs
+++ b/core/tests/memory_env.rs
@@ -79,13 +79,13 @@ fn env_manual_install() -> Result<(), Box<dyn std::error::Error>> {
 
     source_project.write_source(source_path, &mut Cursor::new(source_code), true)?;
 
-    memory_environment.put_project("urn:sysand_test:1", "1.2.3", None, |p| {
+    memory_environment.put_project(iri.as_str(), "1.2.3", None, |p| {
         clone_project(&source_project, p, true)?;
 
         Ok::<(), CloneError<InMemoryError, InMemoryError>>(())
     })?;
 
-    let target_project = memory_environment.get_project("urn:sysand_test:1", "1.2.3")?;
+    let target_project = memory_environment.get_project(iri.as_str(), "1.2.3")?;
 
     assert_eq!(target_project.info, Some(info.clone()));
     assert_eq!(target_project.meta, Some(meta.clone()));

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -29,14 +29,14 @@ anstream = "1.0.0"
 anyhow = "1.0.102"
 clap = { version = "4.5.60", default-features = false, features = ["derive", "unicode", "help", "cargo", "color", "env", "suggestions", "usage"] }
 env_logger = "0.11.9"
-log = { version = "0.4.29", default-features = false }
+log.workspace = true
 sysand-core = { path = "../core", features = ["std", "filesystem", "networking"] }
 thiserror = "2.0.18"
 toml = { version = "1.0.6", features = ["fast_hash"] }
 semver = "1.0.27"
 serde_json = { version = "1.0.149", default-features = false }
 spdx = "0.13.4"
-fluent-uri = { version = "0.4.1", default-features = false, features = ["net"] }
+fluent-uri.workspace = true
 typed-path = { version = "0.12.3", default-features = false }
 url = { version = "2.5.8", default-features = false }
 pubgrub = { version = "0.4.0", default-features = false }

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -293,6 +293,42 @@ pub enum Command {
     },
     /// Prints the root directory of the current project
     PrintRoot,
+    /// Experimental commands. Likely to change in incompatible ways or be
+    /// removed in the future.
+    #[clap(verbatim_doc_comment)]
+    Experimental {
+        #[command(subcommand)]
+        subcommand: ExpCommand,
+    },
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum ExpCommand {
+    /// Add a usage
+    Add {
+        #[clap(flatten)]
+        locator: ExpAddProjectLocatorArgs,
+
+        /// Do not automatically resolve dependencies (and generate lockfile)
+        #[arg(long, default_value_t = false)]
+        no_lock: bool,
+        /// Do not automatically install dependencies
+        #[arg(long, default_value_t = false)]
+        no_sync: bool,
+        #[command(flatten)]
+        resolution_opts: ResolutionOptions,
+    },
+    /// Remove a usage
+    Remove { publisher: String, name: String },
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct ExpAddProjectLocatorArgs {
+    /// Add a project from a local directory path
+    /// Path to the project. Can be relative or absolute, and point
+    /// to a project directory
+    #[arg(long, verbatim_doc_comment)]
+    pub dir: Utf8PathBuf,
 }
 
 #[derive(clap::Args, Debug, Clone)]

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -16,9 +16,10 @@ use sysand_core::{
         local_fs::{CONFIG_FILE, add_project_source_to_config},
     },
     context::ProjectContext,
-    model::InterchangeProjectUsageRaw,
+    model::{InterchangeProjectUsage, InterchangeProjectUsageRaw},
     project::{
         ProjectRead,
+        local_src::LocalSrcProject,
         utils::{relativize_path, wrapfs},
     },
     resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead, standard::standard_resolver},
@@ -249,6 +250,96 @@ pub fn command_add<Policy: HTTPAuthentication>(
     } else {
         do_add(&mut current_project, &usage_raw)?;
         Ok(())
+    }
+}
+
+pub enum ExpAddArgs {
+    Dir { dir: Utf8PathBuf },
+}
+
+// TODO: Collect common arguments
+#[allow(clippy::too_many_arguments)]
+pub fn exp_command_add<Policy: HTTPAuthentication>(
+    add: ExpAddArgs,
+    no_lock: bool,
+    no_sync: bool,
+    resolution_opts: ResolutionOptions,
+    config: Config,
+    ctx: ProjectContext,
+    client: reqwest_middleware::ClientWithMiddleware,
+    runtime: Arc<tokio::runtime::Runtime>,
+    auth_policy: Arc<Policy>,
+) -> Result<()> {
+    let mut current_project = ctx
+        .current_project
+        .clone()
+        .ok_or(CliError::MissingProjectCurrentDir)?;
+
+    match add {
+        ExpAddArgs::Dir { dir } => {
+            let abs_path = wrapfs::canonicalize(dir)?;
+            let relative = relativize_path(&abs_path, current_project.root_path())?;
+            let project = LocalSrcProject::new_access(abs_path, None);
+            let info = project
+                .get_info()?
+                .ok_or_else(|| CliError::MissingProject(project.root_path().to_string()))?;
+            let publisher = info.publisher.ok_or_else(|| {
+                CliError::MissingPublisherForUsage(project.root_path().to_string())
+            })?;
+            let usage = InterchangeProjectUsage::Directory {
+                dir: relative,
+                publisher,
+                name: info.name,
+            };
+
+            if !no_lock {
+                let info_path = current_project.info_path();
+                let info_backup = wrapfs::read_to_string(&info_path)?;
+                let added = do_add(&mut current_project, &usage.into())?;
+                if !added {
+                    return Ok(());
+                }
+
+                let alias_iris = if let Some(w) = &ctx.current_workspace {
+                    w.projects()
+                        .iter()
+                        .find(|p| Path::new(&p.path) == current_project.root_path())
+                        .map(|p| p.iris.to_owned())
+                } else {
+                    None
+                };
+
+                let provided_iris = if !resolution_opts.include_std {
+                    // Don't warn; std libs are all `https://`, so they can't match this usage
+                    crate::known_std_libs()
+                } else {
+                    HashMap::default()
+                };
+
+                match resolve_deps(
+                    no_sync,
+                    resolution_opts,
+                    &config,
+                    client,
+                    runtime,
+                    auth_policy,
+                    current_project.root_path(),
+                    alias_iris,
+                    provided_iris,
+                    ctx,
+                ) {
+                    Ok(_) => Ok(()),
+                    Err(e) => {
+                        // Restore old info
+                        wrapfs::write(&info_path, info_backup)?;
+                        Err(e)
+                    }
+                }
+            } else {
+                do_add(&mut current_project, &usage.into())?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -117,6 +117,7 @@ pub fn command_clone<Policy: HTTPAuthentication>(
         } else {
             HashMap::default()
         };
+
         let resolver = PriorityResolver::new(
             MemoryResolver {
                 iri_predicate: AcceptAll {},
@@ -143,7 +144,7 @@ pub fn command_clone<Policy: HTTPAuthentication>(
             && lock.projects.iter().any(|x| {
                 x.identifiers
                     .iter()
-                    .any(|y| provided_usages.contains_key(y.as_str()))
+                    .any(|y| provided_usages.contains_key(y))
             })
         {
             log::info!(
@@ -287,7 +288,7 @@ fn obtain_project<Policy: HTTPAuthentication>(
                     remote_project,
                 )?;
             } else {
-                let remote_project = LocalSrcProject::new_access(path.to_owned(), None);
+                let remote_project = LocalSrcProject::new_access(path, None);
                 clone_local(
                     version,
                     cloning,

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -28,10 +28,10 @@ use sysand_core::{
     utils::{ProvidedIdentifiers, format_err},
 };
 
-use anstream::{print, println};
+use anstream::println;
 use anyhow::{Result, bail};
 use fluent_uri::Iri;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 use sysand_core::{
     info::{do_info, do_info_project},
     project::utils::wrapfs,
@@ -66,15 +66,9 @@ pub fn pprint_interchange_project(
     if !info.topic.is_empty() {
         println!("{header}Topics:{header:#} {}", info.topic.join(", "));
     }
-
     if info.usage.is_empty() {
         println!("No usages.");
     } else {
-        let has_ignored_usages = info.usage.iter().any(|u| match u {
-            InterchangeProjectUsageRaw::Resource { resource, .. } => {
-                excluded_iris.contains(resource)
-            }
-        });
         let usages_to_print: Vec<_> = info
             .usage
             .iter()
@@ -82,8 +76,10 @@ pub fn pprint_interchange_project(
                 InterchangeProjectUsageRaw::Resource { resource, .. } => {
                     !excluded_iris.contains(resource)
                 }
+                InterchangeProjectUsageRaw::Directory { .. } => true,
             })
             .collect();
+        let has_ignored_usages = info.usage.len() > usages_to_print.len();
         if has_ignored_usages && usages_to_print.is_empty() {
             // TODO: distinguish between provided iris in general and std libs in
             // particular. Here it's assumed that non-empty excluded_iris == std is ignored,
@@ -95,19 +91,7 @@ pub fn pprint_interchange_project(
         } else {
             println!("{header}Usages:{header:#}");
             for usage in usages_to_print.iter() {
-                match usage {
-                    InterchangeProjectUsageRaw::Resource {
-                        resource,
-                        version_constraint,
-                    } => {
-                        print!("    {resource}");
-                        if let Some(v) = version_constraint {
-                            println!(" ({v})");
-                        } else {
-                            println!();
-                        }
-                    }
-                }
+                println!("    {usage}");
             }
             if has_ignored_usages {
                 // Same caveat as for "All usages are ignored"
@@ -139,7 +123,7 @@ fn interpret_project_path<P: AsRef<Utf8Path>>(path: P) -> Result<FileResolverPro
 
 pub fn command_info_path<P: AsRef<Utf8Path>>(
     path: P,
-    excluded_iris: &ProvidedIdentifiers,
+    excluded_iris: &HashSet<Identifier>,
 ) -> Result<()> {
     let project = interpret_project_path(&path)?;
     match do_info_project(&project) {
@@ -351,23 +335,7 @@ fn apply_get_info(
         GetInfoVerb::GetWebsite => print_output(info.website.map(|x| vec![x]), numbered),
         GetInfoVerb::GetTopic => print_output(Some(info.topic), numbered),
         GetInfoVerb::GetUsage => print_output(
-            Some(
-                info.usage
-                    .into_iter()
-                    .map(|usage| match usage {
-                        InterchangeProjectUsageRaw::Resource {
-                            resource,
-                            version_constraint,
-                        } => {
-                            if let Some(version_constraint) = version_constraint {
-                                format!("{resource} ({version_constraint})")
-                            } else {
-                                resource.clone()
-                            }
-                        }
-                    })
-                    .collect(),
-            ),
+            Some(info.usage.iter().map(ToString::to_string).collect()),
             numbered,
         ),
     }

--- a/sysand/src/commands/lock.rs
+++ b/sysand/src/commands/lock.rs
@@ -37,7 +37,7 @@ pub fn command_lock<P: AsRef<Utf8UnixPath>, Policy: HTTPAuthentication, R: AsRef
     auth_policy: Arc<Policy>,
     ctx: &ProjectContext,
 ) -> Result<sysand_core::lock::Lock> {
-    let provided_usages = if !resolution_opts.include_std {
+    let provided_iris = if !resolution_opts.include_std {
         known_std_libs()
     } else {
         HashMap::default()
@@ -48,7 +48,7 @@ pub fn command_lock<P: AsRef<Utf8UnixPath>, Policy: HTTPAuthentication, R: AsRef
         &project_root,
         ctx,
         // TODO: avoid expensive clone here
-        provided_usages.clone(),
+        provided_iris.clone(),
         client,
         runtime,
         auth_policy,
@@ -71,7 +71,7 @@ pub fn command_lock<P: AsRef<Utf8UnixPath>, Policy: HTTPAuthentication, R: AsRef
         &path,
         &project_root,
         alias_iris,
-        &provided_usages,
+        &provided_iris,
         wrapped_resolver,
         ctx,
     )?;

--- a/sysand/src/commands/remove.rs
+++ b/sysand/src/commands/remove.rs
@@ -9,11 +9,12 @@ use sysand_core::{
     config::local_fs::{CONFIG_FILE, remove_project_source_from_config},
     context::ProjectContext,
     model::InterchangeProjectUsageRaw,
-    remove::do_remove,
+    remove::{do_remove, exp_do_remove},
 };
 
 use crate::CliError;
 
+// TODO: update lockfile if present
 pub fn command_remove(
     iri: Iri<String>,
     ctx: ProjectContext,
@@ -33,10 +34,32 @@ pub fn command_remove(
     }
 
     let usages = do_remove(&mut current_project, iri.into_string())?;
+    print_removed(&usages);
 
+    Ok(())
+}
+
+pub fn exp_command_remove(
+    publisher: impl AsRef<str>,
+    name: impl AsRef<str>,
+    ctx: ProjectContext,
+) -> Result<()> {
+    let publisher = publisher.as_ref();
+    let name = name.as_ref();
+    let mut current_project = ctx
+        .current_project
+        .ok_or(CliError::MissingProjectCurrentDir)?;
+
+    let usages = exp_do_remove(&mut current_project, publisher, name)?;
+    print_removed(&usages);
+
+    Ok(())
+}
+
+fn print_removed(usages: &[InterchangeProjectUsageRaw]) {
     let removed = "Removed";
     let header = sysand_core::style::get_style_config().header;
-    if let [usage] = usages.as_slice() {
+    for usage in usages {
         match usage {
             InterchangeProjectUsageRaw::Resource {
                 resource,
@@ -51,25 +74,13 @@ pub fn command_remove(
                     log::info!("{header}{removed:>12}{header:#} `{resource}`");
                 }
             },
-        }
-    } else {
-        log::info!("{header}{removed:>12}{header:#}:");
-        for usage in usages {
-            match usage {
-                InterchangeProjectUsageRaw::Resource {
-                    resource,
-                    version_constraint,
-                } => match version_constraint {
-                    Some(vc) => {
-                        log::info!("{:>13} `{resource}` with version constraints `{vc}`", ' ');
-                    }
-                    None => {
-                        log::info!("{:>13} `{resource}`", ' ');
-                    }
-                },
+            InterchangeProjectUsageRaw::Directory {
+                dir,
+                publisher,
+                name,
+            } => {
+                log::info!("{header}{removed:>12}{header:#} `{publisher}/{name}` (path `{dir}`)");
             }
         }
     }
-
-    Ok(())
 }

--- a/sysand/src/error.rs
+++ b/sysand/src/error.rs
@@ -24,4 +24,9 @@ pub enum CliError {
     MissingProjectVersion(String, String),
     #[error("unable to find interchange project in current directory")]
     MissingProjectCurrentDir,
+    #[error(
+        "project `{0}` does not have a publisher,\n\
+        which is required to add it as a path usage"
+    )]
+    MissingPublisherForUsage(String),
 }

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -48,9 +48,9 @@ use sysand_core::{
 use url::Url;
 
 use crate::{
-    cli::{Args, Command},
+    cli::{Args, Command, ExpCommand},
     commands::{
-        add::command_add,
+        add::{ExpAddArgs, command_add, exp_command_add},
         build::{command_build_for_project, command_build_for_workspace},
         env::{
             command_env, command_env_install, command_env_install_path, command_env_list,
@@ -64,7 +64,7 @@ use crate::{
         lock::command_lock,
         print_root::command_print_root,
         publish::command_publish,
-        remove::command_remove,
+        remove::{command_remove, exp_command_remove},
         sources::{command_sources_env, command_sources_project},
         sync::command_sync,
     },
@@ -409,7 +409,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             }
         }
         Command::Sync { resolution_opts } => {
-            let provided_usages = if !resolution_opts.include_std {
+            let provided_iris = if !resolution_opts.include_std {
                 known_std_libs()
             } else {
                 HashMap::default()
@@ -451,7 +451,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 project_root,
                 &mut local_environment,
                 client,
-                &provided_usages,
+                &provided_iris,
                 runtime,
                 auth_policy,
                 ctx.current_workspace.as_ref(),
@@ -701,7 +701,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 )
             }
         }
-        cli::Command::Publish {
+        Command::Publish {
             path,
             index,
             trusted_publishing,
@@ -735,6 +735,28 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             runtime,
             auth_policy,
         ),
+        Command::Experimental { subcommand } => match subcommand {
+            ExpCommand::Add {
+                locator,
+                resolution_opts,
+                no_lock,
+                no_sync,
+            } => {
+                let add = ExpAddArgs::Dir { dir: locator.dir };
+                exp_command_add(
+                    add,
+                    no_lock,
+                    no_sync,
+                    resolution_opts,
+                    config,
+                    ctx,
+                    client,
+                    runtime,
+                    auth_policy,
+                )
+            }
+            ExpCommand::Remove { publisher, name } => exp_command_remove(publisher, name, ctx),
+        },
     }
 }
 

--- a/sysand/tests/cli_exp_add_remove.rs
+++ b/sysand/tests/cli_exp_add_remove.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+// pub due to https://github.com/rust-lang/rust/issues/46379
+mod common;
+pub use common::*;
+
+#[test]
+fn exp_add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exp_add_and_remove", "1.2.3")?;
+    out.assert().success();
+
+    let dep_dir = cwd.join("dep");
+    std::fs::create_dir_all(&dep_dir)?;
+    cli_init_project_in(&dep_dir, None, "b", Some("my-dep"), Some("1.0.0"), None)?
+        .assert()
+        .success();
+
+    let out = run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "dep"],
+        None,
+    )?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        "Adding usage: `b/my-dep` from `dep`",
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_and_remove",
+  "publisher": "a",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "dir": "dep",
+      "publisher": "b",
+      "name": "my-dep"
+    }
+  ]
+}
+"#
+    );
+
+    let out = run_sysand_in(&cwd, ["experimental", "remove", "b", "my-dep"], None)?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Removing `b/my-dep` from usages"))
+        .stderr(predicate::str::contains("Removed `b/my-dep` (path `dep`)"));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_and_remove",
+  "publisher": "a",
+  "version": "1.2.3"
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exp_add_missing_publisher_fails() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exp_add_no_publisher", "1.2.3")?;
+    out.assert().success();
+
+    let dep_dir = cwd.join("dep");
+    std::fs::create_dir_all(&dep_dir)?;
+    std::fs::write(
+        dep_dir.join(".project.json"),
+        r#"{
+  "name": "no-publisher-dep",
+  "version": "1.0.0"
+}
+"#,
+    )?;
+
+    let out = run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "dep"],
+        None,
+    )?;
+
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("does not have a publisher"));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_no_publisher",
+  "publisher": "a",
+  "version": "1.2.3"
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exp_add_nonexistent_project_fails() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exp_add_nonexistent", "1.2.3")?;
+    out.assert().success();
+
+    let dep_dir = cwd.join("dep");
+    std::fs::create_dir_all(&dep_dir)?;
+    // dep exists as a directory but has no .project.json
+
+    let out = run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "dep"],
+        None,
+    )?;
+
+    out.assert().failure().stderr(predicate::str::contains(
+        "unable to find interchange project",
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn exp_add_already_present_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exp_add_already_present", "1.2.3")?;
+    out.assert().success();
+
+    let dep_dir = cwd.join("dep");
+    std::fs::create_dir_all(&dep_dir)?;
+    cli_init_project_in(&dep_dir, None, "b", Some("my-dep"), Some("1.0.0"), None)?
+        .assert()
+        .success();
+
+    run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "dep"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "dep"],
+        None,
+    )?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("is already present"));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_already_present",
+  "publisher": "a",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "dir": "dep",
+      "publisher": "b",
+      "name": "my-dep"
+    }
+  ]
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exp_remove() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exp_remove", "1.2.3")?;
+    out.assert().success();
+
+    let dep_dir = cwd.join("dep");
+    std::fs::create_dir_all(&dep_dir)?;
+    cli_init_project_in(&dep_dir, None, "b", Some("my-dep"), Some("1.0.0"), None)?
+        .assert()
+        .success();
+
+    run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "dep"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(&cwd, ["experimental", "remove", "b", "my-dep"], None)?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Removing `b/my-dep` from usages"))
+        .stderr(predicate::str::contains("Removed `b/my-dep` (path `dep`)"));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_remove",
+  "publisher": "a",
+  "version": "1.2.3"
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exp_remove_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exp_remove_nonexistent", "1.2.3")?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["experimental", "remove", "a", "nonexistent"], None)?;
+
+    out.assert().failure().stderr(predicate::str::contains(
+        "could not find usage for `a/nonexistent`",
+    ));
+
+    Ok(())
+}

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -854,6 +854,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn Error>> {
             "info",
             "--iri",
             "urn:kpar:other",
+            "-v",
             "--default-index",
             &server.url(),
         ],

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -651,6 +651,178 @@ fn lock_rejects_non_normalized_sysand_purl() -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
+/// A transitive directory usage must be resolved relative to the project
+/// that declares it, not relative to the top-level project being locked:
+/// `app` uses `deps/widget`, and `widget` uses `../gadget`, which points at
+/// `deps/gadget` only when resolved against `widget`'s own directory. If the
+/// solver kept passing the top-level base path down, `../gadget` would land
+/// outside the temporary directory and resolution would fail
+#[test]
+fn lock_directory_usage_transitive() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "app", "1.2.3")?;
+    out.assert().success().stdout(predicate::str::is_empty());
+
+    let widget_dir = cwd.join("deps").join("widget");
+    std::fs::create_dir_all(&widget_dir)?;
+    cli_init_project_in(&widget_dir, None, "b", Some("widget"), Some("1.0.0"), None)?
+        .assert()
+        .success();
+
+    let gadget_dir = cwd.join("deps").join("gadget");
+    std::fs::create_dir_all(&gadget_dir)?;
+    cli_init_project_in(&gadget_dir, None, "c", Some("gadget"), Some("2.0.0"), None)?
+        .assert()
+        .success();
+
+    run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "deps/widget"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    run_sysand_in(
+        &widget_dir,
+        ["experimental", "add", "--no-lock", "--dir", "../gadget"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(&cwd, ["lock"], None)?;
+    out.assert().success();
+
+    let lock_file: Lock =
+        toml::from_str(&std::fs::read_to_string(cwd.join(DEFAULT_LOCKFILE_NAME))?)?;
+    let projects = lock_file.projects;
+
+    assert_eq!(
+        projects.len(),
+        3,
+        "expected app, widget and gadget in the lockfile, got: {projects:#?}"
+    );
+
+    // Resolved paths are relativized back against the top-level project
+    // root when recorded in the lockfile
+    for (name, version, expected_src_path) in [
+        ("widget", "1.0.0", "deps/widget"),
+        ("gadget", "2.0.0", "deps/gadget"),
+    ] {
+        let project = projects
+            .iter()
+            .find(|p| p.name == name)
+            .unwrap_or_else(|| panic!("`{name}` missing from lockfile: {projects:#?}"));
+        assert_eq!(project.version, version);
+        let [Source::LocalSrc { src_path, .. }] = project.sources.as_slice() else {
+            panic!("expected a single local source for `{name}`, got: {project:#?}");
+        };
+        assert_eq!(src_path.as_str(), expected_src_path);
+    }
+
+    Ok(())
+}
+
+/// A dependency resolved *from the environment* can declare a directory
+/// usage whose relative path only made sense in its original source tree:
+/// `app` was authored next to `widget` and uses `../widget`, but once `app`
+/// is installed into `.sysand`, that path (relative to the env-internal
+/// project root) points at nothing. Resolution must then fall back to the
+/// environment, where the usage's publisher/name identify `widget`, instead
+/// of failing the whole lock on the file resolver's `NotFound`
+#[test]
+fn lock_directory_usage_env_installed_dependency() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "consumer", "1.0.0")?;
+    out.assert().success();
+
+    // Source tree: `app` uses `widget` via the directory usage `../widget`
+    let app_dir = cwd.join("src").join("app");
+    let widget_dir = cwd.join("src").join("widget");
+    std::fs::create_dir_all(&app_dir)?;
+    std::fs::create_dir_all(&widget_dir)?;
+    cli_init_project_in(
+        &widget_dir,
+        None,
+        "acme",
+        Some("widget"),
+        Some("1.0.0"),
+        None,
+    )?
+    .assert()
+    .success();
+    cli_init_project_in(&app_dir, None, "acme", Some("app"), Some("1.0.0"), None)?
+        .assert()
+        .success();
+    run_sysand_in(
+        &app_dir,
+        ["experimental", "add", "--no-lock", "--dir", "../widget"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    // Install both projects into the consumer's environment, then delete the
+    // source tree: the env copies are the only ones left, and the `../widget`
+    // recorded in `app` now points at a non-existent path inside `.sysand`
+    run_sysand_in(
+        &cwd,
+        [
+            "env",
+            "install",
+            "pkg:sysand/acme/widget",
+            "--path",
+            "src/widget",
+            "--no-deps",
+            "--no-index",
+        ],
+        None,
+    )?
+    .assert()
+    .success();
+    run_sysand_in(
+        &cwd,
+        [
+            "env",
+            "install",
+            "pkg:sysand/acme/app",
+            "--path",
+            "src/app",
+            "--no-deps",
+            "--no-index",
+        ],
+        None,
+    )?
+    .assert()
+    .success();
+    std::fs::remove_dir_all(cwd.join("src"))?;
+
+    run_sysand_in(&cwd, ["add", "acme/app", "--no-lock", "--no-index"], None)?
+        .assert()
+        .success();
+
+    let out = run_sysand_in(&cwd, ["lock", "--no-index"], None)?;
+    out.assert().success();
+
+    let lock_file: Lock =
+        toml::from_str(&std::fs::read_to_string(cwd.join(DEFAULT_LOCKFILE_NAME))?)?;
+    let projects = lock_file.projects;
+
+    assert_eq!(
+        projects.len(),
+        3,
+        "expected consumer, app and widget in the lockfile, got: {projects:#?}"
+    );
+    for name in ["app", "widget"] {
+        let project = projects
+            .iter()
+            .find(|p| p.name == name)
+            .unwrap_or_else(|| panic!("`{name}` missing from lockfile: {projects:#?}"));
+        assert_eq!(project.version, "1.0.0");
+    }
+
+    Ok(())
+}
+
 #[test]
 fn lock_fail_unsatisfiable() -> Result<(), Box<dyn std::error::Error>> {
     let mut server = Server::new();


### PR DESCRIPTION
This PR adds support for referencing local directory paths as project dependencies, alongside the existing IRI/URL-based usages.

#### New Directory usage type

A new usage variant references a project by a directory path (relative to the declaring project's root) plus its publisher and name. It serialises as `{"dir": ..., "publisher": ..., "name": ...}`. The declared publisher/name must match what's actually found at the path, and there is no version constraint since a directory contains a single version. Only `local_src` projects are supported; KPARs will use another type, to keep resolution unambiguous.

Unlike legacy `resource` usages, where the IRI is both the project's identity and (possibly) its location, typed usages separate the two: identity is always publisher+name, and the source is explicit. This allows avoiding resolution altogether for typed usages. Currently resolution is still done due to large changes required to avoid it; typed usages always resolve to their type.

#### Resolution and solving

Resolvers now receive the full usage (plus an optional base path for relative filesystem paths) instead of a bare IRI. Resolution outcomes distinguish "not found" from "unresolvable", letting a file-resolver miss fall through to other resolvers.

Every usage derives an identifier (a PURL where possible, an URN fallback otherwise; legacy usages keep their IRI). The solver identifies packages by this identifier rather than by version constraint or source, so a package referenced with different constraints/paths by different dependents appears only once in the solution.

#### `experimental` CLI subcommand

Adds `sysand experimental add --dir <path>` and `sysand experimental remove <publisher> <name>`:
- `add` computes a path relative to the current project, reads publisher/name from the dependency, and adds a directory usage. By default it then locks and syncs (`--no-lock`/`--no-sync` opt out), rolling back the project file if resolution fails. No source overrides — typed usages will support everything overrides do, so they can be added directly instead.
- `remove` removes a usage by publisher and name, which will work for all typed usage types.

These are separate from regular `add`/`remove` to avoid breaking changes, and because the UX for other usage types is still unclear. `experimental` commands will likely replace regular commands on next major release, but some accommodation to minimize breaking changes will be required.

#### Other

- Java and Python bindings are adapted to the new usage model, including the new directory usage.

#### Breaking changes

- In the Java and Python bindings, `info` no longer takes a `relative_file_root` argument (it had no effect previously). Java code matching on usage types must also handle the new directory usage class.
- Lockfile interpretation is a bit stricter, but lockfiles generated by sysand remain valid (previously some fields could be missing and the lockfile would still be usable, now it's not).