### PR TITLE
release: prepare 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "sysand"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anstream",
  "anyhow",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-java"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "indexmap",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-js"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "console_log",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-macros"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "sysand-py"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "camino-tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 default-members = ["sysand", "core"]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.96"
 publish = false

--- a/bindings/js/package-lock.json
+++ b/bindings/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysand",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysand",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "devDependencies": {
         "@wasm-tool/wasm-pack-plugin": "^1.7.0",
         "copy-webpack-plugin": "^14.0.0",

--- a/bindings/js/package.json
+++ b/bindings/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysand",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "Sysand for JavaScript",
   "scripts": {


### PR DESCRIPTION
Now is a good time for a release, as #426 and subsequent changes introduce important features and may contain breaking changes; they will also likely introduce new bugs.

Closes #427