### PR TITLE
feat: support URL templates for index locations ({path} / {path_raw})

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,6 +3692,7 @@ dependencies = [
  "log",
  "logos",
  "mockito",
+ "percent-encoding",
  "port_check",
  "predicates",
  "pubgrub",

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -249,8 +249,8 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
         let Some(index_url) = env.get_str(&index_url, "indexUrl") else {
             return JObject::default();
         };
-        match url::Url::parse(&index_url) {
-            Ok(url) => Some(url),
+        match sysand_core::index_location::IndexLocation::parse(&index_url) {
+            Ok(location) => Some(location),
             Err(error) => {
                 env.throw_stdlib_exception(
                     StdlibExceptionKind::UnsupportedOperationException,

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -26,6 +26,7 @@ use sysand_core::{
     },
     exclude::do_exclude,
     include::do_include,
+    index_location::IndexLocation,
     info::{InfoError, InfoProjectError, do_info, do_info_project},
     init::InitError,
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw, InterchangeProjectUsage},
@@ -172,7 +173,7 @@ fn do_info_py(
             .map(|url_strs| {
                 url_strs
                     .iter()
-                    .map(|url_str| url::Url::parse(url_str))
+                    .map(|url_str| IndexLocation::parse(url_str))
                     .collect()
             })
             .transpose()

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,6 +61,7 @@ walkdir = "2.5.0"
 wasm-bindgen = { version = "0.2.114", default-features = false, optional = true }
 zip = { version = "8.0.0", default-features = false, optional = true, features = ["deflate"] }
 url = { version = "2.5.8", default-features = false }
+percent-encoding = { version = "2.3.2", default-features = false, features = ["alloc"] }
 gix = { version = "0.83.0", default-features = false, optional = true, features = ["blocking-http-transport-reqwest", "blocking-network-client", "worktree-mutation", "sha1"] }
 logos = "0.16.1"
 futures = { version = "0.3.32", default-features = false, features = ["alloc", "async-await"] }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -59,3 +59,44 @@ fn basic_globmap_lookup() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn globmap_matches_template_expanded_urls() -> Result<(), Box<dyn std::error::Error>> {
+    // The credential glob a user configures for a templated index
+    // (`SYSAND_CRED_X=https://gitlab.com/api/v4/projects/123/**`) must
+    // match the expanded request URLs, where the file path sits mid-URL
+    // percent-encoded and a query string follows.
+    // This glob only fits the *expanded* request URL: it matches on the
+    // percent-encoded file path (`admin%2F...`), which does not exist in
+    // the raw template (where the placeholder still reads `{path}`).
+    let mut builder = GlobMapBuilder::new();
+    builder.add(
+        "https://gitlab.com/api/v4/projects/123/repository/files/admin%2F*/raw?ref=main",
+        1,
+    );
+    let mut globmap = builder.build()?;
+
+    let template = crate::index_location::IndexLocation::parse(
+        "https://gitlab.com/api/v4/projects/123/repository/files/{path}/raw?ref=main",
+    )?;
+    let expanded = template.resolve("admin/proj0/versions.json".split('/'));
+    assert_eq!(
+        expanded.as_str(),
+        "https://gitlab.com/api/v4/projects/123/repository/files/\
+         admin%2Fproj0%2Fversions.json/raw?ref=main"
+    );
+
+    // The raw template does not match the glob...
+    assert!(matches!(
+        globmap.lookup_mut(&template.to_string()),
+        GlobMapResultMut::NotFound
+    ));
+    // ...but the expanded request URL does.
+    if let GlobMapResultMut::Found(_, val) = globmap.lookup_mut(expanded.as_str()) {
+        assert_eq!(*val, 1);
+    } else {
+        panic!("expected credential glob to match expanded template URL");
+    }
+
+    Ok(())
+}

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -21,6 +21,7 @@ use crate::{
     auth::{ForceBearerAuth, GlobMap, GlobMapResult, HTTPAuthentication},
     env::discovery::{HttpBaseUrlShapeError, validate_http_base_url_shape},
     include::{IncludeError, extract_symbols},
+    index_location::IndexLocation,
     model::{
         InterchangeProjectUsageRaw, InterchangeProjectValidationError, KERML_METAMODEL_PREFIX,
         KerMlChecksumAlg, SYSML_METAMODEL_PREFIX,
@@ -204,7 +205,7 @@ enum SelectedTrustedPublishingProvider<'a> {
 
 pub fn do_publish(
     prepared: PublishPreparation,
-    discovery_root: Url,
+    discovery_root: IndexLocation,
     api_root: Url,
     auth: ForceBearerAuth,
     client: reqwest_middleware::ClientWithMiddleware,
@@ -215,7 +216,7 @@ pub fn do_publish(
     // `api_root`. `discovery_root` is the user-facing URL (what was
     // passed as `--index`) and is kept only so log messages match what
     // the user configured — the actual upload targets `api_root`.
-    let upload_url = build_upload_url(&api_root)?;
+    let upload_url = build_upload_url(&api_root);
     let PublishPreparation {
         norm_publisher: publisher,
         norm_name: name,
@@ -270,30 +271,15 @@ pub fn do_publish(
     map_publish_response(status, &body_bytes, &upload_url_for_log, &response_url)
 }
 
-/// Which root is being validated — selects the error variant so the
-/// message names the spec concept the URL came from.
-#[derive(Debug, Clone, Copy)]
-pub enum EndpointKind {
-    /// User-supplied URL (`--index`).
-    DiscoveryRoot,
-    /// Resolved URL coming back from the discovery document.
-    ApiRoot,
-}
-
-/// Validate the shape of an index-server endpoint URL before the network
-/// step. Applies to both the user-supplied discovery root (pre-discovery)
-/// and the resolved `api_root` that comes back from discovery.
-pub fn validate_endpoint_url_shape(url: &Url, kind: EndpointKind) -> Result<(), PublishError> {
+/// Validate the shape of the resolved `api_root` that comes back from
+/// discovery before the upload step. The user-supplied discovery root is an
+/// [`IndexLocation`], which already enforces the HTTP(S)/no-userinfo
+/// invariant when parsed.
+pub fn validate_api_root_url_shape(url: &Url) -> Result<(), PublishError> {
     let err = |reason: String| -> PublishError {
-        match kind {
-            EndpointKind::DiscoveryRoot => PublishError::InvalidDiscoveryRoot {
-                url: url.as_str().into(),
-                reason,
-            },
-            EndpointKind::ApiRoot => PublishError::InvalidApiRoot {
-                url: url.as_str().into(),
-                reason,
-            },
+        PublishError::InvalidApiRoot {
+            url: url.as_str().into(),
+            reason,
         }
     };
     validate_http_base_url_shape(url).map_err(|e| {
@@ -323,17 +309,14 @@ pub fn validate_endpoint_url_shape(url: &Url, kind: EndpointKind) -> Result<(), 
 }
 
 /// Build the `POST` URL for the publish endpoint from a resolved
-/// `api_root`. The caller is responsible for having resolved the API
-/// root via `sysand-index-config.json`; this function appends the
-/// publish endpoint path to `api_root` as given and does not prepend
-/// any `/api/` segment — that belongs to the API root itself.
-pub fn build_upload_url(api_root: &Url) -> Result<Url, PublishError> {
-    // The `v1/upload` suffix rejection is part of shape validation.
-    validate_endpoint_url_shape(api_root, EndpointKind::ApiRoot)?;
-
-    Ok(crate::env::discovery::with_trailing_slash(api_root.clone())
-        .join(UPLOAD_ENDPOINT_PATH)
-        .unwrap())
+/// `api_root`. Precondition: `api_root` has already been checked with
+/// [`validate_api_root_url_shape`] (done once per publish) and normalized
+/// to end with `/` — both hold for a resolved API root from discovery — so
+/// it is an HTTP(S) base and the endpoint path appends rather than replaces
+/// its last segment. Does not prepend any `/api/` segment; that belongs to
+/// the API root itself.
+pub fn build_upload_url(api_root: &Url) -> Url {
+    api_root.join(UPLOAD_ENDPOINT_PATH).unwrap()
 }
 
 /// Resolve the bearer token used for publishing.
@@ -350,7 +333,7 @@ pub fn resolve_publish_bearer(
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: &Arc<tokio::runtime::Runtime>,
 ) -> Result<ForceBearerAuth, PublishError> {
-    let upload_url = build_upload_url(api_root)?;
+    let upload_url = build_upload_url(api_root);
     match mode {
         TrustedPublishingMode::Auto => {
             if let Some(provider) = env.trusted_publishing_provider()? {
@@ -454,9 +437,9 @@ fn exchange_oidc_token_for_index_token(
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: &Arc<tokio::runtime::Runtime>,
 ) -> Result<String, PublishError> {
-    let exchange_url = crate::env::discovery::with_trailing_slash(api_root.clone())
-        .join(TRUSTED_PUBLISHING_EXCHANGE_PATH)
-        .unwrap();
+    // `api_root` is a resolved API root from discovery, already normalized
+    // to end with `/`, so the exchange path appends rather than replaces.
+    let exchange_url = api_root.join(TRUSTED_PUBLISHING_EXCHANGE_PATH).unwrap();
     let body = serde_json::json!({ "token": oidc_token }).to_string();
 
     let response = runtime
@@ -736,9 +719,6 @@ pub enum PublishError {
         license: Box<str>,
         err: spdx::error::ParseError,
     },
-
-    #[error("invalid index URL `{url}` for publish: {reason}")]
-    InvalidDiscoveryRoot { url: Box<str>, reason: String },
 
     #[error("invalid api_root URL `{url}` for publish: {reason}")]
     InvalidApiRoot { url: Box<str>, reason: String },

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::{
-    AllowedMetamodelKind, EndpointKind, PublishError, TrustedPublishingEnvironment,
-    TrustedPublishingMode, build_upload_url, check_metamodel, check_usage, error_body_to_string,
-    map_publish_response, resolve_publish_bearer, validate_endpoint_url_shape,
+    AllowedMetamodelKind, PublishError, TrustedPublishingEnvironment, TrustedPublishingMode,
+    build_upload_url, check_metamodel, check_usage, error_body_to_string, map_publish_response,
+    resolve_publish_bearer, validate_api_root_url_shape,
 };
 use crate::{
     auth::{ForceBearerAuth, GlobMap, GlobMapBuilder},
@@ -48,31 +48,22 @@ fn github_env(token: &str, url: &str) -> TrustedPublishingEnvironment {
 
 #[test]
 fn build_upload_url_appends_endpoint_path() {
-    // `build_upload_url` takes the resolved `api_root`, not the
-    // discovery root. Well-known discovery has already chosen
-    // `api_root` — this helper just composes `v1/upload` onto it.
+    // `build_upload_url` takes the resolved `api_root` (already normalized
+    // by discovery to end with `/`), not the discovery root. Well-known
+    // discovery has already chosen `api_root` — this helper just composes
+    // `v1/upload` onto it.
     assert_eq!(
-        build_upload_url(&Url::parse("https://example.org").unwrap())
-            .unwrap()
-            .as_str(),
+        build_upload_url(&Url::parse("https://example.org").unwrap()).as_str(),
         "https://example.org/v1/upload"
     );
     assert_eq!(
-        build_upload_url(&Url::parse("https://example.org/").unwrap())
-            .unwrap()
-            .as_str(),
+        build_upload_url(&Url::parse("https://example.org/").unwrap()).as_str(),
         "https://example.org/v1/upload"
     );
+    // A resolved `api_root` with a sub-path already carries its trailing
+    // slash, so the endpoint appends rather than replacing `api`.
     assert_eq!(
-        build_upload_url(&Url::parse("https://example.org/api").unwrap())
-            .unwrap()
-            .as_str(),
-        "https://example.org/api/v1/upload"
-    );
-    assert_eq!(
-        build_upload_url(&Url::parse("https://example.org/api/").unwrap())
-            .unwrap()
-            .as_str(),
+        build_upload_url(&Url::parse("https://example.org/api/").unwrap()).as_str(),
         "https://example.org/api/v1/upload"
     );
 }
@@ -387,57 +378,9 @@ fn resolve_publish_bearer_exchange_malformed_response_errors() {
 #[test]
 fn build_upload_url_preserves_percent_encoded_segments() {
     assert_eq!(
-        build_upload_url(&Url::parse("https://example.org/my%20api/").unwrap())
-            .unwrap()
-            .as_str(),
+        build_upload_url(&Url::parse("https://example.org/my%20api/").unwrap()).as_str(),
         "https://example.org/my%20api/v1/upload"
     );
-}
-
-#[test]
-fn build_upload_url_rejects_upload_endpoint_path() {
-    // If the caller hands us an `api_root` that already ends in the
-    // upload path, they've pasted the full upload URL in the wrong
-    // place. Catch it before we compose `v1/upload/v1/upload`.
-    for url in [
-        "https://example.org/v1/upload",
-        "https://example.org/v1/upload/",
-        "https://example.org/api/v1/upload",
-        "https://example.org/api/v1/upload/",
-    ] {
-        let err = build_upload_url(&Url::parse(url).unwrap()).unwrap_err();
-        assert_matches!(err, PublishError::InvalidApiRoot { .. });
-    }
-}
-
-#[test]
-fn build_upload_url_rejects_query_and_fragment() {
-    let err =
-        build_upload_url(&Url::parse("https://example.org/index?x=1#frag").unwrap()).unwrap_err();
-    assert_matches!(err, PublishError::InvalidApiRoot { .. });
-}
-
-#[test]
-fn build_upload_url_rejects_non_http_scheme() {
-    let err = build_upload_url(&Url::parse("ftp://example.org").unwrap()).unwrap_err();
-    assert_matches!(err, PublishError::InvalidApiRoot { .. });
-}
-
-#[test]
-fn build_upload_url_rejects_non_hierarchical_url() {
-    let err = build_upload_url(&Url::parse("mailto:test@example.org").unwrap()).unwrap_err();
-    assert_matches!(err, PublishError::InvalidApiRoot { .. });
-}
-
-#[test]
-fn build_upload_url_rejects_userinfo() {
-    for raw in [
-        "https://user@example.org/api/",
-        "https://user:password@example.org/api/",
-    ] {
-        let err = build_upload_url(&Url::parse(raw).unwrap()).unwrap_err();
-        assert_matches!(err, PublishError::InvalidApiRoot { .. });
-    }
 }
 
 #[test]
@@ -619,27 +562,59 @@ fn map_publish_response_201_is_ok_new_project() {
     assert_eq!(resp.status, 201);
 }
 
-// --- validate_endpoint_url_shape with DiscoveryRoot ---
+// --- validate_api_root_url_shape ---
 
 #[test]
-fn validate_discovery_root_rejects_non_http_scheme() {
+fn validate_api_root_rejects_non_http_scheme() {
     let url = Url::parse("ftp://example.org").unwrap();
-    let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
-    assert_matches!(err, PublishError::InvalidDiscoveryRoot { .. });
+    let err = validate_api_root_url_shape(&url).unwrap_err();
+    assert_matches!(err, PublishError::InvalidApiRoot { .. });
 }
 
 #[test]
-fn validate_discovery_root_rejects_upload_endpoint_path() {
-    let url = Url::parse("https://example.org/v1/upload").unwrap();
-    let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
-    assert_matches!(err, PublishError::InvalidDiscoveryRoot { .. });
+fn validate_api_root_rejects_upload_endpoint_path() {
+    // An `api_root` that already ends in the upload path means the full
+    // upload URL was pasted in the wrong place; catch it before we would
+    // compose `v1/upload/v1/upload`.
+    for url in [
+        "https://example.org/v1/upload",
+        "https://example.org/v1/upload/",
+        "https://example.org/api/v1/upload",
+        "https://example.org/api/v1/upload/",
+    ] {
+        let err = validate_api_root_url_shape(&Url::parse(url).unwrap()).unwrap_err();
+        assert_matches!(err, PublishError::InvalidApiRoot { .. });
+    }
 }
 
 #[test]
-fn validate_discovery_root_rejects_query_and_fragment() {
-    let url = Url::parse("https://example.org/index?x=1").unwrap();
-    let err = validate_endpoint_url_shape(&url, EndpointKind::DiscoveryRoot).unwrap_err();
-    assert_matches!(err, PublishError::InvalidDiscoveryRoot { .. });
+fn validate_api_root_rejects_query_and_fragment() {
+    for url in [
+        "https://example.org/index?x=1",
+        "https://example.org/index#frag",
+        "https://example.org/index?x=1#frag",
+    ] {
+        let err = validate_api_root_url_shape(&Url::parse(url).unwrap()).unwrap_err();
+        assert_matches!(err, PublishError::InvalidApiRoot { .. });
+    }
+}
+
+#[test]
+fn validate_api_root_rejects_non_hierarchical_url() {
+    let err =
+        validate_api_root_url_shape(&Url::parse("mailto:test@example.org").unwrap()).unwrap_err();
+    assert_matches!(err, PublishError::InvalidApiRoot { .. });
+}
+
+#[test]
+fn validate_api_root_rejects_userinfo() {
+    for raw in [
+        "https://user@example.org/api/",
+        "https://user:password@example.org/api/",
+    ] {
+        let err = validate_api_root_url_shape(&Url::parse(raw).unwrap()).unwrap_err();
+        assert_matches!(err, PublishError::InvalidApiRoot { .. });
+    }
 }
 
 // --- prepare_publish_payload error cases ---

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -4,8 +4,8 @@
 use serde::{Deserialize, Serialize};
 use toml_edit::{InlineTable, Value};
 use typed_path::Utf8UnixPathBuf;
-use url::Url;
 
+use crate::index_location::{IndexLocation, IndexLocationError};
 use crate::project::utils::{deserialize_unix_path, serialize_unix_path};
 
 #[cfg(feature = "filesystem")]
@@ -122,7 +122,7 @@ impl Config {
         index_urls: Vec<String>,
         default_urls: Vec<String>,
         default_override_urls: Vec<String>,
-    ) -> Result<Vec<Url>, url::ParseError> {
+    ) -> Result<Vec<IndexLocation>, IndexLocationError> {
         if default_override_urls.is_empty() {
             self.index_urls_no_default_override(index_urls, default_urls)
         } else {
@@ -134,7 +134,7 @@ impl Config {
         &self,
         index_urls: Vec<String>,
         default_urls: Vec<String>,
-    ) -> Result<Vec<Url>, url::ParseError> {
+    ) -> Result<Vec<IndexLocation>, IndexLocationError> {
         let mut indexes = self.indexes.clone();
 
         indexes.sort_by_key(|i| i.default.unwrap_or(false));
@@ -151,7 +151,7 @@ impl Config {
             .map(|url| url.as_str())
             .chain(indexes.iter().map(|i| i.url.as_str()))
             .chain(end.iter().map(|url| url.as_str()))
-            .map(Url::parse)
+            .map(IndexLocation::parse)
             .collect()
     }
 
@@ -159,7 +159,7 @@ impl Config {
         &self,
         index_urls: Vec<String>,
         default_urls: Vec<String>,
-    ) -> Result<Vec<Url>, url::ParseError> {
+    ) -> Result<Vec<IndexLocation>, IndexLocationError> {
         index_urls
             .iter()
             .map(|url| url.as_str())
@@ -170,7 +170,7 @@ impl Config {
                     .map(|i| i.url.as_str()),
             )
             .chain(default_urls.iter().map(|url| url.as_str()))
-            .map(Url::parse)
+            .map(IndexLocation::parse)
             .collect()
     }
 }

--- a/core/src/config/mod_tests.rs
+++ b/core/src/config/mod_tests.rs
@@ -4,6 +4,7 @@
 use url::Url;
 
 use crate::config::{Config, ConfigProject, Index, OverrideSource};
+use crate::index_location::IndexLocation;
 
 #[test]
 fn default_config() {
@@ -64,9 +65,9 @@ fn index_urls_without_default() {
     assert_eq!(
         index_urls,
         vec![
-            Url::parse("http://www.extra-index.com").unwrap(),
-            Url::parse("http://www.index.com").unwrap(),
-            Url::parse("http://www.default.com").unwrap(),
+            IndexLocation::Root(Url::parse("http://www.extra-index.com").unwrap()),
+            IndexLocation::Root(Url::parse("http://www.index.com").unwrap()),
+            IndexLocation::Root(Url::parse("http://www.default.com").unwrap()),
         ]
     );
 }
@@ -98,9 +99,9 @@ fn index_urls_with_default() {
     assert_eq!(
         index_urls,
         vec![
-            Url::parse("http://www.extra-index.com").unwrap(),
-            Url::parse("http://www.index.com").unwrap(),
-            Url::parse("http://www.config-default.com").unwrap(),
+            IndexLocation::Root(Url::parse("http://www.extra-index.com").unwrap()),
+            IndexLocation::Root(Url::parse("http://www.index.com").unwrap()),
+            IndexLocation::Root(Url::parse("http://www.config-default.com").unwrap()),
         ]
     );
 }
@@ -132,9 +133,61 @@ fn index_urls_with_override() {
     assert_eq!(
         index_urls,
         vec![
-            Url::parse("http://www.extra-index.com").unwrap(),
-            Url::parse("http://www.index.com").unwrap(),
-            Url::parse("http://www.new-default.com").unwrap(),
+            IndexLocation::Root(Url::parse("http://www.extra-index.com").unwrap()),
+            IndexLocation::Root(Url::parse("http://www.index.com").unwrap()),
+            IndexLocation::Root(Url::parse("http://www.new-default.com").unwrap()),
         ]
     );
+}
+
+#[test]
+fn index_urls_accepts_templates_everywhere() {
+    // URL templates are valid wherever an index URL can be configured:
+    // `--index` values, `sysand.toml` `[[index]]` entries, and default
+    // overrides all funnel through the same parser.
+    let config = Config {
+        indexes: vec![Index {
+            url: "https://gitlab.com/api/v4/projects/123/repository/files/{path}/raw?ref=main"
+                .to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let index = vec!["https://example.org/raw/{path_raw}?ref=main".to_string()];
+    let default_urls = vec![];
+    let default_override_urls = vec!["https://other.example/files/{path}/x".to_string()];
+
+    let index_urls = config
+        .index_urls(index, default_urls, default_override_urls)
+        .unwrap();
+
+    assert_eq!(
+        index_urls
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+        vec![
+            "https://example.org/raw/{path_raw}?ref=main",
+            "https://gitlab.com/api/v4/projects/123/repository/files/{path}/raw?ref=main",
+            "https://other.example/files/{path}/x",
+        ]
+    );
+    assert!(
+        index_urls
+            .iter()
+            .all(|l| matches!(l, IndexLocation::Template(_)))
+    );
+}
+
+#[test]
+fn index_urls_rejects_bad_template() {
+    let config = Config::default();
+    let err = config
+        .index_urls(
+            vec!["https://example.org/files/{file}/raw".to_string()],
+            vec![],
+            vec![],
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("unknown placeholder `{file}`"));
 }

--- a/core/src/env/discovery.rs
+++ b/core/src/env/discovery.rs
@@ -17,6 +17,7 @@ use crate::{
     auth::HTTPAuthentication,
     env::index::{HttpFetchError, IndexEnvironmentError, MissingPolicy, fetch_json},
     index::iri::parse_iri,
+    index_location::{IndexLocation, IndexLocationError, with_trailing_slash},
 };
 
 const INDEX_PATH: &str = "index.json";
@@ -29,52 +30,42 @@ const META_JSON_FILE: &str = ".meta.json";
 /// discovery step.
 #[derive(Debug, Clone)]
 pub struct ResolvedEndpoints {
-    /// Base URL of the sysand index (where `index.json` lives).
-    pub index_root: url::Url,
-    /// Base URL of the sysand index API (where `v1/upload` lives).
-    pub api_root: url::Url,
+    /// Location of the sysand index (where `index.json` lives): a plain
+    /// base URL or a `{path}` URL template.
+    pub index_root: IndexLocation,
+    /// Base URL of the sysand index API (where `v1/upload` lives). `None`
+    /// when the discovery root is a URL template and the discovery
+    /// document does not supply an `api_root` — such an index is
+    /// read-only from this client's point of view.
+    pub api_root: Option<url::Url>,
 }
 
 impl ResolvedEndpoints {
-    /// Build a `ResolvedEndpoints` that routes both index and API traffic
-    /// at the discovery root itself. Used when the discovery document is
-    /// absent (HTTP 404) or present with neither field set.
-    pub fn flat(discovery_root: url::Url) -> Self {
+    /// Build a `ResolvedEndpoints` that routes index traffic (and, for a
+    /// plain-URL discovery root, API traffic) at the discovery root
+    /// itself. Used when the discovery document is absent (HTTP 404).
+    pub fn flat(discovery_root: IndexLocation) -> Self {
+        let api_root = discovery_root.as_root().cloned();
         Self {
-            index_root: discovery_root.clone(),
-            api_root: discovery_root,
+            index_root: discovery_root,
+            api_root,
         }
     }
 
-    // TODO: url joins will not fail for HTTP URLs, therefore, unwrap
-    fn url_join(url: &url::Url, join: &str) -> Result<url::Url, IndexEnvironmentError> {
-        url.join(join)
-            .map_err(|e| IndexEnvironmentError::JoinURL(url.as_str().into(), join.into(), e))
+    fn resolve<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> url::Url {
+        self.index_root.resolve(segments)
     }
 
-    pub(crate) fn index_url(&self) -> Result<url::Url, IndexEnvironmentError> {
-        Self::url_join(&self.index_root, INDEX_PATH)
+    pub(crate) fn index_url(&self) -> url::Url {
+        self.resolve([INDEX_PATH])
     }
 
-    pub(crate) fn project_url<S: AsRef<str>>(
-        &self,
-        iri: S,
-    ) -> Result<url::Url, IndexEnvironmentError> {
-        let parsed_iri = parse_iri(iri.as_ref())?;
-        let path = parsed_iri.get_path();
-        Self::url_join(&self.index_root, &format!("{path}/"))
-    }
-
-    /// Per-version directory URL ending with a trailing slash, so that
-    /// `Url::join` treats it as a directory when composing leaf URLs
-    /// (`project.kpar`, `.project.json`, `.meta.json`).
-    pub(crate) fn version_dir_url<S: AsRef<str>, T: AsRef<str>>(
-        &self,
-        iri: S,
-        version: T,
-    ) -> Result<url::Url, IndexEnvironmentError> {
-        let base = self.project_url(iri)?;
-        Self::url_join(&base, &format!("{}/", version.as_ref()))
+    /// The project directory's two path segments for `iri`
+    /// (`[<publisher>, <name>]` or `[_iri, <sha256hex>]`). Returned as
+    /// separate segments so each is encoded independently, avoiding a
+    /// join-then-split round-trip.
+    fn project_rel_segments<S: AsRef<str>>(iri: S) -> Result<[String; 2], IndexEnvironmentError> {
+        Ok(parse_iri(iri.as_ref())?.get_path_segments())
     }
 
     pub(crate) fn kpar_url<S: AsRef<str>, T: AsRef<str>>(
@@ -82,7 +73,13 @@ impl ResolvedEndpoints {
         iri: S,
         version: T,
     ) -> Result<url::Url, IndexEnvironmentError> {
-        Self::url_join(&self.version_dir_url(iri, version)?, KPAR_FILE)
+        let project = Self::project_rel_segments(iri)?;
+        Ok(self.resolve(
+            project
+                .iter()
+                .map(String::as_str)
+                .chain([version.as_ref(), KPAR_FILE]),
+        ))
     }
 
     pub(crate) fn project_json_url<S: AsRef<str>, T: AsRef<str>>(
@@ -90,7 +87,13 @@ impl ResolvedEndpoints {
         iri: S,
         version: T,
     ) -> Result<url::Url, IndexEnvironmentError> {
-        Self::url_join(&self.version_dir_url(iri, version)?, PROJECT_JSON_FILE)
+        let project = Self::project_rel_segments(iri)?;
+        Ok(self.resolve(
+            project
+                .iter()
+                .map(String::as_str)
+                .chain([version.as_ref(), PROJECT_JSON_FILE]),
+        ))
     }
 
     pub(crate) fn meta_json_url<S: AsRef<str>, T: AsRef<str>>(
@@ -98,15 +101,21 @@ impl ResolvedEndpoints {
         iri: S,
         version: T,
     ) -> Result<url::Url, IndexEnvironmentError> {
-        Self::url_join(&self.version_dir_url(iri, version)?, META_JSON_FILE)
+        let project = Self::project_rel_segments(iri)?;
+        Ok(self.resolve(
+            project
+                .iter()
+                .map(String::as_str)
+                .chain([version.as_ref(), META_JSON_FILE]),
+        ))
     }
 
     pub(crate) fn versions_url<S: AsRef<str>>(
         &self,
         iri: S,
     ) -> Result<url::Url, IndexEnvironmentError> {
-        let base = self.project_url(iri)?;
-        Self::url_join(&base, VERSIONS_PATH)
+        let project = Self::project_rel_segments(iri)?;
+        Ok(self.resolve(project.iter().map(String::as_str).chain([VERSIONS_PATH])))
     }
 }
 
@@ -126,7 +135,7 @@ pub enum DiscoveryError {
     #[error(transparent)]
     Fetch(#[from] HttpFetchError),
     #[error(
-        "discovery document at `{url}` supplied a relative URL `{value}` for `{field}`; \
+        "discovery document at `{url}` supplied a relative URL `{value}` for `{field}`;\n\
          absolute HTTP(S) URLs are required"
     )]
     RelativeUrl {
@@ -135,17 +144,17 @@ pub enum DiscoveryError {
         value: String,
     },
     #[error(
-        "discovery document at `{url}` supplied an invalid URL `{value}` for `{field}`: {source}"
+        "discovery document at `{url}` supplied an invalid URL `{value}` for `{field}`:\n\
+         {source}"
     )]
     InvalidUrl {
         url: Box<str>,
         field: &'static str,
         value: String,
-        #[source]
         source: url::ParseError,
     },
     #[error(
-        "discovery document at `{url}` supplied a non-HTTP(S) URL `{value}` for `{field}`; \
+        "discovery document at `{url}` supplied a non-HTTP(S) URL `{value}` for `{field}`;\n\
          only `http` and `https` are supported"
     )]
     UnsupportedScheme {
@@ -154,13 +163,19 @@ pub enum DiscoveryError {
         value: String,
     },
     #[error(
-        "discovery document at `{url}` supplied URL userinfo in `{value}` for `{field}`; \
+        "discovery document at `{url}` supplied URL userinfo in `{value}` for `{field}`;\n\
          username and password are not allowed"
     )]
     Userinfo {
         url: Box<str>,
         field: &'static str,
         value: String,
+    },
+    #[error("discovery document at `{url}` supplied an invalid `{field}`")]
+    InvalidLocation {
+        url: Box<str>,
+        field: &'static str,
+        source: IndexLocationError,
     },
 }
 
@@ -207,33 +222,39 @@ fn discovery_shape_error(
 pub async fn fetch_index_config<P: HTTPAuthentication>(
     client: &reqwest_middleware::ClientWithMiddleware,
     auth: &P,
-    discovery_root: &url::Url,
+    discovery_root: &IndexLocation,
 ) -> Result<ResolvedEndpoints, DiscoveryError> {
-    validate_http_base_url_shape(discovery_root).map_err(|error| {
-        discovery_shape_error(discovery_root, "<discovery_root>", discovery_root, error)
-    })?;
+    // `IndexLocation` enforces its own invariants at construction — a
+    // plain root is already an absolute HTTP(S) URL, without userinfo, and
+    // with a trailing slash so relative-path resolution treats it as a
+    // directory — so no normalization is needed here.
+    let discovery_location = discovery_root.clone();
 
-    // Normalize the discovery root so `join` treats it as a directory.
-    let directory_root = with_trailing_slash(discovery_root.clone());
-    // Build the URL through `join` so that trailing slashes on the
-    // discovery root behave consistently (RFC 3986 §5.3 path resolution).
-    let config_url = directory_root
-        .join("sysand-index-config.json")
-        .expect("joining a fixed relative path onto an HTTP(S) base URL succeeds");
+    let config_url = discovery_location.resolve(["sysand-index-config.json"]);
 
     let parsed: Option<IndexConfigRaw> =
         fetch_json(client, auth, &config_url, MissingPolicy::AllowNotFound).await?;
 
     let Some(raw) = parsed else {
-        return Ok(ResolvedEndpoints::flat(directory_root));
+        let endpoints = ResolvedEndpoints::flat(discovery_location);
+        log_resolved(&endpoints);
+        return Ok(endpoints);
     };
 
-    let parse_field = |field: &'static str, value: Option<String>, default: &url::Url| {
-        let Some(s) = value else {
-            return Ok(default.clone());
-        };
+    // Parse a supplied field value as a plain base URL.
+    // `url::Url::parse` on a relative input (e.g. `"/index/"`) returns
+    // `Err(RelativeUrlWithoutBase)` — map that specifically to
+    // `RelativeUrl` so the error is actionable.
+    let parse_base_url = |field: &'static str, s: String| -> Result<url::Url, DiscoveryError> {
         let parsed = match url::Url::parse(&s) {
             Ok(parsed) => parsed,
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                return Err(DiscoveryError::RelativeUrl {
+                    url: config_url.as_str().into(),
+                    field,
+                    value: s,
+                });
+            }
             Err(source) => {
                 return Err(DiscoveryError::InvalidUrl {
                     url: config_url.as_str().into(),
@@ -248,48 +269,47 @@ pub async fn fetch_index_config<P: HTTPAuthentication>(
         Ok(with_trailing_slash(parsed))
     };
 
-    // `url::Url::parse` on a relative input (e.g. `"/index/"`) returns
-    // `Err(RelativeUrlWithoutBase)` — map that specifically to
-    // `RelativeUrl` so the error is actionable.
-    let parse_or_relative =
-        |field: &'static str, value: Option<String>, default: &url::Url| match parse_field(
-            field, value, default,
-        ) {
-            Err(DiscoveryError::InvalidUrl {
-                url,
-                field,
-                value,
-                source: url::ParseError::RelativeUrlWithoutBase,
-            }) => Err(DiscoveryError::RelativeUrl { url, field, value }),
-            other => other,
-        };
+    // `index_root` may itself be a URL template; `api_root` may not
+    // (uploads are not file fetches, so templating it is meaningless).
+    // Both roots enforce their validity invariants through
+    // `IndexLocation::parse`, so a plain and a templated `index_root` are
+    // validated in the same place.
+    let index_root = match raw.index_root {
+        None => discovery_location.clone(),
+        Some(s) => IndexLocation::parse(&s).map_err(|source| DiscoveryError::InvalidLocation {
+            url: config_url.as_str().into(),
+            field: "index_root",
+            source,
+        })?,
+    };
 
-    let index_root = parse_or_relative("index_root", raw.index_root, &directory_root)?;
-    let api_root = parse_or_relative("api_root", raw.api_root, &directory_root)?;
+    let api_root = match (raw.api_root, discovery_location) {
+        (Some(s), _) => Some(parse_base_url("api_root", s)?),
+        (None, IndexLocation::Root(directory_root)) => Some(directory_root),
+        (None, IndexLocation::Template(_)) => None,
+    };
 
-    Ok(ResolvedEndpoints {
+    let endpoints = ResolvedEndpoints {
         index_root,
         api_root,
-    })
+    };
+    log_resolved(&endpoints);
+    Ok(endpoints)
 }
 
-/// Return `url` with a guaranteed trailing slash on its path so that
-/// `Url::join` treats it as a directory. Operates via `path_segments_mut`
-/// rather than touching the serialized path string, so percent-encoded
-/// segments survive the round-trip unchanged.
-///
-/// Callers must pass an HTTP(S) URL. Such URLs can be a base, so the
-/// `path_segments_mut` call should not fail after endpoint-shape
-/// validation.
-pub(crate) fn with_trailing_slash(mut url: url::Url) -> url::Url {
-    {
-        let mut segments = url
-            .path_segments_mut()
-            .expect("caller passes a URL that can be a base");
-        segments.pop_if_empty();
-        segments.push("");
+/// Discovery decides where every later index fetch goes, so record the
+/// outcome for debugging.
+fn log_resolved(endpoints: &ResolvedEndpoints) {
+    match &endpoints.api_root {
+        Some(api_root) => log::debug!(
+            "resolved index endpoints: index_root `{}`, api_root `{api_root}`",
+            endpoints.index_root
+        ),
+        None => log::debug!(
+            "resolved index endpoints: index_root `{}`, no api_root (read-only index)",
+            endpoints.index_root
+        ),
     }
-    url
 }
 
 #[cfg(test)]

--- a/core/src/env/index.rs
+++ b/core/src/env/index.rs
@@ -39,6 +39,7 @@ use crate::{
         iri::ParseIriError,
         model::{IndexJson, ProjectStatus, VersionStatus, VersionsJson},
     },
+    index_location::IndexLocation,
     model::InterchangeProjectUsageRaw,
     project::index_entry::{IndexEntryProject, IndexEntryProjectError},
     resolve::net_utils::json_get_request,
@@ -69,7 +70,7 @@ pub struct IndexEnvironmentAsync<Policy> {
     /// User-configured discovery root. When present, `endpoints` is
     /// populated lazily from `<discovery_root>/sysand-index-config.json`
     /// on first actual index access.
-    discovery_root: Option<url::Url>,
+    discovery_root: Option<IndexLocation>,
     /// Resolved `(index_root, api_root)` pair. Test callers may seed this
     /// at construction; production index resolvers leave it empty until
     /// the index is actually queried.
@@ -122,7 +123,7 @@ impl<Policy> IndexEnvironmentAsync<Policy> {
     pub fn from_discovery_root(
         client: reqwest_middleware::ClientWithMiddleware,
         auth_policy: Arc<Policy>,
-        discovery_root: url::Url,
+        discovery_root: IndexLocation,
     ) -> Self {
         Self {
             client,
@@ -189,8 +190,6 @@ pub(crate) struct AdvertisedVersion {
 
 #[derive(Error, Debug)]
 pub enum IndexEnvironmentError {
-    #[error("failed to extend URL `{0}` with path `{1}`: {2}")]
-    JoinURL(Box<str>, String, url::ParseError),
     #[error(transparent)]
     Discovery(#[from] DiscoveryError),
     #[error(transparent)]
@@ -359,7 +358,7 @@ impl<Policy: HTTPAuthentication> IndexEnvironmentAsync<Policy> {
         // Propagate a 404 as a hard error for list-all operations:
         // empty-but-live indices serve `{"projects": []}` with 200 OK, so
         // 404 really means "this URL is not a sysand index".
-        let url = self.endpoints().await?.index_url()?;
+        let url = self.endpoints().await?.index_url();
 
         match fetch_json(
             &self.client,

--- a/core/src/env/index_tests.rs
+++ b/core/src/env/index_tests.rs
@@ -36,6 +36,7 @@ use crate::{
     auth::Unauthenticated,
     context::ProjectContext,
     env::{ReadEnvironment, ReadEnvironmentAsync, discovery::ResolvedEndpoints},
+    index_location::{IndexLocation, with_trailing_slash},
     lock::Source,
     project::{
         ProjectRead, index_entry::IndexEntryProjectError,
@@ -118,26 +119,12 @@ fn index_env_async(
     // Tests that specifically cover discovery construct their own env
     // via `index_env_sync_discovery`, which goes through the real
     // `fetch_index_config` against a mock server.
-    let endpoints = ResolvedEndpoints::flat(with_trailing_slash(base));
+    let endpoints = ResolvedEndpoints::flat(IndexLocation::Root(with_trailing_slash(base)));
     Ok(super::IndexEnvironmentAsync::new(
         create_reqwest_client()?,
         Arc::new(Unauthenticated {}),
         endpoints,
     ))
-}
-
-/// Helper: return `url` with a guaranteed trailing slash on its path.
-/// Kept here (rather than pulled from `super::discovery::with_trailing_slash`
-/// which is private) so test-side URL construction matches what the
-/// discovery module produces.
-fn with_trailing_slash(mut url: url::Url) -> url::Url {
-    if url.path().is_empty() {
-        url.set_path("/");
-    } else if !url.path().ends_with('/') {
-        let new_path = format!("{}/", url.path());
-        url.set_path(&new_path);
-    }
-    url
 }
 
 /// Shorthand: resolve the endpoints on a test env. Tests that don't
@@ -158,12 +145,13 @@ fn index_env_sync_discovery(
     crate::env::AsSyncEnvironmentTokio<super::IndexEnvironmentAsync<Unauthenticated>>,
     Box<dyn std::error::Error>,
 > {
-    let base = url::Url::parse(&server.url())?;
     let runtime = make_runtime()?;
     let client = create_reqwest_client()?;
     let auth = Arc::new(Unauthenticated {});
     let endpoints = runtime.block_on(crate::env::discovery::fetch_index_config(
-        &client, &*auth, &base,
+        &client,
+        &*auth,
+        &IndexLocation::parse(&server.url())?,
     ))?;
     let env = super::IndexEnvironmentAsync::new(client, auth, endpoints);
     Ok(env.to_tokio_sync(runtime))
@@ -257,7 +245,7 @@ mod uris {
         let endpoints = resolved_endpoints(&env);
 
         assert_eq!(
-            endpoints.index_url()?.to_string(),
+            endpoints.index_url().to_string(),
             "https://www.example.com/index/index.json"
         );
 
@@ -363,7 +351,7 @@ mod uris {
         let endpoints = resolved_endpoints(&env);
 
         assert_eq!(
-            endpoints.index_url()?.to_string(),
+            endpoints.index_url().to_string(),
             "https://www.example.com/index/index.json"
         );
         assert_eq!(
@@ -2325,6 +2313,39 @@ mod discovery {
     }
 
     #[test]
+    fn discovery_normalizes_api_root_trailing_slash() -> Result<(), Box<dyn std::error::Error>> {
+        // A discovery document may supply `api_root` without a trailing
+        // slash. Discovery is the single place that normalizes it, so the
+        // resolved `api_root` always ends with `/` — later `Url::join` of
+        // the upload path then appends rather than replacing the last
+        // segment.
+        let mut server = mockito::Server::new();
+        let config_body = format!(r#"{{"api_root":"{}/api"}}"#, server.url());
+        let config_mock = mock_json_get(&mut server, "/sysand-index-config.json", config_body);
+
+        let runtime = make_runtime()?;
+        let client = create_reqwest_client()?;
+        let auth = Arc::new(Unauthenticated {});
+        let endpoints = runtime.block_on(crate::env::discovery::fetch_index_config(
+            &client,
+            &*auth,
+            &IndexLocation::parse(&server.url())?,
+        ))?;
+
+        let api_root = endpoints
+            .api_root
+            .expect("a plain discovery root yields an api_root");
+        assert!(
+            api_root.as_str().ends_with("/api/"),
+            "api_root should be normalized with a trailing slash, got `{api_root}`"
+        );
+
+        config_mock.assert();
+
+        Ok(())
+    }
+
+    #[test]
     fn discovery_rejects_relative_index_root() -> Result<(), Box<dyn std::error::Error>> {
         // Relative `index_root` -> `RelativeUrl` error. Discovery is
         // resolved at env construction, so the rejection surfaces from
@@ -2472,6 +2493,164 @@ mod discovery {
         redirect_mock.assert();
         target_mock.assert();
         versions_mock.assert();
+
+        Ok(())
+    }
+
+    /// Like `index_env_sync_discovery`, but with an arbitrary discovery
+    /// location (e.g. a URL template) instead of the mock server's root.
+    fn index_env_sync_discovery_at(
+        discovery_root: IndexLocation,
+    ) -> Result<
+        crate::env::AsSyncEnvironmentTokio<
+            crate::env::index::IndexEnvironmentAsync<Unauthenticated>,
+        >,
+        Box<dyn std::error::Error>,
+    > {
+        let runtime = make_runtime()?;
+        let client = create_reqwest_client()?;
+        let auth = Arc::new(Unauthenticated {});
+        let endpoints = runtime.block_on(crate::env::discovery::fetch_index_config(
+            &client,
+            &*auth,
+            &discovery_root,
+        ))?;
+        let env = crate::env::index::IndexEnvironmentAsync::new(client, auth, endpoints);
+        Ok(env.to_tokio_sync(runtime))
+    }
+
+    #[test]
+    fn discovery_templated_root_serves_gitlab_files_api_shape()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // A `{path}` template as the discovery root: the discovery
+        // document and versions.json are fetched mid-URL with `/`
+        // percent-encoded as `%2F` and the query string preserved — the
+        // GitLab repository files API shape.
+        let mut server = mockito::Server::new();
+        let files = "/api/v4/projects/123/repository/files";
+
+        let config_mock = server
+            .mock(
+                "GET",
+                format!("{files}/sysand-index-config.json/raw").as_str(),
+            )
+            .match_query(mockito::Matcher::UrlEncoded("ref".into(), "main".into()))
+            .with_status(404)
+            .expect(1)
+            .create();
+
+        let versions_mock = server
+            .mock(
+                "GET",
+                format!("{files}/admin%2Fproj0%2Fversions.json/raw").as_str(),
+            )
+            .match_query(mockito::Matcher::UrlEncoded("ref".into(), "main".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(versions_json_body([("1.0.0", "[]")]))
+            .expect(1)
+            .create();
+
+        let template = format!("{}{files}/{{path}}/raw?ref=main", server.url());
+        let env = index_env_sync_discovery_at(IndexLocation::parse(&template)?)?;
+
+        let versions: Vec<_> = env
+            .versions(purl("admin/proj0"))?
+            .collect::<Result<_, _>>()?;
+        assert_eq!(versions, vec!["1.0.0"]);
+
+        config_mock.assert();
+        versions_mock.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn discovery_templated_root_raw_placeholder_keeps_slashes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // `{path_raw}` keeps `/` literal, so a suffix (and query) after
+        // the path still works.
+        let mut server = mockito::Server::new();
+
+        let config_mock = server
+            .mock("GET", "/raw/sysand-index-config.json")
+            .match_query(mockito::Matcher::UrlEncoded("ref".into(), "main".into()))
+            .with_status(404)
+            .expect(1)
+            .create();
+
+        let versions_mock = server
+            .mock("GET", "/raw/admin/proj0/versions.json")
+            .match_query(mockito::Matcher::UrlEncoded("ref".into(), "main".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(versions_json_body([("1.0.0", "[]")]))
+            .expect(1)
+            .create();
+
+        let template = format!("{}/raw/{{path_raw}}?ref=main", server.url());
+        let env = index_env_sync_discovery_at(IndexLocation::parse(&template)?)?;
+
+        let versions: Vec<_> = env
+            .versions(purl("admin/proj0"))?
+            .collect::<Result<_, _>>()?;
+        assert_eq!(versions, vec!["1.0.0"]);
+
+        config_mock.assert();
+        versions_mock.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn discovery_config_remaps_index_root_to_template() -> Result<(), Box<dyn std::error::Error>> {
+        // A plain discovery root whose discovery document redirects
+        // index reads through a URL template (issue #438's original
+        // ask).
+        let mut server = mockito::Server::new();
+
+        let config_body = format!(r#"{{"index_root":"{}/files/{{path}}/raw"}}"#, server.url());
+        let config_mock = mock_json_get(&mut server, "/sysand-index-config.json", config_body);
+
+        let remap_mock = mock_json_get(
+            &mut server,
+            "/files/admin%2Fproj0%2Fversions.json/raw",
+            versions_json_body([("1.0.0", "[]")]),
+        );
+
+        let env = index_env_sync_discovery(&server)?;
+
+        let versions: Vec<_> = env
+            .versions(purl("admin/proj0"))?
+            .collect::<Result<_, _>>()?;
+        assert_eq!(versions, vec!["1.0.0"]);
+
+        config_mock.assert();
+        remap_mock.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    fn discovery_rejects_invalid_template_index_root() -> Result<(), Box<dyn std::error::Error>> {
+        // An `index_root` template with an unknown placeholder is a
+        // discovery error, not a silent literal URL.
+        let mut server = mockito::Server::new();
+
+        let config_mock = mock_json_get(
+            &mut server,
+            "/sysand-index-config.json",
+            r#"{"index_root":"https://example.org/files/{file}/raw"}"#,
+        );
+
+        let err = index_env_sync_discovery(&server).expect_err("bad template must reject");
+        let text = format!("{err:?}");
+        assert!(
+            text.contains("index_root") && text.contains("{file}"),
+            "expected unknown-placeholder error on index_root, got: {text}"
+        );
+
+        config_mock.assert();
 
         Ok(())
     }

--- a/core/src/index/iri.rs
+++ b/core/src/index/iri.rs
@@ -61,16 +61,22 @@ pub(crate) enum ParsedIri {
 }
 
 impl ParsedIri {
-    pub(crate) fn get_path(&self) -> String {
+    /// The two path segments identifying the project directory:
+    /// `[publisher, name]` for a sysand PURL, or `[_iri, <sha256hex>]` for
+    /// any other IRI. Kept as separate segments (rather than a joined
+    /// path) so callers can encode each independently.
+    pub(crate) fn get_path_segments(&self) -> [String; 2] {
         match self {
-            ParsedIri::Sysand { publisher, name } => format!("{publisher}/{name}"),
-            ParsedIri::Other { normalized_iri } => {
-                format!(
-                    "{IRI_HASH_SEGMENT}/{}",
-                    sha256_lowercase_hex(normalized_iri)
-                )
-            }
+            ParsedIri::Sysand { publisher, name } => [publisher.clone(), name.clone()],
+            ParsedIri::Other { normalized_iri } => [
+                IRI_HASH_SEGMENT.to_owned(),
+                sha256_lowercase_hex(normalized_iri),
+            ],
         }
+    }
+
+    pub(crate) fn get_path(&self) -> String {
+        self.get_path_segments().join("/")
     }
 
     pub(crate) fn get_iri(&self) -> String {

--- a/core/src/index_location.rs
+++ b/core/src/index_location.rs
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! User-configurable index locations: either a plain base URL that relative
+//! index paths are appended to (the historical behavior), or a URL template
+//! containing a `{path}` placeholder that the relative index path is
+//! substituted into, percent-encoded as a single path segment. Templates
+//! make it possible to reach indexes served through file-access APIs whose
+//! URL structure is not "base + path", such as the GitLab repository files
+//! API (`.../repository/files/{path}/raw?ref=<branch>`).
+//!
+//! Two placeholder spellings are supported, differing only in how `/` is
+//! treated when the relative index path (for example
+//! `some-publisher/some-project/1.0.0/project.kpar`) is substituted:
+//!
+//! - `{path}` — every byte outside RFC 3986 *unreserved* is
+//!   percent-encoded, including `/` as `%2F`. This is what the GitLab
+//!   repository files API expects.
+//! - `{path_raw}` — `/` stays literal; each path segment is
+//!   percent-encoded individually. For hosts that take the file path as
+//!   ordinary URL path segments but need a suffix after it (for example
+//!   Gitea's `.../raw/<path>?ref=<branch>`).
+//!
+//! The syntax is a deliberately restricted subset of [RFC 6570] URI
+//! Templates: `{path}` behaves like RFC 6570 simple string expansion of
+//! a single value and `{path_raw}` like reserved expansion (`{+path}`),
+//! but only these two fixed names are accepted so that typos fail at
+//! parse time instead of producing wrong URLs. Fixed custom markers in a
+//! package-index template follow crates.io's `config.json` `dl` field
+//! (`{crate}`, `{version}`).
+//!
+//! [RFC 6570]: https://www.rfc-editor.org/rfc/rfc6570
+
+use core::fmt;
+use core::str::FromStr;
+
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use thiserror::Error;
+
+/// Placeholder that expands to the fully percent-encoded relative index
+/// path (`/` becomes `%2F`).
+const PATH_PLACEHOLDER: &str = "{path}";
+
+/// Placeholder that expands to the relative index path with literal `/`
+/// separators (each segment percent-encoded individually).
+const PATH_RAW_PLACEHOLDER: &str = "{path_raw}";
+
+/// Percent-encode everything outside RFC 3986 unreserved
+/// (`A-Z a-z 0-9 - . _ ~`). Notably `/` becomes `%2F`, which is what
+/// file-access APIs like GitLab's expect for a path used as one URL
+/// segment.
+const PATH_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+#[derive(Error, Debug)]
+pub enum IndexLocationError {
+    #[error("invalid index URL `{url}`")]
+    InvalidUrl {
+        url: Box<str>,
+        source: url::ParseError,
+    },
+    #[error(
+        "index URL `{url}` is relative;\n\
+         index locations must be absolute HTTP(S) URLs"
+    )]
+    RelativeUrl { url: Box<str> },
+    #[error(
+        "index URL `{url}` contains `%7B`/`%7D` (percent-encoded braces);\n\
+         did you mean a `{{path}}` template? Placeholders must be written\n\
+         literally, e.g. `.../repository/files/{{path}}/raw?ref=main`"
+    )]
+    PreEncodedPlaceholder { url: Box<str> },
+    #[error(
+        "index URL template `{url}` contains unknown placeholder `{placeholder}`{hint};\n\
+         supported placeholders: `{{path}}` (percent-encoded, `/` becomes `%2F`) and\n\
+         `{{path_raw}}` (literal `/` separators)"
+    )]
+    UnknownPlaceholder {
+        url: Box<str>,
+        placeholder: Box<str>,
+        hint: &'static str,
+    },
+    #[error(
+        "index URL template `{url}` contains a stray `{{` or `}}`;\n\
+         supported placeholders are `{{path}}` and `{{path_raw}}`"
+    )]
+    StrayBrace { url: Box<str> },
+    #[error(
+        "index URL template `{url}` must contain a `{{path}}` or `{{path_raw}}` placeholder\n\
+         exactly once, found {count} occurrences"
+    )]
+    PlaceholderCount { url: Box<str>, count: usize },
+    #[error(
+        "index URL template `{url}` expands to an invalid URL;\n\
+         note that a placeholder may only appear in the path or query\n\
+         of an absolute HTTP(S) URL"
+    )]
+    InvalidTemplate {
+        url: Box<str>,
+        source: url::ParseError,
+    },
+    #[error(
+        "index URL template `{url}` is relative;\n\
+         templates must be absolute HTTP(S) URLs"
+    )]
+    RelativeTemplate { url: Box<str> },
+    #[error(
+        "index URL `{url}` uses scheme `{scheme}`;\n\
+         only `http` and `https` are supported"
+    )]
+    UnsupportedScheme { url: Box<str>, scheme: Box<str> },
+    #[error(
+        "index URL `{url}` includes username or password;\n\
+         URL userinfo is not allowed"
+    )]
+    Userinfo { url: Box<str> },
+    #[error(
+        "index URL template `{url}` includes a `#` fragment;\n\
+         fragments are never sent to the server and are not allowed in templates"
+    )]
+    Fragment { url: Box<str> },
+}
+
+/// How a relative index path is encoded when substituted into a template
+/// placeholder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathEncoding {
+    /// `{path}`: the whole path is one percent-encoded unit, `/` → `%2F`.
+    Encoded,
+    /// `{path_raw}`: `/` stays literal, each segment percent-encoded.
+    Raw,
+}
+
+impl PathEncoding {
+    fn placeholder(self) -> &'static str {
+        match self {
+            Self::Encoded => PATH_PLACEHOLDER,
+            Self::Raw => PATH_RAW_PLACEHOLDER,
+        }
+    }
+
+    /// The separator inserted between consecutive path segments: `%2F` for
+    /// `{path}` (so `/` is encoded away) and a literal `/` for
+    /// `{path_raw}`.
+    fn separator(self) -> &'static str {
+        match self {
+            Self::Encoded => "%2F",
+            Self::Raw => "/",
+        }
+    }
+}
+
+/// A URL template with exactly one `{path}` or `{path_raw}` placeholder,
+/// validated at construction. Stored as the text on either side of the
+/// placeholder rather than as a `url::Url` because `url::Url` percent-encodes
+/// `{` or `}` on parse, which would corrupt the placeholder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexUrlTemplate {
+    prefix: String,
+    suffix: String,
+    encoding: PathEncoding,
+}
+
+impl IndexUrlTemplate {
+    /// Validate `raw` as an index URL template. `raw` must contain exactly
+    /// one `{path}` or `{path_raw}` placeholder, no other `{...}` tokens
+    /// or stray braces, no fragment, and must expand to an absolute
+    /// HTTP(S) URL without userinfo, with the placeholder in the path or
+    /// query.
+    fn parse(raw: &str) -> Result<Self, IndexLocationError> {
+        let boxed_url = || -> Box<str> { raw.into() };
+
+        let encoding = validate_placeholders(raw)?;
+
+        // Fragments are never sent to the server; in a template one is
+        // always a mistake (and would swallow the placeholder if it
+        // followed `#`).
+        if raw.contains('#') {
+            return Err(IndexLocationError::Fragment { url: boxed_url() });
+        }
+
+        let placeholder = encoding.placeholder();
+        let split = raw
+            .find(placeholder)
+            .expect("BUG: validate_placeholders guarantees exactly one placeholder");
+        let template = Self {
+            prefix: raw[..split].to_owned(),
+            suffix: raw[split + placeholder.len()..].to_owned(),
+            encoding,
+        };
+
+        // Expand a probe that encodes to a percent-escape: hosts and
+        // ports cannot contain `%`, so a placeholder in the authority
+        // component fails to parse rather than validating silently.
+        let expanded = match url::Url::parse(&template.build(["pr obe", "probe"])) {
+            Ok(expanded) => expanded,
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                return Err(IndexLocationError::RelativeTemplate { url: boxed_url() });
+            }
+            Err(source) => {
+                return Err(IndexLocationError::InvalidTemplate {
+                    url: boxed_url(),
+                    source,
+                });
+            }
+        };
+        validate_url_shape(raw, &expanded)?;
+
+        Ok(template)
+    }
+
+    /// Build the expanded URL text from `segments`, each percent-encoded and
+    /// joined by the placeholder's separator.
+    fn build<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> String {
+        let mut out = self.prefix.clone();
+        for (i, segment) in segments.into_iter().enumerate() {
+            if i > 0 {
+                out.push_str(self.encoding.separator());
+            }
+            out.extend(utf8_percent_encode(segment, PATH_ENCODE_SET));
+        }
+        out.push_str(&self.suffix);
+        out
+    }
+
+    /// Substitute the relative index path `segments` (each percent-encoded
+    /// according to the placeholder spelling) into the template. Infallible:
+    /// the template was validated at construction and the segments encode to
+    /// URL-safe bytes, so the result is always a valid URL.
+    pub fn expand<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> url::Url {
+        url::Url::parse(&self.build(segments))
+            .expect("BUG: a validated index URL template expands to a valid URL")
+    }
+}
+
+impl fmt::Display for IndexUrlTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{}{}",
+            self.prefix,
+            self.encoding.placeholder(),
+            self.suffix
+        )
+    }
+}
+
+/// Where an index lives: a plain base URL (relative index paths are
+/// RFC 3986-joined onto it, the historical behavior) or a URL template
+/// (relative index paths are percent-encoded into its `{path}`
+/// placeholder).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexLocation {
+    /// A plain base URL. Constructed through [`Self::parse`], its path is
+    /// normalized to end with `/` so that relative index paths append
+    /// rather than replace the last segment; direct constructions must
+    /// uphold the same invariant.
+    Root(url::Url),
+    Template(IndexUrlTemplate),
+}
+
+impl IndexLocation {
+    /// Parse a user-supplied index location string. Strings containing `{`
+    /// or `}` are treated as URL templates; anything else is parsed as a
+    /// plain base URL. Braces are outside the URI character set
+    /// ([RFC 3986 §2]), so no conformant URL is misclassified. (The `url`
+    /// crate previously tolerated literal braces by percent-encoding them
+    /// in paths and keeping them in queries; such non-conformant index
+    /// URLs are now template-syntax errors.)
+    ///
+    /// Both variants enforce the same validity invariants at construction:
+    /// an absolute HTTP(S) URL without userinfo. Later resolution is thus
+    /// infallible.
+    ///
+    /// [RFC 3986 §2]: https://www.rfc-editor.org/rfc/rfc3986#section-2
+    pub fn parse(s: &str) -> Result<Self, IndexLocationError> {
+        if is_template_syntax(s) {
+            return Ok(Self::Template(IndexUrlTemplate::parse(s)?));
+        }
+        // A pre-encoded `%7Bpath%7D` would silently behave as a plain
+        // append-mode URL and 404 on every fetch; catch the paste
+        // accident early instead. Only the exact placeholder spellings
+        // are rejected, so URLs that legitimately contain encoded braces
+        // elsewhere keep working. Gated on `%` so the common case does
+        // not allocate.
+        if s.contains('%') {
+            let lower = s.to_ascii_lowercase();
+            if lower.contains("%7bpath%7d") || lower.contains("%7bpath_raw%7d") {
+                return Err(IndexLocationError::PreEncodedPlaceholder { url: s.into() });
+            }
+        }
+        let url = match url::Url::parse(s) {
+            Ok(url) => url,
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                return Err(IndexLocationError::RelativeUrl { url: s.into() });
+            }
+            Err(source) => {
+                return Err(IndexLocationError::InvalidUrl {
+                    url: s.into(),
+                    source,
+                });
+            }
+        };
+        // Enforce the same shape a template's expansion must satisfy. An
+        // HTTP(S) URL can always be a base, so the trailing-slash
+        // normalization (which `resolve` relies on) cannot fail.
+        validate_url_shape(s, &url)?;
+        Ok(Self::Root(with_trailing_slash(url)))
+    }
+
+    /// Construct the URL for the index file whose relative path is
+    /// `segments` (for example `["index.json"]` or `["<publisher>",
+    /// "<name>", "versions.json"]`). The segments are trusted: callers pass
+    /// components validated upstream (charset-checked publisher/name,
+    /// `_iri`/`<sha256hex>`, parsed semver versions, fixed file names — see
+    /// `design/index-protocol.md` §5), so they cannot smuggle `..` or URL
+    /// syntax into the result. Infallible, since both variants were
+    /// shape-validated at construction.
+    pub fn resolve<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> url::Url {
+        match self {
+            Self::Root(root) => {
+                // Append each segment to a clone of the base rather than
+                // building a `/`-joined string and reparsing it in
+                // `join()`. The root ends with `/` (its invariant), so drop
+                // that trailing empty segment first to avoid a doubled slash.
+                let mut url = root.clone();
+                url.path_segments_mut()
+                    .expect("BUG: an HTTP(S) base URL can have path segments")
+                    .pop_if_empty()
+                    .extend(segments);
+                url
+            }
+            Self::Template(template) => template.expand(segments),
+        }
+    }
+
+    /// The plain base URL, if this location is not a template.
+    pub fn as_root(&self) -> Option<&url::Url> {
+        match self {
+            Self::Root(url) => Some(url),
+            Self::Template(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for IndexLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Root(url) => f.write_str(url.as_str()),
+            Self::Template(template) => write!(f, "{template}"),
+        }
+    }
+}
+
+impl FromStr for IndexLocation {
+    type Err = IndexLocationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+/// Check that every `{...}` token in `raw` is `{path}` or `{path_raw}`,
+/// that braces are balanced and non-nested, and that exactly one
+/// placeholder occurs. Returns the encoding the placeholder selects.
+fn validate_placeholders(raw: &str) -> Result<PathEncoding, IndexLocationError> {
+    let boxed_url = || -> Box<str> { raw.into() };
+    let mut found: Vec<PathEncoding> = Vec::new();
+    let mut rest = raw;
+    while let Some(open) = rest.find(['{', '}']) {
+        if rest.as_bytes()[open] == b'}' {
+            return Err(IndexLocationError::StrayBrace { url: boxed_url() });
+        }
+        let after_open = &rest[open + 1..];
+        let Some(close) = after_open.find(['{', '}']) else {
+            return Err(IndexLocationError::StrayBrace { url: boxed_url() });
+        };
+        if after_open.as_bytes()[close] == b'{' {
+            return Err(IndexLocationError::StrayBrace { url: boxed_url() });
+        }
+        let name = &after_open[..close];
+        match name {
+            "path" => found.push(PathEncoding::Encoded),
+            "path_raw" => found.push(PathEncoding::Raw),
+            _ => {
+                let hint = if name.eq_ignore_ascii_case("path") {
+                    " (did you mean `{path}`?)"
+                } else if name.eq_ignore_ascii_case("path_raw") {
+                    " (did you mean `{path_raw}`?)"
+                } else {
+                    ""
+                };
+                return Err(IndexLocationError::UnknownPlaceholder {
+                    url: boxed_url(),
+                    placeholder: format!("{{{name}}}").into(),
+                    hint,
+                });
+            }
+        }
+        rest = &after_open[close + 1..];
+    }
+    match found.as_slice() {
+        [encoding] => Ok(*encoding),
+        _ => Err(IndexLocationError::PlaceholderCount {
+            url: boxed_url(),
+            count: found.len(),
+        }),
+    }
+}
+
+/// Enforce the shared index-location invariant on `url`: an absolute
+/// HTTP(S) URL without userinfo. `reported` is the string named in any
+/// error (the template text for a template, the URL itself for a root).
+fn validate_url_shape(reported: &str, url: &url::Url) -> Result<(), IndexLocationError> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(IndexLocationError::UnsupportedScheme {
+            url: reported.into(),
+            scheme: url.scheme().into(),
+        });
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(IndexLocationError::Userinfo {
+            url: reported.into(),
+        });
+    }
+    Ok(())
+}
+
+/// Whether `s` uses index URL template syntax (contains a brace).
+fn is_template_syntax(s: &str) -> bool {
+    s.contains(['{', '}'])
+}
+
+/// Return `url` with a guaranteed trailing slash on its path so that
+/// `Url::join` treats it as a directory. Operates via `path_segments_mut`
+/// rather than touching the serialized path string, so percent-encoded
+/// segments survive the round-trip unchanged.
+///
+/// Callers must pass an HTTP(S) URL. Such URLs can be a base, so the
+/// `path_segments_mut` call should not fail after endpoint-shape
+/// validation.
+pub(crate) fn with_trailing_slash(mut url: url::Url) -> url::Url {
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .expect("caller passes a URL that can be a base");
+        segments.pop_if_empty();
+        segments.push("");
+    }
+    url
+}
+
+#[cfg(test)]
+#[path = "./index_location_tests.rs"]
+mod tests;

--- a/core/src/index_location_tests.rs
+++ b/core/src/index_location_tests.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use super::*;
+
+const GITLAB_TEMPLATE: &str =
+    "https://gitlab.com/api/v4/projects/123/repository/files/{path}/raw?ref=main";
+
+fn parse_template(s: &str) -> IndexUrlTemplate {
+    match IndexLocation::parse(s).unwrap() {
+        IndexLocation::Template(template) => template,
+        IndexLocation::Root(url) => panic!("expected template, got root `{url}`"),
+    }
+}
+
+#[test]
+fn plain_url_parses_as_root_with_trailing_slash() {
+    // The trailing slash is an invariant of `Root`, established at parse
+    // time so `resolve` can join without renormalizing.
+    let location = IndexLocation::parse("https://example.org/index").unwrap();
+    assert_eq!(
+        location,
+        IndexLocation::Root(url::Url::parse("https://example.org/index/").unwrap())
+    );
+}
+
+#[test]
+fn relative_url_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("example.org/index"),
+        Err(IndexLocationError::RelativeUrl { .. })
+    ));
+}
+
+#[test]
+fn braces_dispatch_to_template() {
+    assert!(matches!(
+        IndexLocation::parse(GITLAB_TEMPLATE),
+        Ok(IndexLocation::Template(_))
+    ));
+}
+
+#[test]
+fn template_expands_with_full_percent_encoding() {
+    let template = parse_template(GITLAB_TEMPLATE);
+    let url = template.expand("admin/proj0/4.0.20/project.kpar".split('/'));
+    assert_eq!(
+        url.as_str(),
+        "https://gitlab.com/api/v4/projects/123/repository/files/\
+         admin%2Fproj0%2F4.0.20%2Fproject.kpar/raw?ref=main"
+    );
+}
+
+#[test]
+fn template_encodes_non_unreserved_bytes() {
+    let template = parse_template("https://example.org/files/{path}?ref=main");
+    let url = template.expand("a b/+%/ö.json".split('/'));
+    assert_eq!(
+        url.as_str(),
+        "https://example.org/files/a%20b%2F%2B%25%2F%C3%B6.json?ref=main"
+    );
+}
+
+#[test]
+fn template_preserves_unreserved_bytes() {
+    let template = parse_template("https://example.org/files/{path}");
+    let url = template.expand("Az0-9_.~x".split('/'));
+    assert_eq!(url.as_str(), "https://example.org/files/Az0-9_.~x");
+}
+
+#[test]
+fn template_placeholder_in_query_expands() {
+    let template = parse_template("https://example.org/get?file={path}&ref=main");
+    let url = template.expand("a/b.json".split('/'));
+    assert_eq!(
+        url.as_str(),
+        "https://example.org/get?file=a%2Fb.json&ref=main"
+    );
+}
+
+#[test]
+fn raw_template_keeps_slashes_literal() {
+    let template =
+        parse_template("https://gitea.example.org/api/v1/repos/o/r/raw/{path_raw}?ref=main");
+    let url = template.expand("admin/proj0/versions.json".split('/'));
+    assert_eq!(
+        url.as_str(),
+        "https://gitea.example.org/api/v1/repos/o/r/raw/admin/proj0/versions.json?ref=main"
+    );
+}
+
+#[test]
+fn raw_template_encodes_within_segments() {
+    let template = parse_template("https://example.org/raw/{path_raw}");
+    let url = template.expand("a b/ö/c+d.json".split('/'));
+    assert_eq!(
+        url.as_str(),
+        "https://example.org/raw/a%20b/%C3%B6/c%2Bd.json"
+    );
+}
+
+#[test]
+fn mixing_both_placeholders_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("https://example.org/{path}/{path_raw}"),
+        Err(IndexLocationError::PlaceholderCount { count: 2, .. })
+    ));
+}
+
+#[test]
+fn case_typo_raw_placeholder_gets_hint() {
+    let error = IndexLocation::parse("https://example.org/{PATH_RAW}/x").unwrap_err();
+    assert!(error.to_string().contains("did you mean `{path_raw}`?"));
+}
+
+#[test]
+fn resolve_on_root_matches_append_semantics() {
+    let location = IndexLocation::parse("https://example.org/index").unwrap();
+    let url = location.resolve("admin/proj0/versions.json".split('/'));
+    assert_eq!(
+        url.as_str(),
+        "https://example.org/index/admin/proj0/versions.json"
+    );
+    // Trailing slash on the root makes no difference.
+    let location = IndexLocation::parse("https://example.org/index/").unwrap();
+    let url = location.resolve("admin/proj0/versions.json".split('/'));
+    assert_eq!(
+        url.as_str(),
+        "https://example.org/index/admin/proj0/versions.json"
+    );
+}
+
+#[test]
+fn unknown_placeholder_is_rejected() {
+    let error = IndexLocation::parse("https://example.org/{file}/raw").unwrap_err();
+    assert!(matches!(
+        &error,
+        IndexLocationError::UnknownPlaceholder { placeholder, .. } if placeholder.as_ref() == "{file}"
+    ));
+}
+
+#[test]
+fn case_typo_placeholder_gets_hint() {
+    let error = IndexLocation::parse("https://example.org/{Path}/raw").unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("did you mean `{path}`?"), "{message}");
+}
+
+#[test]
+fn missing_placeholder_with_braces_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("https://example.org/files/{path"),
+        Err(IndexLocationError::StrayBrace { .. })
+    ));
+    assert!(matches!(
+        IndexLocation::parse("https://example.org/files/path}"),
+        Err(IndexLocationError::StrayBrace { .. })
+    ));
+}
+
+#[test]
+fn duplicate_placeholder_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("https://example.org/{path}/{path}"),
+        Err(IndexLocationError::PlaceholderCount { count: 2, .. })
+    ));
+}
+
+#[test]
+fn pre_encoded_placeholder_is_rejected_with_hint() {
+    let error =
+        IndexLocation::parse("https://example.org/files/%7Bpath%7D/raw?ref=main").unwrap_err();
+    assert!(matches!(
+        &error,
+        IndexLocationError::PreEncodedPlaceholder { .. }
+    ));
+    assert!(error.to_string().contains("{path}"));
+}
+
+#[test]
+fn encoded_braces_that_are_not_placeholders_are_accepted() {
+    let location = IndexLocation::parse("https://example.org/dir%7Bx/idx").unwrap();
+    assert!(matches!(location, IndexLocation::Root(_)));
+}
+
+#[test]
+fn non_http_root_is_rejected_at_parse() {
+    // A non-hierarchical scheme (`mailto:`) cannot anchor relative index
+    // paths; `IndexLocation` rejects it at construction rather than
+    // deferring to resolution.
+    assert!(matches!(
+        IndexLocation::parse("mailto:foo@example.org"),
+        Err(IndexLocationError::UnsupportedScheme { .. })
+    ));
+}
+
+#[test]
+fn template_fragment_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("https://example.org/files/{path}#frag"),
+        Err(IndexLocationError::Fragment { .. })
+    ));
+}
+
+#[test]
+fn template_in_host_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("https://{path}.example.org/files"),
+        Err(IndexLocationError::InvalidTemplate { .. })
+    ));
+}
+
+#[test]
+fn template_non_http_scheme_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("ftp://example.org/files/{path}"),
+        Err(IndexLocationError::UnsupportedScheme { .. })
+    ));
+}
+
+#[test]
+fn template_userinfo_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("https://user:pass@example.org/files/{path}"),
+        Err(IndexLocationError::Userinfo { .. })
+    ));
+}
+
+#[test]
+fn schemeless_template_is_rejected_as_relative() {
+    assert!(matches!(
+        IndexLocation::parse("example.org/files/{path}"),
+        Err(IndexLocationError::RelativeTemplate { .. })
+    ));
+}
+
+#[test]
+fn display_round_trips_templates_and_normalizes_roots() {
+    assert_eq!(
+        IndexLocation::parse(GITLAB_TEMPLATE).unwrap().to_string(),
+        GITLAB_TEMPLATE
+    );
+    assert_eq!(
+        IndexLocation::parse("https://example.org/index")
+            .unwrap()
+            .to_string(),
+        "https://example.org/index/"
+    );
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod context;
 pub mod env;
 #[cfg(feature = "filesystem")]
 pub mod index;
+pub mod index_location;
 mod iri_normalize;
 pub mod lock;
 pub mod project;

--- a/core/src/resolve/standard.rs
+++ b/core/src/resolve/standard.rs
@@ -12,6 +12,7 @@ use crate::{
         discovery::DiscoveryError, index::IndexEnvironmentAsync,
         local_directory::LocalDirectoryEnvironment,
     },
+    index_location::IndexLocation,
     resolve::{
         AsSyncResolveTokio, ResolveRead, ResolveReadAsync,
         combined::CombinedResolver,
@@ -91,7 +92,7 @@ pub fn standard_local_resolver(local_env: LocalDirectoryEnvironment) -> LocalEnv
 
 pub fn standard_index_resolver<Policy: HTTPAuthentication>(
     client: ClientWithMiddleware,
-    urls: Vec<url::Url>,
+    urls: Vec<IndexLocation>,
     runtime: Arc<tokio::runtime::Runtime>,
     auth_policy: Arc<Policy>,
 ) -> Result<AsSyncResolveTokio<RemoteIndexResolver<Policy>>, DiscoveryError> {
@@ -118,7 +119,7 @@ pub fn standard_resolver<Policy: HTTPAuthentication>(
     cwd: Option<Utf8PathBuf>,
     local_env: Option<LocalDirectoryEnvironment>,
     client: Option<ClientWithMiddleware>,
-    index_urls: Option<Vec<url::Url>>,
+    index_urls: Option<Vec<IndexLocation>>,
     runtime: Arc<tokio::runtime::Runtime>,
     auth_policy: Arc<Policy>,
 ) -> Result<StandardResolver<Policy>, DiscoveryError> {

--- a/design/index-protocol.md
+++ b/design/index-protocol.md
@@ -61,21 +61,26 @@ fields:
 }
 ```
 
-- `index_root` — base URL of the sysand index (where `index.json` lives).
-  When absent, defaults to the discovery root.
+- `index_root` — base URL of the sysand index (where `index.json` lives),
+  or a URL template ([§3.1](#31-url-templates)). When absent, defaults to
+  the discovery root.
 - `api_root` — base URL of the sysand index API (where `v1/upload` and
-  other endpoints live). When absent, defaults to the discovery root.
+  other endpoints live); never a template. When absent, defaults to the
+  discovery root if that is a plain URL; an index whose discovery root is
+  a template and whose discovery document does not set `api_root` has no
+  API endpoints ([§3.1](#31-url-templates)).
 
 `index_root` and `api_root`, when present, MUST be absolute `http` or
 `https` URLs ([RFC 3986 §4.3][rfc3986-43]: scheme + hier-part, no
-relative references) and MUST NOT contain URL userinfo (`username` or
-`password`). Clients MUST reject a discovery document that supplies a
-relative URL or userinfo for either field rather than attempting to
-resolve it against the discovery root or the final URL of the
-discovery-document fetch — relative URLs are excluded to avoid ambiguity
-around the resolution base after redirects, and userinfo is excluded so
-credentials are not logged, persisted, or propagated through generated
-source URLs.
+relative references) — or, for `index_root` only, a URL template
+([§3.1](#31-url-templates)) — and MUST NOT contain URL userinfo
+(`username` or `password`). Clients MUST reject a discovery document that
+supplies a relative URL or userinfo for either field rather than
+attempting to resolve it against the discovery root or the final URL of
+the discovery-document fetch — relative URLs are excluded to avoid
+ambiguity around the resolution base after redirects, and userinfo is
+excluded so credentials are not logged, persisted, or propagated through
+generated source URLs.
 
 If the discovery document is absent (HTTP 404) the client proceeds as
 though it were present with no fields set: `index_root` and `api_root`
@@ -84,6 +89,61 @@ both default to the discovery root. Any other non-success response (e.g.
 
 Clients MUST follow HTTP redirects on the discovery fetch. Unknown fields
 in the document are silently ignored (see [§14]).
+
+### 3.1. URL templates
+
+An index location — the user-configured index URL, or the `index_root`
+field of the discovery document — MAY be a **URL template** instead of a
+base URL. A URL template contains exactly one placeholder that the client
+substitutes with the relative index path (the path that would otherwise
+be joined onto a base URL, e.g.
+`some-publisher/some-project/1.0.0/project.kpar`):
+
+- `{path}` — the relative path is percent-encoded as a single unit:
+  every byte outside RFC 3986 _unreserved_ is encoded, **including `/` as
+  `%2F`**. This matches file-access APIs that take the whole file path as
+  one URL segment, such as the GitLab repository files API:
+
+  ```text
+  https://gitlab.com/api/v4/projects/123/repository/files/{path}/raw?ref=main
+  ```
+
+- `{path_raw}` — `/` separators stay literal and each path segment is
+  percent-encoded individually. For APIs that take the file path as
+  ordinary URL path segments but require a suffix or query string after
+  it, e.g. Gitea's raw-file API:
+
+  ```text
+  https://gitea.example.org/api/v1/repos/org/repo/raw/{path_raw}?ref=main
+  ```
+
+The placeholder syntax is a deliberately restricted subset of
+[RFC 6570][rfc6570] URI Templates: `{path}` behaves like RFC 6570 simple
+string expansion of a single value and `{path_raw}` like reserved
+expansion (`{+path}`), but only these two fixed names are accepted so
+that typos fail at parse time instead of producing wrong URLs. Fixed
+custom markers in a package-index template follow the precedent of
+crates.io's `config.json` `dl` field (`{crate}`, `{version}`).
+
+A string is recognized as a template by the presence of `{` or `}` —
+characters outside the URI character set ([RFC 3986 §2][rfc3986-2]), so
+no conformant URL is misclassified. (Implementations that previously
+tolerated literal braces in a plain index URL now treat such strings as
+template-syntax errors.)
+Templates MUST expand to absolute `http(s)` URLs, MUST NOT contain URL
+userinfo or a fragment, and MUST contain exactly one placeholder, in the
+path or query. Any other `{...}` token is an error. When the configured
+index URL is a template, the discovery document itself is fetched by
+expanding the template with the relative path
+`sysand-index-config.json`, and — absent an
+`index_root` field — all index files are fetched through the same
+template. `api_root` MUST NOT be a template (uploads are not file
+fetches); an index reached through a template whose discovery document
+does not set `api_root` has no API endpoints and is read-only.
+
+Note that append semantics at the end of a URL do not need a template: a
+plain base URL already covers that case. Templates exist for URL
+structures where the path sits mid-URL or a query string follows.
 
 ## 4. Layout
 
@@ -444,7 +504,9 @@ only supported path for creating and mutating an index tree.
 [§14]: #14-forward-compatibility
 [§15]: #15-sysand-index-cli-preview
 [rfc2119]: https://www.rfc-editor.org/rfc/rfc2119.html
+[rfc3986-2]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2
 [rfc3986-43]: https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
+[rfc6570]: https://www.rfc-editor.org/rfc/rfc6570.html
 [rfc3986-reg-name]: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2
 [rfc9110-423]: https://datatracker.ietf.org/doc/html/rfc9110#section-4.2.3
 [purl]: https://packageurl.org/

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -14,10 +14,10 @@ use semver::VersionReq;
 use sysand_core::{
     add::expand_sysand_purl_shorthand,
     build::KparCompressionMethod,
+    index_location::IndexLocation,
     model::{KERML_METAMODEL_PREFIX, SYSML_METAMODEL_PREFIX},
     sources::Dependencies,
 };
-use url::Url;
 
 use crate::env_vars;
 
@@ -209,8 +209,11 @@ pub enum Command {
         /// Configured index URL to publish to (e.g. https://sysand.com)
         /// May point to a path containing sysand-index-config.json, or directly
         /// to the API root (e.g. https://sysand.com/api)
+        /// URL templates (see --index under resolution options) are accepted,
+        /// but publishing then requires the index's sysand-index-config.json
+        /// to set `api_root`
         #[arg(long, value_name = "URL", verbatim_doc_comment)]
-        index: Url,
+        index: IndexLocation,
 
         /// How to use CI trusted publishing for acquiring publish credentials
         #[arg(
@@ -1527,6 +1530,12 @@ pub struct InstallOptions {
 pub struct ResolutionOptions {
     /// Comma-delimited list of index URLs to use when resolving
     /// project(s) and/or their dependencies, in addition to the default indexes.
+    /// An index URL may be a URL template with a `{path}` or `{path_raw}`
+    /// placeholder. `{path}` is replaced by the percent-encoded relative index
+    /// path (`/` becomes `%2F`), e.g. for the GitLab repository files API:
+    /// `https://gitlab.com/api/v4/projects/123/repository/files/{path}/raw?ref=main`
+    /// `{path_raw}` keeps `/` literal, for hosts that accept ordinary path
+    /// segments but need a suffix or query string after the path.
     #[arg(
         long,
         num_args = 0..,
@@ -1539,7 +1548,7 @@ pub struct ResolutionOptions {
     pub index: Vec<String>,
     /// Comma-delimited list of URLs to use as default index
     /// URLs. Default indexes are tried after other indexes
-    /// (default `https://sysand.com`)
+    /// (default `https://sysand.com`). Accepts URL templates like --index.
     #[arg(
         long,
         num_args = 0..,

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -12,6 +12,7 @@ use camino::Utf8Path;
 use sysand_core::{
     auth::HTTPAuthentication,
     context::ProjectContext,
+    index_location::IndexLocation,
     model::{
         InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw,
         InterchangeProjectUsageRaw,
@@ -33,7 +34,6 @@ use sysand_core::{
     project::utils::wrapfs,
     project::{local_kpar::LocalKParProject, local_src::LocalSrcProject},
 };
-use url::Url;
 
 pub fn pprint_interchange_project(
     info: &InterchangeProjectInfoRaw,
@@ -151,7 +151,7 @@ pub fn command_info_uri<Policy: HTTPAuthentication>(
     uri: Iri<String>,
     _normalise: bool,
     client: reqwest_middleware::ClientWithMiddleware,
-    index_urls: Option<Vec<Url>>,
+    index_urls: Option<Vec<IndexLocation>>,
     excluded_iris: &HashSet<String>,
     overrides: Vec<(Iri<String>, Vec<OverrideProject<Policy>>)>,
     runtime: Arc<tokio::runtime::Runtime>,
@@ -228,7 +228,7 @@ pub fn command_info_verb_uri<Policy: HTTPAuthentication>(
     verb: InfoCommandVerb,
     numbered: bool,
     client: reqwest_middleware::ClientWithMiddleware,
-    index_urls: Option<Vec<Url>>,
+    index_urls: Option<Vec<IndexLocation>>,
     overrides: Vec<(Iri<String>, Vec<OverrideProject<Policy>>)>,
     runtime: Arc<tokio::runtime::Runtime>,
     auth_policy: Arc<Policy>,

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -9,20 +9,20 @@ use sysand_core::{
     auth::StandardHTTPAuthentication,
     build::default_kpar_path,
     commands::publish::{
-        EndpointKind, TrustedPublishingEnvironment, do_publish, prepare_publish_payload,
-        resolve_publish_bearer, validate_endpoint_url_shape,
+        TrustedPublishingEnvironment, do_publish, prepare_publish_payload, resolve_publish_bearer,
+        validate_api_root_url_shape,
     },
     context::ProjectContext,
     env::discovery::{ResolvedEndpoints, fetch_index_config},
+    index_location::IndexLocation,
     project::utils::wrapfs,
 };
-use url::Url;
 
 use crate::{CliError, cli::TrustedPublishingMode};
 
 pub fn command_publish(
     path: Option<Utf8PathBuf>,
-    index: Url,
+    index: IndexLocation,
     trusted_publishing: TrustedPublishingMode,
     ctx: &ProjectContext,
     auth_policy: Arc<StandardHTTPAuthentication>,
@@ -33,10 +33,11 @@ pub fn command_publish(
     if !wrapfs::is_file(&kpar_path)? {
         bail!("KPAR file not found at `{kpar_path}`, run `sysand build` first");
     }
-    // Reject obviously-malformed discovery-root URLs (bad scheme,
-    // query/fragment components) before issuing any network request —
-    // a config typo should not cost a DNS lookup + connect attempt.
-    validate_endpoint_url_shape(&index, EndpointKind::DiscoveryRoot)?;
+    // `index` is an `IndexLocation`, so its shape invariants (absolute
+    // HTTP(S), no userinfo) were already enforced when it was parsed. The
+    // `v1/upload` guard still applies to the resolved `api_root` in
+    // `build_upload_url`.
+    //
     // Validate and prepare the kpar payload before any network work,
     // so that kpar-content errors (bad semver, invalid publisher/name,
     // oversized archive) surface before discovery or credential
@@ -47,12 +48,27 @@ pub fn command_publish(
     // are matched against the actual upload URL. Discovery uses the full auth
     // policy because the discovery document may itself be auth-gated.
     let endpoints = runtime.block_on(fetch_index_config(&client, &*auth_policy, &index))?;
+    let ResolvedEndpoints { api_root, .. } = endpoints;
+    // An index reached through a URL template serves files only; without
+    // an explicit `api_root` from its discovery document there is nothing
+    // to upload to. Check before credential handling so this clearer
+    // error is not masked by credential problems.
+    let Some(api_root) = api_root else {
+        bail!(
+            "index `{index}` does not advertise a publish endpoint,\n\
+             so publishing to it is not supported; ask the index administrator\n\
+             whether publishing is available (an index behind a URL template\n\
+             accepts uploads only if its sysand-index-config.json sets `api_root`)"
+        );
+    };
+    // Validate the resolved `api_root` shape once here; both credential
+    // resolution and the upload build the upload URL from it afterwards.
+    validate_api_root_url_shape(&api_root)?;
     // Only now — after discovery has had access to the full policy —
     // do we consume the Arc to extract the publish-specific
     // bearer-credential map. Upload is bearer-only; basic-auth entries
     // are intentionally dropped at this step.
     let bearer_map = Arc::unwrap_or_clone(auth_policy).try_into_publish_bearer_auth_map()?;
-    let ResolvedEndpoints { api_root, .. } = endpoints;
     let trusted_publishing_env = TrustedPublishingEnvironment::from_env();
     let bearer = resolve_publish_bearer(
         &bearer_map,

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -452,6 +452,9 @@ fn publish_explicit_path_outside_project_dir() -> TestResult {
 
 #[test]
 fn publish_invalid_index_url_errors_early() -> TestResult {
+    // `IndexLocation` enforces the HTTP(S) invariant when the `--index`
+    // argument is parsed, so a bad scheme is rejected before any network
+    // work.
     let (_temp_dir, cwd) = setup_built_project_at("invalid-index", "artifact.kpar")?;
     let out = run_sysand_in(
         &cwd,
@@ -461,7 +464,9 @@ fn publish_invalid_index_url_errors_early() -> TestResult {
 
     out.assert()
         .failure()
-        .stderr(predicate::str::contains("invalid index URL"))
+        .stderr(predicate::str::contains(
+            "only `http` and `https` are supported",
+        ))
         .stderr(predicate::str::contains("HTTP request failed").not());
 
     Ok(())
@@ -469,30 +474,33 @@ fn publish_invalid_index_url_errors_early() -> TestResult {
 
 #[test]
 fn publish_rejects_upload_endpoint_index_url() -> TestResult {
-    // If the user pastes the full upload URL as the `--index` value, the
-    // pre-discovery shape check rejects it before discovery or upload.
-    // The error message points the user back at the API root.
+    // If the user pastes the full upload URL as the `--index` value,
+    // discovery treats it as a flat root and the resolved `api_root` shape
+    // check rejects it before any upload. The error points back at the API
+    // root.
     let (_temp_dir, cwd) = setup_built_project_at("upload-endpoint-index", "artifact.kpar")?;
     let mut server = Server::new();
+    // Discovery runs against the pasted root; it 404s (no config), so the
+    // root itself becomes the `api_root`, which is then rejected.
     let config_mock = server
-        .mock("GET", "/sysand-index-config.json")
+        .mock("GET", "/v1/upload/sysand-index-config.json")
         .with_status(404)
-        .expect(0)
+        .expect(1)
         .create();
     let publish_mock = server.mock("POST", "/v1/upload").expect(0).create();
     let endpoint_url = format!("{}/v1/upload", server.url());
 
-    let env = bearer_env_for_url(server.url().as_str());
-    let out = run_sysand_in_with(
+    // No bearer credentials needed: `api_root` shape validation rejects the
+    // `v1/upload` endpoint before credential resolution.
+    let out = run_sysand_in(
         &cwd,
         ["publish", "artifact.kpar", "--index", endpoint_url.as_str()],
         None,
-        &env,
     )?;
 
     out.assert()
         .failure()
-        .stderr(predicate::str::contains("invalid index URL"))
+        .stderr(predicate::str::contains("invalid api_root URL"))
         .stderr(predicate::str::contains("not the `v1/upload` endpoint"))
         .stderr(predicate::str::contains("HTTP request failed").not());
     publish_mock.assert();
@@ -829,4 +837,49 @@ fn publish_500_json_error_body_extracts_error_message() -> TestResult {
         Some("application/json"),
         &["server error (500)", "Invalid token"],
     )
+}
+
+#[test]
+fn publish_to_templated_index_without_api_root_reports_explicit_error() -> TestResult {
+    // An index reached through a `{path}` URL template is file-serving
+    // only; unless its discovery document sets `api_root`, publish must
+    // fail with an actionable message before any upload is attempted.
+    let (_temp_dir, cwd) = setup_built_project("test-publish")?;
+
+    let mut server = Server::new();
+    let config_mock = server
+        .mock("GET", "/files/sysand-index-config.json/raw")
+        .match_query(Matcher::UrlEncoded("ref".into(), "main".into()))
+        .with_status(404)
+        .expect(1)
+        .create();
+
+    let index = format!("{}/files/{{path}}/raw?ref=main", server.url());
+    let out = run_sysand_in(&cwd, ["publish", "--index", index.as_str()], None)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "does not advertise a publish endpoint",
+        ))
+        .stderr(predicate::str::contains("index administrator"));
+
+    config_mock.assert();
+    Ok(())
+}
+
+#[test]
+fn publish_index_with_unknown_placeholder_reports_parse_error() -> TestResult {
+    // Template validation happens at argument parse time, before any
+    // network or kpar work.
+    let (_temp_dir, cwd) = init_project("test-publish")?;
+    let out = run_sysand_in(
+        &cwd,
+        ["publish", "--index", "https://example.org/files/{file}/raw"],
+        None,
+    )?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown placeholder `{file}`"));
+
+    Ok(())
 }


### PR DESCRIPTION
The feature of allowing an index URL to be a template with `{path}` or `{path_raw}` expanding placeholders, allows use of a  index as git content in a GitLab repo branch.

This feature makes the setup of a GitLab based index align with a GitHub based index with regards to:
- Won't need GitLab/GitHub pages to serve content (GitLab Files API URLs can be used, like GitHub's raw.githubusercontent.com URLs), reducing requirements and complexities
- Won't need GitLab classic PAT / GitLab project scoped access tokens, which both have significant downsides. A classic PAT has read access to all repos, and a project scoped access token can only be created by the index project admins rather than the typical low-level-project-reader that an index reader is expected to be.

With this PR landed, the GitLab private index example repo at https://gitlab.com/sensmetry/public/sysand-private-index can provide simpler and safer simpler instructions for the person setting it up and the people using it.

- fixes #438
- associated client docs PR in https://gitlab.com/sensmetry/internal2/tech/syside/sysand/index-website/-/merge_requests/34

## Vacation discalimer

I'm on vacation, but this was fun work and I lack another constructive hobby at the moment. This PR will however introduce work effort in review etc, so feel free to not spend time on it.