### PR TITLE
fix(publish): surface index error details, drop redundant warn-then-error

### DIFF
--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -268,7 +268,7 @@ pub fn do_publish(
         status
     );
 
-    map_publish_response(status, &body_bytes, &upload_url_for_log, &response_url)
+    map_publish_response(status, &body_bytes)
 }
 
 /// Validate the shape of the resolved `api_root` that comes back from
@@ -467,6 +467,7 @@ fn exchange_oidc_token_for_index_token(
         return Err(PublishError::TrustedPublishingExchangeHttpStatus {
             url: exchange_url.as_str().into(),
             status: status.as_u16(),
+            detail: error_body_to_string(&body).into(),
         });
     }
 
@@ -783,8 +784,12 @@ pub enum PublishError {
         status: u16,
     },
 
-    #[error("trusted publishing token exchange at `{url}` failed: HTTP status {status}")]
-    TrustedPublishingExchangeHttpStatus { url: Box<str>, status: u16 },
+    #[error("trusted publishing token exchange at `{url}` failed: HTTP status {status}: {detail}")]
+    TrustedPublishingExchangeHttpStatus {
+        url: Box<str>,
+        status: u16,
+        detail: Box<str>,
+    },
 
     #[error("failed to read {context}")]
     TrustedPublishingResponseBody {
@@ -1196,12 +1201,7 @@ fn check_metamodel(metamodel: &str) -> Result<AllowedMetamodelKind, PublishError
 }
 
 /// Maps an HTTP status and body to a `PublishResponse` or `PublishError`.
-fn map_publish_response(
-    status: u16,
-    body_bytes: &[u8],
-    upload_url_for_log: &str,
-    response_url: &str,
-) -> Result<PublishResponse, PublishError> {
+fn map_publish_response(status: u16, body_bytes: &[u8]) -> Result<PublishResponse, PublishError> {
     match status {
         200 => Ok(PublishResponse {
             status,
@@ -1217,18 +1217,10 @@ fn map_publish_response(
         401 | 403 => Err(PublishError::AuthError(error_body_to_string(body_bytes))),
         404 => Err(PublishError::NotFound(error_body_to_string(body_bytes))),
         409 => Err(PublishError::Conflict(error_body_to_string(body_bytes))),
-        _ => {
-            log::warn!(
-                "publish failed: request URL `{}`, final URL `{}`, status {}",
-                upload_url_for_log,
-                response_url,
-                status
-            );
-            Err(PublishError::ServerError {
-                status,
-                body: error_body_to_string(body_bytes),
-            })
-        }
+        _ => Err(PublishError::ServerError {
+            status,
+            body: error_body_to_string(body_bytes),
+        }),
     }
 }
 

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -322,6 +322,8 @@ fn resolve_publish_bearer_exchange_non_success_errors() {
     let exchange_mock = server
         .mock("POST", "/api/v1/oidc/token")
         .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error": "No matching trusted publisher found"}"#)
         .expect(1)
         .create();
     let api_root = Url::parse(&format!("{}/api/", server.url())).unwrap();
@@ -340,8 +342,15 @@ fn resolve_publish_bearer_exchange_non_success_errors() {
     .unwrap_err();
 
     assert_matches!(
-        err,
-        PublishError::TrustedPublishingExchangeHttpStatus { status: 403, .. }
+        &err,
+        PublishError::TrustedPublishingExchangeHttpStatus { status: 403, detail, .. }
+            if detail.as_ref() == "No matching trusted publisher found"
+    );
+    // The server-provided reason is surfaced in the error's Display output.
+    assert!(
+        err.to_string()
+            .contains("No matching trusted publisher found"),
+        "error message should include the server reason: {err}"
     );
     exchange_mock.assert();
 }
@@ -526,38 +535,20 @@ fn check_usage_rejects_unknown_std_lib() {
 
 #[test]
 fn map_publish_response_400_maps_to_bad_request() {
-    let err = map_publish_response(
-        400,
-        b"bad field",
-        "http://example.org/v1/upload",
-        "http://example.org/v1/upload",
-    )
-    .unwrap_err();
+    let err = map_publish_response(400, b"bad field").unwrap_err();
     assert_matches!(err, PublishError::BadRequest(_));
 }
 
 #[test]
 fn map_publish_response_200_is_ok_not_new_project() {
-    let resp = map_publish_response(
-        200,
-        b"ok",
-        "http://example.org/v1/upload",
-        "http://example.org/v1/upload",
-    )
-    .unwrap();
+    let resp = map_publish_response(200, b"ok").unwrap();
     assert!(!resp.is_new_project);
     assert_eq!(resp.status, 200);
 }
 
 #[test]
 fn map_publish_response_201_is_ok_new_project() {
-    let resp = map_publish_response(
-        201,
-        b"created",
-        "http://example.org/v1/upload",
-        "http://example.org/v1/upload",
-    )
-    .unwrap();
+    let resp = map_publish_response(201, b"created").unwrap();
     assert!(resp.is_new_project);
     assert_eq!(resp.status, 201);
 }


### PR DESCRIPTION
This helps users fix their misconfigurations better, such as not having a protected branch or similar. The trusted publishing requirements on the sysand.com index server is quite stringent, and requires that for example. Instead of presenting just 403 error, this should help the user figure out what to fix.

The removed URL from the removed warning can be found if needed using debug logging still.

---

The trusted-publishing OIDC token exchange discarded the response body
on a non-success status, so users saw only "HTTP status 403" with no
cause. Extract the server-provided `{"error": ...}` message via the
existing error_body_to_string helper and include it in the error.

The upload endpoint already returned the server detail in its 4xx error
variants, but its catch-all branch logged a warning immediately before
returning the error, duplicating what the propagated error already
reports. Remove that warn (and the now-unused url parameters); the
returned error is sufficient on its own.
