### PR TITLE
feat: persist index credentials in the OS keyring (sysand auth)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,21 @@
 Sysand is free and open source software, and as such welcomes contributions from
 everyone. This text intends to document the practicalities of doing so.
 
+## Conventions
+
+### Error messages: core states conditions, the frontend names commands
+
+`sysand-core` is a library with more than one frontend (the `sysand` CLI and
+the js / java / py bindings). Its error and warning messages must describe
+the condition only. They may reference the `SYSAND_CRED_*` environment
+variables (that credential mechanism is core's own, read directly by the
+library), but must not name `sysand <command>` subcommands: that vocabulary
+belongs to the frontend. When a core error warrants a CLI remediation, the
+`sysand` crate matches the error variant and appends the `sysand auth ...`
+hint from the error's fields (see `publish_error_with_hint` and the
+`sysand auth` command handlers). This keeps the library reusable and each
+frontend's hints correct.
+
 ## Developer's Certificate of Origin (DCO)
 
 Sysand is distributed under free software licenses (MIT and Apache-2.0).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "openssl",
+ "zeroize",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +761,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +834,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2313,6 +2361,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "openssl",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2402,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -2594,10 +2668,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3199,7 +3320,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3227,7 +3348,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3286,6 +3407,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -3613,6 +3747,7 @@ dependencies = [
  "digest 0.11.3",
  "dirs",
  "dunce",
+ "fd-lock",
  "fluent-uri",
  "futures",
  "gix",
@@ -3623,6 +3758,7 @@ dependencies = [
  "icu_properties",
  "idna",
  "indexmap",
+ "keyring",
  "log",
  "logos",
  "mockito",
@@ -4092,6 +4228,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-ranges"
@@ -4831,6 +4973,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
  "assert_cmd",
  "camino",
  "camino-tempfile",
+ "chrono",
  "clap",
  "env_logger",
  "fluent-uri",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3721,6 +3742,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "rexpect",
+ "rpassword",
  "semver",
  "serde_json",
  "spdx",
@@ -4587,6 +4609,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,11 +10,22 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cipher",
+ "cipher 0.5.1",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -100,6 +111,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +156,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +283,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -216,6 +358,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,12 +514,22 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
  "crypto-common 0.2.1",
- "inout",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -382,7 +565,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -445,6 +628,15 @@ name = "comma"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console_log"
@@ -528,6 +720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,28 +754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "dbus",
- "openssl",
- "zeroize",
-]
-
-[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +778,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -637,6 +813,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -681,7 +858,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -703,6 +880,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -745,6 +949,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "faster-hex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,17 +983,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "filetime"
@@ -836,21 +1049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +1100,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +1120,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1864,10 +2075,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -2167,6 +2402,16 @@ dependencies = [
 
 [[package]]
 name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
@@ -2246,7 +2491,7 @@ dependencies = [
  "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2307,7 +2552,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2335,7 +2580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2362,18 +2607,23 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "3.6.3"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
  "log",
- "openssl",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -2402,16 +2652,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "libm"
@@ -2475,7 +2715,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2510,7 +2750,7 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2526,6 +2766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2634,10 +2883,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2668,63 +2980,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2756,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
- "hmac",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2772,10 +3053,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "port_check"
@@ -2867,7 +3173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2879,6 +3185,15 @@ dependencies = [
  "equivalent",
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2968,7 +3283,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2980,7 +3295,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3153,7 +3468,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3341,7 +3656,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -3369,7 +3684,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3430,16 +3745,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "security-framework"
-version = "2.11.1"
+name = "secret-service"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
 dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
+ "aes 0.8.4",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
 ]
 
 [[package]]
@@ -3502,7 +3823,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3517,6 +3838,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3605,6 +3937,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3701,6 +4043,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,7 +4070,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3770,7 +4123,6 @@ dependencies = [
  "digest 0.11.3",
  "dirs",
  "dunce",
- "fd-lock",
  "fluent-uri",
  "futures",
  "gix",
@@ -3852,7 +4204,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3948,7 +4300,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3959,7 +4311,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4153,7 +4505,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4182,6 +4546,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -4253,10 +4628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "uuid"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version-ranges"
@@ -4367,7 +4747,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -4410,7 +4790,7 @@ checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4547,7 +4927,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4558,7 +4938,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4566,6 +4946,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4872,7 +5265,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4888,7 +5281,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4955,8 +5348,80 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
 ]
 
 [[package]]
@@ -4976,7 +5441,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4996,7 +5461,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5005,20 +5470,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"
@@ -5052,7 +5503,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5061,14 +5512,14 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes",
+ "aes 0.9.1",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
  "deflate64",
  "flate2",
  "getrandom 0.4.2",
- "hmac",
+ "hmac 0.13.0",
  "indexmap",
  "lzma-rust2",
  "memchr",
@@ -5132,4 +5583,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -83,12 +83,8 @@ icu_properties = "2.1.2"
 # backend reports "absent" and callers fall back to `SYSAND_CRED_*`
 # (section 9 taxonomy). On musl the keyring feature still compiles; the
 # backend reports "absent".
-# On non-musl targets keyring 4.x's `v1` feature selects the native
-# backend per OS: Keychain on macOS, Credential Manager on Windows, and
-# the pure-Rust zbus Secret Service backend on glibc Linux. zbus needs no
-# system libdbus (nothing to vendor) and its crypto-rust session keeps
-# openssl out of the tree, so glibc builds (including CI lint runs with
-# --all-features) need no system libraries.
+# keyring's `v1` feature selects the native backend per OS: Keychain on macOS, Credential
+# Manager on Windows, and the pure-Rust (i.e. no libdbus or openssl) zbus Secret Service on Linux
 [target.'cfg(not(all(target_os = "linux", target_env = "musl")))'.dependencies]
 keyring = { version = "4.1.5", optional = true, default-features = false, features = ["v1"] }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ filesystem = ["dep:camino-tempfile", "dep:dirs", "dep:zip"]
 networking = ["dep:reqwest", "dep:gix"] # "dep:reqwest-middleware", "dep:partialzip"
 # OS-keyring-backed credential store (not for wasm; the js binding must not
 # enable it)
-keyring = ["dep:keyring", "dep:fd-lock", "dep:dirs"]
+keyring = ["dep:keyring", "dep:dirs"]
 # Different compression methods for creating KPARs
 kpar-bzip2 = ["zip?/bzip2"]
 kpar-zstd = ["zip?/zstd"]
@@ -43,7 +43,6 @@ digest = { version = "0.11", default-features = false }
 sha2.workspace = true
 hex.workspace = true
 dirs = { version = "6.0.0", optional = true}
-fd-lock = { version = "4.0.4", optional = true }
 fluent-uri.workspace = true
 idna = { version = "1.1.0", default-features = false, features = ["compiled_data"] }
 indexmap = { version = "2.13.0", default-features = false, features = ["serde"] }
@@ -79,16 +78,19 @@ icu_normalizer = { version = "2.1.1", default-features = false, features = ["com
 icu_casemap = "2.1.1"
 icu_properties = "2.1.2"
 
-# The OS-keyring crate is excluded on musl targets: its Linux Secret
-# Service backend needs dbus, whose vendored C build fails to link there
-# (missing aarch64 outline-atomics helpers), and musl builds are
-# containers/CI where the env-var credential path is the norm anyway.
-# On musl the keyring feature still compiles; the backend reports
-# "absent" and callers fall back to `SYSAND_CRED_*` (section 9 taxonomy).
-# `vendored` builds libdbus from source so glibc Linux builds (including
-# CI lint runs with --all-features) need no system libdbus headers.
+# The OS-keyring crate is excluded on musl targets by policy: musl builds
+# are containers/CI where the env-var credential path is the norm, so the
+# backend reports "absent" and callers fall back to `SYSAND_CRED_*`
+# (section 9 taxonomy). On musl the keyring feature still compiles; the
+# backend reports "absent".
+# On non-musl targets keyring 4.x's `v1` feature selects the native
+# backend per OS: Keychain on macOS, Credential Manager on Windows, and
+# the pure-Rust zbus Secret Service backend on glibc Linux. zbus needs no
+# system libdbus (nothing to vendor) and its crypto-rust session keeps
+# openssl out of the tree, so glibc builds (including CI lint runs with
+# --all-features) need no system libraries.
 [target.'cfg(not(all(target_os = "linux", target_env = "musl")))'.dependencies]
-keyring = { version = "3.6.3", optional = true, default-features = false, features = ["apple-native", "windows-native", "sync-secret-service", "vendored"] }
+keyring = { version = "4.1.5", optional = true, default-features = false, features = ["v1"] }
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,9 @@ python = ["dep:pyo3"]
 js = ["dep:wasm-bindgen"]
 filesystem = ["dep:camino-tempfile", "dep:dirs", "dep:zip"]
 networking = ["dep:reqwest", "dep:gix"] # "dep:reqwest-middleware", "dep:partialzip"
+# OS-keyring-backed credential store (not for wasm; the js binding must not
+# enable it)
+keyring = ["dep:keyring", "dep:fd-lock", "dep:dirs"]
 # Different compression methods for creating KPARs
 kpar-bzip2 = ["zip?/bzip2"]
 kpar-zstd = ["zip?/zstd"]
@@ -40,6 +43,7 @@ digest = { version = "0.11", default-features = false }
 sha2.workspace = true
 hex.workspace = true
 dirs = { version = "6.0.0", optional = true}
+fd-lock = { version = "4.0.4", optional = true }
 fluent-uri.workspace = true
 idna = { version = "1.1.0", default-features = false, features = ["compiled_data"] }
 indexmap = { version = "2.13.0", default-features = false, features = ["serde"] }
@@ -74,6 +78,17 @@ dunce = "1.0.5"
 icu_normalizer = { version = "2.1.1", default-features = false, features = ["compiled_data"] }
 icu_casemap = "2.1.1"
 icu_properties = "2.1.2"
+
+# The OS-keyring crate is excluded on musl targets: its Linux Secret
+# Service backend needs dbus, whose vendored C build fails to link there
+# (missing aarch64 outline-atomics helpers), and musl builds are
+# containers/CI where the env-var credential path is the norm anyway.
+# On musl the keyring feature still compiles; the backend reports
+# "absent" and callers fall back to `SYSAND_CRED_*` (section 9 taxonomy).
+# `vendored` builds libdbus from source so glibc Linux builds (including
+# CI lint runs with --all-features) need no system libdbus headers.
+[target.'cfg(not(all(target_os = "linux", target_env = "musl")))'.dependencies]
+keyring = { version = "3.6.3", optional = true, default-features = false, features = ["apple-native", "windows-native", "sync-secret-service", "vendored"] }
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -808,26 +808,25 @@ where
 
     /// Synchronous variant of [`Self::stored_bearer_map`] for callers
     /// outside the async runtime (publish's credential selection). Shares
-    /// the same once-per-process cache.
-    pub fn stored_bearer_map_blocking(&self) -> &GlobMap<StoredBearerAuth> {
+    /// the same once-per-process cache; returns an owned map (cheap: the
+    /// records hold `Arc`s and small strings, and publish calls this once).
+    pub fn stored_bearer_map_blocking(&self) -> GlobMap<StoredBearerAuth> {
         if let Some(map) = self.cache.get() {
-            return map;
+            return map.clone();
         }
         let map = match &self.store {
             None => GlobMap::default(),
             Some(store) => read_stored_bearer_map(store.as_ref()),
         };
-        // Safe because this never races the async accessor on the current
-        // flow: publish resolves its bearer only after discovery's
-        // `block_on` has returned, and the runtime is current-thread, so no
-        // async `get_or_init` is in flight here. `set` therefore either
-        // succeeds or reports the cell already initialized, and `get` is
-        // populated. If this accessor is ever called concurrently with the
-        // async one (e.g. on a multi-thread runtime), revisit: `set` can
-        // return `InitializingError` with the cell still empty, which would
-        // trip the `expect` below.
-        let _ = self.cache.set(map);
-        self.cache.get().expect("cache was just initialized")
+        // On the current flow this never races the async accessor: publish
+        // resolves its bearer only after discovery's `block_on` has
+        // returned, and the runtime is current-thread, so `set` seeds the
+        // cache for later callers. Should an async `get_or_init` ever be
+        // in flight concurrently (e.g. on a multi-thread runtime), `set`
+        // fails and the locally read map is returned as-is: the cost is
+        // one extra store read, never a panic.
+        let _ = self.cache.set(map.clone());
+        map
     }
 }
 

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -112,6 +112,15 @@ impl ForceBearerAuth {
     pub fn new<S: AsRef<str>>(token: S) -> ForceBearerAuth {
         Self(token.as_ref().into())
     }
+
+    /// The raw token, for callers that send the credential outside a
+    /// policy chain (the `auth whoami` probe). Crate-private so the
+    /// secret never leaks into the public API; gated like
+    /// `commands::auth`, its only consumer.
+    #[cfg(all(feature = "filesystem", feature = "networking"))]
+    pub(crate) fn token(&self) -> &str {
+        &self.0
+    }
 }
 
 impl HTTPAuthentication for ForceBearerAuth {

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -13,7 +13,9 @@ use globset::{GlobBuilder, GlobSetBuilder};
 use reqwest::{Response, header};
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
 
-use crate::credential_store::{CredentialScheme, CredentialStore, CredentialStoreError};
+use crate::credential_store::{
+    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
+};
 
 pub trait HTTPAuthentication: std::fmt::Debug + 'static {
     /// Tries to execute a request with some authentication policy. The request might be retried
@@ -341,6 +343,63 @@ impl<T> GlobMap<T> {
             }
 
             GlobMapResultMut::Ambiguous(result)
+        }
+    }
+}
+
+/// What credential selection found in one source's bearer map for a URL.
+/// Shared by the runtime read retry, whoami, and publish so the collapse
+/// and ambiguity semantics are written once
+/// (design/credential-storage.md section 8).
+#[derive(Debug)]
+pub(crate) enum BearerSelection<'a, T> {
+    /// No matching pattern: the caller falls through to its next source.
+    None,
+    /// Exactly one credential in effect: either a unique match, or
+    /// several matching patterns all carrying the identical token,
+    /// collapsed to the first so any later hint names that entry.
+    Unique(&'a T),
+    /// Matching patterns carry distinct tokens. `candidates` is the full
+    /// pre-collapse match count (what ambiguity errors report), `deduped`
+    /// the distinct-token entries in map order (what try-all consumers
+    /// walk); it always holds at least two entries.
+    Ambiguous {
+        candidates: usize,
+        deduped: Vec<&'a T>,
+    },
+}
+
+/// Select the bearer credential(s) for `url` from one source's map.
+///
+/// One credential commonly covers several (normally non-overlapping) URL
+/// patterns with the same token, so several patterns matching is a real
+/// ambiguity only between *distinct* tokens; `token` extracts the token
+/// to compare. How ambiguity is handled stays with the caller: publish
+/// and whoami refuse it, the runtime read path tries each candidate in
+/// order (design/credential-storage.md section 8).
+pub(crate) fn select_bearer<'a, T>(
+    map: &'a GlobMap<T>,
+    url: &str,
+    token: impl Fn(&T) -> &str,
+) -> BearerSelection<'a, T> {
+    match map.lookup(url) {
+        GlobMapResult::NotFound => BearerSelection::None,
+        GlobMapResult::Found(_, entry) => BearerSelection::Unique(entry),
+        GlobMapResult::Ambiguous(candidates) => {
+            let mut deduped: Vec<&T> = Vec::new();
+            for (_, entry) in &candidates {
+                if !deduped.iter().any(|seen| token(seen) == token(entry)) {
+                    deduped.push(entry);
+                }
+            }
+            if deduped.len() == 1 {
+                BearerSelection::Unique(deduped[0])
+            } else {
+                BearerSelection::Ambiguous {
+                    candidates: candidates.len(),
+                    deduped,
+                }
+            }
         }
     }
 }
@@ -860,7 +919,19 @@ fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<Sto
             return GlobMap::default();
         }
     };
+    stored_bearer_map_from_records(&records)
+}
 
+/// Build the URL-glob to bearer map from credential records. Also the
+/// stored-source map for whoami's credential selection, which reads the
+/// records once and shares the snapshot with its discovery policy.
+///
+/// Each glob is validated individually so one invalid pattern skips only
+/// itself, not every stored credential; a whole-map build failure degrades
+/// to "no stored credentials" with a warning rather than aborting.
+pub(crate) fn stored_bearer_map_from_records(
+    records: &[CredentialRecord],
+) -> GlobMap<StoredBearerAuth> {
     let mut builder = GlobMapBuilder::new();
     for record in records {
         // Exhaustive on purpose: adding a scheme must revisit this map.
@@ -929,37 +1000,25 @@ where
         }
 
         let stored = self.stored_bearer_map().await;
-        let candidates = match stored.lookup(url.as_str()) {
-            GlobMapResult::NotFound => return Ok(initial_response),
-            GlobMapResult::Found(_, auth) => vec![auth],
-            GlobMapResult::Ambiguous(items) => items.into_iter().map(|(_, auth)| auth).collect(),
-        };
-
-        // One stored credential covers several (normally non-overlapping) URL
-        // patterns with the same token, so several patterns matching is a
-        // real ambiguity only between *distinct* tokens. Records with
-        // identical tokens collapse to the first record, so a hint after
-        // a failed retry names that record's key.
-        let mut deduped: Vec<&StoredBearerAuth> = Vec::new();
-        for bearer in candidates {
-            if !deduped.iter().any(|seen| seen.auth.0 == bearer.auth.0) {
-                deduped.push(bearer);
-            }
-        }
-
-        let mut deduped = deduped.into_iter();
-        let first_bearer = deduped.next().expect("lookup produced no candidates");
         // A single distinct token retries once; genuinely ambiguous matches
         // try each in order until one yields a non-4xx response
         // (design/credential-storage.md, section 8), mirroring
         // `RestrictAuthentication`. If every candidate fails, the first
         // retry response is returned. The single-match case is this same
         // path with an empty remainder loop.
-        if deduped.len() == 0 {
-            log::debug!("stored credential matches `{url}`; retrying with forced bearer auth");
-        } else {
-            log::warn!("URL {url} matches multiple stored credentials; trying each in order");
-        }
+        let deduped = match select_bearer(stored, url.as_str(), |bearer| &bearer.auth.0) {
+            BearerSelection::None => return Ok(initial_response),
+            BearerSelection::Unique(bearer) => {
+                log::debug!("stored credential matches `{url}`; retrying with forced bearer auth");
+                vec![bearer]
+            }
+            BearerSelection::Ambiguous { deduped, .. } => {
+                log::warn!("URL {url} matches multiple stored credentials; trying each in order");
+                deduped
+            }
+        };
+        let mut deduped = deduped.into_iter();
+        let first_bearer = deduped.next().expect("selection produced no candidates");
         let first_response = first_bearer
             .auth
             .request_with_authentication(renew_request(&client), renew_request)

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -643,7 +643,7 @@ impl StoredBearerAuth {
         }
         Some(format!(
             "credential for `{key}` may be expired or revoked; \
-             re-run `sysand auth login {key}`",
+             re-authenticate to store a fresh credential",
             key = self.key
         ))
     }

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -900,15 +900,21 @@ where
 
 /// Read all stored records and build the URL-glob to bearer map.
 ///
-/// Store errors degrade to "no stored credentials", and every error
-/// variant is warned about (each caller reads at most once per process,
-/// so at most one warning per caller): the keyring taxonomy cannot tell a
-/// genuinely absent backend from a present-but-malfunctioning one (a
-/// broken Secret Service also maps to `BackendAbsent`), and staying quiet
-/// would silently downgrade a logged-in user to unauthenticated requests.
-/// Only the true no-entry case (a reachable backend with nothing stored)
-/// is quiet, because it is not an error at all. A locked/denied backend
-/// additionally names the unlock and `SYSAND_CRED_*` remediations.
+/// Store errors degrade to "no stored credentials". `BackendAbsent` is
+/// logged at debug only: it is the designed env-fallback state on hosts
+/// with no keyring (CI, musl, headless), where any 4xx on the request
+/// path would otherwise print a keyring warning to users who never asked
+/// for credentials. The cost, accepted deliberately, is that a
+/// present-but-malfunctioning backend that maps to `BackendAbsent` (a
+/// broken Secret Service) degrades quietly here; `auth status` and
+/// `auth login` still report it loudly. Every other error variant warns
+/// (each caller reads at most once per process, so at most one warning
+/// per caller): those variants imply a keyring exists and something is
+/// genuinely wrong, so staying quiet would silently downgrade a
+/// logged-in user to unauthenticated requests. The true no-entry case (a
+/// reachable backend with nothing stored) is quiet, because it is not an
+/// error at all. A locked/denied backend additionally names the unlock
+/// and `SYSAND_CRED_*` remediations.
 /// Degrading (rather than aborting the whole operation) matches
 /// design/credential-storage.md section 9: the request itself may still
 /// succeed via env credentials or anonymously, and hard failure is
@@ -917,7 +923,7 @@ fn read_stored_bearer_map<B: BlobBackend>(store: &LockedBlobStore<B>) -> GlobMap
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
-            log::warn!(
+            log::debug!(
                 "no OS keyring backend ({source}); \
                  using `SYSAND_CRED_*` credentials only"
             );

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -14,7 +14,8 @@ use reqwest::{Response, StatusCode, header};
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
 
 use crate::credential_store::{
-    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
+    CredentialRecord, CredentialScheme, CredentialStoreError,
+    keyring_store::{BlobBackend, LockedBlobStore},
 };
 
 pub trait HTTPAuthentication: std::fmt::Debug + 'static {
@@ -754,8 +755,9 @@ impl StoredBearerAuth {
     }
 }
 
-/// Authentication layer that consults a persistent [`CredentialStore`] on
-/// demand (design/credential-storage.md, section 9).
+/// Authentication layer that consults the persistent credential store
+/// ([`LockedBlobStore`]) on demand (design/credential-storage.md,
+/// section 9).
 ///
 /// `inner` (the eager `SYSAND_CRED_*` env policy) runs first. Only when it
 /// ends in a 4xx is the credential store read, at most once per process
@@ -781,11 +783,11 @@ impl StoredBearerAuth {
 /// [`RestrictAuthentication`], a same-host redirect target is not
 /// re-checked against the stored globs (reqwest forwards the header there)
 /// and a cross-host redirect strips it.
-pub struct CredentialStoreAuthentication<Inner, S> {
+pub struct CredentialStoreAuthentication<Inner, B> {
     inner: Inner,
     /// `None` when no store is available (for example, opening the default
     /// OS keyring store failed); behaves as an always-empty store.
-    store: Option<Arc<S>>,
+    store: Option<Arc<LockedBlobStore<B>>>,
     /// Stored bearer credentials, read lazily. A `tokio` `OnceCell` (not a
     /// sync `OnceLock`) so concurrent first requests (the resolve path
     /// fans out with `join_all`) share a single read: at most one keychain
@@ -794,11 +796,11 @@ pub struct CredentialStoreAuthentication<Inner, S> {
 }
 
 /// Standard composed policy: eager `SYSAND_CRED_*` credentials first, then
-/// lazily read stored credentials from `S`.
-pub type StandardLazyHTTPAuthentication<S> =
-    CredentialStoreAuthentication<StandardHTTPAuthentication, S>;
+/// lazily read stored credentials from a [`LockedBlobStore`] over `B`.
+pub type StandardLazyHTTPAuthentication<B> =
+    CredentialStoreAuthentication<StandardHTTPAuthentication, B>;
 
-impl<Inner, S> std::fmt::Debug for CredentialStoreAuthentication<Inner, S>
+impl<Inner, B> std::fmt::Debug for CredentialStoreAuthentication<Inner, B>
 where
     Inner: std::fmt::Debug,
 {
@@ -814,11 +816,11 @@ where
     }
 }
 
-impl<Inner, S> CredentialStoreAuthentication<Inner, S>
+impl<Inner, B> CredentialStoreAuthentication<Inner, B>
 where
-    S: CredentialStore + Send + Sync + 'static,
+    B: BlobBackend + Send + Sync + 'static,
 {
-    pub fn new(inner: Inner, store: S) -> Self {
+    pub fn new(inner: Inner, store: LockedBlobStore<B>) -> Self {
         CredentialStoreAuthentication {
             inner,
             store: Some(Arc::new(store)),
@@ -833,6 +835,19 @@ where
             inner,
             store: None,
             cache: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// A policy over an already-read snapshot of the store's records: the
+    /// cache is seeded from `records` and no store is ever touched. For
+    /// hosts that read the store once and share the snapshot between this
+    /// policy and their own credential selection (`auth whoami`'s
+    /// single-read guarantee).
+    pub fn preloaded(inner: Inner, records: &[CredentialRecord]) -> Self {
+        CredentialStoreAuthentication {
+            inner,
+            store: None,
+            cache: tokio::sync::OnceCell::new_with(Some(stored_bearer_map_from_records(records))),
         }
     }
 
@@ -898,7 +913,7 @@ where
 /// design/credential-storage.md section 9: the request itself may still
 /// succeed via env credentials or anonymously, and hard failure is
 /// reserved for the `auth` commands.
-fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<StoredBearerAuth> {
+fn read_stored_bearer_map<B: BlobBackend>(store: &LockedBlobStore<B>) -> GlobMap<StoredBearerAuth> {
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
@@ -969,10 +984,10 @@ pub(crate) fn stored_bearer_map_from_records(
     }
 }
 
-impl<Inner, S> HTTPAuthentication for CredentialStoreAuthentication<Inner, S>
+impl<Inner, B> HTTPAuthentication for CredentialStoreAuthentication<Inner, B>
 where
     Inner: HTTPAuthentication,
-    S: CredentialStore + Send + Sync + 'static,
+    B: BlobBackend + Send + Sync + 'static,
 {
     async fn request_with_authentication<F>(
         &self,

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -80,9 +80,8 @@ pub struct ForceHTTPBasicAuth {
     pub password: Box<str>,
 }
 
-// Hand-written so the password is never rendered, matching the redaction
-// on `ForceBearerAuth`. Both are secret-bearing leaves reachable through a
-// composed policy's `Debug`, so both must redact.
+// Hand-written so the password is never rendered; secret-bearing leaves
+// must redact in `Debug` (see `ForceBearerAuth`).
 impl std::fmt::Debug for ForceHTTPBasicAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ForceHTTPBasicAuth")
@@ -123,9 +122,8 @@ impl HTTPAuthentication for ForceHTTPBasicAuth {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ForceBearerAuth(Box<str>);
 
-// Hand-written so the token is never rendered. This is the single
-// secret-bearing leaf: redacting it here keeps every wrapper's `Debug`
-// (and any accidental `{:?}` on a composed policy) from leaking the token.
+// Hand-written so the token is never rendered: redacting the leaf keeps
+// every wrapper's `Debug` from leaking it.
 impl std::fmt::Debug for ForceBearerAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ForceBearerAuth")
@@ -139,10 +137,9 @@ impl ForceBearerAuth {
         Self(token.as_ref().into())
     }
 
-    /// The raw token, for callers that send the credential outside a
-    /// policy chain (the `auth whoami` probe). Crate-private so the
-    /// secret never leaks into the public API; gated like
-    /// `commands::auth`, its only consumer.
+    /// The raw token, for the `auth whoami` probe. Crate-private so the
+    /// secret stays out of the public API; gated like `commands::auth`,
+    /// its only consumer.
     #[cfg(all(feature = "filesystem", feature = "networking"))]
     pub(crate) fn token(&self) -> &str {
         &self.0
@@ -305,10 +302,9 @@ impl<T> GlobMap<T> {
         } else if outcome.len() == 1 {
             GlobMapResult::Found(key.to_owned(), &self.values[outcome[0]])
         } else {
-            // globset returns matched indices in ascending order, so walk one
-            // iterator forward, advancing by the gap since the previous index
-            // (`nth` consumes) rather than indexing the values repeatedly
-            // (which `lookup_mut` cannot do: the vec is borrowed mutably).
+            // Indices are ascending; walk one iterator forward by gaps
+            // (`nth` consumes) to match `lookup_mut`, which cannot index
+            // a mutably borrowed vec repeatedly.
             let mut result = Vec::with_capacity(outcome.len());
             let mut values_iter = self.values.iter();
 
@@ -329,10 +325,7 @@ impl<T> GlobMap<T> {
         } else if outcome.len() == 1 {
             GlobMapResultMut::Found(key.to_owned(), &mut self.values[outcome[0]])
         } else {
-            // globset returns matched indices in ascending order, so walk one
-            // iterator forward, advancing by the gap since the previous index
-            // (`nth` consumes) rather than indexing the values repeatedly
-            // (which `lookup_mut` cannot do: the vec is borrowed mutably).
+            // Same gap-walk as `lookup`, forced here by the mutable borrow.
             let mut result = Vec::with_capacity(outcome.len());
             let mut mut_values_iter = self.values.iter_mut();
 
@@ -374,12 +367,10 @@ pub(crate) enum BearerSelection<'a, T> {
 
 /// Select the bearer credential(s) for `url` from one source's map.
 ///
-/// One credential commonly covers several (normally non-overlapping) URL
-/// patterns with the same token, so several patterns matching is a real
-/// ambiguity only between *distinct* tokens; `token` extracts the token
-/// to compare. How ambiguity is handled stays with the caller: publish
-/// and whoami refuse it, the runtime read path tries each candidate in
-/// order (design/credential-storage.md section 8).
+/// Several matching patterns are a real ambiguity only between *distinct*
+/// tokens (`token` extracts them to compare). Handling stays with the
+/// caller: publish and whoami refuse ambiguity, the runtime read path
+/// tries each candidate (design/credential-storage.md section 8).
 pub(crate) fn select_bearer<'a, T>(
     map: &'a GlobMap<T>,
     url: &str,
@@ -556,8 +547,8 @@ pub struct EnvBearerAuth {
 
 impl std::fmt::Debug for EnvBearerAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // The token is already redacted by `ForceBearerAuth`'s `Debug`;
-        // hand-written only to show just the non-secret label.
+        // Shows only the non-secret label; the token is redacted by
+        // `ForceBearerAuth`'s `Debug`.
         f.debug_struct("EnvBearerAuth")
             .field("label", &self.label)
             .finish_non_exhaustive()
@@ -571,12 +562,9 @@ impl StandardHTTPAuthentication {
     pub fn publish_bearer_auth_map(&self) -> Result<GlobMap<EnvBearerAuth>, globset::Error> {
         let mut partial = GlobMapBuilder::new();
 
-        // `GlobMap` stores keys and values in parallel vectors. This clones the bearer
-        // tokens into the publish-only map; an earlier version consumed `self` to move
-        // them without cloning, but the lazy credential auth layer
-        // (`CredentialStoreAuthentication`) holding this policy is not `Clone`, so
-        // extraction must work by reference (see design/credential-storage.md,
-        // section 9, which accepts the secret clones as the cost of that layer).
+        // Clones the bearer tokens: extraction must work by reference
+        // because the lazy layer holding this policy is not `Clone`
+        // (design/credential-storage.md section 9 accepts the cost).
         for (key, sequence_auth) in self.restricted.keys.iter().zip(&self.restricted.values) {
             if let StandardInnerAuthentication::BearerAuth { auth, env_label } =
                 &sequence_auth.lower
@@ -666,11 +654,10 @@ impl StandardHTTPAuthenticationBuilder {
     }
 }
 
-/// One stored credential as loaded into the lazy credential map: the bearer
-/// token plus the non-secret record fields runtime messages need
-/// (design/credential-storage.md sections 7 and 9): the index key names
-/// the login in hints, and `expires_at` drives the reactive expiry hint
-/// and publish's fail-fast check.
+/// One stored credential as loaded into the lazy credential map: the
+/// bearer token plus the non-secret fields runtime messages need (the key
+/// for hints, `expires_at` for the expiry hint and publish's fail-fast
+/// check).
 #[derive(Clone)]
 pub struct StoredBearerAuth {
     auth: ForceBearerAuth,
@@ -685,9 +672,8 @@ pub struct StoredBearerAuth {
 
 impl std::fmt::Debug for StoredBearerAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // The token is already redacted by `ForceBearerAuth`'s `Debug`;
-        // hand-written only to show the non-secret record fields and drop
-        // the `expiry_warned` `Arc` noise.
+        // Shows only the non-secret record fields; the token is redacted
+        // by `ForceBearerAuth`'s `Debug`.
         f.debug_struct("StoredBearerAuth")
             .field("key", &self.key)
             .field("expires_at", &self.expires_at)
@@ -759,30 +745,17 @@ impl StoredBearerAuth {
 /// ([`LockedBlobStore`]) on demand (design/credential-storage.md,
 /// section 9).
 ///
-/// `inner` (the eager `SYSAND_CRED_*` env policy) runs first. Only when it
-/// ends in a 4xx is the credential store read, at most once per process
-/// (cached), and then:
+/// `inner` (the eager `SYSAND_CRED_*` env policy) runs first; only a 4xx
+/// triggers a store read (cached, at most once per process). Not a stock
+/// [`SequenceAuthentication`]: with no matching record the inner response
+/// is returned with no extra request, whereas a sequence's lower arm would
+/// re-issue on every ordinary 404, doubling round-trips for logged-in
+/// users. A matching record gets a *forced* [`ForceBearerAuth`] retry (v1
+/// stores bearer only). Any 4xx escalates (GitLab-style hosts answer 404
+/// on bad auth) except 429: rate limiting is not an auth verdict.
 ///
-/// - with no stored record matching the request URL, the inner response is
-///   returned untouched, so a routine 404 on the resolve path costs no
-///   extra request. This is why this is not a stock
-///   [`SequenceAuthentication`]: its lower arm cannot see the higher arm's
-///   response and would re-issue an identical request on every ordinary
-///   404, permanently doubling round-trips for logged-in users;
-/// - with a matching record, a *forced* authenticated retry is sent.
-///   v1 stores bearer credentials only ([`CredentialScheme`]), so the
-///   retry is always [`ForceBearerAuth`].
-///
-/// Escalation triggers on *any* 4xx (not just 401/403) because some hosts
-/// (GitLab) answer 404 on missing or under-scoped auth. A 429 is exempt:
-/// rate limiting is not an auth verdict, so it is returned as-is with no
-/// store read. Requests that succeed unauthenticated, and non-4xx
-/// failures, never touch the store.
-///
-/// The store lookup uses the initial request URL. As with
-/// [`RestrictAuthentication`], a same-host redirect target is not
-/// re-checked against the stored globs (reqwest forwards the header there)
-/// and a cross-host redirect strips it.
+/// The store lookup uses the initial request URL; as with
+/// [`RestrictAuthentication`], redirect targets are not re-checked.
 pub struct CredentialStoreAuthentication<Inner, B> {
     inner: Inner,
     /// `None` when no store is available (for example, opening the default
@@ -805,9 +778,8 @@ where
     Inner: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Hand-written to show `has_store`/`cache_read` rather than the
-        // cache contents; the stored tokens it holds are already redacted
-        // by `ForceBearerAuth`'s `Debug`.
+        // Shows `has_store`/`cache_read` rather than the cache contents;
+        // stored tokens are redacted by `ForceBearerAuth`'s `Debug`.
         f.debug_struct("CredentialStoreAuthentication")
             .field("inner", &self.inner)
             .field("has_store", &self.store.is_some())
@@ -864,12 +836,9 @@ where
                 let Some(store) = self.store.clone() else {
                     return GlobMap::default();
                 };
-                // The keyring crate is synchronous: a locked Linux Secret
-                // Service can block on an unlock prompt and the store's
-                // cross-process lock has a bounded (seconds-long) wait, so
-                // the read runs on the blocking pool instead of stalling
-                // sibling futures on the async worker. The blob is tiny
-                // and this runs at most once per process.
+                // The keyring crate is synchronous and can block for
+                // seconds (unlock prompt, cross-process lock), so the
+                // once-per-process read runs on the blocking pool.
                 match tokio::task::spawn_blocking(move || read_stored_bearer_map(&*store)).await {
                     Ok(map) => map,
                     Err(err) => {
@@ -885,11 +854,9 @@ where
     }
 
     /// One direct store read for callers outside the async runtime
-    /// (publish's credential selection, which runs at most once per
-    /// process). Bypasses the request path's cache entirely: exactly one
-    /// backend read per call, with store errors degrading to an empty map
-    /// under [`read_stored_bearer_map`]'s warning semantics. With no store
-    /// available this is the empty map.
+    /// (publish's credential selection). Bypasses the request path's
+    /// cache; errors degrade to an empty map under
+    /// [`read_stored_bearer_map`]'s warning semantics.
     pub fn read_stored_bearer_map_direct(&self) -> GlobMap<StoredBearerAuth> {
         match &self.store {
             None => GlobMap::default(),
@@ -900,25 +867,14 @@ where
 
 /// Read all stored records and build the URL-glob to bearer map.
 ///
-/// Store errors degrade to "no stored credentials". `BackendAbsent` is
-/// logged at debug only: it is the designed env-fallback state on hosts
-/// with no keyring (CI, musl, headless), where any 4xx on the request
-/// path would otherwise print a keyring warning to users who never asked
-/// for credentials. The cost, accepted deliberately, is that a
-/// present-but-malfunctioning backend that maps to `BackendAbsent` (a
-/// broken Secret Service) degrades quietly here; `auth status` and
-/// `auth login` still report it loudly. Every other error variant warns
-/// (each caller reads at most once per process, so at most one warning
-/// per caller): those variants imply a keyring exists and something is
-/// genuinely wrong, so staying quiet would silently downgrade a
-/// logged-in user to unauthenticated requests. The true no-entry case (a
-/// reachable backend with nothing stored) is quiet, because it is not an
-/// error at all. A locked/denied backend additionally names the unlock
-/// and `SYSAND_CRED_*` remediations.
-/// Degrading (rather than aborting the whole operation) matches
-/// design/credential-storage.md section 9: the request itself may still
-/// succeed via env credentials or anonymously, and hard failure is
-/// reserved for the `auth` commands.
+/// Store errors degrade to "no stored credentials" rather than aborting:
+/// the request may still succeed via env credentials or anonymously, and
+/// hard failure is reserved for the `auth` commands
+/// (design/credential-storage.md section 9). `BackendAbsent` is debug-only
+/// (the designed env-fallback state on keyring-less hosts; `auth status`
+/// and `auth login` still report it loudly), while every other variant
+/// warns: a keyring exists and something is wrong, so staying quiet would
+/// silently downgrade a logged-in user to unauthenticated requests.
 fn read_stored_bearer_map<B: BlobBackend>(store: &LockedBlobStore<B>) -> GlobMap<StoredBearerAuth> {
     let records = match store.list() {
         Ok(records) => records,
@@ -945,10 +901,6 @@ fn read_stored_bearer_map<B: BlobBackend>(store: &LockedBlobStore<B>) -> GlobMap
 /// Build the URL-glob to bearer map from credential records. Also the
 /// stored-source map for whoami's credential selection, which reads the
 /// records once and shares the snapshot with its discovery policy.
-///
-/// Each glob is validated individually so one invalid pattern skips only
-/// itself, not every stored credential; a whole-map build failure degrades
-/// to "no stored credentials" with a warning rather than aborting.
 pub(crate) fn stored_bearer_map_from_records(
     records: &[CredentialRecord],
 ) -> GlobMap<StoredBearerAuth> {
@@ -1015,23 +967,17 @@ where
             )
             .await?;
 
-        // A 429 is exempt from the escalation: rate limiting is not an
-        // auth verdict (design/credential-storage.md section 5, "429 is
-        // never a verdict"), and a forced retry would both read the store
-        // needlessly and spend more of the rate budget on a host that
-        // just throttled us. The response is returned as-is.
+        // 429 is never an auth verdict (design/credential-storage.md
+        // section 5): no store read, no forced retry.
         let status = initial_response.status();
         if !status.is_client_error() || status == StatusCode::TOO_MANY_REQUESTS {
             return Ok(initial_response);
         }
 
         let stored = self.stored_bearer_map().await;
-        // A single distinct token retries once; genuinely ambiguous matches
-        // try each in order until one yields a non-4xx response
-        // (design/credential-storage.md, section 8), mirroring
-        // `RestrictAuthentication`. If every candidate fails, the first
-        // retry response is returned. The single-match case is this same
-        // path with an empty remainder loop.
+        // Ambiguous matches try each candidate in order until one yields
+        // a non-4xx response, else the first retry response is returned
+        // (design/credential-storage.md section 8).
         let deduped = match select_bearer(stored, url.as_str(), |bearer| &bearer.auth.0) {
             BearerSelection::None => return Ok(initial_response),
             BearerSelection::Unique(bearer) => {

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -10,7 +10,7 @@ use std::sync::{
 
 use chrono::{DateTime, Utc};
 use globset::{GlobBuilder, GlobSetBuilder};
-use reqwest::{Response, header};
+use reqwest::{Response, StatusCode, header};
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
 
 use crate::credential_store::{
@@ -204,9 +204,11 @@ impl<Higher: HTTPAuthentication, Lower: HTTPAuthentication> HTTPAuthentication
             .await?;
 
         // Many servers (e.g. GitLab pages) generate a 404 instead of a 401 or 403 in response
-        // to lack of authentication.
+        // to lack of authentication. A 429 is exempt: rate limiting is not
+        // an auth verdict, and retrying with other credentials would spend
+        // more of the rate budget on a host that just throttled us.
         let status = initial_response.status();
-        if status.is_client_error() {
+        if status.is_client_error() && status != StatusCode::TOO_MANY_REQUESTS {
             log::debug!("higher priority auth request returned status {status}, trying lower");
             self.lower
                 .request_with_authentication(renew_request(&client), renew_request)
@@ -770,8 +772,10 @@ impl StoredBearerAuth {
 ///   retry is always [`ForceBearerAuth`].
 ///
 /// Escalation triggers on *any* 4xx (not just 401/403) because some hosts
-/// (GitLab) answer 404 on missing or under-scoped auth. Requests that
-/// succeed unauthenticated, and non-4xx failures, never touch the store.
+/// (GitLab) answer 404 on missing or under-scoped auth. A 429 is exempt:
+/// rate limiting is not an auth verdict, so it is returned as-is with no
+/// store read. Requests that succeed unauthenticated, and non-4xx
+/// failures, never touch the store.
 ///
 /// The store lookup uses the initial request URL. As with
 /// [`RestrictAuthentication`], a same-host redirect target is not
@@ -865,45 +869,40 @@ where
             .await
     }
 
-    /// Synchronous variant of [`Self::stored_bearer_map`] for callers
-    /// outside the async runtime (publish's credential selection). Shares
-    /// the same once-per-process cache; returns an owned map (cheap: the
-    /// records hold `Arc`s and small strings, and publish calls this once).
-    pub fn stored_bearer_map_blocking(&self) -> GlobMap<StoredBearerAuth> {
-        if let Some(map) = self.cache.get() {
-            return map.clone();
-        }
-        let map = match &self.store {
+    /// One direct store read for callers outside the async runtime
+    /// (publish's credential selection, which runs at most once per
+    /// process). Bypasses the request path's cache entirely: exactly one
+    /// backend read per call, with store errors degrading to an empty map
+    /// under [`read_stored_bearer_map`]'s warning semantics. With no store
+    /// available this is the empty map.
+    pub fn read_stored_bearer_map_direct(&self) -> GlobMap<StoredBearerAuth> {
+        match &self.store {
             None => GlobMap::default(),
             Some(store) => read_stored_bearer_map(store.as_ref()),
-        };
-        // On the current flow this never races the async accessor: publish
-        // resolves its bearer only after discovery's `block_on` has
-        // returned, and the runtime is current-thread, so `set` seeds the
-        // cache for later callers. Should an async `get_or_init` ever be
-        // in flight concurrently (e.g. on a multi-thread runtime), `set`
-        // fails and the locally read map is returned as-is: the cost is
-        // one extra store read, never a panic.
-        let _ = self.cache.set(map.clone());
-        map
+        }
     }
 }
 
 /// Read all stored records and build the URL-glob to bearer map.
 ///
-/// Store errors degrade to "no stored credentials" for this process (the
-/// result is cached, so at most one keychain touch and one warning): an
-/// absent backend is the normal no-keyring case and only logged at debug
-/// level, while a locked/denied backend is warned about with the unlock
-/// and `SYSAND_CRED_*` remediations. Degrading (rather than aborting the
-/// whole operation) matches design/credential-storage.md section 9: the
-/// request itself may still succeed via env credentials or anonymously,
-/// and hard failure is reserved for the `auth` commands.
+/// Store errors degrade to "no stored credentials", and every error
+/// variant is warned about (each caller reads at most once per process,
+/// so at most one warning per caller): the keyring taxonomy cannot tell a
+/// genuinely absent backend from a present-but-malfunctioning one (a
+/// broken Secret Service also maps to `BackendAbsent`), and staying quiet
+/// would silently downgrade a logged-in user to unauthenticated requests.
+/// Only the true no-entry case (a reachable backend with nothing stored)
+/// is quiet, because it is not an error at all. A locked/denied backend
+/// additionally names the unlock and `SYSAND_CRED_*` remediations.
+/// Degrading (rather than aborting the whole operation) matches
+/// design/credential-storage.md section 9: the request itself may still
+/// succeed via env credentials or anonymously, and hard failure is
+/// reserved for the `auth` commands.
 fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<StoredBearerAuth> {
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
-            log::debug!(
+            log::warn!(
                 "no OS keyring backend ({source}); \
                  using `SYSAND_CRED_*` credentials only"
             );
@@ -995,7 +994,13 @@ where
             )
             .await?;
 
-        if !initial_response.status().is_client_error() {
+        // A 429 is exempt from the escalation: rate limiting is not an
+        // auth verdict (design/credential-storage.md section 5, "429 is
+        // never a verdict"), and a forced retry would both read the store
+        // needlessly and spend more of the rate budget on a host that
+        // just throttled us. The response is returned as-is.
+        let status = initial_response.status();
+        if !status.is_client_error() || status == StatusCode::TOO_MANY_REQUESTS {
             return Ok(initial_response);
         }
 

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -71,10 +71,22 @@ impl HTTPAuthentication for Unauthenticated {
 }
 
 /// Authentication policy that *always* sends a username/password pair
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ForceHTTPBasicAuth {
     pub username: Box<str>,
     pub password: Box<str>,
+}
+
+// Hand-written so the password is never rendered, matching the redaction
+// on `ForceBearerAuth`. Both are secret-bearing leaves reachable through a
+// composed policy's `Debug`, so both must redact.
+impl std::fmt::Debug for ForceHTTPBasicAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForceHTTPBasicAuth")
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .finish()
+    }
 }
 
 impl HTTPAuthentication for ForceHTTPBasicAuth {
@@ -288,7 +300,10 @@ impl<T> GlobMap<T> {
         } else if outcome.len() == 1 {
             GlobMapResult::Found(key.to_owned(), &self.values[outcome[0]])
         } else {
-            // Need to do some magic to keep multiple (disjoint) references into a mutable array
+            // globset returns matched indices in ascending order, so walk one
+            // iterator forward, advancing by the gap since the previous index
+            // (`nth` consumes) rather than indexing the values repeatedly
+            // (which `lookup_mut` cannot do: the vec is borrowed mutably).
             let mut result = Vec::with_capacity(outcome.len());
             let mut values_iter = self.values.iter();
 
@@ -309,7 +324,10 @@ impl<T> GlobMap<T> {
         } else if outcome.len() == 1 {
             GlobMapResultMut::Found(key.to_owned(), &mut self.values[outcome[0]])
         } else {
-            // Need to do some magic to keep multiple (disjoint) references into a mutable array
+            // globset returns matched indices in ascending order, so walk one
+            // iterator forward, advancing by the gap since the previous index
+            // (`nth` consumes) rather than indexing the values repeatedly
+            // (which `lookup_mut` cannot do: the vec is borrowed mutably).
             let mut result = Vec::with_capacity(outcome.len());
             let mut mut_values_iter = self.values.iter_mut();
 
@@ -476,8 +494,8 @@ pub struct EnvBearerAuth {
 
 impl std::fmt::Debug for EnvBearerAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Redacts the token (unlike the pre-existing derived `Debug` on
-        // `ForceBearerAuth`): only the non-secret label is shown.
+        // The token is already redacted by `ForceBearerAuth`'s `Debug`;
+        // hand-written only to show just the non-secret label.
         f.debug_struct("EnvBearerAuth")
             .field("label", &self.label)
             .finish_non_exhaustive()
@@ -605,8 +623,9 @@ pub struct StoredBearerAuth {
 
 impl std::fmt::Debug for StoredBearerAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Redacts the token (unlike the pre-existing derived `Debug` on
-        // `ForceBearerAuth`): only non-secret record fields are shown.
+        // The token is already redacted by `ForceBearerAuth`'s `Debug`;
+        // hand-written only to show the non-secret record fields and drop
+        // the `expiry_warned` `Arc` noise.
         f.debug_struct("StoredBearerAuth")
             .field("key", &self.key)
             .field("expires_at", &self.expires_at)
@@ -721,9 +740,9 @@ where
     Inner: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Deliberately redacts the cache: unlike the (pre-existing) derived
-        // `Debug` on the env layer, stored-login secrets never appear in
-        // debug output of this layer.
+        // Hand-written to show `has_store`/`cache_read` rather than the
+        // cache contents; the stored tokens it holds are already redacted
+        // by `ForceBearerAuth`'s `Debug`.
         f.debug_struct("CredentialStoreAuthentication")
             .field("inner", &self.inner)
             .field("has_store", &self.store.is_some())

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -420,16 +420,17 @@ impl StandardHTTPAuthentication {
     /// Extracts the bearer tokens from the configured credential set into a URL-glob map
     /// suitable for driving publish-time credential selection. Basic-auth entries are
     /// dropped, since publish only supports bearer authentication.
-    pub fn try_into_publish_bearer_auth_map(
-        self,
-    ) -> Result<GlobMap<ForceBearerAuth>, globset::Error> {
+    pub fn publish_bearer_auth_map(&self) -> Result<GlobMap<ForceBearerAuth>, globset::Error> {
         let mut partial = GlobMapBuilder::new();
 
-        // `GlobMap` stores keys and values in parallel vectors; consume `self` so we
-        // can move bearer tokens into a publish-only map without cloning secrets.
-        for (key, sequence_auth) in self.restricted.keys.into_iter().zip(self.restricted.values) {
-            if let StandardInnerAuthentication::BearerAuth(inner) = sequence_auth.lower {
-                partial.add(key, inner);
+        // `GlobMap` stores keys and values in parallel vectors. This clones the bearer
+        // tokens into the publish-only map; an earlier version consumed `self` to move
+        // them without cloning, but the upcoming lazy keyring auth layer is not `Clone`,
+        // so extraction must work by reference (see design/credential-storage.md,
+        // section 9, which accepts the secret clones as the cost of that layer).
+        for (key, sequence_auth) in self.restricted.keys.iter().zip(&self.restricted.values) {
+            if let StandardInnerAuthentication::BearerAuth(inner) = &sequence_auth.lower {
+                partial.add(key, inner.clone());
             }
         }
 

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -490,10 +490,9 @@ pub enum StandardInnerAuthentication {
     HTTPBasicAuth(ForceHTTPBasicAuth),
     BearerAuth {
         auth: ForceBearerAuth,
-        /// The `SYSAND_CRED_<LABEL>` stem this bearer came from, when it
-        /// was built from environment variables. Display-only: publish
-        /// auth failures name the variable to fix.
-        env_label: Option<Box<str>>,
+        /// The `SYSAND_CRED_<LABEL>` stem this bearer was built from.
+        /// Display-only: publish auth failures name the variable to fix.
+        env_label: Box<str>,
     },
 }
 
@@ -541,8 +540,8 @@ pub type StandardHTTPAuthentication = RestrictAuthentication<
 #[derive(Clone)]
 pub struct EnvBearerAuth {
     pub auth: ForceBearerAuth,
-    /// The `SYSAND_CRED_<LABEL>` stem, when known.
-    pub label: Option<String>,
+    /// The `SYSAND_CRED_<LABEL>` stem.
+    pub label: String,
 }
 
 impl std::fmt::Debug for EnvBearerAuth {
@@ -562,8 +561,6 @@ impl StandardHTTPAuthentication {
     pub fn publish_bearer_auth_map(&self) -> Result<GlobMap<EnvBearerAuth>, globset::Error> {
         let mut partial = GlobMapBuilder::new();
 
-        // Clones the bearer tokens: extraction must work by reference
-        // because the lazy layer holding this policy is not `Clone`.
         for (key, sequence_auth) in self.restricted.keys.iter().zip(&self.restricted.values) {
             if let StandardInnerAuthentication::BearerAuth { auth, env_label } =
                 &sequence_auth.lower
@@ -572,7 +569,7 @@ impl StandardHTTPAuthentication {
                     key,
                     EnvBearerAuth {
                         auth: auth.clone(),
-                        label: env_label.as_deref().map(str::to_string),
+                        label: env_label.to_string(),
                     },
                 );
             }
@@ -618,27 +615,14 @@ impl StandardHTTPAuthenticationBuilder {
         );
     }
 
-    pub fn add_bearer_auth<S: AsRef<str>, T: AsRef<str>>(&mut self, globstr: S, token: T) {
-        self.push_bearer_auth(globstr, token, None);
-    }
-
-    /// Like [`Self::add_bearer_auth`], additionally recording the
-    /// `SYSAND_CRED_<LABEL>` stem the credential came from, so publish
-    /// auth failures can name the variable to fix.
-    pub fn add_bearer_auth_labeled<S: AsRef<str>, T: AsRef<str>, L: AsRef<str>>(
+    /// Add a bearer credential. `env_label` is the `SYSAND_CRED_<LABEL>`
+    /// stem the credential came from; every env credential has one, and
+    /// publish auth failures name the variable to fix through it.
+    pub fn add_bearer_auth<S: AsRef<str>, T: AsRef<str>, L: AsRef<str>>(
         &mut self,
         globstr: S,
         token: T,
         env_label: L,
-    ) {
-        self.push_bearer_auth(globstr, token, Some(env_label.as_ref().into()));
-    }
-
-    fn push_bearer_auth<S: AsRef<str>, T: AsRef<str>>(
-        &mut self,
-        globstr: S,
-        token: T,
-        env_label: Option<Box<str>>,
     ) {
         self.partial.add(
             globstr,
@@ -646,7 +630,7 @@ impl StandardHTTPAuthenticationBuilder {
                 higher: Unauthenticated {},
                 lower: StandardInnerAuthentication::BearerAuth {
                     auth: ForceBearerAuth::new(token),
-                    env_label,
+                    env_label: env_label.as_ref().into(),
                 },
             },
         );

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -586,7 +586,7 @@ impl StandardHTTPAuthenticationBuilder {
     }
 }
 
-/// One stored login as loaded into the lazy credential map: the bearer
+/// One stored credential as loaded into the lazy credential map: the bearer
 /// token plus the non-secret record fields runtime messages need
 /// (design/credential-storage.md sections 7 and 9): the index key names
 /// the login in hints, and `expires_at` drives the reactive expiry hint
@@ -858,7 +858,7 @@ fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<Sto
         );
         for glob in &record.globs {
             // Validate each glob individually so one invalid pattern skips
-            // only itself, not every stored login.
+            // only itself, not every stored credential.
             if let Err(err) = GlobBuilder::new(glob).literal_separator(true).build() {
                 log::warn!(
                     "ignoring invalid stored credential URL pattern `{glob}` for `{}`: {err}",
@@ -917,7 +917,7 @@ where
             GlobMapResult::Ambiguous(items) => items.into_iter().map(|(_, auth)| auth).collect(),
         };
 
-        // One stored login covers several (normally non-overlapping) URL
+        // One stored credential covers several (normally non-overlapping) URL
         // patterns with the same token, so several patterns matching is a
         // real ambiguity only between *distinct* tokens. Records with
         // identical tokens collapse to the first record, so a hint after

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -3,9 +3,13 @@
 
 //! This module includes utilities for creating and using authentication policies for requests.
 
+use std::sync::Arc;
+
 use globset::{GlobBuilder, GlobSetBuilder};
 use reqwest::{Response, header};
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
+
+use crate::credential_store::{CredentialScheme, CredentialStore, CredentialStoreError};
 
 pub trait HTTPAuthentication: std::fmt::Debug + 'static {
     /// Tries to execute a request with some authentication policy. The request might be retried
@@ -438,8 +442,9 @@ impl StandardHTTPAuthentication {
 
         // `GlobMap` stores keys and values in parallel vectors. This clones the bearer
         // tokens into the publish-only map; an earlier version consumed `self` to move
-        // them without cloning, but the upcoming lazy keyring auth layer is not `Clone`,
-        // so extraction must work by reference (see design/credential-storage.md,
+        // them without cloning, but the lazy credential auth layer
+        // (`CredentialStoreAuthentication`) holding this policy is not `Clone`, so
+        // extraction must work by reference (see design/credential-storage.md,
         // section 9, which accepts the secret clones as the cost of that layer).
         for (key, sequence_auth) in self.restricted.keys.iter().zip(&self.restricted.values) {
             if let StandardInnerAuthentication::BearerAuth(inner) = &sequence_auth.lower {
@@ -495,6 +500,276 @@ impl StandardHTTPAuthenticationBuilder {
                 lower: StandardInnerAuthentication::BearerAuth(ForceBearerAuth::new(token)),
             },
         );
+    }
+}
+
+/// Authentication layer that consults a persistent [`CredentialStore`] on
+/// demand (design/credential-storage.md, section 9).
+///
+/// `inner` (the eager `SYSAND_CRED_*` env policy) runs first. Only when it
+/// ends in a 4xx is the credential store read, at most once per process
+/// (cached), and then:
+///
+/// - with no stored record matching the request URL, the inner response is
+///   returned untouched, so a routine 404 on the resolve path costs no
+///   extra request. This is why this is not a stock
+///   [`SequenceAuthentication`]: its lower arm cannot see the higher arm's
+///   response and would re-issue an identical request on every ordinary
+///   404, permanently doubling round-trips for logged-in users;
+/// - with a matching record, a *forced* authenticated retry is sent.
+///   v1 stores bearer credentials only ([`CredentialScheme`]), so the
+///   retry is always [`ForceBearerAuth`].
+///
+/// Escalation triggers on *any* 4xx (not just 401/403) because some hosts
+/// (GitLab) answer 404 on missing or under-scoped auth. Requests that
+/// succeed unauthenticated, and non-4xx failures, never touch the store.
+///
+/// The store lookup uses the initial request URL. As with
+/// [`RestrictAuthentication`], a same-host redirect target is not
+/// re-checked against the stored globs (reqwest forwards the header there)
+/// and a cross-host redirect strips it.
+pub struct CredentialStoreAuthentication<Inner, S> {
+    inner: Inner,
+    /// `None` when no store is available (for example, opening the default
+    /// OS keyring store failed); behaves as an always-empty store.
+    store: Option<Arc<S>>,
+    /// Stored bearer credentials, read lazily. A `tokio` `OnceCell` (not a
+    /// sync `OnceLock`) so concurrent first requests (the resolve path
+    /// fans out with `join_all`) share a single read: at most one keychain
+    /// touch per process.
+    cache: tokio::sync::OnceCell<GlobMap<ForceBearerAuth>>,
+}
+
+/// Standard composed policy: eager `SYSAND_CRED_*` credentials first, then
+/// lazily read stored credentials from `S`.
+pub type StandardLazyHTTPAuthentication<S> =
+    CredentialStoreAuthentication<StandardHTTPAuthentication, S>;
+
+impl<Inner, S> std::fmt::Debug for CredentialStoreAuthentication<Inner, S>
+where
+    Inner: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately redacts the cache: unlike the (pre-existing) derived
+        // `Debug` on the env layer, stored-login secrets never appear in
+        // debug output of this layer.
+        f.debug_struct("CredentialStoreAuthentication")
+            .field("inner", &self.inner)
+            .field("has_store", &self.store.is_some())
+            .field("cache_read", &self.cache.get().is_some())
+            .finish()
+    }
+}
+
+impl<Inner, S> CredentialStoreAuthentication<Inner, S>
+where
+    S: CredentialStore + Send + Sync + 'static,
+{
+    pub fn new(inner: Inner, store: S) -> Self {
+        CredentialStoreAuthentication {
+            inner,
+            store: Some(Arc::new(store)),
+            cache: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// A policy with no credential store: only `inner` ever answers.
+    /// For hosts where opening the store failed.
+    pub fn without_store(inner: Inner) -> Self {
+        CredentialStoreAuthentication {
+            inner,
+            store: None,
+            cache: tokio::sync::OnceCell::new(),
+        }
+    }
+
+    /// The eager env-credential policy this layer wraps. Publish extracts
+    /// its bearer map from here without touching the store.
+    pub fn env_policy(&self) -> &Inner {
+        &self.inner
+    }
+
+    /// The stored bearer credentials, read and cached on first use.
+    pub async fn stored_bearer_map(&self) -> &GlobMap<ForceBearerAuth> {
+        self.cache
+            .get_or_init(|| async {
+                let Some(store) = self.store.clone() else {
+                    return GlobMap::default();
+                };
+                // The keyring crate is synchronous: a locked Linux Secret
+                // Service can block on an unlock prompt and the store's
+                // cross-process lock has a bounded (seconds-long) wait, so
+                // the read runs on the blocking pool instead of stalling
+                // sibling futures on the async worker. The blob is tiny
+                // and this runs at most once per process.
+                match tokio::task::spawn_blocking(move || read_stored_bearer_map(&*store)).await {
+                    Ok(map) => map,
+                    Err(err) => {
+                        log::warn!(
+                            "credential store read failed: {err}; \
+                             continuing without stored credentials"
+                        );
+                        GlobMap::default()
+                    }
+                }
+            })
+            .await
+    }
+
+    /// Synchronous variant of [`Self::stored_bearer_map`] for callers
+    /// outside the async runtime (publish's credential selection). Shares
+    /// the same once-per-process cache.
+    pub fn stored_bearer_map_blocking(&self) -> &GlobMap<ForceBearerAuth> {
+        if let Some(map) = self.cache.get() {
+            return map;
+        }
+        let map = match &self.store {
+            None => GlobMap::default(),
+            Some(store) => read_stored_bearer_map(store.as_ref()),
+        };
+        // `set` fails only if a concurrent initialization won; either way
+        // the cell holds a value now.
+        let _ = self.cache.set(map);
+        self.cache.get().expect("cache was just initialized")
+    }
+}
+
+/// Read all stored records and build the URL-glob to bearer map.
+///
+/// Store errors degrade to "no stored credentials" for this process (the
+/// result is cached, so at most one keychain touch and one warning): an
+/// absent backend is the normal no-keyring case and only logged at debug
+/// level, while a locked/denied backend is warned about with the unlock
+/// and `SYSAND_CRED_*` remediations. Degrading (rather than aborting the
+/// whole operation) matches design/credential-storage.md section 9: the
+/// request itself may still succeed via env credentials or anonymously,
+/// and hard failure is reserved for the `auth` commands.
+fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<ForceBearerAuth> {
+    let records = match store.list() {
+        Ok(records) => records,
+        Err(CredentialStoreError::BackendAbsent { source }) => {
+            log::debug!(
+                "no OS keyring backend ({source}); \
+                 using `SYSAND_CRED_*` credentials only"
+            );
+            return GlobMap::default();
+        }
+        Err(err) => {
+            log::warn!(
+                "could not read stored credentials: {err}; \
+                 unlock your OS keyring, or provide credentials via \
+                 `SYSAND_CRED_*` environment variables; \
+                 continuing without stored credentials"
+            );
+            return GlobMap::default();
+        }
+    };
+
+    let mut builder = GlobMapBuilder::new();
+    for record in records {
+        // Exhaustive on purpose: adding a scheme must revisit this map.
+        match record.scheme {
+            CredentialScheme::Bearer => {}
+        }
+        let auth = ForceBearerAuth::new(&record.secret);
+        for glob in &record.globs {
+            // Validate each glob individually so one invalid pattern skips
+            // only itself, not every stored login.
+            if let Err(err) = GlobBuilder::new(glob).literal_separator(true).build() {
+                log::warn!(
+                    "ignoring invalid stored credential URL pattern `{glob}` for `{}`: {err}",
+                    record.key
+                );
+                continue;
+            }
+            builder.add(glob, auth.clone());
+        }
+    }
+    match builder.build() {
+        Ok(map) => map,
+        Err(err) => {
+            log::warn!(
+                "could not build stored credential URL patterns: {err}; \
+                 continuing without stored credentials"
+            );
+            GlobMap::default()
+        }
+    }
+}
+
+impl<Inner, S> HTTPAuthentication for CredentialStoreAuthentication<Inner, S>
+where
+    Inner: HTTPAuthentication,
+    S: CredentialStore + Send + Sync + 'static,
+{
+    async fn request_with_authentication<F>(
+        &self,
+        request: RequestBuilder,
+        renew_request: &F,
+    ) -> Result<Response, reqwest_middleware::Error>
+    where
+        F: Fn(&ClientWithMiddleware) -> RequestBuilder + 'static,
+    {
+        let (client, current_request_result) = request.build_split();
+        let current_request = current_request_result?;
+        let url = current_request.url().clone();
+
+        let initial_response = self
+            .inner
+            .request_with_authentication(
+                RequestBuilder::from_parts(client.clone(), current_request),
+                renew_request,
+            )
+            .await?;
+
+        if !initial_response.status().is_client_error() {
+            return Ok(initial_response);
+        }
+
+        let stored = self.stored_bearer_map().await;
+        let candidates = match stored.lookup(url.as_str()) {
+            GlobMapResult::NotFound => return Ok(initial_response),
+            GlobMapResult::Found(_, auth) => vec![auth],
+            GlobMapResult::Ambiguous(items) => items.into_iter().map(|(_, auth)| auth).collect(),
+        };
+
+        // One stored login covers several (normally non-overlapping) URL
+        // patterns with the same token, so several patterns matching is a
+        // real ambiguity only between *distinct* tokens.
+        let mut deduped: Vec<&ForceBearerAuth> = Vec::new();
+        for auth in candidates {
+            if !deduped.iter().any(|seen| seen.0 == auth.0) {
+                deduped.push(auth);
+            }
+        }
+
+        let mut deduped = deduped.into_iter();
+        let first_auth = deduped.next().expect("lookup produced no candidates");
+        if deduped.len() == 0 {
+            log::debug!("stored credential matches `{url}`; retrying with forced bearer auth");
+            return first_auth
+                .request_with_authentication(renew_request(&client), renew_request)
+                .await;
+        }
+
+        // Genuinely ambiguous: reads try all matches, in order, until one
+        // yields a non-4xx response (design/credential-storage.md, section
+        // 8), mirroring `RestrictAuthentication`. If every candidate
+        // fails, the first retry response is returned.
+        log::warn!("URL {url} matches multiple stored credentials; trying each in order");
+        let first_response = first_auth
+            .request_with_authentication(renew_request(&client), renew_request)
+            .await?;
+        if !first_response.status().is_client_error() {
+            return Ok(first_response);
+        }
+        for auth in deduped {
+            let response = auth.with_authentication(&client, renew_request).await?;
+            if !response.status().is_client_error() {
+                return Ok(response);
+            }
+        }
+        Ok(first_response)
     }
 }
 

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -345,8 +345,7 @@ impl<T> GlobMap<T> {
 
 /// What credential selection found in one source's bearer map for a URL.
 /// Shared by the runtime read retry, whoami, and publish so the collapse
-/// and ambiguity semantics are written once
-/// (design/credential-storage.md section 8).
+/// and ambiguity semantics are written once.
 #[derive(Debug)]
 pub(crate) enum BearerSelection<'a, T> {
     /// No matching pattern: the caller falls through to its next source.
@@ -370,7 +369,7 @@ pub(crate) enum BearerSelection<'a, T> {
 /// Several matching patterns are a real ambiguity only between *distinct*
 /// tokens (`token` extracts them to compare). Handling stays with the
 /// caller: publish and whoami refuse ambiguity, the runtime read path
-/// tries each candidate (design/credential-storage.md section 8).
+/// tries each candidate.
 pub(crate) fn select_bearer<'a, T>(
     map: &'a GlobMap<T>,
     url: &str,
@@ -490,8 +489,7 @@ pub enum StandardInnerAuthentication {
         auth: ForceBearerAuth,
         /// The `SYSAND_CRED_<LABEL>` stem this bearer came from, when it
         /// was built from environment variables. Display-only: publish
-        /// auth failures name the variable to fix
-        /// (design/credential-storage.md section 7).
+        /// auth failures name the variable to fix.
         env_label: Option<Box<str>>,
     },
 }
@@ -536,8 +534,7 @@ pub type StandardHTTPAuthentication = RestrictAuthentication<
 
 /// One environment-sourced bearer credential as extracted for publish:
 /// the token plus the `SYSAND_CRED_<LABEL>` stem it came from, so an
-/// upload auth failure can name the variable to fix
-/// (design/credential-storage.md section 7).
+/// upload auth failure can name the variable to fix.
 #[derive(Clone)]
 pub struct EnvBearerAuth {
     pub auth: ForceBearerAuth,
@@ -563,8 +560,7 @@ impl StandardHTTPAuthentication {
         let mut partial = GlobMapBuilder::new();
 
         // Clones the bearer tokens: extraction must work by reference
-        // because the lazy layer holding this policy is not `Clone`
-        // (design/credential-storage.md section 9 accepts the cost).
+        // because the lazy layer holding this policy is not `Clone`.
         for (key, sequence_auth) in self.restricted.keys.iter().zip(&self.restricted.values) {
             if let StandardInnerAuthentication::BearerAuth { auth, env_label } =
                 &sequence_auth.lower
@@ -711,8 +707,7 @@ impl StoredBearerAuth {
         self.expires_at
     }
 
-    /// The reactive expiry hint (design/credential-storage.md section 9),
-    /// returned at most once per record: `Some` exactly when the record
+    /// The reactive expiry hint, returned at most once per record: `Some` exactly when the record
     /// carries a past `expires_at` and no hint was emitted before.
     fn take_expiry_warning(&self, now: DateTime<Utc>) -> Option<String> {
         let expires_at = self.expires_at?;
@@ -728,7 +723,7 @@ impl StoredBearerAuth {
 
     /// Emit the reactive expiry hint after a forced retry that still
     /// ended in a 4xx. Any 4xx counts, not just 401: GitLab-style hosts
-    /// answer 404 on bad auth (design/credential-storage.md section 9).
+    /// answer 404 on bad auth.
     fn warn_if_expired(&self) {
         if let Some(message) = self.take_expiry_warning(Utc::now()) {
             log::warn!("{message}");
@@ -742,8 +737,7 @@ impl StoredBearerAuth {
 }
 
 /// Authentication layer that consults the persistent credential store
-/// ([`LockedBlobStore`]) on demand (design/credential-storage.md,
-/// section 9).
+/// ([`LockedBlobStore`]) on demand.
 ///
 /// `inner` (the eager `SYSAND_CRED_*` env policy) runs first; only a 4xx
 /// triggers a store read (cached, at most once per process). Not a stock
@@ -869,8 +863,8 @@ where
 ///
 /// Store errors degrade to "no stored credentials" rather than aborting:
 /// the request may still succeed via env credentials or anonymously, and
-/// hard failure is reserved for the `auth` commands
-/// (design/credential-storage.md section 9). `BackendAbsent` is debug-only
+/// hard failure is reserved for the `auth` commands.
+/// `BackendAbsent` is debug-only
 /// (the designed env-fallback state on keyring-less hosts; `auth status`
 /// and `auth login` still report it loudly), while every other variant
 /// warns: a keyring exists and something is wrong, so staying quiet would
@@ -967,8 +961,7 @@ where
             )
             .await?;
 
-        // 429 is never an auth verdict (design/credential-storage.md
-        // section 5): no store read, no forced retry.
+        // 429 is never an auth verdict: no store read, no forced retry.
         let status = initial_response.status();
         if !status.is_client_error() || status == StatusCode::TOO_MANY_REQUESTS {
             return Ok(initial_response);
@@ -976,8 +969,7 @@ where
 
         let stored = self.stored_bearer_map().await;
         // Ambiguous matches try each candidate in order until one yields
-        // a non-4xx response, else the first retry response is returned
-        // (design/credential-storage.md section 8).
+        // a non-4xx response, else the first retry response is returned.
         let deduped = match select_bearer(stored, url.as_str(), |bearer| &bearer.auth.0) {
             BearerSelection::None => return Ok(initial_response),
             BearerSelection::Unique(bearer) => {

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -650,6 +650,8 @@ pub struct StoredBearerAuth {
     /// record. `Arc`d so the flag is shared across the record's globs and
     /// across map clones: together with the once-per-process map cache
     /// this gives at most one warning per record per process.
+    /// (credential expiry is checked for every request that escalates to it,
+    /// so it can happen multiple times for a single credential)
     expiry_warned: Arc<AtomicBool>,
 }
 

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -97,6 +97,7 @@ impl HTTPAuthentication for ForceHTTPBasicAuth {
 
 /// Authentication policy that *always* includes a bearer token
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ForceBearerAuth(Box<str>);
 
 impl ForceBearerAuth {
@@ -185,6 +186,18 @@ pub struct GlobMap<T> {
     keys: Vec<String>,
     values: Vec<T>,
     globset: globset::GlobSet,
+}
+
+impl<T> Default for GlobMap<T> {
+    /// An empty map: every lookup is `NotFound`. Unlike `GlobMapBuilder::build`,
+    /// constructing the empty map cannot fail.
+    fn default() -> Self {
+        GlobMap {
+            keys: vec![],
+            values: vec![],
+            globset: globset::GlobSet::empty(),
+        }
+    }
 }
 
 impl<T> Default for GlobMapBuilder<T> {

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -359,6 +359,9 @@ pub(crate) enum BearerSelection<'a, T> {
     /// the distinct-token entries in map order (what try-all consumers
     /// walk); it always holds at least two entries.
     Ambiguous {
+        // Read only by whoami and publish; without `filesystem` those
+        // consumers are compiled out and only `deduped` is used.
+        #[cfg_attr(not(feature = "filesystem"), allow(dead_code))]
         candidates: usize,
         deduped: Vec<&'a T>,
     },

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -3,8 +3,12 @@
 
 //! This module includes utilities for creating and using authentication policies for requests.
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
+use chrono::{DateTime, Utc};
 use globset::{GlobBuilder, GlobSetBuilder};
 use reqwest::{Response, header};
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
@@ -391,7 +395,14 @@ impl<Restricted: HTTPAuthentication, Unrestricted: HTTPAuthentication> HTTPAuthe
 #[derive(Debug, Clone)]
 pub enum StandardInnerAuthentication {
     HTTPBasicAuth(ForceHTTPBasicAuth),
-    BearerAuth(ForceBearerAuth),
+    BearerAuth {
+        auth: ForceBearerAuth,
+        /// The `SYSAND_CRED_<LABEL>` stem this bearer came from, when it
+        /// was built from environment variables. Display-only: publish
+        /// auth failures name the variable to fix
+        /// (design/credential-storage.md section 7).
+        env_label: Option<Box<str>>,
+    },
 }
 
 impl HTTPAuthentication for StandardInnerAuthentication {
@@ -409,9 +420,8 @@ impl HTTPAuthentication for StandardInnerAuthentication {
                     .request_with_authentication(request, renew_request)
                     .await
             }
-            StandardInnerAuthentication::BearerAuth(inner) => {
-                inner
-                    .request_with_authentication(request, renew_request)
+            StandardInnerAuthentication::BearerAuth { auth, .. } => {
+                auth.request_with_authentication(request, renew_request)
                     .await
             }
         }
@@ -433,11 +443,32 @@ pub type StandardHTTPAuthentication = RestrictAuthentication<
     Unauthenticated,
 >;
 
+/// One environment-sourced bearer credential as extracted for publish:
+/// the token plus the `SYSAND_CRED_<LABEL>` stem it came from, so an
+/// upload auth failure can name the variable to fix
+/// (design/credential-storage.md section 7).
+#[derive(Clone)]
+pub struct EnvBearerAuth {
+    pub auth: ForceBearerAuth,
+    /// The `SYSAND_CRED_<LABEL>` stem, when known.
+    pub label: Option<String>,
+}
+
+impl std::fmt::Debug for EnvBearerAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redacts the token (unlike the pre-existing derived `Debug` on
+        // `ForceBearerAuth`): only the non-secret label is shown.
+        f.debug_struct("EnvBearerAuth")
+            .field("label", &self.label)
+            .finish_non_exhaustive()
+    }
+}
+
 impl StandardHTTPAuthentication {
     /// Extracts the bearer tokens from the configured credential set into a URL-glob map
     /// suitable for driving publish-time credential selection. Basic-auth entries are
     /// dropped, since publish only supports bearer authentication.
-    pub fn publish_bearer_auth_map(&self) -> Result<GlobMap<ForceBearerAuth>, globset::Error> {
+    pub fn publish_bearer_auth_map(&self) -> Result<GlobMap<EnvBearerAuth>, globset::Error> {
         let mut partial = GlobMapBuilder::new();
 
         // `GlobMap` stores keys and values in parallel vectors. This clones the bearer
@@ -447,8 +478,16 @@ impl StandardHTTPAuthentication {
         // extraction must work by reference (see design/credential-storage.md,
         // section 9, which accepts the secret clones as the cost of that layer).
         for (key, sequence_auth) in self.restricted.keys.iter().zip(&self.restricted.values) {
-            if let StandardInnerAuthentication::BearerAuth(inner) = &sequence_auth.lower {
-                partial.add(key, inner.clone());
+            if let StandardInnerAuthentication::BearerAuth { auth, env_label } =
+                &sequence_auth.lower
+            {
+                partial.add(
+                    key,
+                    EnvBearerAuth {
+                        auth: auth.clone(),
+                        label: env_label.as_deref().map(str::to_string),
+                    },
+                );
             }
         }
 
@@ -493,13 +532,125 @@ impl StandardHTTPAuthenticationBuilder {
     }
 
     pub fn add_bearer_auth<S: AsRef<str>, T: AsRef<str>>(&mut self, globstr: S, token: T) {
+        self.push_bearer_auth(globstr, token, None);
+    }
+
+    /// Like [`Self::add_bearer_auth`], additionally recording the
+    /// `SYSAND_CRED_<LABEL>` stem the credential came from, so publish
+    /// auth failures can name the variable to fix.
+    pub fn add_bearer_auth_labeled<S: AsRef<str>, T: AsRef<str>, L: AsRef<str>>(
+        &mut self,
+        globstr: S,
+        token: T,
+        env_label: L,
+    ) {
+        self.push_bearer_auth(globstr, token, Some(env_label.as_ref().into()));
+    }
+
+    fn push_bearer_auth<S: AsRef<str>, T: AsRef<str>>(
+        &mut self,
+        globstr: S,
+        token: T,
+        env_label: Option<Box<str>>,
+    ) {
         self.partial.add(
             globstr,
             SequenceAuthentication {
                 higher: Unauthenticated {},
-                lower: StandardInnerAuthentication::BearerAuth(ForceBearerAuth::new(token)),
+                lower: StandardInnerAuthentication::BearerAuth {
+                    auth: ForceBearerAuth::new(token),
+                    env_label,
+                },
             },
         );
+    }
+}
+
+/// One stored login as loaded into the lazy credential map: the bearer
+/// token plus the non-secret record fields runtime messages need
+/// (design/credential-storage.md sections 7 and 9): the index key names
+/// the login in hints, and `expires_at` drives the reactive expiry hint
+/// and publish's fail-fast check.
+#[derive(Clone)]
+pub struct StoredBearerAuth {
+    auth: ForceBearerAuth,
+    key: String,
+    expires_at: Option<DateTime<Utc>>,
+    /// Whether the reactive expiry hint has already been emitted for this
+    /// record. `Arc`d so the flag is shared across the record's globs and
+    /// across map clones: together with the once-per-process map cache
+    /// this gives at most one warning per record per process.
+    expiry_warned: Arc<AtomicBool>,
+}
+
+impl std::fmt::Debug for StoredBearerAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redacts the token (unlike the pre-existing derived `Debug` on
+        // `ForceBearerAuth`): only non-secret record fields are shown.
+        f.debug_struct("StoredBearerAuth")
+            .field("key", &self.key)
+            .field("expires_at", &self.expires_at)
+            .finish_non_exhaustive()
+    }
+}
+
+impl StoredBearerAuth {
+    pub(crate) fn new(
+        auth: ForceBearerAuth,
+        key: String,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Self {
+        StoredBearerAuth {
+            auth,
+            key,
+            expires_at,
+            expiry_warned: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// The forced-retry bearer policy for this login.
+    pub fn auth(&self) -> &ForceBearerAuth {
+        &self.auth
+    }
+
+    /// The normalized index key the login was stored under, in the exact
+    /// form `sysand auth login <key>` accepts.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Expiry, when a validating login learned it.
+    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.expires_at
+    }
+
+    /// The reactive expiry hint (design/credential-storage.md section 9),
+    /// returned at most once per record: `Some` exactly when the record
+    /// carries a past `expires_at` and no hint was emitted before.
+    fn take_expiry_warning(&self, now: DateTime<Utc>) -> Option<String> {
+        let expires_at = self.expires_at?;
+        if expires_at >= now || self.expiry_warned.swap(true, Ordering::SeqCst) {
+            return None;
+        }
+        Some(format!(
+            "credential for `{key}` may be expired or revoked; \
+             re-run `sysand auth login {key}`",
+            key = self.key
+        ))
+    }
+
+    /// Emit the reactive expiry hint after a forced retry that still
+    /// ended in a 4xx. Any 4xx counts, not just 401: GitLab-style hosts
+    /// answer 404 on bad auth (design/credential-storage.md section 9).
+    fn warn_if_expired(&self) {
+        if let Some(message) = self.take_expiry_warning(Utc::now()) {
+            log::warn!("{message}");
+        }
+    }
+
+    #[cfg(test)]
+    fn expiry_warning_emitted(&self) -> bool {
+        self.expiry_warned.load(Ordering::SeqCst)
     }
 }
 
@@ -537,7 +688,7 @@ pub struct CredentialStoreAuthentication<Inner, S> {
     /// sync `OnceLock`) so concurrent first requests (the resolve path
     /// fans out with `join_all`) share a single read: at most one keychain
     /// touch per process.
-    cache: tokio::sync::OnceCell<GlobMap<ForceBearerAuth>>,
+    cache: tokio::sync::OnceCell<GlobMap<StoredBearerAuth>>,
 }
 
 /// Standard composed policy: eager `SYSAND_CRED_*` credentials first, then
@@ -590,7 +741,7 @@ where
     }
 
     /// The stored bearer credentials, read and cached on first use.
-    pub async fn stored_bearer_map(&self) -> &GlobMap<ForceBearerAuth> {
+    pub async fn stored_bearer_map(&self) -> &GlobMap<StoredBearerAuth> {
         self.cache
             .get_or_init(|| async {
                 let Some(store) = self.store.clone() else {
@@ -619,7 +770,7 @@ where
     /// Synchronous variant of [`Self::stored_bearer_map`] for callers
     /// outside the async runtime (publish's credential selection). Shares
     /// the same once-per-process cache.
-    pub fn stored_bearer_map_blocking(&self) -> &GlobMap<ForceBearerAuth> {
+    pub fn stored_bearer_map_blocking(&self) -> &GlobMap<StoredBearerAuth> {
         if let Some(map) = self.cache.get() {
             return map;
         }
@@ -644,7 +795,7 @@ where
 /// whole operation) matches design/credential-storage.md section 9: the
 /// request itself may still succeed via env credentials or anonymously,
 /// and hard failure is reserved for the `auth` commands.
-fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<ForceBearerAuth> {
+fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<StoredBearerAuth> {
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
@@ -671,7 +822,13 @@ fn read_stored_bearer_map<S: CredentialStore + ?Sized>(store: &S) -> GlobMap<For
         match record.scheme {
             CredentialScheme::Bearer => {}
         }
-        let auth = ForceBearerAuth::new(&record.secret);
+        // One `StoredBearerAuth` per record, cloned per glob: the clones
+        // share the record's expiry-warned flag.
+        let auth = StoredBearerAuth::new(
+            ForceBearerAuth::new(&record.secret),
+            record.key.clone(),
+            record.expires_at,
+        );
         for glob in &record.globs {
             // Validate each glob individually so one invalid pattern skips
             // only itself, not every stored login.
@@ -735,21 +892,28 @@ where
 
         // One stored login covers several (normally non-overlapping) URL
         // patterns with the same token, so several patterns matching is a
-        // real ambiguity only between *distinct* tokens.
-        let mut deduped: Vec<&ForceBearerAuth> = Vec::new();
-        for auth in candidates {
-            if !deduped.iter().any(|seen| seen.0 == auth.0) {
-                deduped.push(auth);
+        // real ambiguity only between *distinct* tokens. Records with
+        // identical tokens collapse to the first record, so a hint after
+        // a failed retry names that record's key.
+        let mut deduped: Vec<&StoredBearerAuth> = Vec::new();
+        for bearer in candidates {
+            if !deduped.iter().any(|seen| seen.auth.0 == bearer.auth.0) {
+                deduped.push(bearer);
             }
         }
 
         let mut deduped = deduped.into_iter();
-        let first_auth = deduped.next().expect("lookup produced no candidates");
+        let first_bearer = deduped.next().expect("lookup produced no candidates");
         if deduped.len() == 0 {
             log::debug!("stored credential matches `{url}`; retrying with forced bearer auth");
-            return first_auth
+            let response = first_bearer
+                .auth
                 .request_with_authentication(renew_request(&client), renew_request)
-                .await;
+                .await?;
+            if response.status().is_client_error() {
+                first_bearer.warn_if_expired();
+            }
+            return Ok(response);
         }
 
         // Genuinely ambiguous: reads try all matches, in order, until one
@@ -757,17 +921,23 @@ where
         // 8), mirroring `RestrictAuthentication`. If every candidate
         // fails, the first retry response is returned.
         log::warn!("URL {url} matches multiple stored credentials; trying each in order");
-        let first_response = first_auth
+        let first_response = first_bearer
+            .auth
             .request_with_authentication(renew_request(&client), renew_request)
             .await?;
         if !first_response.status().is_client_error() {
             return Ok(first_response);
         }
-        for auth in deduped {
-            let response = auth.with_authentication(&client, renew_request).await?;
+        first_bearer.warn_if_expired();
+        for bearer in deduped {
+            let response = bearer
+                .auth
+                .with_authentication(&client, renew_request)
+                .await?;
             if !response.status().is_client_error() {
                 return Ok(response);
             }
+            bearer.warn_if_expired();
         }
         Ok(first_response)
     }

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -354,15 +354,15 @@ pub(crate) enum BearerSelection<'a, T> {
     /// several matching patterns all carrying the identical token,
     /// collapsed to the first so any later hint names that entry.
     Unique(&'a T),
-    /// Matching patterns carry distinct tokens. `candidates` is the full
-    /// pre-collapse match count (what ambiguity errors report), `deduped`
-    /// the distinct-token entries in map order (what try-all consumers
-    /// walk); it always holds at least two entries.
+    /// Matching patterns carry distinct tokens. `matched` is the full
+    /// pre-collapse match list in map order (what ambiguity errors name),
+    /// `deduped` the distinct-token entries in map order (what try-all
+    /// consumers walk); it always holds at least two entries.
     Ambiguous {
         // Read only by whoami and publish; without `filesystem` those
         // consumers are compiled out and only `deduped` is used.
         #[cfg_attr(not(feature = "filesystem"), allow(dead_code))]
-        candidates: usize,
+        matched: Vec<&'a T>,
         deduped: Vec<&'a T>,
     },
 }
@@ -392,7 +392,7 @@ pub(crate) fn select_bearer<'a, T>(
                 BearerSelection::Unique(deduped[0])
             } else {
                 BearerSelection::Ambiguous {
-                    candidates: candidates.len(),
+                    matched: candidates.into_iter().map(|(_, entry)| entry).collect(),
                     deduped,
                 }
             }
@@ -704,7 +704,7 @@ impl StoredBearerAuth {
             return None;
         }
         Some(format!(
-            "credential for `{key}` may be expired or revoked; \
+            "credential for `{key}` may be expired or revoked;\n\
              re-authenticate to store a fresh credential",
             key = self.key
         ))
@@ -826,7 +826,7 @@ where
                     Ok(map) => map,
                     Err(err) => {
                         log::warn!(
-                            "credential store read failed: {err}; \
+                            "credential store read failed: {err};\n\
                              continuing without stored credentials"
                         );
                         GlobMap::default()
@@ -863,16 +863,15 @@ fn read_stored_bearer_map<B: BlobBackend>(store: &LockedBlobStore<B>) -> GlobMap
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
             log::debug!(
-                "no OS keyring backend ({source}); \
+                "no OS keyring backend ({source});\n\
                  using `SYSAND_CRED_*` credentials only"
             );
             return GlobMap::default();
         }
         Err(err) => {
             log::warn!(
-                "could not read stored credentials: {err}; \
-                 unlock your OS keyring, or provide credentials via \
-                 `SYSAND_CRED_*` environment variables; \
+                "could not read stored credentials: {err};\n\
+                 unlock your OS keyring, or provide credentials via `SYSAND_CRED_*` environment variables;\n\
                  continuing without stored credentials"
             );
             return GlobMap::default();
@@ -905,7 +904,7 @@ pub(crate) fn stored_bearer_map_from_records(
             // only itself, not every stored credential.
             if let Err(err) = GlobBuilder::new(glob).literal_separator(true).build() {
                 log::warn!(
-                    "ignoring invalid stored credential URL pattern `{glob}` for `{}`: {err}",
+                    "ignoring invalid stored credential URL pattern `{glob}` for `{}`:\n{err}",
                     record.key
                 );
                 continue;
@@ -917,7 +916,7 @@ pub(crate) fn stored_bearer_map_from_records(
         Ok(map) => map,
         Err(err) => {
             log::warn!(
-                "could not build stored credential URL patterns: {err}; \
+                "could not build stored credential URL patterns: {err};\n\
                  continuing without stored credentials"
             );
             GlobMap::default()

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -104,9 +104,20 @@ impl HTTPAuthentication for ForceHTTPBasicAuth {
 }
 
 /// Authentication policy that *always* includes a bearer token
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ForceBearerAuth(Box<str>);
+
+// Hand-written so the token is never rendered. This is the single
+// secret-bearing leaf: redacting it here keeps every wrapper's `Debug`
+// (and any accidental `{:?}` on a composed policy) from leaking the token.
+impl std::fmt::Debug for ForceBearerAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ForceBearerAuth")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
 
 impl ForceBearerAuth {
     pub fn new<S: AsRef<str>>(token: S) -> ForceBearerAuth {
@@ -787,8 +798,15 @@ where
             None => GlobMap::default(),
             Some(store) => read_stored_bearer_map(store.as_ref()),
         };
-        // `set` fails only if a concurrent initialization won; either way
-        // the cell holds a value now.
+        // Safe because this never races the async accessor on the current
+        // flow: publish resolves its bearer only after discovery's
+        // `block_on` has returned, and the runtime is current-thread, so no
+        // async `get_or_init` is in flight here. `set` therefore either
+        // succeeds or reports the cell already initialized, and `get` is
+        // populated. If this accessor is ever called concurrently with the
+        // async one (e.g. on a multi-thread runtime), revisit: `set` can
+        // return `InitializingError` with the cell still empty, which would
+        // trip the `expect` below.
         let _ = self.cache.set(map);
         self.cache.get().expect("cache was just initialized")
     }
@@ -913,23 +931,17 @@ where
 
         let mut deduped = deduped.into_iter();
         let first_bearer = deduped.next().expect("lookup produced no candidates");
+        // A single distinct token retries once; genuinely ambiguous matches
+        // try each in order until one yields a non-4xx response
+        // (design/credential-storage.md, section 8), mirroring
+        // `RestrictAuthentication`. If every candidate fails, the first
+        // retry response is returned. The single-match case is this same
+        // path with an empty remainder loop.
         if deduped.len() == 0 {
             log::debug!("stored credential matches `{url}`; retrying with forced bearer auth");
-            let response = first_bearer
-                .auth
-                .request_with_authentication(renew_request(&client), renew_request)
-                .await?;
-            if response.status().is_client_error() {
-                first_bearer.warn_if_expired();
-            }
-            return Ok(response);
+        } else {
+            log::warn!("URL {url} matches multiple stored credentials; trying each in order");
         }
-
-        // Genuinely ambiguous: reads try all matches, in order, until one
-        // yields a non-4xx response (design/credential-storage.md, section
-        // 8), mirroring `RestrictAuthentication`. If every candidate
-        // fails, the first retry response is returned.
-        log::warn!("URL {url} matches multiple stored credentials; trying each in order");
         let first_response = first_bearer
             .auth
             .request_with_authentication(renew_request(&client), renew_request)

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -159,18 +159,6 @@ mod select_bearer {
     }
 
     #[test]
-    fn distinct_tokens_are_ambiguous_with_the_pre_collapse_count() {
-        let map = map(&[
-            ("https://example.com/**", "tok-a"),
-            ("https://example.com/api/**", "tok-b"),
-        ]);
-        assert!(matches!(
-            select(&map),
-            BearerSelection::Ambiguous { candidates: 2, .. }
-        ));
-    }
-
-    #[test]
     fn mixed_candidates_dedupe_in_map_order_and_count_all_matches() {
         // Two patterns of one credential plus a distinct one: the error
         // count reports all three matches, while try-all consumers walk
@@ -194,10 +182,12 @@ mod select_bearer {
 }
 
 #[test]
-fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std::error::Error>> {
+fn publish_bearer_auth_map_keeps_bearer_drops_basic_and_carries_labels()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut builder = crate::auth::StandardHTTPAuthenticationBuilder::new();
     builder.add_basic_auth("https://basic.example.com/*", "user", "password");
     builder.add_bearer_auth("https://bearer.example.com/*", "tok");
+    builder.add_bearer_auth_labeled("https://labeled.example.com/*", "tok2", "TEAMIDX");
     let policy = builder.build()?;
 
     // By-ref extraction: the policy stays usable afterwards.
@@ -212,6 +202,15 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std:
         panic!("expected bearer entry to be extracted");
     }
 
+    if let crate::auth::GlobMapResult::Found(_, entry) =
+        bearer_map.lookup("https://labeled.example.com/upload")
+    {
+        assert_eq!(&*entry.auth.0, "tok2");
+        assert_eq!(entry.label.as_deref(), Some("TEAMIDX"));
+    } else {
+        panic!("expected labeled bearer entry to be extracted");
+    }
+
     assert!(matches!(
         bearer_map.lookup("https://basic.example.com/upload"),
         crate::auth::GlobMapResult::NotFound
@@ -220,26 +219,6 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std:
         bearer_map.lookup("https://other.example.com/upload"),
         crate::auth::GlobMapResult::NotFound
     ));
-
-    Ok(())
-}
-
-#[test]
-fn publish_bearer_auth_map_carries_the_env_label() -> Result<(), Box<dyn std::error::Error>> {
-    let mut builder = crate::auth::StandardHTTPAuthenticationBuilder::new();
-    builder.add_bearer_auth_labeled("https://bearer.example.com/*", "tok", "TEAMIDX");
-    let policy = builder.build()?;
-
-    let bearer_map = policy.publish_bearer_auth_map()?;
-
-    if let crate::auth::GlobMapResult::Found(_, entry) =
-        bearer_map.lookup("https://bearer.example.com/upload")
-    {
-        assert_eq!(&*entry.auth.0, "tok");
-        assert_eq!(entry.label.as_deref(), Some("TEAMIDX"));
-    } else {
-        panic!("expected labeled bearer entry to be extracted");
-    }
 
     Ok(())
 }
@@ -372,88 +351,64 @@ fn get<P: HTTPAuthentication>(
         .unwrap()
 }
 
-#[test]
-fn lazy_layer_never_reads_store_on_unauthenticated_success() {
-    let mut server = mockito::Server::new();
-    let mock = server
-        .mock("GET", "/pkg/versions.json")
-        .with_status(200)
-        .expect(1)
-        .create();
-
-    let (store, lists) = counting_store(vec![bearer_record(
-        &[format!("{}/**", server.url())],
-        "stored-token",
-    )]);
-    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
-    let runtime = runtime();
-
-    let response = get(
-        &runtime,
-        &policy,
+/// One GET for `server`'s `/pkg/versions.json` through `policy`.
+fn get_versions<P: HTTPAuthentication>(
+    runtime: &tokio::runtime::Runtime,
+    policy: &P,
+    server: &mockito::Server,
+) -> reqwest::Response {
+    get(
+        runtime,
+        policy,
         &format!("{}/pkg/versions.json", server.url()),
-    );
+    )
+}
 
-    assert_eq!(response.status().as_u16(), 200);
-    assert_eq!(lists.load(Ordering::SeqCst), 0);
-    mock.assert();
+/// Mock `GET /pkg/versions.json`: with `bearer` the request must carry
+/// exactly that token; without, it must carry no credential at all.
+/// Answered with `status` for exactly `hits` requests.
+fn versions_mock(
+    server: &mut mockito::Server,
+    bearer: Option<&str>,
+    status: usize,
+    hits: usize,
+) -> mockito::Mock {
+    let mock = server.mock("GET", "/pkg/versions.json");
+    let mock = match bearer {
+        None => mock.match_header("authorization", mockito::Matcher::Missing),
+        Some(token) => mock.match_header("authorization", format!("Bearer {token}").as_str()),
+    };
+    mock.with_status(status).expect(hits).create()
 }
 
 #[test]
-fn lazy_layer_never_reads_store_on_server_error() {
-    let mut server = mockito::Server::new();
-    let mock = server
-        .mock("GET", "/pkg/versions.json")
-        .with_status(500)
-        .expect(1)
-        .create();
+fn lazy_layer_never_reads_store_on_success_server_error_or_rate_limiting() {
+    // 2xx needs no credential, 5xx is not an auth verdict, and 429 is
+    // rate limiting, never a verdict: each response is returned as-is,
+    // with no store read and no forced retry (expect(1) asserts that; a
+    // retry against a host that just throttled us would spend more of the
+    // rate budget).
+    for status in [200, 500, 429] {
+        let mut server = mockito::Server::new();
+        let mock = versions_mock(&mut server, None, status, 1);
 
-    let (store, lists) = counting_store(vec![bearer_record(
-        &[format!("{}/**", server.url())],
-        "stored-token",
-    )]);
-    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
-    let runtime = runtime();
+        let (store, lists) = counting_store(vec![bearer_record(
+            &[format!("{}/**", server.url())],
+            "stored-token",
+        )]);
+        let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+        let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+        let response = get(
+            &runtime,
+            &policy,
+            &format!("{}/pkg/versions.json", server.url()),
+        );
 
-    assert_eq!(response.status().as_u16(), 500);
-    assert_eq!(lists.load(Ordering::SeqCst), 0);
-    mock.assert();
-}
-
-#[test]
-fn lazy_layer_never_reads_store_on_rate_limiting() {
-    // 429 is rate limiting, not an auth verdict: the response is returned
-    // as-is, with no store read and no forced retry against a host that
-    // just throttled us (expect(1) asserts no retry happens).
-    let mut server = mockito::Server::new();
-    let mock = server
-        .mock("GET", "/pkg/versions.json")
-        .with_status(429)
-        .expect(1)
-        .create();
-
-    let (store, lists) = counting_store(vec![bearer_record(
-        &[format!("{}/**", server.url())],
-        "stored-token",
-    )]);
-    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
-    let runtime = runtime();
-
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
-
-    assert_eq!(response.status().as_u16(), 429);
-    assert_eq!(lists.load(Ordering::SeqCst), 0);
-    mock.assert();
+        assert_eq!(response.status().as_u16(), status as u16);
+        assert_eq!(lists.load(Ordering::SeqCst), 0, "status = {status}");
+        mock.assert();
+    }
 }
 
 #[test]
@@ -461,28 +416,15 @@ fn sequence_auth_does_not_try_lower_on_rate_limiting() {
     // The same 429 carve-out in `SequenceAuthentication`: a rate-limited
     // unauthenticated request must not be retried with the env credential.
     let mut server = mockito::Server::new();
-    let mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(429)
-        .expect(1)
-        .create();
-    let bearer_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer env-token")
-        .expect(0)
-        .create();
+    let mock = versions_mock(&mut server, None, 429, 1);
+    let bearer_mock = versions_mock(&mut server, Some("env-token"), 200, 0);
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
     env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token");
     let policy = env_builder.build().unwrap();
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 429);
     mock.assert();
@@ -496,11 +438,7 @@ fn lazy_layer_reads_store_once_and_returns_original_response_on_no_match() {
     // across requests, and with no matching record each original response
     // comes back untouched with no extra request (expect(2) with two
     // `get`s asserts no retries happen).
-    let mock = server
-        .mock("GET", "/pkg/versions.json")
-        .with_status(404)
-        .expect(2)
-        .create();
+    let mock = versions_mock(&mut server, None, 404, 2);
 
     let (store, lists) = counting_store(vec![bearer_record(
         &["https://other.example.com/**".to_string()],
@@ -522,18 +460,8 @@ fn lazy_layer_reads_store_once_and_returns_original_response_on_no_match() {
 #[test]
 fn lazy_layer_matching_record_forces_authenticated_retry() {
     let mut server = mockito::Server::new();
-    let unauth_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .expect(1)
-        .create();
-    let bearer_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stored-token")
-        .with_status(200)
-        .expect(1)
-        .create();
+    let unauth_mock = versions_mock(&mut server, None, 401, 1);
+    let bearer_mock = versions_mock(&mut server, Some("stored-token"), 200, 1);
 
     let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
@@ -542,11 +470,7 @@ fn lazy_layer_matching_record_forces_authenticated_retry() {
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 200);
     assert_eq!(lists.load(Ordering::SeqCst), 1);
@@ -557,18 +481,8 @@ fn lazy_layer_matching_record_forces_authenticated_retry() {
 #[test]
 fn lazy_layer_env_credential_wins_without_store_read() {
     let mut server = mockito::Server::new();
-    let unauth_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .expect(1)
-        .create();
-    let env_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer env-token")
-        .with_status(200)
-        .expect(1)
-        .create();
+    let unauth_mock = versions_mock(&mut server, None, 401, 1);
+    let env_mock = versions_mock(&mut server, Some("env-token"), 200, 1);
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
     env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token");
@@ -579,11 +493,7 @@ fn lazy_layer_env_credential_wins_without_store_read() {
     let policy = CredentialStoreAuthentication::new(env_builder.build().unwrap(), store);
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 200);
     assert_eq!(lists.load(Ordering::SeqCst), 0);
@@ -594,24 +504,9 @@ fn lazy_layer_env_credential_wins_without_store_read() {
 #[test]
 fn lazy_layer_failed_env_credential_escalates_to_store() {
     let mut server = mockito::Server::new();
-    let unauth_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .expect(1)
-        .create();
-    let env_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stale-env-token")
-        .with_status(401)
-        .expect(1)
-        .create();
-    let stored_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stored-token")
-        .with_status(200)
-        .expect(1)
-        .create();
+    let unauth_mock = versions_mock(&mut server, None, 401, 1);
+    let env_mock = versions_mock(&mut server, Some("stale-env-token"), 401, 1);
+    let stored_mock = versions_mock(&mut server, Some("stored-token"), 200, 1);
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
     env_builder.add_bearer_auth(format!("{}/**", server.url()), "stale-env-token");
@@ -622,11 +517,7 @@ fn lazy_layer_failed_env_credential_escalates_to_store() {
     let policy = CredentialStoreAuthentication::new(env_builder.build().unwrap(), store);
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 200);
     assert_eq!(lists.load(Ordering::SeqCst), 1);
@@ -638,20 +529,10 @@ fn lazy_layer_failed_env_credential_escalates_to_store() {
 #[test]
 fn lazy_layer_overlapping_globs_of_one_record_retry_once() {
     let mut server = mockito::Server::new();
-    let unauth_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .expect(1)
-        .create();
+    let unauth_mock = versions_mock(&mut server, None, 401, 1);
     // One login covering the URL with two patterns is not an ambiguity:
     // exactly one forced retry with its token.
-    let bearer_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stored-token")
-        .with_status(200)
-        .expect(1)
-        .create();
+    let bearer_mock = versions_mock(&mut server, Some("stored-token"), 200, 1);
 
     let (store, _lists) = counting_store(vec![bearer_record(
         &[
@@ -663,11 +544,7 @@ fn lazy_layer_overlapping_globs_of_one_record_retry_once() {
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 200);
     unauth_mock.assert();
@@ -677,24 +554,9 @@ fn lazy_layer_overlapping_globs_of_one_record_retry_once() {
 #[test]
 fn lazy_layer_ambiguous_distinct_records_try_all_in_order() {
     let mut server = mockito::Server::new();
-    let unauth_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .expect(1)
-        .create();
-    let rejected_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer broad-token")
-        .with_status(401)
-        .expect(1)
-        .create();
-    let accepted_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer narrow-token")
-        .with_status(200)
-        .expect(1)
-        .create();
+    let unauth_mock = versions_mock(&mut server, None, 401, 1);
+    let rejected_mock = versions_mock(&mut server, Some("broad-token"), 401, 1);
+    let accepted_mock = versions_mock(&mut server, Some("narrow-token"), 200, 1);
 
     let mut broad = bearer_record(&[format!("{}/**", server.url())], "broad-token");
     broad.key = "https://example.com/broad/".to_string();
@@ -704,11 +566,7 @@ fn lazy_layer_ambiguous_distinct_records_try_all_in_order() {
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 200);
     unauth_mock.assert();
@@ -719,18 +577,8 @@ fn lazy_layer_ambiguous_distinct_records_try_all_in_order() {
 #[test]
 fn lazy_layer_invalid_stored_glob_skips_only_that_pattern() {
     let mut server = mockito::Server::new();
-    let unauth_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .expect(1)
-        .create();
-    let bearer_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stored-token")
-        .with_status(200)
-        .expect(1)
-        .create();
+    let unauth_mock = versions_mock(&mut server, None, 401, 1);
+    let bearer_mock = versions_mock(&mut server, Some("stored-token"), 200, 1);
 
     let (store, _lists) = counting_store(vec![bearer_record(
         &["[invalid".to_string(), format!("{}/**", server.url())],
@@ -739,11 +587,7 @@ fn lazy_layer_invalid_stored_glob_skips_only_that_pattern() {
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 200);
     unauth_mock.assert();
@@ -754,11 +598,7 @@ fn lazy_layer_invalid_stored_glob_skips_only_that_pattern() {
 fn lazy_layer_store_errors_degrade_to_no_credentials() {
     for absent in [true, false] {
         let mut server = mockito::Server::new();
-        let mock = server
-            .mock("GET", "/pkg/versions.json")
-            .with_status(404)
-            .expect(2)
-            .create();
+        let mock = versions_mock(&mut server, None, 404, 2);
 
         let (store, lists) = failing_store(absent);
         let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
@@ -780,21 +620,13 @@ fn lazy_layer_store_errors_degrade_to_no_credentials() {
 #[test]
 fn lazy_layer_without_store_returns_original_response() {
     let mut server = mockito::Server::new();
-    let mock = server
-        .mock("GET", "/pkg/versions.json")
-        .with_status(404)
-        .expect(1)
-        .create();
+    let mock = versions_mock(&mut server, None, 404, 1);
 
     let policy: CredentialStoreAuthentication<_, InMemoryBlobBackend> =
         CredentialStoreAuthentication::without_store(empty_env_policy());
     let runtime = runtime();
 
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
+    let response = get_versions(&runtime, &policy, &server);
 
     assert_eq!(response.status().as_u16(), 404);
     mock.assert();
@@ -839,7 +671,7 @@ fn direct_stored_bearer_read_degrades_store_errors_to_an_empty_map() {
 // never reach logs via an accidental `{:?}`; pin that here.
 
 #[test]
-fn debug_of_secret_bearing_leaves_shows_the_marker_not_the_secret() {
+fn debug_never_renders_secrets() {
     let bearer = crate::auth::ForceBearerAuth::new("bearer-secret");
     let rendered = format!("{bearer:?}");
     assert!(rendered.contains("<redacted>"), "rendered: {rendered}");
@@ -853,10 +685,6 @@ fn debug_of_secret_bearing_leaves_shows_the_marker_not_the_secret() {
     assert!(rendered.contains("alice"), "rendered: {rendered}");
     assert!(rendered.contains("<redacted>"), "rendered: {rendered}");
     assert!(!rendered.contains("basic-secret"), "rendered: {rendered}");
-}
-
-#[test]
-fn debug_of_wrappers_and_composed_policy_never_renders_secrets() {
     let env = crate::auth::EnvBearerAuth {
         auth: crate::auth::ForceBearerAuth::new("env-secret"),
         label: Some("TEAMIDX".to_string()),
@@ -970,18 +798,8 @@ fn lazy_layer_warns_once_for_an_expired_record_that_keeps_failing() {
     // GitLab-style host: bad auth answers 404, not 401 (the hint must
     // fire on any 4xx). Two full escalations; the flag must latch after
     // the first, so the hint is emitted at most once per process.
-    let unauth_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(404)
-        .expect(2)
-        .create();
-    let forced_mock = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stored-token")
-        .with_status(404)
-        .expect(2)
-        .create();
+    let unauth_mock = versions_mock(&mut server, None, 404, 2);
+    let forced_mock = versions_mock(&mut server, Some("stored-token"), 404, 2);
 
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
     record.expires_at = Some(Utc::now() - Duration::days(1));
@@ -1008,16 +826,8 @@ fn lazy_layer_warns_once_for_an_expired_record_that_keeps_failing() {
 fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
     // Case 1: unexpired record, failing retry: no hint.
     let mut server = mockito::Server::new();
-    let _unauth = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .create();
-    let _forced = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stored-token")
-        .with_status(404)
-        .create();
+    let _unauth = versions_mock(&mut server, None, 401, 1);
+    let _forced = versions_mock(&mut server, Some("stored-token"), 404, 1);
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
     record.expires_at = Some(Utc::now() + Duration::days(1));
     let (store, _lists) = counting_store(vec![record]);
@@ -1030,16 +840,8 @@ fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
     // Case 2: expired record, but the forced retry succeeds: no hint
     // (the credential demonstrably still works).
     let mut server = mockito::Server::new();
-    let _unauth = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(401)
-        .create();
-    let _forced = server
-        .mock("GET", "/pkg/versions.json")
-        .match_header("authorization", "Bearer stored-token")
-        .with_status(200)
-        .create();
+    let _unauth = versions_mock(&mut server, None, 401, 1);
+    let _forced = versions_mock(&mut server, Some("stored-token"), 200, 1);
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
     record.expires_at = Some(Utc::now() - Duration::days(1));
     let (store, _lists) = counting_store(vec![record]);

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -10,9 +10,10 @@ use crate::auth::{
     CredentialStoreAuthentication, GlobMapBuilder, GlobMapResultMut, HTTPAuthentication,
     StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder,
 };
+use crate::credential_store::keyring_store::{BlobBackend, LockedBlobStore};
+use crate::credential_store::test_support::{InMemoryBlobBackend, unique_lock_path};
 use crate::credential_store::{
-    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
-    InMemoryCredentialStore,
+    CredentialBlob, CredentialRecord, CredentialScheme, CredentialStoreError, serialize_blob,
 };
 use crate::resolve::net_utils::create_reqwest_client;
 
@@ -246,67 +247,53 @@ fn publish_bearer_auth_map_carries_the_env_label() -> Result<(), Box<dyn std::er
 // Tests for the lazy credential store layer
 // (`CredentialStoreAuthentication`).
 
-/// Counts `list` calls so tests can assert when (and how often) the
-/// credential store is actually read.
-#[derive(Debug)]
-struct CountingStore {
-    inner: InMemoryCredentialStore,
-    lists: Arc<AtomicUsize>,
+/// A backend that counts its reads, so tests can assert when (and how
+/// often) the credential store is actually read (one backend read per
+/// store `list`).
+#[derive(Debug, Clone)]
+struct CountingBackend {
+    inner: InMemoryBlobBackend,
+    reads: Arc<AtomicUsize>,
 }
 
-impl CountingStore {
-    fn with_records(records: Vec<CredentialRecord>) -> (Self, Arc<AtomicUsize>) {
-        let mut inner = InMemoryCredentialStore::new();
-        for record in records {
-            inner.upsert(record).unwrap();
-        }
-        let lists = Arc::new(AtomicUsize::new(0));
-        (
-            CountingStore {
-                inner,
-                lists: lists.clone(),
-            },
-            lists,
-        )
-    }
-}
-
-impl CredentialStore for CountingStore {
-    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
-        self.lists.fetch_add(1, Ordering::SeqCst);
-        self.inner.list()
+impl BlobBackend for CountingBackend {
+    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        self.inner.read()
     }
 
-    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
-        self.inner.upsert(record)
+    fn write(&self, raw: &str) -> Result<(), CredentialStoreError> {
+        self.inner.write(raw)
     }
 
-    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
-        self.inner.remove(key)
+    fn delete(&self) -> Result<(), CredentialStoreError> {
+        self.inner.delete()
     }
 }
 
-/// A store whose reads always fail, for the degrade-to-no-credentials
+/// A store holding exactly `records`, counting its backend reads.
+fn counting_store(
+    records: Vec<CredentialRecord>,
+) -> (LockedBlobStore<CountingBackend>, Arc<AtomicUsize>) {
+    let raw = serialize_blob(&CredentialBlob::new(records)).unwrap();
+    let reads = Arc::new(AtomicUsize::new(0));
+    let backend = CountingBackend {
+        inner: InMemoryBlobBackend::with_contents(&raw),
+        reads: reads.clone(),
+    };
+    (LockedBlobStore::new(backend, unique_lock_path()), reads)
+}
+
+/// A backend whose reads always fail, for the degrade-to-no-credentials
 /// paths. `absent` selects `BackendAbsent` over `BackendDenied` (both are
 /// warned about); the request-level behavior must be identical.
 #[derive(Debug)]
-struct FailingStore {
+struct FailingBackend {
     absent: bool,
-    lists: Arc<AtomicUsize>,
+    reads: Arc<AtomicUsize>,
 }
 
-impl FailingStore {
-    fn new(absent: bool) -> (Self, Arc<AtomicUsize>) {
-        let lists = Arc::new(AtomicUsize::new(0));
-        (
-            FailingStore {
-                absent,
-                lists: lists.clone(),
-            },
-            lists,
-        )
-    }
-
+impl FailingBackend {
     fn error(&self) -> CredentialStoreError {
         if self.absent {
             CredentialStoreError::BackendAbsent {
@@ -320,19 +307,28 @@ impl FailingStore {
     }
 }
 
-impl CredentialStore for FailingStore {
-    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
-        self.lists.fetch_add(1, Ordering::SeqCst);
+impl BlobBackend for FailingBackend {
+    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
         Err(self.error())
     }
 
-    fn upsert(&mut self, _record: CredentialRecord) -> Result<(), CredentialStoreError> {
+    fn write(&self, _raw: &str) -> Result<(), CredentialStoreError> {
         Err(self.error())
     }
 
-    fn remove(&mut self, _key: &str) -> Result<bool, CredentialStoreError> {
+    fn delete(&self) -> Result<(), CredentialStoreError> {
         Err(self.error())
     }
+}
+
+fn failing_store(absent: bool) -> (LockedBlobStore<FailingBackend>, Arc<AtomicUsize>) {
+    let reads = Arc::new(AtomicUsize::new(0));
+    let backend = FailingBackend {
+        absent,
+        reads: reads.clone(),
+    };
+    (LockedBlobStore::new(backend, unique_lock_path()), reads)
 }
 
 fn bearer_record(globs: &[String], secret: &str) -> CredentialRecord {
@@ -385,7 +381,7 @@ fn lazy_layer_never_reads_store_on_unauthenticated_success() {
         .expect(1)
         .create();
 
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
     )]);
@@ -412,7 +408,7 @@ fn lazy_layer_never_reads_store_on_server_error() {
         .expect(1)
         .create();
 
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
     )]);
@@ -442,7 +438,7 @@ fn lazy_layer_never_reads_store_on_rate_limiting() {
         .expect(1)
         .create();
 
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
     )]);
@@ -506,7 +502,7 @@ fn lazy_layer_reads_store_once_and_returns_original_response_on_no_match() {
         .expect(2)
         .create();
 
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &["https://other.example.com/**".to_string()],
         "stored-token",
     )]);
@@ -539,7 +535,7 @@ fn lazy_layer_matching_record_forces_authenticated_retry() {
         .expect(1)
         .create();
 
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
     )]);
@@ -576,7 +572,7 @@ fn lazy_layer_env_credential_wins_without_store_read() {
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
     env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token");
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
     )]);
@@ -619,7 +615,7 @@ fn lazy_layer_failed_env_credential_escalates_to_store() {
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
     env_builder.add_bearer_auth(format!("{}/**", server.url()), "stale-env-token");
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
     )]);
@@ -657,7 +653,7 @@ fn lazy_layer_overlapping_globs_of_one_record_retry_once() {
         .expect(1)
         .create();
 
-    let (store, _lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, _lists) = counting_store(vec![bearer_record(
         &[
             format!("{}/**", server.url()),
             format!("{}/pkg/*", server.url()),
@@ -704,7 +700,7 @@ fn lazy_layer_ambiguous_distinct_records_try_all_in_order() {
     broad.key = "https://example.com/broad/".to_string();
     let mut narrow = bearer_record(&[format!("{}/pkg/*", server.url())], "narrow-token");
     narrow.key = "https://example.com/narrow/".to_string();
-    let (store, _lists) = CountingStore::with_records(vec![broad, narrow]);
+    let (store, _lists) = counting_store(vec![broad, narrow]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
 
@@ -736,7 +732,7 @@ fn lazy_layer_invalid_stored_glob_skips_only_that_pattern() {
         .expect(1)
         .create();
 
-    let (store, _lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, _lists) = counting_store(vec![bearer_record(
         &["[invalid".to_string(), format!("{}/**", server.url())],
         "stored-token",
     )]);
@@ -764,7 +760,7 @@ fn lazy_layer_store_errors_degrade_to_no_credentials() {
             .expect(2)
             .create();
 
-        let (store, lists) = FailingStore::new(absent);
+        let (store, lists) = failing_store(absent);
         let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
         let runtime = runtime();
         let url = format!("{}/pkg/versions.json", server.url());
@@ -790,7 +786,7 @@ fn lazy_layer_without_store_returns_original_response() {
         .expect(1)
         .create();
 
-    let policy: CredentialStoreAuthentication<_, InMemoryCredentialStore> =
+    let policy: CredentialStoreAuthentication<_, InMemoryBlobBackend> =
         CredentialStoreAuthentication::without_store(empty_env_policy());
     let runtime = runtime();
 
@@ -806,7 +802,7 @@ fn lazy_layer_without_store_returns_original_response() {
 
 #[test]
 fn direct_stored_bearer_read_does_exactly_one_store_read_per_call() {
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, lists) = counting_store(vec![bearer_record(
         &["https://other.example.com/**".to_string()],
         "stored-token",
     )]);
@@ -824,7 +820,7 @@ fn direct_stored_bearer_read_does_exactly_one_store_read_per_call() {
 #[test]
 fn direct_stored_bearer_read_degrades_store_errors_to_an_empty_map() {
     for absent in [true, false] {
-        let (store, lists) = FailingStore::new(absent);
+        let (store, lists) = failing_store(absent);
         let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
 
         let map = policy.read_stored_bearer_map_direct();
@@ -885,7 +881,7 @@ fn debug_of_wrappers_and_composed_policy_never_renders_secrets() {
     // in the populated cache. Neither secret may surface.
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
     env_builder.add_bearer_auth("https://bearer.example.com/**", "env-secret");
-    let (store, _lists) = CountingStore::with_records(vec![bearer_record(
+    let (store, _lists) = counting_store(vec![bearer_record(
         &["https://other.example.com/**".to_string()],
         "stored-secret",
     )]);
@@ -954,13 +950,13 @@ fn stored_bearer_expiry_warning_skips_unexpired_and_unknown_expiry() {
 /// go through the request path's cache (not a direct store read, which
 /// would build fresh records with fresh flags); the clone shares the
 /// record's `expiry_warned` flag (it is an `Arc`).
-fn stored_bearer_for<Inner, S>(
+fn stored_bearer_for<Inner, B>(
     runtime: &tokio::runtime::Runtime,
-    policy: &CredentialStoreAuthentication<Inner, S>,
+    policy: &CredentialStoreAuthentication<Inner, B>,
     url: &str,
 ) -> StoredBearerAuth
 where
-    S: CredentialStore + Send + Sync + 'static,
+    B: BlobBackend + Send + Sync + 'static,
 {
     match runtime.block_on(policy.stored_bearer_map()).lookup(url) {
         crate::auth::GlobMapResult::Found(_, bearer) => bearer.clone(),
@@ -989,7 +985,7 @@ fn lazy_layer_warns_once_for_an_expired_record_that_keeps_failing() {
 
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
     record.expires_at = Some(Utc::now() - Duration::days(1));
-    let (store, _lists) = CountingStore::with_records(vec![record]);
+    let (store, _lists) = counting_store(vec![record]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
     let url = format!("{}/pkg/versions.json", server.url());
@@ -1024,7 +1020,7 @@ fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
         .create();
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
     record.expires_at = Some(Utc::now() + Duration::days(1));
-    let (store, _lists) = CountingStore::with_records(vec![record]);
+    let (store, _lists) = counting_store(vec![record]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
     let url = format!("{}/pkg/versions.json", server.url());
@@ -1046,7 +1042,7 @@ fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
         .create();
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
     record.expires_at = Some(Utc::now() - Duration::days(1));
-    let (store, _lists) = CountingStore::with_records(vec![record]);
+    let (store, _lists) = counting_store(vec![record]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let url = format!("{}/pkg/versions.json", server.url());
     let response = get(&runtime, &policy, &url);

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -114,6 +114,84 @@ fn globmap_matches_template_expanded_urls() -> Result<(), Box<dyn std::error::Er
     Ok(())
 }
 
+// select_bearer: the selection semantics shared by the runtime read
+// retry, whoami, and publish. The end-to-end behavior of each consumer is
+// pinned by its own tests; these cover the helper's collapse rules
+// directly, in particular the mixed identical-plus-distinct case only
+// the runtime's try-all path can observe.
+mod select_bearer {
+    use crate::auth::{BearerSelection, GlobMap, GlobMapBuilder, select_bearer};
+
+    const URL: &str = "https://example.com/api/v1/upload";
+
+    fn map(entries: &[(&str, &str)]) -> GlobMap<String> {
+        let mut builder = GlobMapBuilder::new();
+        for (pattern, token) in entries {
+            builder.add(*pattern, (*token).to_string());
+        }
+        builder.build().unwrap()
+    }
+
+    fn select(map: &GlobMap<String>) -> BearerSelection<'_, String> {
+        select_bearer(map, URL, String::as_str)
+    }
+
+    #[test]
+    fn no_matching_pattern_is_none() {
+        let map = map(&[("https://other.example/**", "tok")]);
+        assert!(matches!(select(&map), BearerSelection::None));
+    }
+
+    #[test]
+    fn a_unique_match_is_unique() {
+        let map = map(&[("https://example.com/**", "tok")]);
+        assert!(matches!(select(&map), BearerSelection::Unique(tok) if tok == "tok"));
+    }
+
+    #[test]
+    fn identical_token_candidates_collapse_to_the_first() {
+        let map = map(&[
+            ("https://example.com/**", "same"),
+            ("https://example.com/api/**", "same"),
+        ]);
+        assert!(matches!(select(&map), BearerSelection::Unique(tok) if tok == "same"));
+    }
+
+    #[test]
+    fn distinct_tokens_are_ambiguous_with_the_pre_collapse_count() {
+        let map = map(&[
+            ("https://example.com/**", "tok-a"),
+            ("https://example.com/api/**", "tok-b"),
+        ]);
+        assert!(matches!(
+            select(&map),
+            BearerSelection::Ambiguous { candidates: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn mixed_candidates_dedupe_in_map_order_and_count_all_matches() {
+        // Two patterns of one credential plus a distinct one: the error
+        // count reports all three matches, while try-all consumers walk
+        // the two distinct tokens in map order.
+        let map = map(&[
+            ("https://example.com/**", "tok-a"),
+            ("https://example.com/api/**", "tok-a"),
+            ("https://example.com/api/v1/**", "tok-b"),
+        ]);
+        match select(&map) {
+            BearerSelection::Ambiguous {
+                candidates: 3,
+                deduped,
+            } => {
+                let tokens: Vec<&str> = deduped.iter().map(|token| token.as_str()).collect();
+                assert_eq!(tokens, ["tok-a", "tok-b"]);
+            }
+            other => panic!("expected a three-candidate ambiguity, got {other:?}"),
+        }
+    }
+}
+
 #[test]
 fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = crate::auth::StandardHTTPAuthenticationBuilder::new();

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -159,9 +159,9 @@ mod select_bearer {
     }
 
     #[test]
-    fn mixed_candidates_dedupe_in_map_order_and_count_all_matches() {
+    fn mixed_candidates_dedupe_in_map_order_and_keep_all_matches() {
         // Two patterns of one credential plus a distinct one: the error
-        // count reports all three matches, while try-all consumers walk
+        // naming sees all three matches, while try-all consumers walk
         // the two distinct tokens in map order.
         let map = map(&[
             ("https://example.com/**", "tok-a"),
@@ -169,10 +169,9 @@ mod select_bearer {
             ("https://example.com/api/v1/**", "tok-b"),
         ]);
         match select(&map) {
-            BearerSelection::Ambiguous {
-                candidates: 3,
-                deduped,
-            } => {
+            BearerSelection::Ambiguous { matched, deduped } => {
+                let all: Vec<&str> = matched.iter().map(|token| token.as_str()).collect();
+                assert_eq!(all, ["tok-a", "tok-a", "tok-b"]);
                 let tokens: Vec<&str> = deduped.iter().map(|token| token.as_str()).collect();
                 assert_eq!(tokens, ["tok-a", "tok-b"]);
             }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -254,7 +254,7 @@ impl BlobBackend for CountingBackend {
 fn counting_store(
     records: Vec<CredentialRecord>,
 ) -> (LockedBlobStore<CountingBackend>, Arc<AtomicUsize>) {
-    let raw = serialize_blob(&CredentialBlob::new(records)).unwrap();
+    let raw = serialize_blob(&CredentialBlob::new(records));
     let reads = Arc::new(AtomicUsize::new(0));
     let backend = CountingBackend {
         inner: InMemoryBlobBackend::with_contents(&raw),

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -267,6 +267,7 @@ fn bearer_record(globs: &[String], secret: &str) -> CredentialRecord {
         subject: None,
         token_name: None,
         token_prefix: None,
+        validated: Vec::new(),
         extra: serde_json::Map::new(),
     }
 }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -721,7 +721,7 @@ fn debug_never_renders_secrets() {
     assert!(!rendered.contains("stored-secret"), "rendered: {rendered}");
 }
 
-// Reactive expiry hint (design/credential-storage.md section 9).
+// The reactive expiry hint.
 
 use chrono::{Duration, Utc};
 

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -287,8 +287,8 @@ impl CredentialStore for CountingStore {
 }
 
 /// A store whose reads always fail, for the degrade-to-no-credentials
-/// paths. `absent` selects `BackendAbsent` (quiet) over `BackendDenied`
-/// (warned about); the request-level behavior must be identical.
+/// paths. `absent` selects `BackendAbsent` over `BackendDenied` (both are
+/// warned about); the request-level behavior must be identical.
 #[derive(Debug)]
 struct FailingStore {
     absent: bool,
@@ -428,6 +428,69 @@ fn lazy_layer_never_reads_store_on_server_error() {
     assert_eq!(response.status().as_u16(), 500);
     assert_eq!(lists.load(Ordering::SeqCst), 0);
     mock.assert();
+}
+
+#[test]
+fn lazy_layer_never_reads_store_on_rate_limiting() {
+    // 429 is rate limiting, not an auth verdict: the response is returned
+    // as-is, with no store read and no forced retry against a host that
+    // just throttled us (expect(1) asserts no retry happens).
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/pkg/versions.json")
+        .with_status(429)
+        .expect(1)
+        .create();
+
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &[format!("{}/**", server.url())],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 429);
+    assert_eq!(lists.load(Ordering::SeqCst), 0);
+    mock.assert();
+}
+
+#[test]
+fn sequence_auth_does_not_try_lower_on_rate_limiting() {
+    // The same 429 carve-out in `SequenceAuthentication`: a rate-limited
+    // unauthenticated request must not be retried with the env credential.
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(429)
+        .expect(1)
+        .create();
+    let bearer_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer env-token")
+        .expect(0)
+        .create();
+
+    let mut env_builder = StandardHTTPAuthenticationBuilder::new();
+    env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token");
+    let policy = env_builder.build().unwrap();
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 429);
+    mock.assert();
+    bearer_mock.assert();
 }
 
 #[test]
@@ -742,57 +805,38 @@ fn lazy_layer_without_store_returns_original_response() {
 }
 
 #[test]
-fn stored_bearer_map_blocking_shares_the_request_path_cache() {
-    let mut server = mockito::Server::new();
-    let mock = server
-        .mock("GET", "/pkg/versions.json")
-        .with_status(404)
-        .expect(1)
-        .create();
-
+fn direct_stored_bearer_read_does_exactly_one_store_read_per_call() {
     let (store, lists) = CountingStore::with_records(vec![bearer_record(
         &["https://other.example.com/**".to_string()],
         "stored-token",
     )]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
-    let runtime = runtime();
 
-    // Publish-style synchronous read first...
-    let map = policy.stored_bearer_map_blocking();
+    // Publish-style direct read: one `list` per call, no cache involved.
+    let map = policy.read_stored_bearer_map_direct();
     assert!(matches!(
         map.lookup("https://other.example.com/upload"),
         crate::auth::GlobMapResult::Found(_, _)
     ));
-    // ...then a request-path escalation reuses the same cache.
-    let response = get(
-        &runtime,
-        &policy,
-        &format!("{}/pkg/versions.json", server.url()),
-    );
-
-    assert_eq!(response.status().as_u16(), 404);
     assert_eq!(lists.load(Ordering::SeqCst), 1);
-    mock.assert();
 }
 
 #[test]
-fn stored_bearer_map_blocking_reuses_an_async_initialized_cache() {
-    let (store, lists) = CountingStore::with_records(vec![bearer_record(
-        &["https://other.example.com/**".to_string()],
-        "stored-token",
-    )]);
-    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
-    let runtime = runtime();
+fn direct_stored_bearer_read_degrades_store_errors_to_an_empty_map() {
+    for absent in [true, false] {
+        let (store, lists) = FailingStore::new(absent);
+        let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
 
-    // The async accessor initializes the cache first...
-    runtime.block_on(policy.stored_bearer_map());
-    // ...and the synchronous accessor reuses it: still one store read.
-    let map = policy.stored_bearer_map_blocking();
-    assert!(matches!(
-        map.lookup("https://other.example.com/upload"),
-        crate::auth::GlobMapResult::Found(_, _)
-    ));
-    assert_eq!(lists.load(Ordering::SeqCst), 1);
+        let map = policy.read_stored_bearer_map_direct();
+        assert!(
+            matches!(
+                map.lookup("https://example.com/upload"),
+                crate::auth::GlobMapResult::NotFound
+            ),
+            "absent = {absent}"
+        );
+        assert_eq!(lists.load(Ordering::SeqCst), 1, "absent = {absent}");
+    }
 }
 
 // Debug redaction: the hand-written `Debug` impls exist so a secret can
@@ -846,7 +890,7 @@ fn debug_of_wrappers_and_composed_policy_never_renders_secrets() {
         "stored-secret",
     )]);
     let policy = CredentialStoreAuthentication::new(env_builder.build().unwrap(), store);
-    let _ = policy.stored_bearer_map_blocking();
+    runtime().block_on(policy.stored_bearer_map());
     let rendered = format!("{policy:?}");
     assert!(rendered.contains("<redacted>"), "rendered: {rendered}");
     assert!(!rendered.contains("env-secret"), "rendered: {rendered}");
@@ -906,16 +950,19 @@ fn stored_bearer_expiry_warning_skips_unexpired_and_unknown_expiry() {
 }
 
 /// Look the stored bearer for `url` up in the policy's cached map, to
-/// observe the per-record expiry-warned flag after driving requests. The
-/// clone shares the record's `expiry_warned` flag (it is an `Arc`).
+/// observe the per-record expiry-warned flag after driving requests. Must
+/// go through the request path's cache (not a direct store read, which
+/// would build fresh records with fresh flags); the clone shares the
+/// record's `expiry_warned` flag (it is an `Arc`).
 fn stored_bearer_for<Inner, S>(
+    runtime: &tokio::runtime::Runtime,
     policy: &CredentialStoreAuthentication<Inner, S>,
     url: &str,
 ) -> StoredBearerAuth
 where
     S: CredentialStore + Send + Sync + 'static,
 {
-    match policy.stored_bearer_map_blocking().lookup(url) {
+    match runtime.block_on(policy.stored_bearer_map()).lookup(url) {
         crate::auth::GlobMapResult::Found(_, bearer) => bearer.clone(),
         other => panic!("expected a stored bearer for `{url}`, got {other:?}"),
     }
@@ -951,12 +998,12 @@ fn lazy_layer_warns_once_for_an_expired_record_that_keeps_failing() {
     // The hint was emitted (and latched) during the first escalation, so
     // the second identical failure cannot repeat it: `take_expiry_warning`
     // returns `None` once the flag is set (covered by the unit test above).
-    assert!(stored_bearer_for(&policy, &url).expiry_warning_emitted());
+    assert!(stored_bearer_for(&runtime, &policy, &url).expiry_warning_emitted());
     let second = get(&runtime, &policy, &url);
 
     assert_eq!(first.status().as_u16(), 404);
     assert_eq!(second.status().as_u16(), 404);
-    assert!(stored_bearer_for(&policy, &url).expiry_warning_emitted());
+    assert!(stored_bearer_for(&runtime, &policy, &url).expiry_warning_emitted());
     unauth_mock.assert();
     forced_mock.assert();
 }
@@ -982,7 +1029,7 @@ fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
     let runtime = runtime();
     let url = format!("{}/pkg/versions.json", server.url());
     get(&runtime, &policy, &url);
-    assert!(!stored_bearer_for(&policy, &url).expiry_warning_emitted());
+    assert!(!stored_bearer_for(&runtime, &policy, &url).expiry_warning_emitted());
 
     // Case 2: expired record, but the forced retry succeeds: no hint
     // (the credential demonstrably still works).
@@ -1004,5 +1051,5 @@ fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
     let url = format!("{}/pkg/versions.json", server.url());
     let response = get(&runtime, &policy, &url);
     assert_eq!(response.status().as_u16(), 200);
-    assert!(!stored_bearer_for(&policy, &url).expiry_warning_emitted());
+    assert!(!stored_bearer_for(&runtime, &policy, &url).expiry_warning_emitted());
 }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -124,10 +124,11 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std:
     // By-ref extraction: the policy stays usable afterwards.
     let bearer_map = policy.publish_bearer_auth_map()?;
 
-    if let crate::auth::GlobMapResult::Found(_, auth) =
+    if let crate::auth::GlobMapResult::Found(_, entry) =
         bearer_map.lookup("https://bearer.example.com/upload")
     {
-        assert_eq!(&*auth.0, "tok");
+        assert_eq!(&*entry.auth.0, "tok");
+        assert_eq!(entry.label, None);
     } else {
         panic!("expected bearer entry to be extracted");
     }
@@ -140,6 +141,26 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std:
         bearer_map.lookup("https://other.example.com/upload"),
         crate::auth::GlobMapResult::NotFound
     ));
+
+    Ok(())
+}
+
+#[test]
+fn publish_bearer_auth_map_carries_the_env_label() -> Result<(), Box<dyn std::error::Error>> {
+    let mut builder = crate::auth::StandardHTTPAuthenticationBuilder::new();
+    builder.add_bearer_auth_labeled("https://bearer.example.com/*", "tok", "TEAMIDX");
+    let policy = builder.build()?;
+
+    let bearer_map = policy.publish_bearer_auth_map()?;
+
+    if let crate::auth::GlobMapResult::Found(_, entry) =
+        bearer_map.lookup("https://bearer.example.com/upload")
+    {
+        assert_eq!(&*entry.auth.0, "tok");
+        assert_eq!(entry.label.as_deref(), Some("TEAMIDX"));
+    } else {
+        panic!("expected labeled bearer entry to be extracted");
+    }
 
     Ok(())
 }
@@ -673,4 +694,155 @@ fn stored_bearer_map_blocking_shares_the_request_path_cache() {
     assert_eq!(response.status().as_u16(), 404);
     assert_eq!(lists.load(Ordering::SeqCst), 1);
     mock.assert();
+}
+
+// Reactive expiry hint (design/credential-storage.md section 9).
+
+use chrono::{Duration, Utc};
+
+use crate::auth::{ForceBearerAuth, StoredBearerAuth};
+
+#[test]
+fn stored_bearer_expiry_warning_fires_at_most_once() {
+    let now = Utc::now();
+    let bearer = StoredBearerAuth::new(
+        ForceBearerAuth::new("tok"),
+        "https://example.com/".to_string(),
+        Some(now - Duration::hours(1)),
+    );
+
+    let message = bearer
+        .take_expiry_warning(now)
+        .expect("an expired record must produce the hint once");
+    assert!(
+        message.contains("credential for `https://example.com/` may be expired or revoked"),
+        "message: {message}"
+    );
+    assert!(
+        message.contains("re-run `sysand auth login https://example.com/`"),
+        "message: {message}"
+    );
+    // Second failure on the same record: no repeat hint.
+    assert_eq!(bearer.take_expiry_warning(now), None);
+}
+
+#[test]
+fn stored_bearer_expiry_warning_skips_unexpired_and_unknown_expiry() {
+    let now = Utc::now();
+    let unexpired = StoredBearerAuth::new(
+        ForceBearerAuth::new("tok"),
+        "https://example.com/".to_string(),
+        Some(now + Duration::hours(1)),
+    );
+    assert_eq!(unexpired.take_expiry_warning(now), None);
+    assert!(!unexpired.expiry_warning_emitted());
+
+    let unknown = StoredBearerAuth::new(
+        ForceBearerAuth::new("tok"),
+        "https://example.com/".to_string(),
+        None,
+    );
+    assert_eq!(unknown.take_expiry_warning(now), None);
+    assert!(!unknown.expiry_warning_emitted());
+}
+
+/// Look the stored bearer for `url` up in the policy's cached map, to
+/// observe the per-record expiry-warned flag after driving requests.
+fn stored_bearer_for<'a, Inner, S>(
+    policy: &'a CredentialStoreAuthentication<Inner, S>,
+    url: &str,
+) -> &'a StoredBearerAuth
+where
+    S: CredentialStore + Send + Sync + 'static,
+{
+    match policy.stored_bearer_map_blocking().lookup(url) {
+        crate::auth::GlobMapResult::Found(_, bearer) => bearer,
+        other => panic!("expected a stored bearer for `{url}`, got {other:?}"),
+    }
+}
+
+#[test]
+fn lazy_layer_warns_once_for_an_expired_record_that_keeps_failing() {
+    let mut server = mockito::Server::new();
+    // GitLab-style host: bad auth answers 404, not 401 (the hint must
+    // fire on any 4xx). Two full escalations; the flag must latch after
+    // the first, so the hint is emitted at most once per process.
+    let unauth_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(404)
+        .expect(2)
+        .create();
+    let forced_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stored-token")
+        .with_status(404)
+        .expect(2)
+        .create();
+
+    let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
+    record.expires_at = Some(Utc::now() - Duration::days(1));
+    let (store, _lists) = CountingStore::with_records(vec![record]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+    let url = format!("{}/pkg/versions.json", server.url());
+
+    let first = get(&runtime, &policy, &url);
+    // The hint was emitted (and latched) during the first escalation, so
+    // the second identical failure cannot repeat it: `take_expiry_warning`
+    // returns `None` once the flag is set (covered by the unit test above).
+    assert!(stored_bearer_for(&policy, &url).expiry_warning_emitted());
+    let second = get(&runtime, &policy, &url);
+
+    assert_eq!(first.status().as_u16(), 404);
+    assert_eq!(second.status().as_u16(), 404);
+    assert!(stored_bearer_for(&policy, &url).expiry_warning_emitted());
+    unauth_mock.assert();
+    forced_mock.assert();
+}
+
+#[test]
+fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
+    // Case 1: unexpired record, failing retry: no hint.
+    let mut server = mockito::Server::new();
+    let _unauth = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .create();
+    let _forced = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stored-token")
+        .with_status(404)
+        .create();
+    let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
+    record.expires_at = Some(Utc::now() + Duration::days(1));
+    let (store, _lists) = CountingStore::with_records(vec![record]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+    let url = format!("{}/pkg/versions.json", server.url());
+    get(&runtime, &policy, &url);
+    assert!(!stored_bearer_for(&policy, &url).expiry_warning_emitted());
+
+    // Case 2: expired record, but the forced retry succeeds: no hint
+    // (the credential demonstrably still works).
+    let mut server = mockito::Server::new();
+    let _unauth = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .create();
+    let _forced = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stored-token")
+        .with_status(200)
+        .create();
+    let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
+    record.expires_at = Some(Utc::now() - Duration::days(1));
+    let (store, _lists) = CountingStore::with_records(vec![record]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let url = format!("{}/pkg/versions.json", server.url());
+    let response = get(&runtime, &policy, &url);
+    assert_eq!(response.status().as_u16(), 200);
+    assert!(!stored_bearer_for(&policy, &url).expiry_warning_emitted());
 }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -1,7 +1,20 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use crate::auth::{GlobMapBuilder, GlobMapResultMut};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use crate::auth::{
+    CredentialStoreAuthentication, GlobMapBuilder, GlobMapResultMut, HTTPAuthentication,
+    StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder,
+};
+use crate::credential_store::{
+    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
+    InMemoryCredentialStore,
+};
+use crate::resolve::net_utils::create_reqwest_client;
 
 #[test]
 fn basic_globmap_lookup() -> Result<(), Box<dyn std::error::Error>> {
@@ -129,4 +142,532 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std:
     ));
 
     Ok(())
+}
+
+// Tests for the lazy credential store layer
+// (`CredentialStoreAuthentication`).
+
+/// Counts `list` calls so tests can assert when (and how often) the
+/// credential store is actually read.
+#[derive(Debug)]
+struct CountingStore {
+    inner: InMemoryCredentialStore,
+    lists: Arc<AtomicUsize>,
+}
+
+impl CountingStore {
+    fn with_records(records: Vec<CredentialRecord>) -> (Self, Arc<AtomicUsize>) {
+        let mut inner = InMemoryCredentialStore::new();
+        for record in records {
+            inner.upsert(record).unwrap();
+        }
+        let lists = Arc::new(AtomicUsize::new(0));
+        (
+            CountingStore {
+                inner,
+                lists: lists.clone(),
+            },
+            lists,
+        )
+    }
+}
+
+impl CredentialStore for CountingStore {
+    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+        self.lists.fetch_add(1, Ordering::SeqCst);
+        self.inner.list()
+    }
+
+    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
+        self.inner.upsert(record)
+    }
+
+    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
+        self.inner.remove(key)
+    }
+}
+
+/// A store whose reads always fail, for the degrade-to-no-credentials
+/// paths. `absent` selects `BackendAbsent` (quiet) over `BackendDenied`
+/// (warned about); the request-level behavior must be identical.
+#[derive(Debug)]
+struct FailingStore {
+    absent: bool,
+    lists: Arc<AtomicUsize>,
+}
+
+impl FailingStore {
+    fn new(absent: bool) -> (Self, Arc<AtomicUsize>) {
+        let lists = Arc::new(AtomicUsize::new(0));
+        (
+            FailingStore {
+                absent,
+                lists: lists.clone(),
+            },
+            lists,
+        )
+    }
+
+    fn error(&self) -> CredentialStoreError {
+        if self.absent {
+            CredentialStoreError::BackendAbsent {
+                source: "no keyring backend".into(),
+            }
+        } else {
+            CredentialStoreError::BackendDenied {
+                source: "keyring is locked".into(),
+            }
+        }
+    }
+}
+
+impl CredentialStore for FailingStore {
+    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+        self.lists.fetch_add(1, Ordering::SeqCst);
+        Err(self.error())
+    }
+
+    fn upsert(&mut self, _record: CredentialRecord) -> Result<(), CredentialStoreError> {
+        Err(self.error())
+    }
+
+    fn remove(&mut self, _key: &str) -> Result<bool, CredentialStoreError> {
+        Err(self.error())
+    }
+}
+
+fn bearer_record(globs: &[String], secret: &str) -> CredentialRecord {
+    CredentialRecord {
+        key: "https://example.com/".to_string(),
+        globs: globs.to_vec(),
+        scheme: CredentialScheme::Bearer,
+        secret: secret.to_string(),
+        expires_at: None,
+        extra: serde_json::Map::new(),
+    }
+}
+
+fn empty_env_policy() -> StandardHTTPAuthentication {
+    StandardHTTPAuthenticationBuilder::new().build().unwrap()
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap()
+}
+
+/// Drive one GET for `url` through `policy`, like the resolve path does.
+fn get<P: HTTPAuthentication>(
+    runtime: &tokio::runtime::Runtime,
+    policy: &P,
+    url: &str,
+) -> reqwest::Response {
+    let client = create_reqwest_client().unwrap();
+    let url = url.to_string();
+    let renew = move |c: &reqwest_middleware::ClientWithMiddleware| c.get(&url);
+    runtime
+        .block_on(policy.with_authentication(&client, &renew))
+        .unwrap()
+}
+
+#[test]
+fn lazy_layer_never_reads_store_on_unauthenticated_success() {
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/pkg/versions.json")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &[format!("{}/**", server.url())],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(lists.load(Ordering::SeqCst), 0);
+    mock.assert();
+}
+
+#[test]
+fn lazy_layer_never_reads_store_on_server_error() {
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/pkg/versions.json")
+        .with_status(500)
+        .expect(1)
+        .create();
+
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &[format!("{}/**", server.url())],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 500);
+    assert_eq!(lists.load(Ordering::SeqCst), 0);
+    mock.assert();
+}
+
+#[test]
+fn lazy_layer_reads_store_once_and_returns_original_response_on_no_match() {
+    let mut server = mockito::Server::new();
+    // Routine 404s on the resolve path: the store is read exactly once
+    // across requests, and with no matching record each original response
+    // comes back untouched with no extra request (expect(2) with two
+    // `get`s asserts no retries happen).
+    let mock = server
+        .mock("GET", "/pkg/versions.json")
+        .with_status(404)
+        .expect(2)
+        .create();
+
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &["https://other.example.com/**".to_string()],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+    let url = format!("{}/pkg/versions.json", server.url());
+
+    let first = get(&runtime, &policy, &url);
+    let second = get(&runtime, &policy, &url);
+
+    assert_eq!(first.status().as_u16(), 404);
+    assert_eq!(second.status().as_u16(), 404);
+    assert_eq!(lists.load(Ordering::SeqCst), 1);
+    mock.assert();
+}
+
+#[test]
+fn lazy_layer_matching_record_forces_authenticated_retry() {
+    let mut server = mockito::Server::new();
+    let unauth_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .expect(1)
+        .create();
+    let bearer_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stored-token")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &[format!("{}/**", server.url())],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(lists.load(Ordering::SeqCst), 1);
+    unauth_mock.assert();
+    bearer_mock.assert();
+}
+
+#[test]
+fn lazy_layer_env_credential_wins_without_store_read() {
+    let mut server = mockito::Server::new();
+    let unauth_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .expect(1)
+        .create();
+    let env_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer env-token")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let mut env_builder = StandardHTTPAuthenticationBuilder::new();
+    env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token");
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &[format!("{}/**", server.url())],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(env_builder.build().unwrap(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(lists.load(Ordering::SeqCst), 0);
+    unauth_mock.assert();
+    env_mock.assert();
+}
+
+#[test]
+fn lazy_layer_failed_env_credential_escalates_to_store() {
+    let mut server = mockito::Server::new();
+    let unauth_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .expect(1)
+        .create();
+    let env_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stale-env-token")
+        .with_status(401)
+        .expect(1)
+        .create();
+    let stored_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stored-token")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let mut env_builder = StandardHTTPAuthenticationBuilder::new();
+    env_builder.add_bearer_auth(format!("{}/**", server.url()), "stale-env-token");
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &[format!("{}/**", server.url())],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(env_builder.build().unwrap(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(lists.load(Ordering::SeqCst), 1);
+    unauth_mock.assert();
+    env_mock.assert();
+    stored_mock.assert();
+}
+
+#[test]
+fn lazy_layer_overlapping_globs_of_one_record_retry_once() {
+    let mut server = mockito::Server::new();
+    let unauth_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .expect(1)
+        .create();
+    // One login covering the URL with two patterns is not an ambiguity:
+    // exactly one forced retry with its token.
+    let bearer_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stored-token")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let (store, _lists) = CountingStore::with_records(vec![bearer_record(
+        &[
+            format!("{}/**", server.url()),
+            format!("{}/pkg/*", server.url()),
+        ],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 200);
+    unauth_mock.assert();
+    bearer_mock.assert();
+}
+
+#[test]
+fn lazy_layer_ambiguous_distinct_records_try_all_in_order() {
+    let mut server = mockito::Server::new();
+    let unauth_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .expect(1)
+        .create();
+    let rejected_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer broad-token")
+        .with_status(401)
+        .expect(1)
+        .create();
+    let accepted_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer narrow-token")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let mut broad = bearer_record(&[format!("{}/**", server.url())], "broad-token");
+    broad.key = "https://example.com/broad/".to_string();
+    let mut narrow = bearer_record(&[format!("{}/pkg/*", server.url())], "narrow-token");
+    narrow.key = "https://example.com/narrow/".to_string();
+    let (store, _lists) = CountingStore::with_records(vec![broad, narrow]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 200);
+    unauth_mock.assert();
+    rejected_mock.assert();
+    accepted_mock.assert();
+}
+
+#[test]
+fn lazy_layer_invalid_stored_glob_skips_only_that_pattern() {
+    let mut server = mockito::Server::new();
+    let unauth_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .expect(1)
+        .create();
+    let bearer_mock = server
+        .mock("GET", "/pkg/versions.json")
+        .match_header("authorization", "Bearer stored-token")
+        .with_status(200)
+        .expect(1)
+        .create();
+
+    let (store, _lists) = CountingStore::with_records(vec![bearer_record(
+        &["[invalid".to_string(), format!("{}/**", server.url())],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 200);
+    unauth_mock.assert();
+    bearer_mock.assert();
+}
+
+#[test]
+fn lazy_layer_store_errors_degrade_to_no_credentials() {
+    for absent in [true, false] {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/pkg/versions.json")
+            .with_status(404)
+            .expect(2)
+            .create();
+
+        let (store, lists) = FailingStore::new(absent);
+        let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+        let runtime = runtime();
+        let url = format!("{}/pkg/versions.json", server.url());
+
+        // Both error kinds behave as "no stored credentials" for the
+        // request, and the failed read is cached like a successful one.
+        let first = get(&runtime, &policy, &url);
+        let second = get(&runtime, &policy, &url);
+
+        assert_eq!(first.status().as_u16(), 404, "absent = {absent}");
+        assert_eq!(second.status().as_u16(), 404, "absent = {absent}");
+        assert_eq!(lists.load(Ordering::SeqCst), 1, "absent = {absent}");
+        mock.assert();
+    }
+}
+
+#[test]
+fn lazy_layer_without_store_returns_original_response() {
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/pkg/versions.json")
+        .with_status(404)
+        .expect(1)
+        .create();
+
+    let policy: CredentialStoreAuthentication<_, InMemoryCredentialStore> =
+        CredentialStoreAuthentication::without_store(empty_env_policy());
+    let runtime = runtime();
+
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 404);
+    mock.assert();
+}
+
+#[test]
+fn stored_bearer_map_blocking_shares_the_request_path_cache() {
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/pkg/versions.json")
+        .with_status(404)
+        .expect(1)
+        .create();
+
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &["https://other.example.com/**".to_string()],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    // Publish-style synchronous read first...
+    let map = policy.stored_bearer_map_blocking();
+    assert!(matches!(
+        map.lookup("https://other.example.com/upload"),
+        crate::auth::GlobMapResult::Found(_, _)
+    ));
+    // ...then a request-path escalation reuses the same cache.
+    let response = get(
+        &runtime,
+        &policy,
+        &format!("{}/pkg/versions.json", server.url()),
+    );
+
+    assert_eq!(response.status().as_u16(), 404);
+    assert_eq!(lists.load(Ordering::SeqCst), 1);
+    mock.assert();
 }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -697,6 +697,84 @@ fn stored_bearer_map_blocking_shares_the_request_path_cache() {
     mock.assert();
 }
 
+#[test]
+fn stored_bearer_map_blocking_reuses_an_async_initialized_cache() {
+    let (store, lists) = CountingStore::with_records(vec![bearer_record(
+        &["https://other.example.com/**".to_string()],
+        "stored-token",
+    )]);
+    let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
+    let runtime = runtime();
+
+    // The async accessor initializes the cache first...
+    runtime.block_on(policy.stored_bearer_map());
+    // ...and the synchronous accessor reuses it: still one store read.
+    let map = policy.stored_bearer_map_blocking();
+    assert!(matches!(
+        map.lookup("https://other.example.com/upload"),
+        crate::auth::GlobMapResult::Found(_, _)
+    ));
+    assert_eq!(lists.load(Ordering::SeqCst), 1);
+}
+
+// Debug redaction: the hand-written `Debug` impls exist so a secret can
+// never reach logs via an accidental `{:?}`; pin that here.
+
+#[test]
+fn debug_of_secret_bearing_leaves_shows_the_marker_not_the_secret() {
+    let bearer = crate::auth::ForceBearerAuth::new("bearer-secret");
+    let rendered = format!("{bearer:?}");
+    assert!(rendered.contains("<redacted>"), "rendered: {rendered}");
+    assert!(!rendered.contains("bearer-secret"), "rendered: {rendered}");
+
+    let basic = crate::auth::ForceHTTPBasicAuth {
+        username: "alice".into(),
+        password: "basic-secret".into(),
+    };
+    let rendered = format!("{basic:?}");
+    assert!(rendered.contains("alice"), "rendered: {rendered}");
+    assert!(rendered.contains("<redacted>"), "rendered: {rendered}");
+    assert!(!rendered.contains("basic-secret"), "rendered: {rendered}");
+}
+
+#[test]
+fn debug_of_wrappers_and_composed_policy_never_renders_secrets() {
+    let env = crate::auth::EnvBearerAuth {
+        auth: crate::auth::ForceBearerAuth::new("env-secret"),
+        label: Some("TEAMIDX".to_string()),
+    };
+    let rendered = format!("{env:?}");
+    assert!(rendered.contains("TEAMIDX"), "rendered: {rendered}");
+    assert!(!rendered.contains("env-secret"), "rendered: {rendered}");
+
+    let stored = crate::auth::StoredBearerAuth::new(
+        crate::auth::ForceBearerAuth::new("stored-secret"),
+        "https://example.com/".to_string(),
+        None,
+    );
+    let rendered = format!("{stored:?}");
+    assert!(
+        rendered.contains("https://example.com/"),
+        "rendered: {rendered}"
+    );
+    assert!(!rendered.contains("stored-secret"), "rendered: {rendered}");
+
+    // The composed policy: env credentials in `inner`, stored credentials
+    // in the populated cache. Neither secret may surface.
+    let mut env_builder = StandardHTTPAuthenticationBuilder::new();
+    env_builder.add_bearer_auth("https://bearer.example.com/**", "env-secret");
+    let (store, _lists) = CountingStore::with_records(vec![bearer_record(
+        &["https://other.example.com/**".to_string()],
+        "stored-secret",
+    )]);
+    let policy = CredentialStoreAuthentication::new(env_builder.build().unwrap(), store);
+    let _ = policy.stored_bearer_map_blocking();
+    let rendered = format!("{policy:?}");
+    assert!(rendered.contains("<redacted>"), "rendered: {rendered}");
+    assert!(!rendered.contains("env-secret"), "rendered: {rendered}");
+    assert!(!rendered.contains("stored-secret"), "rendered: {rendered}");
+}
+
 // Reactive expiry hint (design/credential-storage.md section 9).
 
 use chrono::{Duration, Utc};
@@ -750,16 +828,17 @@ fn stored_bearer_expiry_warning_skips_unexpired_and_unknown_expiry() {
 }
 
 /// Look the stored bearer for `url` up in the policy's cached map, to
-/// observe the per-record expiry-warned flag after driving requests.
-fn stored_bearer_for<'a, Inner, S>(
-    policy: &'a CredentialStoreAuthentication<Inner, S>,
+/// observe the per-record expiry-warned flag after driving requests. The
+/// clone shares the record's `expiry_warned` flag (it is an `Arc`).
+fn stored_bearer_for<Inner, S>(
+    policy: &CredentialStoreAuthentication<Inner, S>,
     url: &str,
-) -> &'a StoredBearerAuth
+) -> StoredBearerAuth
 where
     S: CredentialStore + Send + Sync + 'static,
 {
     match policy.stored_bearer_map_blocking().lookup(url) {
-        crate::auth::GlobMapResult::Found(_, bearer) => bearer,
+        crate::auth::GlobMapResult::Found(_, bearer) => bearer.clone(),
         other => panic!("expected a stored bearer for `{url}`, got {other:?}"),
     }
 }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -100,3 +100,33 @@ fn globmap_matches_template_expanded_urls() -> Result<(), Box<dyn std::error::Er
 
     Ok(())
 }
+
+#[test]
+fn publish_bearer_auth_map_keeps_bearer_drops_basic() -> Result<(), Box<dyn std::error::Error>> {
+    let mut builder = crate::auth::StandardHTTPAuthenticationBuilder::new();
+    builder.add_basic_auth("https://basic.example.com/*", "user", "password");
+    builder.add_bearer_auth("https://bearer.example.com/*", "tok");
+    let policy = builder.build()?;
+
+    // By-ref extraction: the policy stays usable afterwards.
+    let bearer_map = policy.publish_bearer_auth_map()?;
+
+    if let crate::auth::GlobMapResult::Found(_, auth) =
+        bearer_map.lookup("https://bearer.example.com/upload")
+    {
+        assert_eq!(&*auth.0, "tok");
+    } else {
+        panic!("expected bearer entry to be extracted");
+    }
+
+    assert!(matches!(
+        bearer_map.lookup("https://basic.example.com/upload"),
+        crate::auth::GlobMapResult::NotFound
+    ));
+    assert!(matches!(
+        bearer_map.lookup("https://other.example.com/upload"),
+        crate::auth::GlobMapResult::NotFound
+    ));
+
+    Ok(())
+}

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -186,8 +186,8 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic_and_carries_labels()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = crate::auth::StandardHTTPAuthenticationBuilder::new();
     builder.add_basic_auth("https://basic.example.com/*", "user", "password");
-    builder.add_bearer_auth("https://bearer.example.com/*", "tok");
-    builder.add_bearer_auth_labeled("https://labeled.example.com/*", "tok2", "TEAMIDX");
+    builder.add_bearer_auth("https://bearer.example.com/*", "tok", "MYIDX");
+    builder.add_bearer_auth("https://labeled.example.com/*", "tok2", "TEAMIDX");
     let policy = builder.build()?;
 
     // By-ref extraction: the policy stays usable afterwards.
@@ -197,7 +197,7 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic_and_carries_labels()
         bearer_map.lookup("https://bearer.example.com/upload")
     {
         assert_eq!(&*entry.auth.0, "tok");
-        assert_eq!(entry.label, None);
+        assert_eq!(entry.label, "MYIDX");
     } else {
         panic!("expected bearer entry to be extracted");
     }
@@ -206,7 +206,7 @@ fn publish_bearer_auth_map_keeps_bearer_drops_basic_and_carries_labels()
         bearer_map.lookup("https://labeled.example.com/upload")
     {
         assert_eq!(&*entry.auth.0, "tok2");
-        assert_eq!(entry.label.as_deref(), Some("TEAMIDX"));
+        assert_eq!(entry.label, "TEAMIDX");
     } else {
         panic!("expected labeled bearer entry to be extracted");
     }
@@ -420,7 +420,7 @@ fn sequence_auth_does_not_try_lower_on_rate_limiting() {
     let bearer_mock = versions_mock(&mut server, Some("env-token"), 200, 0);
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
-    env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token");
+    env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token", "ENVIDX");
     let policy = env_builder.build().unwrap();
     let runtime = runtime();
 
@@ -485,7 +485,7 @@ fn lazy_layer_env_credential_wins_without_store_read() {
     let env_mock = versions_mock(&mut server, Some("env-token"), 200, 1);
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
-    env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token");
+    env_builder.add_bearer_auth(format!("{}/**", server.url()), "env-token", "ENVIDX");
     let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
@@ -509,7 +509,7 @@ fn lazy_layer_failed_env_credential_escalates_to_store() {
     let stored_mock = versions_mock(&mut server, Some("stored-token"), 200, 1);
 
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
-    env_builder.add_bearer_auth(format!("{}/**", server.url()), "stale-env-token");
+    env_builder.add_bearer_auth(format!("{}/**", server.url()), "stale-env-token", "ENVIDX");
     let (store, lists) = counting_store(vec![bearer_record(
         &[format!("{}/**", server.url())],
         "stored-token",
@@ -687,7 +687,7 @@ fn debug_never_renders_secrets() {
     assert!(!rendered.contains("basic-secret"), "rendered: {rendered}");
     let env = crate::auth::EnvBearerAuth {
         auth: crate::auth::ForceBearerAuth::new("env-secret"),
-        label: Some("TEAMIDX".to_string()),
+        label: "TEAMIDX".to_string(),
     };
     let rendered = format!("{env:?}");
     assert!(rendered.contains("TEAMIDX"), "rendered: {rendered}");
@@ -708,7 +708,7 @@ fn debug_never_renders_secrets() {
     // The composed policy: env credentials in `inner`, stored credentials
     // in the populated cache. Neither secret may surface.
     let mut env_builder = StandardHTTPAuthenticationBuilder::new();
-    env_builder.add_bearer_auth("https://bearer.example.com/**", "env-secret");
+    env_builder.add_bearer_auth("https://bearer.example.com/**", "env-secret", "ENVIDX");
     let (store, _lists) = counting_store(vec![bearer_record(
         &["https://other.example.com/**".to_string()],
         "stored-secret",

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -243,6 +243,9 @@ fn bearer_record(globs: &[String], secret: &str) -> CredentialRecord {
         scheme: CredentialScheme::Bearer,
         secret: secret.to_string(),
         expires_at: None,
+        subject: None,
+        token_name: None,
+        token_prefix: None,
         extra: serde_json::Map::new(),
     }
 }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -719,10 +719,12 @@ fn stored_bearer_expiry_warning_fires_at_most_once() {
         message.contains("credential for `https://example.com/` may be expired or revoked"),
         "message: {message}"
     );
+    // The core warning names no CLI command; it says to re-authenticate.
     assert!(
-        message.contains("re-run `sysand auth login https://example.com/`"),
+        message.contains("re-authenticate to store a fresh credential"),
         "message: {message}"
     );
+    assert!(!message.contains("sysand auth"), "message: {message}");
     // Second failure on the same record: no repeat hint.
     assert_eq!(bearer.take_expiry_warning(now), None);
 }

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -27,7 +27,7 @@ use crate::{
         CredentialSubject, normalize_index_key,
     },
     env::discovery::{ResolvedEndpoints, fetch_index_config},
-    index_location::{IndexLocation, is_template_syntax},
+    index_location::{IndexLocation, IndexLocationError, is_template_syntax},
 };
 
 /// Errors from the `sysand auth` commands.
@@ -42,15 +42,17 @@ pub enum AuthCommandError {
     /// The target could not be parsed or normalized as an index URL.
     #[error("invalid index URL for credential storage: {0}")]
     InvalidIndexUrl(String),
-    /// The target is a URL-template index location, which `sysand auth`
-    /// does not support in v1 (a template does not normalize to a stable
-    /// index key). `SYSAND_CRED_*` environment variables remain the
-    /// authentication path for templated indexes.
+    /// The target is a URL template whose literal prefix has no anchor at
+    /// a safe URL boundary (at least `scheme://authority/`), so no
+    /// credential scope glob could be derived for it (the section 8
+    /// clamp). `SYSAND_CRED_*` environment variables remain the
+    /// authentication path for such templates.
     #[error(
-        "`{url}`: URL-template index locations are not supported by `sysand auth`;\n\
-         use `SYSAND_CRED_*` environment variables to authenticate a templated index"
+        "`{url}`: this URL template has no literal prefix at a safe URL boundary\n\
+         (at least `scheme://authority/`) to scope a credential to;\n\
+         use `SYSAND_CRED_*` environment variables to authenticate it"
     )]
-    TemplateIndexUrl { url: String },
+    TemplateWithoutAnchor { url: String },
     /// Every surface that exercised the credential rejected it and none
     /// accepted it, so nothing was stored (design/credential-storage.md
     /// section 5 refusal rule).
@@ -155,7 +157,10 @@ pub struct StoredCredentialStatus {
     /// record's key URL. Env credentials take precedence per matched
     /// request URL, so an env pattern matching only part of the covered
     /// URLs (or spelled so it misses the key, for example with a port
-    /// wildcard) may shadow requests without being listed here.
+    /// wildcard) may shadow requests without being listed here. For a
+    /// template key the match target contains the literal placeholder
+    /// text, which no request URL contains, so shadow detection is extra
+    /// approximate for templates.
     pub shadowed_by: Vec<String>,
 }
 
@@ -177,19 +182,32 @@ pub struct AuthStatus {
     pub env: Vec<EnvCredentialEntry>,
 }
 
-/// Validate that `index_url` is an absolute, non-template HTTP(S) URL and
-/// normalize it to its credential store key form.
+/// Validate that `index_url` is an absolute HTTP(S) index location (a
+/// plain URL or a `{path}`/`{path_raw}` URL template) and normalize it to
+/// its credential store key form.
+///
+/// A plain URL normalizes via
+/// [`normalize_index_key`]. A template's key is
+/// the template text with its anchorable literal prefix rewritten through
+/// `url::Url` serialization (lowercased scheme and host, default port
+/// stripped, IDN punycoded); the text after the prefix's last `/`, the
+/// placeholder, and the suffix stay verbatim, since they are raw template
+/// text, not a parsed URL. The result is idempotent and round-trips
+/// through [`IndexLocation::parse`] / `Display`, so `auth status` prints
+/// template keys in the exact form `auth logout` accepts. A template with
+/// no safe anchor (at least `scheme://authority/`) is rejected
+/// ([`AuthCommandError::TemplateWithoutAnchor`]): no credential scope
+/// glob could be derived for it.
 ///
 /// Public so the CLI can validate the target before reading a secret (a
-/// `file://` or template target must fail before any prompt).
+/// `file://` or unanchorable-template target must fail before any
+/// prompt).
 pub fn validated_index_key(index_url: &str) -> Result<String, AuthCommandError> {
-    // Reject template syntax before `Url::parse`: the `url` crate would
+    // Handle template syntax before `Url::parse`: the `url` crate would
     // percent-encode the braces and normalization would then silently
     // produce a mangled `%7Bpath%7D` key.
     if is_template_syntax(index_url) {
-        return Err(AuthCommandError::TemplateIndexUrl {
-            url: index_url.to_string(),
-        });
+        return normalized_template_key(index_url);
     }
     // Check the scheme before normalizing so a non-HTTP(S) location gets
     // the dedicated message instead of a generic normalization error.
@@ -207,6 +225,39 @@ pub fn validated_index_key(index_url: &str) -> Result<String, AuthCommandError> 
         CredentialStoreError::InvalidIndexUrl(msg) => AuthCommandError::InvalidIndexUrl(msg),
         other => AuthCommandError::Store(other),
     })
+}
+
+/// The credential-key form of a URL-template target: see
+/// [`validated_index_key`].
+fn normalized_template_key(index_url: &str) -> Result<String, AuthCommandError> {
+    let location = IndexLocation::parse(index_url).map_err(|err| match err {
+        IndexLocationError::UnsupportedScheme { .. } => AuthCommandError::NotHttpIndex {
+            url: index_url.to_string(),
+        },
+        // The index-location errors already name the URL; no re-prefixing.
+        other => AuthCommandError::InvalidIndexUrl(other.to_string()),
+    })?;
+    let IndexLocation::Template(template) = &location else {
+        // `IndexLocation::parse` classifies every brace-containing string
+        // as a template, and `index_url` contains a brace.
+        unreachable!("BUG: template syntax parsed as a plain URL");
+    };
+    let prefix = template.prefix();
+    let Some((cut, anchor)) = template_anchor_root(prefix) else {
+        return Err(AuthCommandError::TemplateWithoutAnchor {
+            url: index_url.to_string(),
+        });
+    };
+    // `Display` reproduces the validated template text, so slicing off
+    // the prefix leaves the placeholder plus suffix verbatim. The rest of
+    // the prefix past its last `/` contains no `/` by construction, so
+    // reassembly keeps the anchor as the key's own anchor (idempotence).
+    let tail = location.to_string();
+    Ok(format!(
+        "{anchor}{}{}",
+        &prefix[cut + 1..],
+        &tail[prefix.len()..]
+    ))
 }
 
 /// Progress notice emitted by [`do_auth_login`] while it works, so the
@@ -285,12 +336,15 @@ pub enum AuthLoginOutcome {
     },
 }
 
-/// Derive the escaped URL glob patterns a login for `key` covers
+/// Derive the escaped URL glob patterns a login covers
 /// (design/credential-storage.md section 8).
 ///
-/// The primary glob anchors on the normalized user-supplied discovery URL
-/// (`globset::escape(<root ending in />)` + `**`), so the discovery fetch
-/// itself is authenticated on later runs. The resolved `index_root` and
+/// The primary glob anchors on `primary_root`: the normalized
+/// user-supplied discovery URL for a plain-URL target (so the discovery
+/// fetch itself is authenticated on later runs), or the literal-prefix
+/// anchor for a template target
+/// (`globset::escape(<root ending in />)` + `**` either way). The
+/// resolved `index_root` and
 /// `api_root` add further globs only when not already covered by an
 /// earlier root (Case B, disjoint host or path); a root that is itself a
 /// prefix of an earlier one is also skipped, keeping the set minimal. A
@@ -301,7 +355,7 @@ pub enum AuthLoginOutcome {
 /// Both derivation and runtime matching serialize URLs via
 /// `url::Url::as_str()`, so IDN/percent-encoding agree on both sides.
 fn derive_credential_globs(
-    key: &str,
+    primary_root: &str,
     endpoints: Option<&ResolvedEndpoints>,
     notify: &mut impl FnMut(AuthLoginNotice),
 ) -> Vec<String> {
@@ -309,7 +363,7 @@ fn derive_credential_globs(
     // covered when one of these is its string prefix: the corresponding
     // `<escaped root>**` glob then matches every URL under the candidate
     // (`**` after `/` crosses separators).
-    let mut roots: Vec<String> = vec![key.to_string()];
+    let mut roots: Vec<String> = vec![primary_root.to_string()];
 
     let push_if_uncovered = |roots: &mut Vec<String>, candidate: &str| {
         if !roots
@@ -327,7 +381,7 @@ fn derive_credential_globs(
         match &endpoints.index_root {
             IndexLocation::Root(url) => push_if_uncovered(&mut roots, url.as_str()),
             IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
-                Some(anchor) => push_if_uncovered(&mut roots, anchor.as_str()),
+                Some((_, anchor)) => push_if_uncovered(&mut roots, anchor.as_str()),
                 None => notify(AuthLoginNotice::TemplateIndexRootSkipped {
                     template: template.to_string(),
                 }),
@@ -344,20 +398,21 @@ fn derive_credential_globs(
         .collect()
 }
 
-/// Anchor a templated `index_root`'s literal prefix at a safe URL
-/// boundary: the prefix cut back to its last `/`, reparsed as a URL so the
-/// anchor uses the same serialization runtime request URLs will (host
-/// case, default port). Returns `None` when no anchor at least as deep as
-/// `scheme://authority/` exists (for example a placeholder directly in the
-/// query of a path-less URL, whose last `/` is the one in `://`).
-fn template_anchor_root(prefix: &str) -> Option<Url> {
+/// Anchor a URL template's literal prefix at a safe URL boundary: the
+/// prefix cut back to its last `/`, reparsed as a URL so the anchor uses
+/// the same serialization runtime request URLs will (host case, default
+/// port). Returns the cut position (the byte index of that last `/`)
+/// alongside the anchor. Returns `None` when no anchor at least as deep
+/// as `scheme://authority/` exists (for example a placeholder directly in
+/// the query of a path-less URL, whose last `/` is the one in `://`).
+fn template_anchor_root(prefix: &str) -> Option<(usize, Url)> {
     let cut = prefix.rfind('/')?;
     let candidate = &prefix[..=cut];
     let url = Url::parse(candidate).ok()?;
     if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
         return None;
     }
-    Some(url)
+    Some((cut, url))
 }
 
 /// Identity fields parsed from a successful `v1/whoami` probe, persisted
@@ -721,6 +776,19 @@ pub fn do_auth_login<S: CredentialStore>(
     let key = validated_index_key(index_url)?;
     let location = IndexLocation::parse(&key)
         .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
+    // The primary glob root: the key itself for a plain URL (it ends in
+    // `/`), the literal-prefix anchor for a template target. Key
+    // validation already rejected unanchorable templates; this re-check
+    // just avoids a panic path.
+    let primary_root = match &location {
+        IndexLocation::Root(_) => key.clone(),
+        IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
+            Some((_, anchor)) => anchor.as_str().to_string(),
+            None => {
+                return Err(AuthCommandError::TemplateWithoutAnchor { url: key });
+            }
+        },
+    };
 
     let endpoints =
         match runtime.block_on(fetch_index_config(client, &Unauthenticated {}, &location)) {
@@ -732,7 +800,7 @@ pub fn do_auth_login<S: CredentialStore>(
                 None
             }
         };
-    let globs = derive_credential_globs(&key, endpoints.as_ref(), &mut notify);
+    let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
 
     // Detect an existing login before writing, so the host can announce
     // the replacement before the write. `list` and `upsert` are

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -66,12 +66,16 @@ pub enum AuthCommandError {
     /// Every surface that exercised the credential rejected it and none
     /// accepted it, so nothing was stored (design/credential-storage.md
     /// section 5 refusal rule).
-    #[error("{}", validation_rejected_message(.index, .rejected, *.basic_challenge))]
+    #[error("{}", validation_rejected_message(.index, .rejected, *.read_status, *.basic_challenge))]
     ValidationRejected {
         /// The normalized index key the login targeted.
         index: String,
         /// The surfaces that exercised and rejected the credential.
         rejected: Vec<ProbeSurface>,
+        /// The HTTP status of the read surface's rejection, when the read
+        /// surface rejected. A 404 hedges the message: it can mean a
+        /// rejected token, but also a URL with no index at all.
+        read_status: Option<u16>,
         /// Whether the read surface answered with a `WWW-Authenticate:
         /// Basic` challenge: the index wants username/password, not a
         /// bearer token, and the message routes the user to
@@ -120,20 +124,45 @@ pub enum AuthCommandError {
 fn validation_rejected_message(
     index: &str,
     rejected: &[ProbeSurface],
+    read_status: Option<u16>,
     basic_challenge: bool,
 ) -> String {
-    let surfaces: Vec<&str> = rejected
-        .iter()
-        .map(|surface| match surface {
-            ProbeSurface::Read => "the index read surface (`index.json`)",
-            ProbeSurface::Api => "the index API (`v1/whoami`)",
-        })
-        .collect();
-    let mut message = format!(
-        "credential for `{index}` was rejected by {} and accepted by no surface; \
-         nothing was stored",
-        surfaces.join(" and ")
-    );
+    let mut message = match rejected {
+        // Exactly one surface rejected: plain wording naming the endpoint
+        // and its answer. A read-surface 404 is hedged: it can also mean
+        // there is simply no index at this URL, so the token must not be
+        // blamed outright.
+        [surface] => {
+            let (endpoint, status) = match surface {
+                ProbeSurface::Read => ("index.json", read_status.unwrap_or(401)),
+                // The API surface rejects only on 401.
+                ProbeSurface::Api => ("v1/whoami", 401),
+            };
+            let hedge = if *surface == ProbeSurface::Read && status == 404 {
+                ", or no index exists at this URL"
+            } else {
+                ""
+            };
+            format!(
+                "the index rejected the token for `{index}` \
+                 (`{endpoint}` answered HTTP {status}){hedge}; nothing was stored"
+            )
+        }
+        _ => {
+            let surfaces: Vec<&str> = rejected
+                .iter()
+                .map(|surface| match surface {
+                    ProbeSurface::Read => "the index read surface (`index.json`)",
+                    ProbeSurface::Api => "the index API (`v1/whoami`)",
+                })
+                .collect();
+            format!(
+                "credential for `{index}` was rejected by {} and accepted by no surface; \
+                 nothing was stored",
+                surfaces.join(" and ")
+            )
+        }
+    };
     if basic_challenge {
         message.push_str(
             "\nthis index uses username/password (HTTP basic) authentication; configure \
@@ -554,6 +583,8 @@ fn parse_whoami_identity(
 struct ProbeOutcome {
     accepted: Vec<ProbeSurface>,
     rejected: Vec<ProbeSurface>,
+    /// The HTTP status of the read surface's rejection, when it rejected.
+    read_status: Option<u16>,
     basic_challenge: bool,
     identity: Option<WhoamiIdentity>,
 }
@@ -713,6 +744,7 @@ fn probe_read_surface(
         outcome.accepted.push(surface);
     } else if forced_status.is_client_error() {
         outcome.rejected.push(surface);
+        outcome.read_status = Some(forced_status.as_u16());
         outcome.basic_challenge = basic_challenge || offers_basic_challenge(forced.headers());
     } else {
         notify(AuthLoginNotice::ProbeUnreachable {
@@ -779,9 +811,10 @@ fn probe_api_surface(
 }
 
 /// Fetch discovery for a login (design/credential-storage.md sections 5,
-/// 8): an unauthenticated baseline, then, on any 4xx answer, one
-/// forced-bearer retry carrying the in-hand secret, mirroring the probe
-/// mechanism. The forced retry is what distinguishes a hidden discovery
+/// 8): an unauthenticated baseline, then, on any 4xx answer except 429,
+/// one forced-bearer retry carrying the in-hand secret, mirroring the
+/// probe mechanism (including its 429 carve-out: a throttling host gets
+/// no retry and no secret). The forced retry is what distinguishes a hidden discovery
 /// document from an absent one: a fully private index answers 401 (or, in
 /// GitLab's style, 404) to the unauthenticated fetch whether or not a
 /// document exists, and only the credentialed answer settles it, letting
@@ -810,12 +843,15 @@ fn fetch_login_endpoints(
     )) {
         Ok(endpoints) => Some(endpoints),
         Err(DiscoveryError::Fetch(HttpFetchError::BadHttpStatus { status, .. }))
-            if status.is_client_error() =>
+            if status.is_client_error() && status != reqwest::StatusCode::TOO_MANY_REQUESTS =>
         {
             forced_discovery_fetch(location, secret, runtime, notify)
         }
-        // Network failures, 5xx, and a present-but-invalid document are
-        // not "possibly hidden from me" signals: no secret is sent.
+        // Network failures, 5xx, a 429 baseline (the retry would spend
+        // more of the rate budget and send the secret to a throttling
+        // host, mirroring the probes' 429 carve-out), and a
+        // present-but-invalid document are not "possibly hidden from me"
+        // signals: no secret is sent.
         Err(err) => {
             notify(AuthLoginNotice::DiscoveryUnreachable {
                 error: err.to_string(),
@@ -954,7 +990,8 @@ fn run_validation_probes(
 /// Discovery is fetched best-effort to resolve `index_root` and
 /// `api_root` for glob scoping: an unauthenticated baseline, retried once
 /// with the in-hand secret as a forced bearer when the baseline answers
-/// any 4xx, so a fully private index can still advertise its topology
+/// any 4xx except 429, so a fully private index can still advertise its
+/// topology
 /// ([`fetch_login_endpoints`]); only the backend-absent path stays
 /// strictly unauthenticated, since its secret is discarded. When no usable
 /// document results, the credential falls back to the URL-derived glob
@@ -1066,6 +1103,7 @@ pub fn do_auth_login<S: CredentialStore>(
         return Err(AuthCommandError::ValidationRejected {
             index: key,
             rejected: outcome.rejected,
+            read_status: outcome.read_status,
             basic_challenge: outcome.basic_challenge,
         });
     }

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -1135,7 +1135,7 @@ pub enum WhoamiVerdict {
 
 /// What [`do_auth_whoami`] found: the normalized index key, the exact URL
 /// asked, which credential was sent (the host must name it: an env
-/// credential shadows a stored login, so "re-login" would be the wrong
+/// credential shadows a stored credential, so "re-login" would be the wrong
 /// remediation for a rejected env credential), and the verdict.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthWhoamiOutcome {
@@ -1233,7 +1233,7 @@ fn select_whoami_credential(
                 None => {
                     return Err(AuthCommandError::AmbiguousWhoamiCredential {
                         url: whoami_url.as_str().to_string(),
-                        source_name: "stored logins",
+                        source_name: "stored credentials",
                         candidates: candidates.len(),
                     });
                 }

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -2,8 +2,9 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 //! `sysand auth` command orchestration (design/credential-storage.md
-//! sections 4, 8, 9, 14): `do_auth_login`, `do_auth_logout`, and
-//! `do_auth_status`, generic over [`CredentialStore`].
+//! sections 4, 8, 9, 14): `do_auth_login`, `do_auth_logout`,
+//! `do_auth_status`, and `do_auth_whoami`, generic over
+//! [`CredentialStore`].
 //!
 //! Library calls never prompt and never print; the login secret arrives as
 //! a parameter and progress is reported through [`AuthLoginNotice`] values
@@ -21,7 +22,9 @@ use url::Url;
 use serde::Deserialize;
 
 use crate::{
-    auth::Unauthenticated,
+    auth::{
+        EnvBearerAuth, GlobMap, GlobMapBuilder, GlobMapResult, HTTPAuthentication, Unauthenticated,
+    },
     credential_store::{
         CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
         CredentialSubject, normalize_index_key,
@@ -68,6 +71,43 @@ pub enum AuthCommandError {
         /// `SYSAND_CRED_*` basic credentials (section 5).
         basic_challenge: bool,
     },
+    /// `whoami` could not read the index configuration, so the API root
+    /// (and with it the `v1/whoami` URL) could not be resolved.
+    #[error(
+        "could not read the index configuration for `{index}` ({error}); cannot resolve its API"
+    )]
+    WhoamiDiscoveryFailed { index: String, error: String },
+    /// `whoami` targeted an index whose discovery configuration does not
+    /// explicitly advertise `api_root`: there is no API identity endpoint
+    /// to ask. The parenthetical matters: a private index can hide its
+    /// configuration from a client whose credentials do not cover it, which
+    /// resolves to the same unadvertised state.
+    #[error(
+        "index `{index}` does not advertise an API (`api_root`) in its\n\
+         discovery configuration, so there is no identity endpoint to ask\n\
+         (a private index may also hide its configuration from clients it\n\
+         cannot authenticate)"
+    )]
+    NoAdvertisedApi { index: String },
+    /// More than one credential from one source matches the `v1/whoami`
+    /// URL (after collapsing entries carrying the same token), so no
+    /// single identity question can be asked.
+    #[error(
+        "{candidates} credentials from {source_name} match `{url}`; \
+         refine the patterns so exactly one matches"
+    )]
+    AmbiguousWhoamiCredential {
+        url: String,
+        // Not `source`: thiserror reserves that name for error chaining.
+        source_name: &'static str,
+        candidates: usize,
+    },
+    /// No credential of either source matches the `v1/whoami` URL.
+    #[error(
+        "no credential matches `{url}`; run `sysand auth login {index}` to \
+         store one, or set `SYSAND_CRED_*` environment variables"
+    )]
+    NoWhoamiCredential { url: String, index: String },
     /// The credential store failed.
     #[error(transparent)]
     Store(#[from] CredentialStoreError),
@@ -415,13 +455,16 @@ fn template_anchor_root(prefix: &str) -> Option<(usize, Url)> {
     Some((cut, url))
 }
 
-/// Identity fields parsed from a successful `v1/whoami` probe, persisted
-/// on the stored record (design/credential-storage.md sections 5, 6, 9).
-struct WhoamiIdentity {
-    subject: CredentialSubject,
-    token_name: Option<String>,
-    token_prefix: Option<String>,
-    expires_at: Option<DateTime<Utc>>,
+/// Identity fields parsed from a successful `v1/whoami` response:
+/// persisted on the stored record by a validating login
+/// (design/credential-storage.md sections 5, 6, 9) and rendered live by
+/// `auth whoami`. Never contains the secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhoamiIdentity {
+    pub subject: CredentialSubject,
+    pub token_name: Option<String>,
+    pub token_prefix: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 /// Wire shape of a `v1/whoami` 200 body (design/index-api-protocol.md,
@@ -908,6 +951,282 @@ pub fn do_auth_logout<S: CredentialStore>(
     } else {
         Err(AuthCommandError::NoStoredCredential { index: key })
     }
+}
+
+/// Where the credential `auth whoami` selected came from. Selection
+/// mirrors publish's source precedence (design/credential-storage.md
+/// section 7): environment credentials before stored logins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WhoamiCredentialSource {
+    /// A `SYSAND_CRED_*` environment bearer; `label` is the
+    /// `SYSAND_CRED_<LABEL>` stem when known.
+    Env { label: Option<String> },
+    /// A stored login (`sysand auth login`) for the given index key.
+    Stored { key: String },
+}
+
+/// Verdict of the single `v1/whoami` request `auth whoami` sends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WhoamiVerdict {
+    /// HTTP 200: the index accepted the credential. `identity` is `None`
+    /// when the response body could not be parsed (the 200 remains the
+    /// verdict, only the details are lost).
+    Identified { identity: Option<WhoamiIdentity> },
+    /// HTTP 401: the index rejected the credential.
+    Rejected,
+    /// No verdict: a redirect, rate limiting, an unexpected status, or a
+    /// network error, described by `detail`.
+    Unreachable { detail: String },
+}
+
+/// What [`do_auth_whoami`] found: the normalized index key, the exact URL
+/// asked, which credential was sent (the host must name it: an env
+/// credential shadows a stored login, so "re-login" would be the wrong
+/// remediation for a rejected env credential), and the verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthWhoamiOutcome {
+    pub key: String,
+    pub whoami_url: Url,
+    pub source: WhoamiCredentialSource,
+    pub verdict: WhoamiVerdict,
+}
+
+/// The single entry left after collapsing candidates that carry the same
+/// token (overlapping globs for one credential must not read as
+/// ambiguity), or `None` when genuinely distinct credentials collide.
+fn unique_by_token<'a, T>(
+    candidates: &[(String, &'a T)],
+    token: impl Fn(&T) -> &str,
+) -> Option<&'a T> {
+    let ((_, first), rest) = candidates.split_first()?;
+    rest.iter()
+        .all(|(_, candidate)| token(candidate) == token(first))
+        .then_some(*first)
+}
+
+/// Select the credential `auth whoami` sends, mirroring the runtime and
+/// publish precedence (design/credential-storage.md sections 7, 9): a
+/// `SYSAND_CRED_*` env bearer matching the whoami URL wins over a stored
+/// login; within a source exactly one credential may match (candidates
+/// carrying the same token collapse to one). Invalid stored glob patterns
+/// are skipped individually, like the runtime's lazy stored map: one bad
+/// pattern must not hide the other credentials.
+fn select_whoami_credential(
+    env_bearers: &GlobMap<EnvBearerAuth>,
+    records: &[CredentialRecord],
+    whoami_url: &Url,
+    index_key: &str,
+) -> Result<(WhoamiCredentialSource, String), AuthCommandError> {
+    match env_bearers.lookup(whoami_url.as_str()) {
+        GlobMapResult::Found(_, entry) => {
+            return Ok((
+                WhoamiCredentialSource::Env {
+                    label: entry.label.clone(),
+                },
+                entry.auth.token().to_string(),
+            ));
+        }
+        GlobMapResult::Ambiguous(candidates) => {
+            let Some(entry) =
+                unique_by_token(&candidates, |entry: &EnvBearerAuth| entry.auth.token())
+            else {
+                return Err(AuthCommandError::AmbiguousWhoamiCredential {
+                    url: whoami_url.as_str().to_string(),
+                    source_name: "`SYSAND_CRED_*` environment variables",
+                    candidates: candidates.len(),
+                });
+            };
+            return Ok((
+                WhoamiCredentialSource::Env {
+                    label: entry.label.clone(),
+                },
+                entry.auth.token().to_string(),
+            ));
+        }
+        GlobMapResult::NotFound => {}
+    }
+
+    let mut builder: GlobMapBuilder<&CredentialRecord> = GlobMapBuilder::new();
+    for record in records {
+        if record.scheme != CredentialScheme::Bearer {
+            continue;
+        }
+        for glob in &record.globs {
+            // Compile each pattern individually first, exactly as the map
+            // build will: `GlobMapBuilder::build` fails wholesale on one
+            // bad pattern.
+            if GlobBuilder::new(glob)
+                .literal_separator(true)
+                .build()
+                .is_ok()
+            {
+                builder.add(glob, record);
+            }
+        }
+    }
+    // Every added pattern was pre-compiled above, so the build cannot
+    // fail; degrade rather than panic if it somehow does.
+    let stored = builder.build().unwrap_or_default();
+
+    let entry = match stored.lookup(whoami_url.as_str()) {
+        GlobMapResult::Found(_, record) => Some(*record),
+        GlobMapResult::Ambiguous(candidates) => {
+            let unique = unique_by_token(&candidates, |record: &&CredentialRecord| {
+                record.secret.as_str()
+            });
+            match unique {
+                Some(record) => Some(*record),
+                None => {
+                    return Err(AuthCommandError::AmbiguousWhoamiCredential {
+                        url: whoami_url.as_str().to_string(),
+                        source_name: "stored logins",
+                        candidates: candidates.len(),
+                    });
+                }
+            }
+        }
+        GlobMapResult::NotFound => None,
+    };
+    match entry {
+        Some(record) => Ok((
+            WhoamiCredentialSource::Stored {
+                key: record.key.clone(),
+            },
+            record.secret.clone(),
+        )),
+        None => Err(AuthCommandError::NoWhoamiCredential {
+            url: whoami_url.as_str().to_string(),
+            index: index_key.to_string(),
+        }),
+    }
+}
+
+/// Query-only live identity check (design/credential-storage.md section
+/// 4): resolve the index API, select the credential the runtime would use
+/// (env over stored, [`select_whoami_credential`]), and send one
+/// forced-bearer GET to `api_root/v1/whoami` with the no-redirect probe
+/// client. Never prompts, never prints, and never writes the credential
+/// store: cached identity fields on a stored record are deliberately not
+/// refreshed.
+///
+/// `discovery_auth` is the policy for the discovery fetch: unlike login
+/// (which is unauthenticated because no credential exists yet), whoami
+/// runs when a credential does exist, and a private index may gate its
+/// discovery document, so the CLI passes its regular read policy here.
+///
+/// An absent keyring backend degrades to env-only selection; a locked or
+/// denied backend is a hard error the caller must surface, like the other
+/// auth commands.
+pub fn do_auth_whoami<S: CredentialStore, P: HTTPAuthentication>(
+    store: &S,
+    index_url: &str,
+    env_bearers: &GlobMap<EnvBearerAuth>,
+    discovery_auth: &P,
+    client: &reqwest_middleware::ClientWithMiddleware,
+    runtime: &tokio::runtime::Runtime,
+) -> Result<AuthWhoamiOutcome, AuthCommandError> {
+    let key = validated_index_key(index_url)?;
+    let location = IndexLocation::parse(&key)
+        .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
+
+    let endpoints = runtime
+        .block_on(fetch_index_config(client, discovery_auth, &location))
+        .map_err(|err| AuthCommandError::WhoamiDiscoveryFailed {
+            index: key.clone(),
+            error: err.to_string(),
+        })?;
+    // Only an explicitly advertised API is asked (the same
+    // `api_root_advertised` gate as login's validation probes): a static
+    // index's plain-URL runtime default is not an identity endpoint.
+    if !endpoints.api_root_advertised {
+        return Err(AuthCommandError::NoAdvertisedApi { index: key });
+    }
+    let Some(api_root) = &endpoints.api_root else {
+        // `api_root_advertised` implies `api_root` is `Some`; keep a
+        // non-panicking path anyway.
+        return Err(AuthCommandError::NoAdvertisedApi { index: key });
+    };
+    // `api_root` always ends in `/` (discovery normalizes it), so the
+    // join appends rather than replacing the last segment.
+    let whoami_url =
+        api_root
+            .join("v1/whoami")
+            .map_err(|err| AuthCommandError::WhoamiDiscoveryFailed {
+                index: key.clone(),
+                error: format!("could not build the whoami URL: {err}"),
+            })?;
+
+    let records = match store.list() {
+        Ok(records) => records,
+        // No keyring backend: only env credentials can apply. A locked or
+        // denied backend propagates instead: "no credential, run login"
+        // would be the wrong remediation for an unlockable store.
+        Err(CredentialStoreError::BackendAbsent { .. }) => Vec::new(),
+        Err(err) => return Err(err.into()),
+    };
+    let (source, token) = select_whoami_credential(env_bearers, &records, &whoami_url, &key)?;
+
+    let verdict = match probe_client() {
+        Err(err) => WhoamiVerdict::Unreachable {
+            detail: format!("could not build the probe HTTP client: {err}"),
+        },
+        Ok(probe) => match probe_get(runtime, &probe, &whoami_url, Some(&token)) {
+            Err(error) => WhoamiVerdict::Unreachable { detail: error },
+            Ok(response) => {
+                let status = response.status();
+                if status == reqwest::StatusCode::OK {
+                    let parsed = runtime
+                        .block_on(response.bytes())
+                        .map_err(|err| err.to_string())
+                        .and_then(|body| {
+                            serde_json::from_slice::<WhoamiBody>(&body)
+                                .map_err(|err| err.to_string())
+                        });
+                    let identity = match parsed {
+                        Ok(body) => Some(WhoamiIdentity {
+                            subject: CredentialSubject {
+                                kind: body.subject.kind,
+                                name: body.subject.name,
+                            },
+                            token_name: body.token.name,
+                            token_prefix: body.token.prefix,
+                            expires_at: body.token.expires_at,
+                        }),
+                        // Lenient: the 200 is the verdict; an unparseable
+                        // body only loses the details.
+                        Err(err) => {
+                            log::debug!("whoami body was not read: {err}");
+                            None
+                        }
+                    };
+                    WhoamiVerdict::Identified { identity }
+                } else if status == reqwest::StatusCode::UNAUTHORIZED {
+                    WhoamiVerdict::Rejected
+                } else if status.is_redirection() {
+                    WhoamiVerdict::Unreachable {
+                        detail: format!(
+                            "redirected to `{}`; whoami does not follow redirects",
+                            redirect_target(&response)
+                        ),
+                    }
+                } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    WhoamiVerdict::Unreachable {
+                        detail: "rate limited (HTTP 429)".to_string(),
+                    }
+                } else {
+                    WhoamiVerdict::Unreachable {
+                        detail: format!("unexpected status {status}"),
+                    }
+                }
+            }
+        },
+    };
+    Ok(AuthWhoamiOutcome {
+        key,
+        whoami_url,
+        source,
+        verdict,
+    })
 }
 
 /// Assemble the `auth status` view from stored records and environment

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -632,17 +632,19 @@ fn probe_client() -> Result<reqwest::Client, reqwest::Error> {
         .build()
 }
 
-/// Send one probe GET, optionally with a forced bearer credential.
+/// Send one probe request, optionally with a forced bearer credential.
 /// Returns the response unread (probes never consume bodies; the whoami
-/// body is read separately on a 200).
-fn probe_get(
+/// body is read separately on a 200). The read surface probes with HEAD
+/// since only the status matters there; body-consuming probes use GET.
+fn probe_request(
     runtime: &tokio::runtime::Runtime,
     client: &reqwest::Client,
+    method: reqwest::Method,
     url: &Url,
     bearer: Option<&str>,
 ) -> Result<reqwest::Response, String> {
     runtime.block_on(async {
-        let mut request = client.get(url.clone());
+        let mut request = client.request(method, url.clone());
         if let Some(token) = bearer {
             request = request.bearer_auth(token);
         }
@@ -710,7 +712,8 @@ fn probe_read_surface(
     notify: &mut impl FnMut(AuthLoginNotice),
 ) {
     let surface = ProbeSurface::Read;
-    let baseline = match probe_get(runtime, client, index_json_url, None) {
+    let baseline = match probe_request(runtime, client, reqwest::Method::HEAD, index_json_url, None)
+    {
         Ok(response) => response,
         Err(error) => {
             notify(AuthLoginNotice::ProbeUnreachable { surface, error });
@@ -745,7 +748,13 @@ fn probe_read_surface(
         return;
     }
     let basic_challenge = offers_basic_challenge(baseline.headers());
-    let forced = match probe_get(runtime, client, index_json_url, Some(secret)) {
+    let forced = match probe_request(
+        runtime,
+        client,
+        reqwest::Method::HEAD,
+        index_json_url,
+        Some(secret),
+    ) {
         Ok(response) => response,
         Err(error) => {
             notify(AuthLoginNotice::ProbeUnreachable { surface, error });
@@ -802,7 +811,13 @@ fn probe_api_surface(
             return;
         }
     };
-    let response = match probe_get(runtime, client, &whoami_url, Some(secret)) {
+    let response = match probe_request(
+        runtime,
+        client,
+        reqwest::Method::GET,
+        &whoami_url,
+        Some(secret),
+    ) {
         Ok(response) => response,
         Err(error) => {
             notify(AuthLoginNotice::ProbeUnreachable { surface, error });
@@ -898,7 +913,13 @@ fn forced_discovery_fetch(
             return unreachable(format!("could not build the probe HTTP client: {err}"));
         }
     };
-    let response = match probe_get(runtime, &client, &config_url, Some(secret)) {
+    let response = match probe_request(
+        runtime,
+        &client,
+        reqwest::Method::GET,
+        &config_url,
+        Some(secret),
+    ) {
         Ok(response) => response,
         Err(error) => {
             return unreachable(format!("HTTP request to `{config_url}` failed: {error}"));
@@ -1297,7 +1318,13 @@ pub fn do_auth_whoami<P: HTTPAuthentication>(
         Err(err) => WhoamiVerdict::Unreachable {
             detail: format!("could not build the probe HTTP client: {err}"),
         },
-        Ok(probe) => match probe_get(runtime, &probe, &whoami_url, Some(&token)) {
+        Ok(probe) => match probe_request(
+            runtime,
+            &probe,
+            reqwest::Method::GET,
+            &whoami_url,
+            Some(&token),
+        ) {
             Err(error) => WhoamiVerdict::Unreachable { detail: error },
             Ok(response) => {
                 let status = response.status();

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -915,8 +915,9 @@ fn run_validation_probes(
         notify,
     );
 
+    // `api_root` is set only when discovery advertises it, so only an index
+    // with an API gets probed.
     if let Some(endpoints) = endpoints
-        && endpoints.api_root_advertised
         && let Some(api_root) = &endpoints.api_root
     {
         probe_api_surface(runtime, &client, api_root, secret, &mut outcome, notify);
@@ -1292,15 +1293,8 @@ pub fn do_auth_whoami<S: CredentialStore, P: HTTPAuthentication>(
             index: key.clone(),
             error: err.to_string(),
         })?;
-    // Only an explicitly advertised API is asked (the same
-    // `api_root_advertised` gate as login's validation probes): a static
-    // index's plain-URL runtime default is not an identity endpoint.
-    if !endpoints.api_root_advertised {
-        return Err(AuthCommandError::NoAdvertisedApi { index: key });
-    }
+    // No advertised `api_root` means the index has no API to ask.
     let Some(api_root) = &endpoints.api_root else {
-        // `api_root_advertised` implies `api_root` is `Some`; keep a
-        // non-panicking path anyway.
         return Err(AuthCommandError::NoAdvertisedApi { index: key });
     };
     // `api_root` always ends in `/` (discovery normalizes it), so the

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -1160,8 +1160,8 @@ pub fn do_auth_logout<B: BlobBackend>(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WhoamiCredentialSource {
     /// A `SYSAND_CRED_*` environment bearer; `label` is the
-    /// `SYSAND_CRED_<LABEL>` stem when known.
-    Env { label: Option<String> },
+    /// `SYSAND_CRED_<LABEL>` stem.
+    Env { label: String },
     /// A stored credential (`sysand auth login`) for the given index key.
     Stored { key: String },
 }

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! `sysand auth` command orchestration (design/credential-storage.md
+//! sections 4, 9, 14): `do_auth_logout` and `do_auth_status`, generic over
+//! [`CredentialStore`].
+//!
+//! Library calls never prompt and never print; they return data for the
+//! host (CLI or bindings) to render. Environment credentials are passed in
+//! as [`EnvCredentialEntry`] values: this module does not read the process
+//! environment.
+
+use chrono::{DateTime, Utc};
+use globset::GlobBuilder;
+use thiserror::Error;
+use url::Url;
+
+use crate::credential_store::{
+    CredentialRecord, CredentialStore, CredentialStoreError, normalize_index_key,
+};
+
+/// Errors from the `sysand auth` commands.
+#[derive(Debug, Error)]
+pub enum AuthCommandError {
+    /// `logout` targeted an index with no stored credential.
+    #[error("no stored credential for `{index}`")]
+    NoStoredCredential { index: String },
+    /// The target is not an HTTP(S) index (for example a `file://` URL).
+    #[error("`{url}`: not an HTTP(S) index; nothing to authenticate to")]
+    NotHttpIndex { url: String },
+    /// The target could not be parsed or normalized as an index URL.
+    #[error("invalid index URL for credential storage: {0}")]
+    InvalidIndexUrl(String),
+    /// The credential store failed.
+    #[error(transparent)]
+    Store(#[from] CredentialStoreError),
+}
+
+/// One `SYSAND_CRED_*` environment credential, as seen by `auth status`:
+/// the full variable name carrying the URL pattern, and the pattern value.
+/// Never the secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvCredentialEntry {
+    /// The environment variable name, for example `SYSAND_CRED_TEAMIDX`.
+    pub label: String,
+    /// The URL glob pattern the variable holds.
+    pub pattern: String,
+}
+
+/// Status of one stored login, as shown by `auth status`. Never contains
+/// the secret.
+///
+/// Extension point: the validation work (`auth login --validation`) will
+/// add identity fields here (`subject`, token `prefix` from `v1/whoami`,
+/// design/credential-storage.md section 9) once the record shape carries
+/// them; this struct deliberately shows only what the record stores today.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredCredentialStatus {
+    /// The normalized index key, in the exact form
+    /// `sysand auth logout <key>` accepts.
+    pub key: String,
+    /// The URL glob patterns the credential applies to.
+    pub globs: Vec<String>,
+    /// Expiry, when a validating login learned it.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Whether `expires_at` is known and in the past.
+    pub expired: bool,
+    /// Labels of `SYSAND_CRED_*` entries that may shadow this login.
+    ///
+    /// Approximate: an env entry is listed when its pattern matches this
+    /// record's key URL. Env credentials take precedence per matched
+    /// request URL, so an env pattern matching only part of the covered
+    /// URLs (or spelled so it misses the key, for example with a port
+    /// wildcard) may shadow requests without being listed here.
+    pub shadowed_by: Vec<String>,
+}
+
+/// The stored side of `auth status`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoredCredentialsStatus {
+    /// Stored logins were read (possibly none).
+    Available(Vec<StoredCredentialStatus>),
+    /// No usable OS keyring backend on this host; only environment
+    /// credentials apply.
+    BackendUnavailable { reason: String },
+}
+
+/// The unified `auth status` view: everything sysand will authenticate
+/// with, from both sources. Never contains secrets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthStatus {
+    pub stored: StoredCredentialsStatus,
+    pub env: Vec<EnvCredentialEntry>,
+}
+
+/// Validate that `index_url` is an absolute HTTP(S) URL and normalize it
+/// to its credential store key form.
+fn index_key_for(index_url: &str) -> Result<String, AuthCommandError> {
+    // Check the scheme before normalizing so a non-HTTP(S) location gets
+    // the dedicated message instead of a generic normalization error.
+    let url = Url::parse(index_url)
+        .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{index_url}`: {err}")))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => {
+            return Err(AuthCommandError::NotHttpIndex {
+                url: index_url.to_string(),
+            });
+        }
+    }
+    normalize_index_key(index_url).map_err(|err| match err {
+        CredentialStoreError::InvalidIndexUrl(msg) => AuthCommandError::InvalidIndexUrl(msg),
+        other => AuthCommandError::Store(other),
+    })
+}
+
+/// Remove the stored login for `index_url`.
+///
+/// Returns the normalized index key the record was stored under. Removing
+/// a login that does not exist is an error
+/// ([`AuthCommandError::NoStoredCredential`]).
+pub fn do_auth_logout<S: CredentialStore>(
+    store: &mut S,
+    index_url: &str,
+) -> Result<String, AuthCommandError> {
+    let key = index_key_for(index_url)?;
+    if store.remove(&key)? {
+        Ok(key)
+    } else {
+        Err(AuthCommandError::NoStoredCredential { index: key })
+    }
+}
+
+/// Assemble the `auth status` view from stored records and environment
+/// entries, against the given clock. Exposed for deterministic tests;
+/// [`do_auth_status`] is the store-reading entry point.
+pub fn assemble_auth_status(
+    records: Vec<CredentialRecord>,
+    env: Vec<EnvCredentialEntry>,
+    now: DateTime<Utc>,
+) -> AuthStatus {
+    // Compile each env pattern the same way runtime matching does
+    // (`GlobMapBuilder`, `literal_separator(true)`). An invalid pattern
+    // cannot shadow anything and is skipped.
+    let env_matchers: Vec<(&str, globset::GlobMatcher)> = env
+        .iter()
+        .filter_map(|entry| {
+            GlobBuilder::new(&entry.pattern)
+                .literal_separator(true)
+                .build()
+                .ok()
+                .map(|glob| (entry.label.as_str(), glob.compile_matcher()))
+        })
+        .collect();
+
+    let stored = records
+        .into_iter()
+        .map(|record| {
+            let shadowed_by = env_matchers
+                .iter()
+                .filter(|(_, matcher)| matcher.is_match(&record.key))
+                .map(|(label, _)| (*label).to_string())
+                .collect();
+            StoredCredentialStatus {
+                expired: record.expires_at.is_some_and(|expiry| expiry < now),
+                key: record.key,
+                globs: record.globs,
+                expires_at: record.expires_at,
+                shadowed_by,
+            }
+        })
+        .collect();
+
+    AuthStatus {
+        stored: StoredCredentialsStatus::Available(stored),
+        env,
+    }
+}
+
+/// Read the stored logins and assemble the unified `auth status` view.
+///
+/// An absent keyring backend degrades to the env-only view
+/// ([`StoredCredentialsStatus::BackendUnavailable`]); a present but locked
+/// or denied backend is a hard error the caller must surface
+/// (design/credential-storage.md section 9 taxonomy).
+pub fn do_auth_status<S: CredentialStore>(
+    store: &S,
+    env: Vec<EnvCredentialEntry>,
+) -> Result<AuthStatus, AuthCommandError> {
+    match store.list() {
+        Ok(records) => Ok(assemble_auth_status(records, env, Utc::now())),
+        Err(CredentialStoreError::BackendAbsent { source }) => Ok(AuthStatus {
+            stored: StoredCredentialsStatus::BackendUnavailable {
+                reason: source.to_string(),
+            },
+            env,
+        }),
+        Err(err) => Err(err.into()),
+    }
+}
+
+// Private tests
+
+#[cfg(test)]
+#[path = "./auth_tests.rs"]
+mod tests;

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -44,7 +44,10 @@ pub enum AuthCommandError {
     #[error("no stored credential for `{index}`")]
     NoStoredCredential { index: String },
     /// The target is not an HTTP(S) index (for example a `file://` URL).
-    #[error("`{url}`: not an HTTP(S) index; nothing to authenticate to")]
+    #[error(
+        "`{url}`: not an HTTP(S) index; nothing to authenticate to \
+         (use an https:// index URL)"
+    )]
     NotHttpIndex { url: String },
     /// The target could not be parsed or normalized as an index URL.
     #[error("invalid index URL for credential storage: {0}")]
@@ -175,7 +178,7 @@ impl std::fmt::Display for ProbeSurface {
     }
 }
 
-/// Status of one stored login, as shown by `auth status`. Never contains
+/// Status of one stored credential, as shown by `auth status`. Never contains
 /// the secret.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoredCredentialStatus {
@@ -1090,7 +1093,7 @@ pub fn do_auth_login<S: CredentialStore>(
     }
 }
 
-/// Remove the stored login for `index_url`.
+/// Remove the stored credential for `index_url`.
 ///
 /// Returns the normalized index key the record was stored under. Removing
 /// a login that does not exist is an error
@@ -1109,13 +1112,13 @@ pub fn do_auth_logout<S: CredentialStore>(
 
 /// Where the credential `auth whoami` selected came from. Selection
 /// mirrors publish's source precedence (design/credential-storage.md
-/// section 7): environment credentials before stored logins.
+/// section 7): environment credentials before stored credentials.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WhoamiCredentialSource {
     /// A `SYSAND_CRED_*` environment bearer; `label` is the
     /// `SYSAND_CRED_<LABEL>` stem when known.
     Env { label: Option<String> },
-    /// A stored login (`sysand auth login`) for the given index key.
+    /// A stored credential (`sysand auth login`) for the given index key.
     Stored { key: String },
 }
 
@@ -1457,7 +1460,7 @@ pub fn assemble_auth_status(
     }
 }
 
-/// Read the stored logins and assemble the unified `auth status` view.
+/// Read the stored credentials and assemble the unified `auth status` view.
 ///
 /// An absent keyring backend degrades to the env-only view
 /// ([`StoredCredentialsStatus::BackendUnavailable`]); a present but locked

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -28,14 +28,13 @@ use crate::{
         CredentialRecord, CredentialScheme, CredentialStoreError, CredentialSubject,
         ValidatedSurface,
         keyring_store::{BlobBackend, LockedBlobStore},
-        normalize_index_key,
     },
     env::discovery::{
         DiscoveryError, INDEX_CONFIG_PATH, IndexConfigRaw, ResolvedEndpoints, fetch_index_config,
         fetch_index_config_strict, resolve_index_config,
     },
     env::index::HttpFetchError,
-    index_location::{IndexLocation, IndexLocationError, IndexUrlTemplate, is_template_syntax},
+    index_location::{IndexLocation, IndexLocationError, IndexUrlTemplate},
 };
 
 /// Errors from the `sysand auth` commands.
@@ -319,8 +318,8 @@ pub struct IndexKey {
     /// The key parsed as an index location (plain root or template), so
     /// commands need not reparse the key.
     location: IndexLocation,
-    /// The URL root credential globs anchor on: the key itself for a
-    /// plain URL, the literal-prefix anchor for a template key.
+    /// The URL root credential globs anchor on: the query-stripped URL
+    /// for a plain key, the literal-prefix anchor for a template key.
     glob_root: String,
 }
 
@@ -329,61 +328,30 @@ impl IndexKey {
     /// plain URL or a `{path}`/`{path_raw}` URL template) and normalize it
     /// to its credential store key form.
     ///
-    /// A plain URL normalizes via [`normalize_index_key`]. A template
-    /// normalizes inside [`IndexLocation::parse`], which canonicalizes the
-    /// literal prefix (lowercase host, default port dropped, explicit root
-    /// `/`) and keeps the placeholder and suffix verbatim; its `Display`
-    /// text is the key. Both forms are idempotent and round-trip through
-    /// [`IndexLocation::parse`] / `Display`, so `auth status` prints template
-    /// keys in the exact form `auth logout` accepts.
+    /// All index-location invariants and normalization live in
+    /// [`IndexLocation::parse`]; the key is its `Display` text. Both forms
+    /// are idempotent and round-trip through parse / `Display`, so
+    /// `auth status` prints keys in the exact form `auth logout` accepts.
     ///
     /// This is the only validation path; the CLI calls it once, before
     /// reading a secret.
     pub fn validate(index_url: &str) -> Result<Self, AuthCommandError> {
-        // Template syntax dispatches before `Url::parse`: it would
-        // percent-encode the braces into a mangled `%7Bpath%7D` key.
-        let (key, location) = if is_template_syntax(index_url) {
-            let location = IndexLocation::parse(index_url).map_err(|err| match err {
-                IndexLocationError::UnsupportedScheme { .. } => AuthCommandError::NotHttpIndex {
-                    url: index_url.to_string(),
-                },
-                // The index-location errors already name the URL; no
-                // re-prefixing.
-                other => AuthCommandError::InvalidIndexUrl(other.to_string()),
-            })?;
-            (location.to_string(), location)
-        } else {
-            // Scheme check first, so a non-HTTP(S) location gets the
-            // dedicated message instead of a generic normalization error.
-            let url = Url::parse(index_url).map_err(|err| {
-                AuthCommandError::InvalidIndexUrl(format!("`{index_url}`: {err}"))
-            })?;
-            match url.scheme() {
-                "http" | "https" => {}
-                _ => {
-                    return Err(AuthCommandError::NotHttpIndex {
-                        url: index_url.to_string(),
-                    });
-                }
-            }
-            let key = normalize_index_key(index_url).map_err(|err| match err {
-                CredentialStoreError::InvalidIndexUrl(msg) => {
-                    AuthCommandError::InvalidIndexUrl(msg)
-                }
-                other => AuthCommandError::Store(other),
-            })?;
-            let location = IndexLocation::parse(&key)
-                .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
-            (key, location)
-        };
+        let location = IndexLocation::parse(index_url).map_err(|err| match err {
+            IndexLocationError::UnsupportedScheme { .. } => AuthCommandError::NotHttpIndex {
+                url: index_url.to_string(),
+            },
+            // The index-location errors already name the URL; no
+            // re-prefixing.
+            other => AuthCommandError::InvalidIndexUrl(other.to_string()),
+        })?;
         let glob_root = match &location {
-            IndexLocation::Root(_) => key.clone(),
+            IndexLocation::Root(url) => root_anchor(url).as_str().to_string(),
             IndexLocation::Template(template) => {
                 template_anchor_root(template).as_str().to_string()
             }
         };
         Ok(Self {
-            key,
+            key: location.to_string(),
             location,
             glob_root,
         })
@@ -503,13 +471,13 @@ fn derive_credential_globs(
 
     if let Some(endpoints) = endpoints {
         match &endpoints.index_root {
-            IndexLocation::Root(url) => push_if_uncovered(&mut roots, url.as_str()),
+            IndexLocation::Root(url) => push_if_uncovered(&mut roots, root_anchor(url).as_str()),
             IndexLocation::Template(template) => {
                 push_if_uncovered(&mut roots, template_anchor_root(template).as_str())
             }
         }
         if let Some(api_root) = &endpoints.api_root {
-            push_if_uncovered(&mut roots, api_root.as_str());
+            push_if_uncovered(&mut roots, root_anchor(api_root).as_str());
         }
     }
 
@@ -517,6 +485,16 @@ fn derive_credential_globs(
         .into_iter()
         .map(|root| format!("{}**", globset::escape(&root)))
         .collect()
+}
+
+/// Anchor a plain root URL for glob derivation: the URL without its
+/// query. `resolve` appends path segments before the query, so request
+/// URLs continue the path text, not the query text; a query in the
+/// anchor would make the glob match nothing.
+fn root_anchor(url: &Url) -> Url {
+    let mut anchor = url.clone();
+    anchor.set_query(None);
+    anchor
 }
 
 /// Anchor a URL template's literal prefix at a safe URL boundary: the

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -18,11 +18,13 @@ use globset::GlobBuilder;
 use thiserror::Error;
 use url::Url;
 
+use serde::Deserialize;
+
 use crate::{
     auth::Unauthenticated,
     credential_store::{
         CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
-        normalize_index_key,
+        CredentialSubject, normalize_index_key,
     },
     env::discovery::{ResolvedEndpoints, fetch_index_config},
     index_location::{IndexLocation, is_template_syntax},
@@ -49,9 +51,51 @@ pub enum AuthCommandError {
          use `SYSAND_CRED_*` environment variables to authenticate a templated index"
     )]
     TemplateIndexUrl { url: String },
+    /// Every surface that exercised the credential rejected it and none
+    /// accepted it, so nothing was stored (design/credential-storage.md
+    /// section 5 refusal rule).
+    #[error("{}", validation_rejected_message(.index, .rejected, *.basic_challenge))]
+    ValidationRejected {
+        /// The normalized index key the login targeted.
+        index: String,
+        /// The surfaces that exercised and rejected the credential.
+        rejected: Vec<ProbeSurface>,
+        /// Whether the read surface answered with a `WWW-Authenticate:
+        /// Basic` challenge: the index wants username/password, not a
+        /// bearer token, and the message routes the user to
+        /// `SYSAND_CRED_*` basic credentials (section 5).
+        basic_challenge: bool,
+    },
     /// The credential store failed.
     #[error(transparent)]
     Store(#[from] CredentialStoreError),
+}
+
+fn validation_rejected_message(
+    index: &str,
+    rejected: &[ProbeSurface],
+    basic_challenge: bool,
+) -> String {
+    let surfaces: Vec<&str> = rejected
+        .iter()
+        .map(|surface| match surface {
+            ProbeSurface::Read => "the index read surface (`index.json`)",
+            ProbeSurface::Api => "the index API (`v1/whoami`)",
+        })
+        .collect();
+    let mut message = format!(
+        "credential for `{index}` was rejected by {} and accepted by no surface; \
+         nothing was stored",
+        surfaces.join(" and ")
+    );
+    if basic_challenge {
+        message.push_str(
+            "\nthis index uses username/password (HTTP basic) authentication; configure \
+             `SYSAND_CRED_<X>_BASIC_USER` / `SYSAND_CRED_<X>_BASIC_PASS` environment \
+             variables instead",
+        );
+    }
+    message
 }
 
 /// One `SYSAND_CRED_*` environment credential, as seen by `auth status`:
@@ -65,13 +109,26 @@ pub struct EnvCredentialEntry {
     pub pattern: String,
 }
 
+/// A credential-probing surface of an index (design/credential-storage.md
+/// section 5): the read surface (`index_root/index.json`) or the API
+/// surface (`api_root/v1/whoami`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeSurface {
+    Read,
+    Api,
+}
+
+impl std::fmt::Display for ProbeSurface {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProbeSurface::Read => write!(f, "read"),
+            ProbeSurface::Api => write!(f, "api"),
+        }
+    }
+}
+
 /// Status of one stored login, as shown by `auth status`. Never contains
 /// the secret.
-///
-/// Extension point: the validation work (`auth login --validation`) will
-/// add identity fields here (`subject`, token `prefix` from `v1/whoami`,
-/// design/credential-storage.md section 9) once the record shape carries
-/// them; this struct deliberately shows only what the record stores today.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoredCredentialStatus {
     /// The normalized index key, in the exact form
@@ -83,6 +140,15 @@ pub struct StoredCredentialStatus {
     pub expires_at: Option<DateTime<Utc>>,
     /// Whether `expires_at` is known and in the past.
     pub expired: bool,
+    /// Whole days until `expires_at`, against the assembly clock. Present
+    /// exactly when `expires_at` is; negative once expired.
+    pub expires_in_days: Option<i64>,
+    /// Who the credential authenticates as, when a validating login
+    /// learned it from `v1/whoami`.
+    pub subject: Option<CredentialSubject>,
+    /// The token's non-secret display prefix, when a validating login
+    /// learned it.
+    pub token_prefix: Option<String>,
     /// Labels of `SYSAND_CRED_*` entries that may shadow this login.
     ///
     /// Approximate: an env entry is listed when its pattern matches this
@@ -160,6 +226,29 @@ pub enum AuthLoginNotice {
     /// `scheme://authority/`), so no glob was derived for it. Deriving one
     /// anyway could produce a pattern matching other hosts.
     TemplateIndexRootSkipped { template: String },
+    /// A validation probe was answered with a redirect. Probes never
+    /// follow redirects (the verdict would come from a different URL than
+    /// the surface nominally probed), so the surface counts as not
+    /// tested. `target` names the redirect target when the response
+    /// carried one.
+    ProbeRedirected {
+        surface: ProbeSurface,
+        target: String,
+    },
+    /// A validation probe could not produce a verdict (network error,
+    /// 5xx, or an unexpected status); the surface counts as not tested.
+    ProbeUnreachable {
+        surface: ProbeSurface,
+        error: String,
+    },
+    /// A surface rejected the credential, but another surface accepted
+    /// it, so the credential was stored anyway. `basic_challenge` is true
+    /// when the read surface answered with a `WWW-Authenticate: Basic`
+    /// challenge (the index wants username/password, not a bearer token).
+    SurfaceRejected {
+        surface: ProbeSurface,
+        basic_challenge: bool,
+    },
 }
 
 /// Outcome of [`do_auth_login`].
@@ -171,7 +260,17 @@ pub enum AuthLoginNotice {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthLoginOutcome {
     /// The credential was persisted.
-    Stored { key: String, globs: Vec<String> },
+    Stored {
+        key: String,
+        globs: Vec<String>,
+        /// The surfaces that exercised and accepted the credential, in
+        /// probe order (read before api). Empty means "stored, not
+        /// validated": either `validation` was disabled or nothing
+        /// exercised the credential. Hosts must scope the claim to these
+        /// surfaces and never print a bare "validated"
+        /// (design/credential-storage.md section 5).
+        validated: Vec<ProbeSurface>,
+    },
     /// No usable OS keyring backend on this host; nothing was persisted
     /// and the secret was discarded.
     BackendUnavailable {
@@ -256,8 +355,312 @@ fn template_anchor_root(prefix: &str) -> Option<Url> {
     Some(url)
 }
 
+/// Identity fields parsed from a successful `v1/whoami` probe, persisted
+/// on the stored record (design/credential-storage.md sections 5, 6, 9).
+struct WhoamiIdentity {
+    subject: CredentialSubject,
+    token_name: Option<String>,
+    token_prefix: Option<String>,
+    expires_at: Option<DateTime<Utc>>,
+}
+
+/// Wire shape of a `v1/whoami` 200 body (design/index-api-protocol.md,
+/// Token Identity). Parsed leniently: an unparseable body keeps the 200
+/// verdict (accepted) and merely loses the identity fields.
+#[derive(Deserialize)]
+struct WhoamiBody {
+    subject: WhoamiSubject,
+    token: WhoamiToken,
+}
+
+#[derive(Deserialize)]
+struct WhoamiSubject {
+    #[serde(rename = "type")]
+    kind: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct WhoamiToken {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    prefix: Option<String>,
+    // chrono's serde impl parses the protocol's RFC 3339 timestamp.
+    #[serde(default)]
+    expires_at: Option<DateTime<Utc>>,
+}
+
+/// What the validation probes concluded (design/credential-storage.md
+/// section 5). A surface appears in `accepted` or `rejected` only when it
+/// actually exercised the credential; surfaces that were public,
+/// redirected, or unreachable appear in neither (they were reported as
+/// notices instead).
+#[derive(Default)]
+struct ProbeOutcome {
+    accepted: Vec<ProbeSurface>,
+    rejected: Vec<ProbeSurface>,
+    basic_challenge: bool,
+    identity: Option<WhoamiIdentity>,
+}
+
+/// Build the dedicated probe client: same user agent as the runtime
+/// client, but with redirects disabled (a redirected probe's verdict
+/// would come from a different URL than the surface nominally probed, and
+/// a cross-host redirect strips the Authorization header, misreading
+/// "rejected") and a timeout so a hung probe cannot hang `auth login`.
+fn probe_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .user_agent(crate::resolve::net_utils::USER_AGENT)
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+}
+
+/// Send one probe GET, optionally with a forced bearer credential.
+/// Returns the response unread (probes never consume bodies; the whoami
+/// body is read separately on a 200).
+fn probe_get(
+    runtime: &tokio::runtime::Runtime,
+    client: &reqwest::Client,
+    url: &Url,
+    bearer: Option<&str>,
+) -> Result<reqwest::Response, String> {
+    runtime.block_on(async {
+        let mut request = client.get(url.clone());
+        if let Some(token) = bearer {
+            request = request.bearer_auth(token);
+        }
+        request.send().await.map_err(|err| err.to_string())
+    })
+}
+
+/// The redirect target for a 3xx probe response, for the "not tested"
+/// warning. Kept verbatim (possibly relative); a missing `Location`
+/// header is named as such rather than printed empty.
+fn redirect_target(response: &reqwest::Response) -> String {
+    response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+        .unwrap_or_else(|| "(no Location header)".to_string())
+}
+
+/// Whether any `WWW-Authenticate` challenge on the response offers the
+/// `Basic` scheme. Scheme tokens are case-insensitive (RFC 7235) and one
+/// header value can carry several comma-separated challenges; a full
+/// challenge parser is overkill, but a plain substring check would
+/// false-positive on e.g. `Bearer realm="Basic migration"`.
+fn offers_basic_challenge(headers: &reqwest::header::HeaderMap) -> bool {
+    headers
+        .get_all(reqwest::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .any(|value| {
+            value.split(',').any(|part| {
+                let token = part.trim_start().split([' ', '\t']).next().unwrap_or("");
+                token.eq_ignore_ascii_case("basic")
+            })
+        })
+}
+
+/// Probe the read surface (`index_root/index.json`): an unauthenticated
+/// baseline, then a forced-bearer retry only when the baseline was a 4xx.
+/// The surface exercises the credential only in that case (a public
+/// surface returns 2xx without the credential ever being sent, proving
+/// nothing).
+fn probe_read_surface(
+    runtime: &tokio::runtime::Runtime,
+    client: &reqwest::Client,
+    index_json_url: &Url,
+    secret: &str,
+    outcome: &mut ProbeOutcome,
+    notify: &mut impl FnMut(AuthLoginNotice),
+) {
+    let surface = ProbeSurface::Read;
+    let baseline = match probe_get(runtime, client, index_json_url, None) {
+        Ok(response) => response,
+        Err(error) => {
+            notify(AuthLoginNotice::ProbeUnreachable { surface, error });
+            return;
+        }
+    };
+    let status = baseline.status();
+    if status.is_redirection() {
+        notify(AuthLoginNotice::ProbeRedirected {
+            surface,
+            target: redirect_target(&baseline),
+        });
+        return;
+    }
+    if status.is_success() {
+        // Public read surface: the credential was never sent, so the
+        // surface is not tested (no notice; this is the normal public
+        // case, not a failure).
+        return;
+    }
+    if !status.is_client_error() {
+        notify(AuthLoginNotice::ProbeUnreachable {
+            surface,
+            error: format!("unexpected status {status}"),
+        });
+        return;
+    }
+    let basic_challenge = offers_basic_challenge(baseline.headers());
+    let forced = match probe_get(runtime, client, index_json_url, Some(secret)) {
+        Ok(response) => response,
+        Err(error) => {
+            notify(AuthLoginNotice::ProbeUnreachable { surface, error });
+            return;
+        }
+    };
+    let forced_status = forced.status();
+    if forced_status.is_redirection() {
+        notify(AuthLoginNotice::ProbeRedirected {
+            surface,
+            target: redirect_target(&forced),
+        });
+    } else if forced_status.is_success() {
+        outcome.accepted.push(surface);
+    } else if forced_status.is_client_error() {
+        outcome.rejected.push(surface);
+        outcome.basic_challenge = basic_challenge || offers_basic_challenge(forced.headers());
+    } else {
+        notify(AuthLoginNotice::ProbeUnreachable {
+            surface,
+            error: format!("unexpected status {forced_status}"),
+        });
+    }
+}
+
+/// Probe the API surface (`api_root/v1/whoami`), forced-only: the
+/// endpoint is always authenticated, so its unauthenticated baseline is a
+/// known 401 and only the forced request is sent. 200 accepts (and its
+/// body carries the identity to persist), 401 rejects, anything else is
+/// not tested.
+fn probe_api_surface(
+    runtime: &tokio::runtime::Runtime,
+    client: &reqwest::Client,
+    api_root: &Url,
+    secret: &str,
+    outcome: &mut ProbeOutcome,
+    notify: &mut impl FnMut(AuthLoginNotice),
+) {
+    let surface = ProbeSurface::Api;
+    // `api_root` always ends in `/` (discovery normalizes it), so the
+    // join appends rather than replacing the last segment.
+    let whoami_url = match api_root.join("v1/whoami") {
+        Ok(url) => url,
+        Err(err) => {
+            notify(AuthLoginNotice::ProbeUnreachable {
+                surface,
+                error: format!("could not build the whoami URL: {err}"),
+            });
+            return;
+        }
+    };
+    let response = match probe_get(runtime, client, &whoami_url, Some(secret)) {
+        Ok(response) => response,
+        Err(error) => {
+            notify(AuthLoginNotice::ProbeUnreachable { surface, error });
+            return;
+        }
+    };
+    let status = response.status();
+    if status.is_redirection() {
+        notify(AuthLoginNotice::ProbeRedirected {
+            surface,
+            target: redirect_target(&response),
+        });
+    } else if status == reqwest::StatusCode::OK {
+        outcome.accepted.push(surface);
+        let parsed = runtime
+            .block_on(response.bytes())
+            .map_err(|err| err.to_string())
+            .and_then(|body| {
+                serde_json::from_slice::<WhoamiBody>(&body).map_err(|err| err.to_string())
+            });
+        match parsed {
+            Ok(body) => {
+                outcome.identity = Some(WhoamiIdentity {
+                    subject: CredentialSubject {
+                        kind: body.subject.kind,
+                        name: body.subject.name,
+                    },
+                    token_name: body.token.name,
+                    token_prefix: body.token.prefix,
+                    expires_at: body.token.expires_at,
+                });
+            }
+            // Lenient: the 200 status is the acceptance verdict; a body
+            // this client cannot parse only loses the identity fields.
+            Err(err) => log::debug!("whoami body was not read: {err}"),
+        }
+    } else if status == reqwest::StatusCode::UNAUTHORIZED {
+        outcome.rejected.push(surface);
+    } else {
+        notify(AuthLoginNotice::ProbeUnreachable {
+            surface,
+            error: format!("unexpected status {status}"),
+        });
+    }
+}
+
+/// Run the validation probes (design/credential-storage.md section 5):
+/// discovery-first (the already-fetched discovery result is reused; when
+/// it was unreachable the read surface falls back to the URL-derived
+/// `index.json`, so a fully private index still gets its read surface
+/// exercised), and the API surface only when discovery explicitly
+/// advertised `api_root` (never the plain-URL runtime default), so a
+/// static index is not phantom-probed for an API it does not have.
+fn run_validation_probes(
+    endpoints: Option<&ResolvedEndpoints>,
+    location: &IndexLocation,
+    secret: &str,
+    runtime: &tokio::runtime::Runtime,
+    notify: &mut impl FnMut(AuthLoginNotice),
+) -> ProbeOutcome {
+    let mut outcome = ProbeOutcome::default();
+    let client = match probe_client() {
+        Ok(client) => client,
+        Err(err) => {
+            notify(AuthLoginNotice::ProbeUnreachable {
+                surface: ProbeSurface::Read,
+                error: format!("could not build the probe HTTP client: {err}"),
+            });
+            return outcome;
+        }
+    };
+
+    // For a templated `index_root` this expands the placeholder exactly
+    // like runtime reads of the top-level `index.json` do, so the probe
+    // hits the real read surface.
+    let index_json_url = match endpoints {
+        Some(endpoints) => endpoints.index_url(),
+        None => location.resolve(["index.json"]),
+    };
+    probe_read_surface(
+        runtime,
+        &client,
+        &index_json_url,
+        secret,
+        &mut outcome,
+        notify,
+    );
+
+    if let Some(endpoints) = endpoints
+        && endpoints.api_root_advertised
+        && let Some(api_root) = &endpoints.api_root
+    {
+        probe_api_surface(runtime, &client, api_root, secret, &mut outcome, notify);
+    }
+
+    outcome
+}
+
 /// Store a bearer credential for `index_url` (design/credential-storage.md
-/// sections 4, 8, 9). The secret arrives as a parameter: a library call
+/// sections 4, 5, 8, 9). The secret arrives as a parameter: a library call
 /// never prompts.
 ///
 /// Discovery is fetched best-effort with the unauthenticated policy (no
@@ -266,15 +669,27 @@ fn template_anchor_root(prefix: &str) -> Option<Url> {
 /// falls back to the URL-derived glob with a
 /// [`AuthLoginNotice::DiscoveryUnreachable`] notice. Overwriting an
 /// existing record for the same key is reported through
-/// [`AuthLoginNotice::ReplacingExisting`] before the write happens.
+/// [`AuthLoginNotice::ReplacingExisting`] before the write happens (and
+/// only once validation has decided the write will happen: a refused
+/// login never announces a replacement).
 ///
-/// No validation probe runs here yet: the `--validation` flow
-/// (design/credential-storage.md section 5) slots in between glob
-/// derivation and the store write.
+/// `validation` maps the `--validation true|false` flag: `None` means the
+/// default, `true`. When enabled, the section 5 probes run between glob
+/// derivation and the store write, and the refusal rule applies: the
+/// credential is stored if any exercised surface accepted it, refused
+/// ([`AuthCommandError::ValidationRejected`]) when at least one exercised
+/// surface rejected it and none accepted, and stored as "not validated"
+/// when nothing exercised it. `Some(false)` skips every probe and stores
+/// directly. An absent keyring backend returns
+/// [`AuthLoginOutcome::BackendUnavailable`] before any probe runs (no
+/// network is spent on a credential that cannot be stored), so the
+/// `SYSAND_CRED_*` guidance a no-keyring host prints always describes an
+/// unvalidated credential.
 pub fn do_auth_login<S: CredentialStore>(
     store: &mut S,
     index_url: &str,
     secret: String,
+    validation: Option<bool>,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
     mut notify: impl FnMut(AuthLoginNotice),
@@ -296,8 +711,9 @@ pub fn do_auth_login<S: CredentialStore>(
     let globs = derive_credential_globs(&key, endpoints.as_ref(), &mut notify);
 
     // Detect an existing login before writing, so the host can announce
-    // the replacement first. `list` and `upsert` are separately locked, so
-    // this is best-effort under cross-process races.
+    // the replacement before the write. `list` and `upsert` are
+    // separately locked, so this is best-effort under cross-process
+    // races.
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
@@ -309,23 +725,71 @@ pub fn do_auth_login<S: CredentialStore>(
         }
         Err(err) => return Err(err.into()),
     };
-    if records.iter().any(|record| record.key == key) {
+    let replacing = records.iter().any(|record| record.key == key);
+
+    // Validation probes (design/credential-storage.md section 5), between
+    // glob derivation and the store write.
+    let mut validated: Vec<ProbeSurface> = Vec::new();
+    let mut identity: Option<WhoamiIdentity> = None;
+    if validation.unwrap_or(true) {
+        let outcome = run_validation_probes(
+            endpoints.as_ref(),
+            &location,
+            &secret,
+            &runtime,
+            &mut notify,
+        );
+        // The refusal rule: refuse only when at least one exercised
+        // surface rejected the credential and none accepted it.
+        if outcome.accepted.is_empty() && !outcome.rejected.is_empty() {
+            return Err(AuthCommandError::ValidationRejected {
+                index: key,
+                rejected: outcome.rejected,
+                basic_challenge: outcome.basic_challenge,
+            });
+        }
+        // Stored anyway (some surface accepted): warn about each surface
+        // that rejected.
+        for surface in &outcome.rejected {
+            notify(AuthLoginNotice::SurfaceRejected {
+                surface: *surface,
+                basic_challenge: outcome.basic_challenge && *surface == ProbeSurface::Read,
+            });
+        }
+        validated = outcome.accepted;
+        identity = outcome.identity;
+    }
+
+    if replacing {
         notify(AuthLoginNotice::ReplacingExisting { key: key.clone() });
     }
 
-    // Validation probes (design/credential-storage.md section 5) will run
-    // here, between glob derivation and the store write.
-
+    let (subject, token_name, token_prefix, expires_at) = match identity {
+        Some(identity) => (
+            Some(identity.subject),
+            identity.token_name,
+            identity.token_prefix,
+            identity.expires_at,
+        ),
+        None => (None, None, None, None),
+    };
     let record = CredentialRecord {
         key: key.clone(),
         globs: globs.clone(),
         scheme: CredentialScheme::Bearer,
         secret,
-        expires_at: None,
+        expires_at,
+        subject,
+        token_name,
+        token_prefix,
         extra: serde_json::Map::new(),
     };
     match store.upsert(record) {
-        Ok(()) => Ok(AuthLoginOutcome::Stored { key, globs }),
+        Ok(()) => Ok(AuthLoginOutcome::Stored {
+            key,
+            globs,
+            validated,
+        }),
         Err(CredentialStoreError::BackendAbsent { source }) => {
             Ok(AuthLoginOutcome::BackendUnavailable {
                 key,
@@ -386,9 +850,12 @@ pub fn assemble_auth_status(
                 .collect();
             StoredCredentialStatus {
                 expired: record.expires_at.is_some_and(|expiry| expiry < now),
+                expires_in_days: record.expires_at.map(|expiry| (expiry - now).num_days()),
                 key: record.key,
                 globs: record.globs,
                 expires_at: record.expires_at,
+                subject: record.subject,
+                token_prefix: record.token_prefix,
                 shadowed_by,
             }
         })

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -21,7 +21,8 @@ use serde::Deserialize;
 
 use crate::{
     auth::{
-        EnvBearerAuth, GlobMap, GlobMapBuilder, GlobMapResult, HTTPAuthentication, Unauthenticated,
+        BearerSelection, EnvBearerAuth, GlobMap, HTTPAuthentication, Unauthenticated,
+        select_bearer, stored_bearer_map_from_records,
     },
     credential_store::{
         CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
@@ -1227,34 +1228,22 @@ pub struct AuthWhoamiOutcome {
     pub verdict: WhoamiVerdict,
 }
 
-/// The single entry left after collapsing candidates that carry the same
-/// token (overlapping globs for one credential must not read as
-/// ambiguity), or `None` when genuinely distinct credentials collide.
-fn unique_by_token<'a, T>(
-    candidates: &[(String, &'a T)],
-    token: impl Fn(&T) -> &str,
-) -> Option<&'a T> {
-    let ((_, first), rest) = candidates.split_first()?;
-    rest.iter()
-        .all(|(_, candidate)| token(candidate) == token(first))
-        .then_some(*first)
-}
-
 /// Select the credential `auth whoami` sends, mirroring the runtime and
 /// publish precedence (design/credential-storage.md sections 7, 9): a
 /// `SYSAND_CRED_*` env bearer matching the whoami URL wins over a stored
 /// login; within a source exactly one credential may match (candidates
-/// carrying the same token collapse to one). Invalid stored glob patterns
-/// are skipped individually, like the runtime's lazy stored map: one bad
-/// pattern must not hide the other credentials.
+/// carrying the same token collapse to one, [`select_bearer`]). The
+/// stored map is built by the same [`stored_bearer_map_from_records`] the
+/// runtime's lazy layer uses, so invalid glob patterns are skipped
+/// individually: one bad pattern must not hide the other credentials.
 fn select_whoami_credential(
     env_bearers: &GlobMap<EnvBearerAuth>,
     records: &[CredentialRecord],
     whoami_url: &Url,
     index_key: &str,
 ) -> Result<(WhoamiCredentialSource, String), AuthCommandError> {
-    match env_bearers.lookup(whoami_url.as_str()) {
-        GlobMapResult::Found(_, entry) => {
+    match select_bearer(env_bearers, whoami_url.as_str(), |entry| entry.auth.token()) {
+        BearerSelection::Unique(entry) => {
             return Ok((
                 WhoamiCredentialSource::Env {
                     label: entry.label.clone(),
@@ -1262,75 +1251,32 @@ fn select_whoami_credential(
                 entry.auth.token().to_string(),
             ));
         }
-        GlobMapResult::Ambiguous(candidates) => {
-            let Some(entry) =
-                unique_by_token(&candidates, |entry: &EnvBearerAuth| entry.auth.token())
-            else {
-                return Err(AuthCommandError::AmbiguousWhoamiCredential {
-                    url: whoami_url.as_str().to_string(),
-                    source_name: "`SYSAND_CRED_*` environment variables",
-                    candidates: candidates.len(),
-                });
-            };
-            return Ok((
-                WhoamiCredentialSource::Env {
-                    label: entry.label.clone(),
-                },
-                entry.auth.token().to_string(),
-            ));
-        }
-        GlobMapResult::NotFound => {}
-    }
-
-    let mut builder: GlobMapBuilder<&CredentialRecord> = GlobMapBuilder::new();
-    for record in records {
-        if record.scheme != CredentialScheme::Bearer {
-            continue;
-        }
-        for glob in &record.globs {
-            // Compile each pattern individually first, exactly as the map
-            // build will: `GlobMapBuilder::build` fails wholesale on one
-            // bad pattern.
-            if GlobBuilder::new(glob)
-                .literal_separator(true)
-                .build()
-                .is_ok()
-            {
-                builder.add(glob, record);
-            }
-        }
-    }
-    // Every added pattern was pre-compiled above, so the build cannot
-    // fail; degrade rather than panic if it somehow does.
-    let stored = builder.build().unwrap_or_default();
-
-    let entry = match stored.lookup(whoami_url.as_str()) {
-        GlobMapResult::Found(_, record) => Some(*record),
-        GlobMapResult::Ambiguous(candidates) => {
-            let unique = unique_by_token(&candidates, |record: &&CredentialRecord| {
-                record.secret.as_str()
+        BearerSelection::Ambiguous { candidates, .. } => {
+            return Err(AuthCommandError::AmbiguousWhoamiCredential {
+                url: whoami_url.as_str().to_string(),
+                source_name: "`SYSAND_CRED_*` environment variables",
+                candidates,
             });
-            match unique {
-                Some(record) => Some(*record),
-                None => {
-                    return Err(AuthCommandError::AmbiguousWhoamiCredential {
-                        url: whoami_url.as_str().to_string(),
-                        source_name: "stored credentials",
-                        candidates: candidates.len(),
-                    });
-                }
-            }
         }
-        GlobMapResult::NotFound => None,
-    };
-    match entry {
-        Some(record) => Ok((
+        BearerSelection::None => {}
+    }
+
+    let stored = stored_bearer_map_from_records(records);
+    match select_bearer(&stored, whoami_url.as_str(), |entry| entry.auth().token()) {
+        BearerSelection::Unique(entry) => Ok((
             WhoamiCredentialSource::Stored {
-                key: record.key.clone(),
+                key: entry.key().to_string(),
             },
-            record.secret.clone(),
+            entry.auth().token().to_string(),
         )),
-        None => Err(AuthCommandError::NoWhoamiCredential {
+        BearerSelection::Ambiguous { candidates, .. } => {
+            Err(AuthCommandError::AmbiguousWhoamiCredential {
+                url: whoami_url.as_str().to_string(),
+                source_name: "stored credentials",
+                candidates,
+            })
+        }
+        BearerSelection::None => Err(AuthCommandError::NoWhoamiCredential {
             url: whoami_url.as_str().to_string(),
             index: index_key.to_string(),
         }),

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-//! `sysand auth` command orchestration (design/credential-storage.md
-//! sections 4, 8, 9, 14): `do_auth_login`, `do_auth_logout`,
+//! `sysand auth` command orchestration (the full design is in
+//! design/credential-storage.md): `do_auth_login`, `do_auth_logout`,
 //! `do_auth_status`, and `do_auth_whoami`, over the credential store
 //! ([`LockedBlobStore`], generic over its [`BlobBackend`]).
 //!
@@ -54,7 +54,7 @@ pub enum AuthCommandError {
     InvalidIndexUrl(String),
     /// The target is a URL template with no literal prefix at a safe URL
     /// boundary (at least `scheme://authority/`), so no credential scope
-    /// glob can be derived (the section 8 clamp).
+    /// glob can be derived.
     #[error(
         "`{url}`: this URL template has no literal prefix at a safe URL boundary\n\
          (at least `scheme://authority/`) to scope a credential to;\n\
@@ -62,7 +62,7 @@ pub enum AuthCommandError {
     )]
     TemplateWithoutAnchor { url: String },
     /// Every exercised surface rejected the credential and none accepted
-    /// it, so nothing was stored (section 5 refusal rule).
+    /// it, so nothing was stored.
     #[error("{}", validation_rejected_message(.index, .rejected, *.read_status, *.basic_challenge))]
     ValidationRejected {
         /// The normalized index key the login targeted.
@@ -76,7 +76,7 @@ pub enum AuthCommandError {
         /// Whether the read surface answered with a `WWW-Authenticate:
         /// Basic` challenge: the index wants username/password, not a
         /// bearer token, and the message routes the user to
-        /// `SYSAND_CRED_*` basic credentials (section 5).
+        /// `SYSAND_CRED_*` basic credentials.
         basic_challenge: bool,
     },
     /// `whoami` could not read the index configuration, so the API root
@@ -188,8 +188,8 @@ pub struct EnvCredentialEntry {
     pub applies_to_default: bool,
 }
 
-/// A credential-probing surface of an index (design/credential-storage.md
-/// section 5): the read surface (`index_root/index.json`) or the API
+/// A credential-probing surface of an index: the read surface
+/// (`index_root/index.json`) or the API
 /// surface (`api_root/v1/whoami`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProbeSurface {
@@ -363,7 +363,7 @@ pub enum AuthLoginNotice {
         error: String,
     },
     /// A validation probe was answered with HTTP 429. A 429 is never a
-    /// verdict (section 5): the surface counts as not tested, so rate
+    /// verdict: the surface counts as not tested, so rate
     /// limiting can never refuse a credential.
     ProbeRateLimited { surface: ProbeSurface },
     /// A surface rejected the credential but another accepted it, so it
@@ -382,8 +382,7 @@ pub enum AuthLoginNotice {
 ///
 /// An absent keyring backend is an outcome rather than an error because
 /// the host still needs the derived globs: the CLI prints the exact
-/// `SYSAND_CRED_*` lines to set instead (design/credential-storage.md
-/// section 9).
+/// `SYSAND_CRED_*` lines to set instead.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthLoginOutcome {
     /// The credential was persisted.
@@ -393,7 +392,7 @@ pub enum AuthLoginOutcome {
         /// The surfaces that exercised and accepted the credential, in
         /// probe order. Empty means "stored, not validated". Hosts must
         /// scope the claim to these surfaces and never print a bare
-        /// "validated" (section 5).
+        /// "validated".
         validated: Vec<ProbeSurface>,
     },
     /// No usable OS keyring backend on this host; nothing was persisted
@@ -405,8 +404,7 @@ pub enum AuthLoginOutcome {
     },
 }
 
-/// Derive the escaped URL glob patterns a login covers
-/// (design/credential-storage.md section 8).
+/// Derive the escaped URL glob patterns a login covers.
 ///
 /// The primary glob anchors on `primary_root`
 /// (`globset::escape(<root ending in />)` + `**`); the resolved
@@ -541,8 +539,8 @@ fn parse_whoami_identity(
     }
 }
 
-/// What the validation probes concluded (design/credential-storage.md
-/// section 5). A surface appears in `accepted` or `rejected` only when it
+/// What the validation probes concluded. A surface appears in
+/// `accepted` or `rejected` only when it
 /// actually exercised the credential; surfaces that were public,
 /// redirected, or unreachable appear in neither (they were reported as
 /// notices instead).
@@ -670,7 +668,7 @@ fn probe_read_surface(
     }
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
         // Never force-retry a rate-limited surface (429 is never a
-        // verdict, section 5).
+        // verdict).
         notify(AuthLoginNotice::ProbeRateLimited { surface });
         return;
     }
@@ -696,7 +694,7 @@ fn probe_read_surface(
             target: redirect_target(&forced),
         });
     } else if forced_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        // 429 is never a verdict (section 5): counting it as rejected
+        // 429 is never a verdict: counting it as rejected
         // would let throttling false-refuse a valid token.
         notify(AuthLoginNotice::ProbeRateLimited { surface });
     } else if forced_status.is_success() {
@@ -758,7 +756,7 @@ fn probe_api_surface(
     } else if status == reqwest::StatusCode::UNAUTHORIZED {
         outcome.rejected.push(surface);
     } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        // 429 is never a verdict (section 5); the protocol explicitly
+        // 429 is never a verdict; the protocol explicitly
         // allows rate limiting on `v1/whoami`.
         notify(AuthLoginNotice::ProbeRateLimited { surface });
     } else {
@@ -769,9 +767,8 @@ fn probe_api_surface(
     }
 }
 
-/// Fetch discovery for a login (design/credential-storage.md sections 5,
-/// 8): an unauthenticated baseline, then one forced-bearer retry on any
-/// 4xx except 429. The forced retry distinguishes a hidden discovery
+/// Fetch discovery for a login: an unauthenticated baseline, then one
+/// forced-bearer retry on any 4xx except 429. The forced retry distinguishes a hidden discovery
 /// document from an absent one: a fully private index answers 401 (or
 /// GitLab-style 404) unauthenticated either way, and only the
 /// credentialed answer settles it.
@@ -878,7 +875,7 @@ fn forced_discovery_fetch(
     }
 }
 
-/// Run the validation probes (design/credential-storage.md section 5).
+/// Run the validation probes.
 /// When discovery was unreachable the read surface falls back to the
 /// URL-derived `index.json`; the API surface is probed only when
 /// discovery advertised `api_root`, so a static index is not
@@ -953,14 +950,13 @@ fn guidance_globs(
     derive_credential_globs(primary_root, endpoints.as_ref(), notify)
 }
 
-/// Store a bearer credential for `index_url` (design/credential-storage.md
-/// sections 4, 5, 8, 9). The secret arrives as a parameter: a library
-/// call never prompts.
+/// Store a bearer credential for `index_url`. The secret arrives as a
+/// parameter: a library call never prompts.
 ///
 /// Discovery is fetched best-effort for glob scoping
 /// ([`fetch_login_endpoints`]); with no usable document the credential
 /// falls back to the URL-derived glob. Validation always runs, between
-/// glob derivation and the store write, with the section 5 refusal rule:
+/// glob derivation and the store write, with the refusal rule:
 /// stored if any exercised surface accepted, refused
 /// ([`AuthCommandError::ValidationRejected`]) when surfaces only
 /// rejected, stored "not validated" when nothing exercised the credential
@@ -1105,8 +1101,8 @@ pub fn do_auth_logout<B: BlobBackend>(
 }
 
 /// Where the credential `auth whoami` selected came from. Selection
-/// mirrors publish's source precedence (design/credential-storage.md
-/// section 7): environment credentials before stored credentials.
+/// mirrors publish's source precedence: environment credentials before
+/// stored credentials.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WhoamiCredentialSource {
     /// A `SYSAND_CRED_*` environment bearer; `label` is the
@@ -1143,7 +1139,7 @@ pub struct AuthWhoamiOutcome {
 }
 
 /// Select the credential `auth whoami` sends, mirroring the runtime and
-/// publish precedence (design/credential-storage.md sections 7, 9): env
+/// publish precedence: env
 /// over stored, and within a source exactly one credential may match
 /// (same-token candidates collapse, [`select_bearer`]). The stored map is
 /// built by the same [`stored_bearer_map_from_records`] the runtime uses,
@@ -1195,8 +1191,8 @@ fn select_whoami_credential(
     }
 }
 
-/// Query-only live identity check (design/credential-storage.md section
-/// 4): resolve the index API, select the credential the runtime would use
+/// Query-only live identity check: resolve the index API, select the
+/// credential the runtime would use
 /// ([`select_whoami_credential`]), and send one forced-bearer GET to
 /// `api_root/v1/whoami` with the no-redirect probe client. Never prompts,
 /// never prints, never touches a credential store: taking a `records`
@@ -1377,8 +1373,7 @@ pub fn assemble_auth_status(
 ///
 /// An absent keyring backend degrades to the env-only view
 /// ([`StoredCredentialsStatus::BackendUnavailable`]); a present but locked
-/// or denied backend is a hard error the caller must surface
-/// (design/credential-storage.md section 9 taxonomy).
+/// or denied backend is a hard error the caller must surface.
 pub fn do_auth_status<B: BlobBackend>(
     store: &LockedBlobStore<B>,
     env: Vec<EnvCredentialEntry>,

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -625,13 +625,17 @@ fn parse_whoami_identity(
     runtime: &tokio::runtime::Runtime,
     response: reqwest::Response,
 ) -> Option<WhoamiIdentity> {
-    let parsed = runtime
-        .block_on(response.bytes())
-        .map_err(|err| err.to_string())
-        .and_then(|body| {
-            serde_json::from_slice::<WhoamiBody>(&body).map_err(|err| err.to_string())
-        });
-    match parsed {
+    let body = match runtime.block_on(response.bytes()) {
+        Ok(body) => body,
+        Err(err) => {
+            log::debug!(
+                "whoami body was not read: {}",
+                crate::utils::format_err(err)
+            );
+            return None;
+        }
+    };
+    match serde_json::from_slice::<WhoamiBody>(&body) {
         Ok(body) => Some(WhoamiIdentity {
             subject: CredentialSubject {
                 // The wire value stays lenient; unknown types become
@@ -644,7 +648,11 @@ fn parse_whoami_identity(
             expires_at: body.token.expires_at,
         }),
         Err(err) => {
-            log::debug!("whoami body was not read: {err}");
+            // The body is index metadata about the token, never a secret.
+            log::debug!(
+                "whoami body was not parsed: {err};\nbody: {}",
+                String::from_utf8_lossy(&body)
+            );
             None
         }
     }
@@ -695,7 +703,7 @@ fn probe_request(
         if let Some(token) = bearer {
             request = request.bearer_auth(token);
         }
-        request.send().await.map_err(|err| err.to_string())
+        request.send().await.map_err(crate::utils::format_err)
     })
 }
 
@@ -939,7 +947,7 @@ fn fetch_login_endpoints(
         // is sent.
         Err(err) => {
             notify(AuthLoginNotice::DiscoveryUnreachable {
-                error: err.to_string(),
+                error: crate::utils::format_err(err),
             });
             None
         }
@@ -993,7 +1001,7 @@ fn forced_discovery_fetch(
         match raw {
             Ok(raw) => match resolve_index_config(raw, &config_url, location.clone()) {
                 Ok(endpoints) => Some(endpoints),
-                Err(err) => unreachable(err.to_string()),
+                Err(err) => unreachable(crate::utils::format_err(err)),
             },
             Err(error) => unreachable(error),
         }
@@ -1084,7 +1092,7 @@ fn guidance_globs(
             Ok(endpoints) => Some(endpoints),
             Err(err) => {
                 notify(AuthLoginNotice::DiscoveryUnreachable {
-                    error: err.to_string(),
+                    error: crate::utils::format_err(err),
                 });
                 None
             }
@@ -1357,7 +1365,7 @@ pub fn do_auth_whoami<P: HTTPAuthentication>(
         ))
         .map_err(|err| AuthCommandError::WhoamiDiscoveryFailed {
             index: key.clone(),
-            error: err.to_string(),
+            error: crate::utils::format_err(err),
         })?;
     // No advertised `api_root` means the index has no API to ask.
     let Some(api_root) = &endpoints.api_root else {

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -512,6 +512,36 @@ struct WhoamiToken {
     expires_at: Option<DateTime<Utc>>,
 }
 
+/// Read and parse a `v1/whoami` `200` body into the identity fields.
+/// Lenient: a body this client cannot read only loses the identity (the
+/// `200` was already the acceptance verdict), so failures return `None`.
+fn parse_whoami_identity(
+    runtime: &tokio::runtime::Runtime,
+    response: reqwest::Response,
+) -> Option<WhoamiIdentity> {
+    let parsed = runtime
+        .block_on(response.bytes())
+        .map_err(|err| err.to_string())
+        .and_then(|body| {
+            serde_json::from_slice::<WhoamiBody>(&body).map_err(|err| err.to_string())
+        });
+    match parsed {
+        Ok(body) => Some(WhoamiIdentity {
+            subject: CredentialSubject {
+                kind: body.subject.kind,
+                name: body.subject.name,
+            },
+            token_name: body.token.name,
+            token_prefix: body.token.prefix,
+            expires_at: body.token.expires_at,
+        }),
+        Err(err) => {
+            log::debug!("whoami body was not read: {err}");
+            None
+        }
+    }
+}
+
 /// What the validation probes concluded (design/credential-storage.md
 /// section 5). A surface appears in `accepted` or `rejected` only when it
 /// actually exercised the credential; surfaces that were public,
@@ -709,28 +739,7 @@ fn probe_api_surface(
         });
     } else if status == reqwest::StatusCode::OK {
         outcome.accepted.push(surface);
-        let parsed = runtime
-            .block_on(response.bytes())
-            .map_err(|err| err.to_string())
-            .and_then(|body| {
-                serde_json::from_slice::<WhoamiBody>(&body).map_err(|err| err.to_string())
-            });
-        match parsed {
-            Ok(body) => {
-                outcome.identity = Some(WhoamiIdentity {
-                    subject: CredentialSubject {
-                        kind: body.subject.kind,
-                        name: body.subject.name,
-                    },
-                    token_name: body.token.name,
-                    token_prefix: body.token.prefix,
-                    expires_at: body.token.expires_at,
-                });
-            }
-            // Lenient: the 200 status is the acceptance verdict; a body
-            // this client cannot parse only loses the identity fields.
-            Err(err) => log::debug!("whoami body was not read: {err}"),
-        }
+        outcome.identity = parse_whoami_identity(runtime, response);
     } else if status == reqwest::StatusCode::UNAUTHORIZED {
         outcome.rejected.push(surface);
     } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
@@ -1320,30 +1329,7 @@ pub fn do_auth_whoami<S: CredentialStore, P: HTTPAuthentication>(
             Ok(response) => {
                 let status = response.status();
                 if status == reqwest::StatusCode::OK {
-                    let parsed = runtime
-                        .block_on(response.bytes())
-                        .map_err(|err| err.to_string())
-                        .and_then(|body| {
-                            serde_json::from_slice::<WhoamiBody>(&body)
-                                .map_err(|err| err.to_string())
-                        });
-                    let identity = match parsed {
-                        Ok(body) => Some(WhoamiIdentity {
-                            subject: CredentialSubject {
-                                kind: body.subject.kind,
-                                name: body.subject.name,
-                            },
-                            token_name: body.token.name,
-                            token_prefix: body.token.prefix,
-                            expires_at: body.token.expires_at,
-                        }),
-                        // Lenient: the 200 is the verdict; an unparseable
-                        // body only loses the details.
-                        Err(err) => {
-                            log::debug!("whoami body was not read: {err}");
-                            None
-                        }
-                    };
+                    let identity = parse_whoami_identity(runtime, response);
                     WhoamiVerdict::Identified { identity }
                 } else if status == reqwest::StatusCode::UNAUTHORIZED {
                     WhoamiVerdict::Rejected

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -380,9 +380,9 @@ impl IndexKey {
             IndexLocation::Root(_) => key.clone(),
             IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
                 Some((_, anchor)) => anchor.as_str().to_string(),
-                // The raw-input check already rejected unanchorable
-                // templates; this arm just avoids a panic path.
-                None => return Err(AuthCommandError::TemplateWithoutAnchor { url: key }),
+                None => {
+                    unreachable!("BUG: unanchorable template should have been rejected earlier")
+                }
             },
         };
         Ok(Self {
@@ -426,9 +426,12 @@ fn normalized_template_key(index_url: &str) -> Result<String, AuthCommandError> 
             url: index_url.to_string(),
         });
     };
-    // `Display` reproduces the validated template text; the prefix past
-    // its last `/` contains no `/`, so reassembly keeps the anchor as the
-    // key's own anchor (idempotence).
+    // Unlike plain `Display` (which reproduces the template text as
+    // given), the key swaps in the URL-normalized anchor (lowercased
+    // host, default port dropped), so spellings of the same template
+    // collapse to one key. The rest of the prefix and the placeholder
+    // tail are reattached verbatim, and re-validating the result yields
+    // the same key again.
     let tail = location.to_string();
     Ok(format!(
         "{anchor}{}{}",

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -12,8 +12,6 @@
 //! passed in as [`EnvCredentialEntry`] values: this module does not read
 //! the process environment.
 
-use std::sync::Arc;
-
 use chrono::{DateTime, Utc};
 use globset::GlobBuilder;
 use thiserror::Error;
@@ -113,8 +111,10 @@ pub enum AuthCommandError {
         source_name: &'static str,
         candidates: usize,
     },
-    /// No credential of either source matches the `v1/whoami` URL.
-    #[error("no credential matches `{url}`; set `SYSAND_CRED_*` environment variables")]
+    /// No credential of either source matches the `v1/whoami` URL. The
+    /// message states the bare condition; the frontend appends its own
+    /// remediation (`sysand auth login`, `SYSAND_CRED_*`) from the fields.
+    #[error("no credential matches `{url}`")]
     NoWhoamiCredential { url: String, index: String },
     /// The credential store failed.
     #[error(transparent)]
@@ -164,6 +164,9 @@ fn validation_rejected_message(
         }
     };
     if basic_challenge {
+        // Keep this basic-auth routing hint consistent with the
+        // stored-anyway variant in sysand/src/commands/auth.rs
+        // (render_login_notice).
         message.push_str(
             "\nthis index uses username/password (HTTP basic) authentication; configure \
              `SYSAND_CRED_<X>_BASIC_USER` / `SYSAND_CRED_<X>_BASIC_PASS` environment \
@@ -388,11 +391,15 @@ pub enum AuthLoginNotice {
     /// tested, so rate limiting can never refuse a credential.
     ProbeRateLimited { surface: ProbeSurface },
     /// A surface rejected the credential, but another surface accepted
-    /// it, so the credential was stored anyway. `basic_challenge` is true
+    /// it, so the credential was stored anyway. `read_status` is the HTTP
+    /// status of the read surface's rejection (set only when `surface` is
+    /// the read surface); a 404 hedges the warning, since it can also
+    /// mean no `index.json` exists at that URL. `basic_challenge` is true
     /// when the read surface answered with a `WWW-Authenticate: Basic`
     /// challenge (the index wants username/password, not a bearer token).
     SurfaceRejected {
         surface: ProbeSurface,
+        read_status: Option<u16>,
         basic_challenge: bool,
     },
 }
@@ -1043,7 +1050,7 @@ pub fn do_auth_login<S: CredentialStore>(
     index_url: &str,
     secret: String,
     client: &reqwest_middleware::ClientWithMiddleware,
-    runtime: Arc<tokio::runtime::Runtime>,
+    runtime: &tokio::runtime::Runtime,
     mut notify: impl FnMut(AuthLoginNotice),
 ) -> Result<AuthLoginOutcome, AuthCommandError> {
     let key = validated_index_key(index_url)?;
@@ -1074,7 +1081,7 @@ pub fn do_auth_login<S: CredentialStore>(
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
-            let globs = guidance_globs(client, &location, &primary_root, &runtime, &mut notify);
+            let globs = guidance_globs(client, &location, &primary_root, runtime, &mut notify);
             return Ok(AuthLoginOutcome::BackendUnavailable {
                 key,
                 globs,
@@ -1085,18 +1092,13 @@ pub fn do_auth_login<S: CredentialStore>(
     };
     let replacing = records.iter().any(|record| record.key == key);
 
-    let endpoints = fetch_login_endpoints(client, &location, &secret, &runtime, &mut notify);
+    let endpoints = fetch_login_endpoints(client, &location, &secret, runtime, &mut notify);
     let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
 
     // Validation probes (design/credential-storage.md section 5), between
     // glob derivation and the store write.
-    let outcome = run_validation_probes(
-        endpoints.as_ref(),
-        &location,
-        &secret,
-        &runtime,
-        &mut notify,
-    );
+    let outcome =
+        run_validation_probes(endpoints.as_ref(), &location, &secret, runtime, &mut notify);
     // The refusal rule: refuse only when at least one exercised
     // surface rejected the credential and none accepted it.
     if outcome.accepted.is_empty() && !outcome.rejected.is_empty() {
@@ -1112,6 +1114,11 @@ pub fn do_auth_login<S: CredentialStore>(
     for surface in &outcome.rejected {
         notify(AuthLoginNotice::SurfaceRejected {
             surface: *surface,
+            read_status: if *surface == ProbeSurface::Read {
+                outcome.read_status
+            } else {
+                None
+            },
             basic_challenge: outcome.basic_challenge && *surface == ProbeSurface::Read,
         });
     }
@@ -1334,20 +1341,20 @@ fn select_whoami_credential(
 /// 4): resolve the index API, select the credential the runtime would use
 /// (env over stored, [`select_whoami_credential`]), and send one
 /// forced-bearer GET to `api_root/v1/whoami` with the no-redirect probe
-/// client. Never prompts, never prints, and never writes the credential
-/// store: cached identity fields on a stored record are deliberately not
-/// refreshed.
+/// client. Never prompts, never prints, and never touches a credential
+/// store: the caller reads the store once and passes the `records`
+/// snapshot (an absent backend passes an empty slice; a locked or denied
+/// backend is the caller's hard error). Taking records instead of a store
+/// lets the host share one store read between this selection and its
+/// discovery policy, keeping whoami at one keychain touch. Cached
+/// identity fields on a stored record are deliberately not refreshed.
 ///
 /// `discovery_auth` is the policy for the discovery fetch: unlike login
 /// (which is unauthenticated because no credential exists yet), whoami
 /// runs when a credential does exist, and a private index may gate its
 /// discovery document, so the CLI passes its regular read policy here.
-///
-/// An absent keyring backend degrades to env-only selection; a locked or
-/// denied backend is a hard error the caller must surface, like the other
-/// auth commands.
-pub fn do_auth_whoami<S: CredentialStore, P: HTTPAuthentication>(
-    store: &S,
+pub fn do_auth_whoami<P: HTTPAuthentication>(
+    records: &[CredentialRecord],
     index_url: &str,
     env_bearers: &GlobMap<EnvBearerAuth>,
     discovery_auth: &P,
@@ -1378,15 +1385,7 @@ pub fn do_auth_whoami<S: CredentialStore, P: HTTPAuthentication>(
                 error: format!("could not build the whoami URL: {err}"),
             })?;
 
-    let records = match store.list() {
-        Ok(records) => records,
-        // No keyring backend: only env credentials can apply. A locked or
-        // denied backend propagates instead: "no credential, run login"
-        // would be the wrong remediation for an unlockable store.
-        Err(CredentialStoreError::BackendAbsent { .. }) => Vec::new(),
-        Err(err) => return Err(err.into()),
-    };
-    let (source, token) = select_whoami_credential(env_bearers, &records, &whoami_url, &key)?;
+    let (source, token) = select_whoami_credential(env_bearers, records, &whoami_url, &key)?;
 
     let verdict = match probe_client() {
         Err(err) => WhoamiVerdict::Unreachable {

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -29,7 +29,11 @@ use crate::{
         CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
         CredentialSubject, normalize_index_key,
     },
-    env::discovery::{ResolvedEndpoints, fetch_index_config},
+    env::discovery::{
+        DiscoveryError, INDEX_CONFIG_PATH, IndexConfigRaw, ResolvedEndpoints, fetch_index_config,
+        fetch_index_config_strict, resolve_index_config,
+    },
+    env::index::HttpFetchError,
     index_location::{IndexLocation, IndexLocationError, is_template_syntax},
 };
 
@@ -197,8 +201,8 @@ pub struct StoredCredentialStatus {
     /// learned it.
     pub token_prefix: Option<String>,
     /// The surfaces that exercised and accepted the credential at login
-    /// (`"read"`, `"api"`, in probe order). Empty means the credential
-    /// was stored without validation.
+    /// (`"read"`, `"api"`, in probe order). Empty means nothing
+    /// exercised the credential ("stored, not validated").
     pub validated: Vec<String>,
     /// Labels of `SYSAND_CRED_*` entries that may shadow this login.
     ///
@@ -324,9 +328,10 @@ pub enum AuthLoginNotice {
     /// A stored credential for the same key exists and is about to be
     /// overwritten.
     ReplacingExisting { key: String },
-    /// The discovery document could not be read (network failure, or an
-    /// HTTP error such as 401 on a private index); the credential is
-    /// scoped to the URL-derived pattern only.
+    /// The discovery document could not be read: a network failure, or an
+    /// HTTP error that survived login's authenticated retry (see
+    /// [`fetch_login_endpoints`]). The credential is scoped to the
+    /// URL-derived pattern only.
     DiscoveryUnreachable { error: String },
     /// Discovery resolved a templated `index_root` whose literal prefix
     /// cannot be anchored at a safe URL boundary (at least
@@ -377,7 +382,7 @@ pub enum AuthLoginOutcome {
         globs: Vec<String>,
         /// The surfaces that exercised and accepted the credential, in
         /// probe order (read before api). Empty means "stored, not
-        /// validated": either `validation` was disabled or nothing
+        /// validated": nothing
         /// exercised the credential. Hosts must scope the claim to these
         /// surfaces and never print a bare "validated"
         /// (design/credential-storage.md section 5).
@@ -743,6 +748,122 @@ fn probe_api_surface(
     }
 }
 
+/// Fetch discovery for a login (design/credential-storage.md sections 5,
+/// 8): an unauthenticated baseline, then, on any 4xx answer, one
+/// forced-bearer retry carrying the in-hand secret, mirroring the probe
+/// mechanism. The forced retry is what distinguishes a hidden discovery
+/// document from an absent one: a fully private index answers 401 (or, in
+/// GitLab's style, 404) to the unauthenticated fetch whether or not a
+/// document exists, and only the credentialed answer settles it, letting
+/// such an index advertise its `api_root` for glob scoping and the whoami
+/// probe.
+///
+/// Discovery here is about knowing the topology, not validating the
+/// credential, and its outcome never refuses a login. `None` means "no
+/// usable document"; the caller falls back to the URL-derived glob after
+/// a [`AuthLoginNotice::DiscoveryUnreachable`] notice.
+fn fetch_login_endpoints(
+    client: &reqwest_middleware::ClientWithMiddleware,
+    location: &IndexLocation,
+    secret: &str,
+    runtime: &tokio::runtime::Runtime,
+    notify: &mut impl FnMut(AuthLoginNotice),
+) -> Option<ResolvedEndpoints> {
+    // The baseline goes through the regular middleware client (following
+    // redirects, exactly like every other discovery fetch); the strict
+    // variant surfaces an absent document as its 404 status so the retry
+    // decision below can see it.
+    match runtime.block_on(fetch_index_config_strict(
+        client,
+        &Unauthenticated {},
+        location,
+    )) {
+        Ok(endpoints) => Some(endpoints),
+        Err(DiscoveryError::Fetch(HttpFetchError::BadHttpStatus { status, .. }))
+            if status.is_client_error() =>
+        {
+            forced_discovery_fetch(location, secret, runtime, notify)
+        }
+        // Network failures, 5xx, and a present-but-invalid document are
+        // not "possibly hidden from me" signals: no secret is sent.
+        Err(err) => {
+            notify(AuthLoginNotice::DiscoveryUnreachable {
+                error: err.to_string(),
+            });
+            None
+        }
+    }
+}
+
+/// The forced leg of [`fetch_login_endpoints`]: one GET of the discovery
+/// document with a forced bearer, through the no-redirect probe client. A
+/// 200 with a valid document is used exactly like a public discovery
+/// success; a 404 is the authoritative "no document" answer to the
+/// credential and reconstructs the flat topology, like a public 404 (no
+/// notice: this is the normal discovery-less case, not a failure).
+/// Everything else (other 4xx, 429, redirect, 5xx, network failure) falls
+/// back to `None` with a notice; the validation probes still deliver the
+/// credential verdict.
+fn forced_discovery_fetch(
+    location: &IndexLocation,
+    secret: &str,
+    runtime: &tokio::runtime::Runtime,
+    notify: &mut impl FnMut(AuthLoginNotice),
+) -> Option<ResolvedEndpoints> {
+    let config_url = location.resolve([INDEX_CONFIG_PATH]);
+    let mut unreachable = |error: String| {
+        notify(AuthLoginNotice::DiscoveryUnreachable { error });
+        None
+    };
+    let client = match probe_client() {
+        Ok(client) => client,
+        Err(err) => {
+            return unreachable(format!("could not build the probe HTTP client: {err}"));
+        }
+    };
+    let response = match probe_get(runtime, &client, &config_url, Some(secret)) {
+        Ok(response) => response,
+        Err(error) => {
+            return unreachable(format!("HTTP request to `{config_url}` failed: {error}"));
+        }
+    };
+    let status = response.status();
+    if status == reqwest::StatusCode::OK {
+        let raw = runtime
+            .block_on(response.bytes())
+            .map_err(|err| format!("failed to read HTTP response body from `{config_url}`: {err}"))
+            .and_then(|body| {
+                serde_json::from_slice::<IndexConfigRaw>(&body)
+                    .map_err(|err| format!("failed to parse JSON from `{config_url}`: {err}"))
+            });
+        match raw {
+            Ok(raw) => match resolve_index_config(raw, &config_url, location.clone()) {
+                Ok(endpoints) => Some(endpoints),
+                Err(err) => unreachable(err.to_string()),
+            },
+            Err(error) => unreachable(error),
+        }
+    } else if status == reqwest::StatusCode::NOT_FOUND {
+        Some(ResolvedEndpoints::flat(location.clone()))
+    } else if status.is_redirection() {
+        // The probe client never follows redirects (unlike the baseline's
+        // middleware client), so a redirect-fronted discovery document
+        // gains this notice instead of a forced answer.
+        unreachable(format!(
+            "the authenticated retry for `{config_url}` was redirected to `{}`",
+            redirect_target(&response)
+        ))
+    } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        unreachable(format!(
+            "the authenticated retry for `{config_url}` was rate limited (HTTP 429)"
+        ))
+    } else {
+        unreachable(format!(
+            "the authenticated retry for `{config_url}` returned status {status}"
+        ))
+    }
+}
+
 /// Run the validation probes (design/credential-storage.md section 5):
 /// discovery-first (the already-fetched discovery result is reused; when
 /// it was unreachable the read surface falls back to the URL-derived
@@ -799,35 +920,35 @@ fn run_validation_probes(
 /// sections 4, 5, 8, 9). The secret arrives as a parameter: a library call
 /// never prompts.
 ///
-/// Discovery is fetched best-effort with the unauthenticated policy (no
-/// credential exists for the index yet) to resolve `index_root` and
-/// `api_root` for glob scoping; when it cannot be read the credential
-/// falls back to the URL-derived glob with a
-/// [`AuthLoginNotice::DiscoveryUnreachable`] notice. Overwriting an
+/// Discovery is fetched best-effort to resolve `index_root` and
+/// `api_root` for glob scoping: an unauthenticated baseline, retried once
+/// with the in-hand secret as a forced bearer when the baseline answers
+/// any 4xx, so a fully private index can still advertise its topology
+/// ([`fetch_login_endpoints`]); only the backend-absent path stays
+/// strictly unauthenticated, since its secret is discarded. When no usable
+/// document results, the credential falls back to the URL-derived glob
+/// with a [`AuthLoginNotice::DiscoveryUnreachable`] notice. Overwriting an
 /// existing record for the same key is reported through
 /// [`AuthLoginNotice::ReplacingExisting`] before the write happens (and
 /// only once validation has decided the write will happen: a refused
 /// login never announces a replacement).
 ///
-/// `validation`: `None` means the default, `true`; the CLI's
-/// `--no-validation` flag maps to `Some(false)`, and language bindings can
-/// expose this as an optional keyword. When enabled, the section 5 probes
-/// run between glob
-/// derivation and the store write, and the refusal rule applies: the
-/// credential is stored if any exercised surface accepted it, refused
+/// Validation always runs (there is no opt-out; design section 5): the
+/// probes run between glob derivation and the store write, and the
+/// refusal rule applies. The credential is stored if any exercised
+/// surface accepted it, refused
 /// ([`AuthCommandError::ValidationRejected`]) when at least one exercised
 /// surface rejected it and none accepted, and stored as "not validated"
-/// when nothing exercised it. `Some(false)` skips every probe and stores
-/// directly. An absent keyring backend returns
-/// [`AuthLoginOutcome::BackendUnavailable`] before any probe runs (no
-/// network is spent on a credential that cannot be stored), so the
-/// `SYSAND_CRED_*` guidance a no-keyring host prints always describes an
-/// unvalidated credential.
+/// when nothing exercised it (which is how an offline or unreachable
+/// index degrades: warnings, no verdict, no refusal). An absent keyring
+/// backend returns [`AuthLoginOutcome::BackendUnavailable`] before any
+/// probe runs (no network is spent on a credential that cannot be
+/// stored), so the `SYSAND_CRED_*` guidance a no-keyring host prints
+/// always describes an unvalidated credential.
 pub fn do_auth_login<S: CredentialStore>(
     store: &mut S,
     index_url: &str,
     secret: String,
-    validation: Option<bool>,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
     mut notify: impl FnMut(AuthLoginNotice),
@@ -849,25 +970,31 @@ pub fn do_auth_login<S: CredentialStore>(
         },
     };
 
-    let endpoints =
-        match runtime.block_on(fetch_index_config(client, &Unauthenticated {}, &location)) {
-            Ok(endpoints) => Some(endpoints),
-            Err(err) => {
-                notify(AuthLoginNotice::DiscoveryUnreachable {
-                    error: err.to_string(),
-                });
-                None
-            }
-        };
-    let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
-
-    // Detect an existing login before writing, so the host can announce
-    // the replacement before the write. `list` and `upsert` are
-    // separately locked, so this is best-effort under cross-process
-    // races.
+    // Read the store before any network so an absent keyring backend is
+    // detected before the secret could be spent on a credentialed request
+    // (the BackendUnavailable outcome discards the secret, so its
+    // best-effort discovery for the `SYSAND_CRED_*` guidance globs stays
+    // strictly unauthenticated). This also detects an existing login
+    // before writing, so the host can announce the replacement before the
+    // write; `list` and `upsert` are separately locked, so that part is
+    // best-effort under cross-process races.
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
+            let endpoints = match runtime.block_on(fetch_index_config(
+                client,
+                &Unauthenticated {},
+                &location,
+            )) {
+                Ok(endpoints) => Some(endpoints),
+                Err(err) => {
+                    notify(AuthLoginNotice::DiscoveryUnreachable {
+                        error: err.to_string(),
+                    });
+                    None
+                }
+            };
+            let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
             return Ok(AuthLoginOutcome::BackendUnavailable {
                 key,
                 globs,
@@ -878,38 +1005,37 @@ pub fn do_auth_login<S: CredentialStore>(
     };
     let replacing = records.iter().any(|record| record.key == key);
 
+    let endpoints = fetch_login_endpoints(client, &location, &secret, &runtime, &mut notify);
+    let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
+
     // Validation probes (design/credential-storage.md section 5), between
     // glob derivation and the store write.
-    let mut validated: Vec<ProbeSurface> = Vec::new();
-    let mut identity: Option<WhoamiIdentity> = None;
-    if validation.unwrap_or(true) {
-        let outcome = run_validation_probes(
-            endpoints.as_ref(),
-            &location,
-            &secret,
-            &runtime,
-            &mut notify,
-        );
-        // The refusal rule: refuse only when at least one exercised
-        // surface rejected the credential and none accepted it.
-        if outcome.accepted.is_empty() && !outcome.rejected.is_empty() {
-            return Err(AuthCommandError::ValidationRejected {
-                index: key,
-                rejected: outcome.rejected,
-                basic_challenge: outcome.basic_challenge,
-            });
-        }
-        // Stored anyway (some surface accepted): warn about each surface
-        // that rejected.
-        for surface in &outcome.rejected {
-            notify(AuthLoginNotice::SurfaceRejected {
-                surface: *surface,
-                basic_challenge: outcome.basic_challenge && *surface == ProbeSurface::Read,
-            });
-        }
-        validated = outcome.accepted;
-        identity = outcome.identity;
+    let outcome = run_validation_probes(
+        endpoints.as_ref(),
+        &location,
+        &secret,
+        &runtime,
+        &mut notify,
+    );
+    // The refusal rule: refuse only when at least one exercised
+    // surface rejected the credential and none accepted it.
+    if outcome.accepted.is_empty() && !outcome.rejected.is_empty() {
+        return Err(AuthCommandError::ValidationRejected {
+            index: key,
+            rejected: outcome.rejected,
+            basic_challenge: outcome.basic_challenge,
+        });
     }
+    // Stored anyway (some surface accepted): warn about each surface
+    // that rejected.
+    for surface in &outcome.rejected {
+        notify(AuthLoginNotice::SurfaceRejected {
+            surface: *surface,
+            basic_challenge: outcome.basic_challenge && *surface == ProbeSurface::Read,
+        });
+    }
+    let validated = outcome.accepted;
+    let identity = outcome.identity;
 
     if replacing {
         notify(AuthLoginNotice::ReplacingExisting { key: key.clone() });

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -149,6 +149,11 @@ pub struct EnvCredentialEntry {
     pub label: String,
     /// The URL glob pattern the variable holds.
     pub pattern: String,
+    /// Whether this entry applies to the default index passed to
+    /// [`assemble_auth_status`]: its pattern matches the default index
+    /// root URL. Callers construct entries with `false`; status assembly
+    /// sets it.
+    pub applies_to_default: bool,
 }
 
 /// A credential-probing surface of an index (design/credential-storage.md
@@ -206,6 +211,13 @@ pub struct StoredCredentialStatus {
     /// text, which no request URL contains, so shadow detection is extra
     /// approximate for templates.
     pub shadowed_by: Vec<String>,
+    /// Whether this entry applies to the default index passed to
+    /// [`assemble_auth_status`]: its key equals the default's normalized
+    /// key, or one of its globs matches the default index root URL (an
+    /// entry can cover the default without being keyed by it, for example
+    /// via a disjoint `api_root` glob). Shares the root-URL approximation
+    /// documented on `shadowed_by`.
+    pub applies_to_default: bool,
 }
 
 /// The stored side of `auth status`.
@@ -1239,14 +1251,59 @@ pub fn do_auth_whoami<S: CredentialStore, P: HTTPAuthentication>(
     })
 }
 
+/// The URL-glob match target of a validated index key: the key itself for
+/// a plain URL (it is normalized and ends in `/`), the literal-prefix
+/// anchor for a template key. `None` when the key does not parse or the
+/// template has no safe anchor.
+fn index_key_glob_root(key: &str) -> Option<String> {
+    match IndexLocation::parse(key).ok()? {
+        IndexLocation::Root(url) => Some(url.as_str().to_string()),
+        IndexLocation::Template(template) => {
+            template_anchor_root(template.prefix()).map(|(_, anchor)| anchor.as_str().to_string())
+        }
+    }
+}
+
+/// Whether `pattern` matches `target`, compiled the same way runtime
+/// matching does (`literal_separator(true)`). Lenient: an invalid pattern
+/// matches nothing instead of erroring, because `auth status` must stay
+/// usable to diagnose exactly such patterns.
+fn lenient_glob_matches(pattern: &str, target: &str) -> bool {
+    GlobBuilder::new(pattern)
+        .literal_separator(true)
+        .build()
+        .map(|glob| glob.compile_matcher().is_match(target))
+        .unwrap_or(false)
+}
+
 /// Assemble the `auth status` view from stored records and environment
 /// entries, against the given clock. Exposed for deterministic tests;
 /// [`do_auth_status`] is the store-reading entry point.
+///
+/// `default_key` is the normalized key (see [`validated_index_key`]) of
+/// the default index, when the caller could resolve one; entries that
+/// apply to it are marked (`applies_to_default`), answering "which
+/// credential will bare commands use". A stored entry applies on key
+/// equality or when one of its globs matches the default index root URL
+/// (for a template default, its literal-prefix anchor); an env entry
+/// applies when its pattern matches that root. Purely diagnostic: `None`
+/// simply marks nothing.
 pub fn assemble_auth_status(
     records: Vec<CredentialRecord>,
     env: Vec<EnvCredentialEntry>,
     now: DateTime<Utc>,
+    default_key: Option<&str>,
 ) -> AuthStatus {
+    let default_glob_root = default_key.and_then(index_key_glob_root);
+    let default_applies = |globs: &[String]| {
+        default_glob_root
+            .as_deref()
+            .is_some_and(|root| globs.iter().any(|glob| lenient_glob_matches(glob, root)))
+    };
+    let mut env = env;
+    for entry in &mut env {
+        entry.applies_to_default = default_applies(std::slice::from_ref(&entry.pattern));
+    }
     // Compile each env pattern the same way runtime matching does
     // (`GlobMapBuilder`, `literal_separator(true)`). An invalid pattern
     // cannot shadow anything and is skipped.
@@ -1272,6 +1329,8 @@ pub fn assemble_auth_status(
             StoredCredentialStatus {
                 expired: record.expires_at.is_some_and(|expiry| expiry < now),
                 expires_in_days: record.expires_at.map(|expiry| (expiry - now).num_days()),
+                applies_to_default: default_key == Some(record.key.as_str())
+                    || default_applies(&record.globs),
                 key: record.key,
                 globs: record.globs,
                 expires_at: record.expires_at,
@@ -1298,9 +1357,10 @@ pub fn assemble_auth_status(
 pub fn do_auth_status<S: CredentialStore>(
     store: &S,
     env: Vec<EnvCredentialEntry>,
+    default_key: Option<&str>,
 ) -> Result<AuthStatus, AuthCommandError> {
     match store.list() {
-        Ok(records) => Ok(assemble_auth_status(records, env, Utc::now())),
+        Ok(records) => Ok(assemble_auth_status(records, env, Utc::now(), default_key)),
         Err(CredentialStoreError::BackendAbsent { source }) => Ok(AuthStatus {
             stored: StoredCredentialsStatus::BackendUnavailable {
                 reason: source.to_string(),

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -263,45 +263,96 @@ pub struct AuthStatus {
     pub env: Vec<EnvCredentialEntry>,
 }
 
-/// Validate that `index_url` is an absolute HTTP(S) index location (a
-/// plain URL or a `{path}`/`{path_raw}` URL template) and normalize it to
-/// its credential store key form.
-///
-/// A plain URL normalizes via [`normalize_index_key`]. A template's key
-/// rewrites only the anchorable literal prefix through `url::Url`
-/// serialization; the rest stays verbatim (raw template text, not a
-/// parsed URL). The result is idempotent and round-trips through
-/// [`IndexLocation::parse`] / `Display`, so `auth status` prints template
-/// keys in the exact form `auth logout` accepts. A template with no safe
-/// anchor is rejected ([`AuthCommandError::TemplateWithoutAnchor`]).
-///
-/// Public so the CLI can validate the target before reading a secret.
-pub fn validated_index_key(index_url: &str) -> Result<String, AuthCommandError> {
-    // Before `Url::parse`: it would percent-encode the braces into a
-    // mangled `%7Bpath%7D` key.
-    if is_template_syntax(index_url) {
-        return normalized_template_key(index_url);
+/// A validated, normalized index credential key. Constructed only
+/// through [`IndexKey::validate`], so holding one proves the target was
+/// already validated: the `do_auth_*` commands take it instead of a raw
+/// string and never re-validate.
+#[derive(Debug, Clone)]
+pub struct IndexKey {
+    /// The normalized key, exactly as stored and printed.
+    key: String,
+    /// The key parsed as an index location (plain root or template), so
+    /// commands need not reparse the key.
+    location: IndexLocation,
+    /// The URL root credential globs anchor on: the key itself for a
+    /// plain URL, the literal-prefix anchor for a template key.
+    glob_root: String,
+}
+
+impl IndexKey {
+    /// Validate that `index_url` is an absolute HTTP(S) index location (a
+    /// plain URL or a `{path}`/`{path_raw}` URL template) and normalize it
+    /// to its credential store key form.
+    ///
+    /// A plain URL normalizes via [`normalize_index_key`]. A template's key
+    /// rewrites only the anchorable literal prefix through `url::Url`
+    /// serialization; the rest stays verbatim (raw template text, not a
+    /// parsed URL). The result is idempotent and round-trips through
+    /// [`IndexLocation::parse`] / `Display`, so `auth status` prints template
+    /// keys in the exact form `auth logout` accepts. A template with no safe
+    /// anchor is rejected ([`AuthCommandError::TemplateWithoutAnchor`]).
+    ///
+    /// This is the only validation path; the CLI calls it once, before
+    /// reading a secret.
+    pub fn validate(index_url: &str) -> Result<Self, AuthCommandError> {
+        // Before `Url::parse`: it would percent-encode the braces into a
+        // mangled `%7Bpath%7D` key.
+        let key = if is_template_syntax(index_url) {
+            normalized_template_key(index_url)?
+        } else {
+            // Scheme check first, so a non-HTTP(S) location gets the
+            // dedicated message instead of a generic normalization error.
+            let url = Url::parse(index_url).map_err(|err| {
+                AuthCommandError::InvalidIndexUrl(format!("`{index_url}`: {err}"))
+            })?;
+            match url.scheme() {
+                "http" | "https" => {}
+                _ => {
+                    return Err(AuthCommandError::NotHttpIndex {
+                        url: index_url.to_string(),
+                    });
+                }
+            }
+            normalize_index_key(index_url).map_err(|err| match err {
+                CredentialStoreError::InvalidIndexUrl(msg) => {
+                    AuthCommandError::InvalidIndexUrl(msg)
+                }
+                other => AuthCommandError::Store(other),
+            })?
+        };
+        let location = IndexLocation::parse(&key)
+            .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
+        let glob_root = match &location {
+            IndexLocation::Root(_) => key.clone(),
+            IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
+                Some((_, anchor)) => anchor.as_str().to_string(),
+                // The raw-input check already rejected unanchorable
+                // templates; this arm just avoids a panic path.
+                None => return Err(AuthCommandError::TemplateWithoutAnchor { url: key }),
+            },
+        };
+        Ok(Self {
+            key,
+            location,
+            glob_root,
+        })
     }
-    // Scheme check first, so a non-HTTP(S) location gets the dedicated
-    // message instead of a generic normalization error.
-    let url = Url::parse(index_url)
-        .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{index_url}`: {err}")))?;
-    match url.scheme() {
-        "http" | "https" => {}
-        _ => {
-            return Err(AuthCommandError::NotHttpIndex {
-                url: index_url.to_string(),
-            });
-        }
+
+    /// The normalized key string, in the exact form credentials are
+    /// stored and printed under.
+    pub fn as_str(&self) -> &str {
+        &self.key
     }
-    normalize_index_key(index_url).map_err(|err| match err {
-        CredentialStoreError::InvalidIndexUrl(msg) => AuthCommandError::InvalidIndexUrl(msg),
-        other => AuthCommandError::Store(other),
-    })
+}
+
+impl std::fmt::Display for IndexKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.key)
+    }
 }
 
 /// The credential-key form of a URL-template target: see
-/// [`validated_index_key`].
+/// [`IndexKey::validate`].
 fn normalized_template_key(index_url: &str) -> Result<String, AuthCommandError> {
     let location = IndexLocation::parse(index_url).map_err(|err| match err {
         IndexLocationError::UnsupportedScheme { .. } => AuthCommandError::NotHttpIndex {
@@ -950,8 +1001,8 @@ fn guidance_globs(
     derive_credential_globs(primary_root, endpoints.as_ref(), notify)
 }
 
-/// Store a bearer credential for `index_url`. The secret arrives as a
-/// parameter: a library call never prompts.
+/// Store a bearer credential for the index `index_key` names. The secret
+/// arrives as a parameter: a library call never prompts.
 ///
 /// Discovery is fetched best-effort for glob scoping
 /// ([`fetch_login_endpoints`]); with no usable document the credential
@@ -967,26 +1018,15 @@ fn guidance_globs(
 /// probe runs: no network is spent on a credential that cannot be stored.
 pub fn do_auth_login<B: BlobBackend>(
     store: &mut LockedBlobStore<B>,
-    index_url: &str,
+    index_key: &IndexKey,
     secret: String,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: &tokio::runtime::Runtime,
     mut notify: impl FnMut(AuthLoginNotice),
 ) -> Result<AuthLoginOutcome, AuthCommandError> {
-    let key = validated_index_key(index_url)?;
-    let location = IndexLocation::parse(&key)
-        .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
-    // Key validation already rejected unanchorable templates; this
-    // re-check just avoids a panic path.
-    let primary_root = match &location {
-        IndexLocation::Root(_) => key.clone(),
-        IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
-            Some((_, anchor)) => anchor.as_str().to_string(),
-            None => {
-                return Err(AuthCommandError::TemplateWithoutAnchor { url: key });
-            }
-        },
-    };
+    let key = index_key.as_str().to_string();
+    let location = &index_key.location;
+    let primary_root = index_key.glob_root.clone();
 
     // Read the store before any network: an absent keyring backend must
     // be detected before the secret could be spent on a credentialed
@@ -996,7 +1036,7 @@ pub fn do_auth_login<B: BlobBackend>(
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
-            let globs = guidance_globs(client, &location, &primary_root, runtime, &mut notify);
+            let globs = guidance_globs(client, location, &primary_root, runtime, &mut notify);
             return Ok(AuthLoginOutcome::BackendUnavailable {
                 key,
                 globs,
@@ -1007,11 +1047,11 @@ pub fn do_auth_login<B: BlobBackend>(
     };
     let replacing = records.iter().any(|record| record.key == key);
 
-    let endpoints = fetch_login_endpoints(client, &location, &secret, runtime, &mut notify);
+    let endpoints = fetch_login_endpoints(client, location, &secret, runtime, &mut notify);
     let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
 
     let outcome =
-        run_validation_probes(endpoints.as_ref(), &location, &secret, runtime, &mut notify);
+        run_validation_probes(endpoints.as_ref(), location, &secret, runtime, &mut notify);
     // Refuse only when an exercised surface rejected and none accepted.
     if outcome.accepted.is_empty() && !outcome.rejected.is_empty() {
         return Err(AuthCommandError::ValidationRejected {
@@ -1083,16 +1123,16 @@ pub fn do_auth_login<B: BlobBackend>(
     }
 }
 
-/// Remove the stored credential for `index_url`.
+/// Remove the stored credential for the index `index_key` names.
 ///
 /// Returns the normalized index key the record was stored under. Removing
 /// a login that does not exist is an error
 /// ([`AuthCommandError::NoStoredCredential`]).
 pub fn do_auth_logout<B: BlobBackend>(
     store: &mut LockedBlobStore<B>,
-    index_url: &str,
+    index_key: &IndexKey,
 ) -> Result<String, AuthCommandError> {
-    let key = validated_index_key(index_url)?;
+    let key = index_key.as_str().to_string();
     if store.remove(&key)? {
         Ok(key)
     } else {
@@ -1205,18 +1245,20 @@ fn select_whoami_credential(
 /// discovery document, so the CLI passes its regular read policy.
 pub fn do_auth_whoami<P: HTTPAuthentication>(
     records: &[CredentialRecord],
-    index_url: &str,
+    index_key: &IndexKey,
     env_bearers: &GlobMap<EnvBearerAuth>,
     discovery_auth: &P,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: &tokio::runtime::Runtime,
 ) -> Result<AuthWhoamiOutcome, AuthCommandError> {
-    let key = validated_index_key(index_url)?;
-    let location = IndexLocation::parse(&key)
-        .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
+    let key = index_key.as_str().to_string();
 
     let endpoints = runtime
-        .block_on(fetch_index_config(client, discovery_auth, &location))
+        .block_on(fetch_index_config(
+            client,
+            discovery_auth,
+            &index_key.location,
+        ))
         .map_err(|err| AuthCommandError::WhoamiDiscoveryFailed {
             index: key.clone(),
             error: err.to_string(),

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -344,10 +344,7 @@ impl IndexKey {
             // re-prefixing.
             other => AuthCommandError::InvalidIndexUrl(other.to_string()),
         })?;
-        let glob_root = match &location {
-            IndexLocation::Root(url) => root_anchor(url).into(),
-            IndexLocation::Template(template) => template_anchor_root(template).into(),
-        };
+        let glob_root = location_glob_root(&location);
         Ok(Self {
             key: location.to_string(),
             location,
@@ -468,12 +465,7 @@ fn derive_credential_globs(
     };
 
     if let Some(endpoints) = endpoints {
-        match &endpoints.index_root {
-            IndexLocation::Root(url) => push_if_uncovered(&mut roots, root_anchor(url).into()),
-            IndexLocation::Template(template) => {
-                push_if_uncovered(&mut roots, template_anchor_root(template).into())
-            }
-        }
+        push_if_uncovered(&mut roots, location_glob_root(&endpoints.index_root));
         if let Some(api_root) = &endpoints.api_root {
             push_if_uncovered(&mut roots, root_anchor(api_root).into());
         }
@@ -508,6 +500,16 @@ fn template_anchor_root(template: &IndexUrlTemplate) -> Url {
         .expect("BUG: a normalized template prefix has an explicit path `/`");
     Url::parse(&prefix[..=cut])
         .expect("BUG: a normalized template prefix cut at a `/` parses as a URL")
+}
+
+/// The URL root credential globs anchor on for `location`: the
+/// query-stripped URL for a plain root, the literal-prefix anchor for a
+/// template.
+fn location_glob_root(location: &IndexLocation) -> String {
+    match location {
+        IndexLocation::Root(url) => root_anchor(url).into(),
+        IndexLocation::Template(template) => template_anchor_root(template).into(),
+    }
 }
 
 /// Identity fields parsed from a successful `v1/whoami` response:
@@ -1359,14 +1361,11 @@ pub fn do_auth_whoami<P: HTTPAuthentication>(
     })
 }
 
-/// The URL-glob match target of a validated index key: the key itself for
-/// a plain URL (it is normalized and ends in `/`), the literal-prefix
-/// anchor for a template key. `None` when the key does not parse.
+/// The URL-glob match target of a validated index key
+/// ([`location_glob_root`] of its parsed location). `None` when the key
+/// does not parse.
 fn index_key_glob_root(key: &str) -> Option<String> {
-    match IndexLocation::parse(key).ok()? {
-        IndexLocation::Root(url) => Some(url.into()),
-        IndexLocation::Template(template) => Some(template_anchor_root(&template).into()),
-    }
+    Some(location_glob_root(&IndexLocation::parse(key).ok()?))
 }
 
 /// Whether `pattern` matches `target`, compiled the same way runtime

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -603,19 +603,40 @@ fn redirect_target(response: &reqwest::Response) -> String {
 
 /// Whether any `WWW-Authenticate` challenge on the response offers the
 /// `Basic` scheme. Scheme tokens are case-insensitive (RFC 7235) and one
-/// header value can carry several comma-separated challenges; a full
-/// challenge parser is overkill, but a plain substring check would
-/// false-positive on e.g. `Bearer realm="Basic migration"`.
+/// header value can carry several comma-separated challenges. A plain
+/// substring check would false-positive on `Bearer realm="Basic
+/// migration"`, and splitting on every comma would false-positive on a
+/// comma inside a quoted parameter value (`Bearer realm="use, basic"`),
+/// so we split on top-level commas only and check each challenge's leading
+/// scheme token. (A quoted `\"` inside a value is not handled, but such
+/// realms do not occur in practice, and this only tunes a hint message.)
 fn offers_basic_challenge(headers: &reqwest::header::HeaderMap) -> bool {
     headers
         .get_all(reqwest::header::WWW_AUTHENTICATE)
         .iter()
         .filter_map(|value| value.to_str().ok())
-        .any(|value| {
-            value.split(',').any(|part| {
-                let token = part.trim_start().split([' ', '\t']).next().unwrap_or("");
-                token.eq_ignore_ascii_case("basic")
-            })
+        .any(header_offers_basic)
+}
+
+fn header_offers_basic(value: &str) -> bool {
+    // Split into challenges on commas outside double quotes: the toggling
+    // closure flips `in_quotes` on each `"` and treats a `,` as a
+    // separator only while outside quotes.
+    let mut in_quotes = false;
+    value
+        .split(|c: char| {
+            if c == '"' {
+                in_quotes = !in_quotes;
+            }
+            c == ',' && !in_quotes
+        })
+        .any(|challenge| {
+            let token = challenge
+                .trim_start()
+                .split([' ', '\t'])
+                .next()
+                .unwrap_or("");
+            token.eq_ignore_ascii_case("basic")
         })
 }
 
@@ -877,9 +898,9 @@ fn forced_discovery_fetch(
 /// discovery-first (the already-fetched discovery result is reused; when
 /// it was unreachable the read surface falls back to the URL-derived
 /// `index.json`, so a fully private index still gets its read surface
-/// exercised), and the API surface only when discovery explicitly
-/// advertised `api_root` (never the plain-URL runtime default), so a
-/// static index is not phantom-probed for an API it does not have.
+/// exercised), and the API surface only when discovery advertised
+/// `api_root` (which the protocol now requires explicitly), so a static
+/// index is not phantom-probed for an API it does not have.
 fn run_validation_probes(
     endpoints: Option<&ResolvedEndpoints>,
     location: &IndexLocation,

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -3,8 +3,8 @@
 
 //! `sysand auth` command orchestration (design/credential-storage.md
 //! sections 4, 8, 9, 14): `do_auth_login`, `do_auth_logout`,
-//! `do_auth_status`, and `do_auth_whoami`, generic over
-//! [`CredentialStore`].
+//! `do_auth_status`, and `do_auth_whoami`, over the credential store
+//! ([`LockedBlobStore`], generic over its [`BlobBackend`]).
 //!
 //! Library calls never prompt and never print; the login secret arrives as
 //! a parameter and progress is reported through [`AuthLoginNotice`] values
@@ -25,8 +25,9 @@ use crate::{
         select_bearer, stored_bearer_map_from_records,
     },
     credential_store::{
-        CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
-        CredentialSubject, normalize_index_key,
+        CredentialRecord, CredentialScheme, CredentialStoreError, CredentialSubject,
+        keyring_store::{BlobBackend, LockedBlobStore},
+        normalize_index_key,
     },
     env::discovery::{
         DiscoveryError, INDEX_CONFIG_PATH, IndexConfigRaw, ResolvedEndpoints, fetch_index_config,
@@ -1046,8 +1047,8 @@ fn guidance_globs(
     derive_credential_globs(primary_root, endpoints.as_ref(), notify)
 }
 
-pub fn do_auth_login<S: CredentialStore>(
-    store: &mut S,
+pub fn do_auth_login<B: BlobBackend>(
+    store: &mut LockedBlobStore<B>,
     index_url: &str,
     secret: String,
     client: &reqwest_middleware::ClientWithMiddleware,
@@ -1178,8 +1179,8 @@ pub fn do_auth_login<S: CredentialStore>(
 /// Returns the normalized index key the record was stored under. Removing
 /// a login that does not exist is an error
 /// ([`AuthCommandError::NoStoredCredential`]).
-pub fn do_auth_logout<S: CredentialStore>(
-    store: &mut S,
+pub fn do_auth_logout<B: BlobBackend>(
+    store: &mut LockedBlobStore<B>,
     index_url: &str,
 ) -> Result<String, AuthCommandError> {
     let key = validated_index_key(index_url)?;
@@ -1476,8 +1477,8 @@ pub fn assemble_auth_status(
 /// ([`StoredCredentialsStatus::BackendUnavailable`]); a present but locked
 /// or denied backend is a hard error the caller must surface
 /// (design/credential-storage.md section 9 taxonomy).
-pub fn do_auth_status<S: CredentialStore>(
-    store: &S,
+pub fn do_auth_status<B: BlobBackend>(
+    store: &LockedBlobStore<B>,
     env: Vec<EnvCredentialEntry>,
     default_key: Option<&str>,
 ) -> Result<AuthStatus, AuthCommandError> {

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -35,7 +35,7 @@ use crate::{
         fetch_index_config_strict, resolve_index_config,
     },
     env::index::HttpFetchError,
-    index_location::{IndexLocation, IndexLocationError, is_template_syntax},
+    index_location::{IndexLocation, IndexLocationError, IndexUrlTemplate, is_template_syntax},
 };
 
 /// Errors from the `sysand auth` commands.
@@ -53,15 +53,6 @@ pub enum AuthCommandError {
     /// The target could not be parsed or normalized as an index URL.
     #[error("invalid index URL for credential storage: {0}")]
     InvalidIndexUrl(String),
-    /// The target is a URL template with no literal prefix at a safe URL
-    /// boundary (at least `scheme://authority/`), so no credential scope
-    /// glob can be derived.
-    #[error(
-        "`{url}`: this URL template has no literal prefix at a safe URL boundary\n\
-         (at least `scheme://authority/`) to scope a credential to;\n\
-         use `SYSAND_CRED_*` environment variables to authenticate it"
-    )]
-    TemplateWithoutAnchor { url: String },
     /// Every exercised surface rejected the credential and none accepted
     /// it, so nothing was stored.
     #[error("{}", validation_rejected_message(.index, .rejected, .challenge_schemes))]
@@ -338,21 +329,29 @@ impl IndexKey {
     /// plain URL or a `{path}`/`{path_raw}` URL template) and normalize it
     /// to its credential store key form.
     ///
-    /// A plain URL normalizes via [`normalize_index_key`]. A template's key
-    /// rewrites only the anchorable literal prefix through `url::Url`
-    /// serialization; the rest stays verbatim (raw template text, not a
-    /// parsed URL). The result is idempotent and round-trips through
+    /// A plain URL normalizes via [`normalize_index_key`]. A template
+    /// normalizes inside [`IndexLocation::parse`], which canonicalizes the
+    /// literal prefix (lowercase host, default port dropped, explicit root
+    /// `/`) and keeps the placeholder and suffix verbatim; its `Display`
+    /// text is the key. Both forms are idempotent and round-trip through
     /// [`IndexLocation::parse`] / `Display`, so `auth status` prints template
-    /// keys in the exact form `auth logout` accepts. A template with no safe
-    /// anchor is rejected ([`AuthCommandError::TemplateWithoutAnchor`]).
+    /// keys in the exact form `auth logout` accepts.
     ///
     /// This is the only validation path; the CLI calls it once, before
     /// reading a secret.
     pub fn validate(index_url: &str) -> Result<Self, AuthCommandError> {
-        // Before `Url::parse`: it would percent-encode the braces into a
-        // mangled `%7Bpath%7D` key.
-        let key = if is_template_syntax(index_url) {
-            normalized_template_key(index_url)?
+        // Template syntax dispatches before `Url::parse`: it would
+        // percent-encode the braces into a mangled `%7Bpath%7D` key.
+        let (key, location) = if is_template_syntax(index_url) {
+            let location = IndexLocation::parse(index_url).map_err(|err| match err {
+                IndexLocationError::UnsupportedScheme { .. } => AuthCommandError::NotHttpIndex {
+                    url: index_url.to_string(),
+                },
+                // The index-location errors already name the URL; no
+                // re-prefixing.
+                other => AuthCommandError::InvalidIndexUrl(other.to_string()),
+            })?;
+            (location.to_string(), location)
         } else {
             // Scheme check first, so a non-HTTP(S) location gets the
             // dedicated message instead of a generic normalization error.
@@ -367,23 +366,21 @@ impl IndexKey {
                     });
                 }
             }
-            normalize_index_key(index_url).map_err(|err| match err {
+            let key = normalize_index_key(index_url).map_err(|err| match err {
                 CredentialStoreError::InvalidIndexUrl(msg) => {
                     AuthCommandError::InvalidIndexUrl(msg)
                 }
                 other => AuthCommandError::Store(other),
-            })?
+            })?;
+            let location = IndexLocation::parse(&key)
+                .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
+            (key, location)
         };
-        let location = IndexLocation::parse(&key)
-            .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
         let glob_root = match &location {
             IndexLocation::Root(_) => key.clone(),
-            IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
-                Some((_, anchor)) => anchor.as_str().to_string(),
-                None => {
-                    unreachable!("BUG: unanchorable template should have been rejected earlier")
-                }
-            },
+            IndexLocation::Template(template) => {
+                template_anchor_root(template).as_str().to_string()
+            }
         };
         Ok(Self {
             key,
@@ -405,41 +402,6 @@ impl std::fmt::Display for IndexKey {
     }
 }
 
-/// The credential-key form of a URL-template target: see
-/// [`IndexKey::validate`].
-fn normalized_template_key(index_url: &str) -> Result<String, AuthCommandError> {
-    let location = IndexLocation::parse(index_url).map_err(|err| match err {
-        IndexLocationError::UnsupportedScheme { .. } => AuthCommandError::NotHttpIndex {
-            url: index_url.to_string(),
-        },
-        // The index-location errors already name the URL; no re-prefixing.
-        other => AuthCommandError::InvalidIndexUrl(other.to_string()),
-    })?;
-    let IndexLocation::Template(template) = &location else {
-        // `IndexLocation::parse` classifies every brace-containing string
-        // as a template, and `index_url` contains a brace.
-        unreachable!("BUG: template syntax parsed as a plain URL");
-    };
-    let prefix = template.prefix();
-    let Some((cut, anchor)) = template_anchor_root(prefix) else {
-        return Err(AuthCommandError::TemplateWithoutAnchor {
-            url: index_url.to_string(),
-        });
-    };
-    // Unlike plain `Display` (which reproduces the template text as
-    // given), the key swaps in the URL-normalized anchor (lowercased
-    // host, default port dropped), so spellings of the same template
-    // collapse to one key. The rest of the prefix and the placeholder
-    // tail are reattached verbatim, and re-validating the result yields
-    // the same key again.
-    let tail = location.to_string();
-    Ok(format!(
-        "{anchor}{}{}",
-        &prefix[cut + 1..],
-        &tail[prefix.len()..]
-    ))
-}
-
 /// Progress notice emitted by [`do_auth_login`] while it works, so the
 /// host can render it at the right moment (in particular, a replacement is
 /// reported strictly before the store write happens).
@@ -453,10 +415,6 @@ pub enum AuthLoginNotice {
     /// [`fetch_login_endpoints`]). The credential is scoped to the
     /// URL-derived pattern only.
     DiscoveryUnreachable { error: String },
-    /// Discovery resolved a templated `index_root` with no safe anchor,
-    /// so no glob was derived: deriving one anyway could produce a
-    /// pattern matching other hosts.
-    TemplateIndexRootSkipped { template: String },
     /// A validation probe was answered with a redirect. Probes never
     /// follow redirects (the verdict would come from a different URL),
     /// so the surface counts as not tested.
@@ -526,7 +484,6 @@ pub enum AuthLoginOutcome {
 fn derive_credential_globs(
     primary_root: &str,
     endpoints: Option<&ResolvedEndpoints>,
-    notify: &mut impl FnMut(AuthLoginNotice),
 ) -> Vec<String> {
     // Roots already covered, each ending in `/`. A candidate whose string
     // prefix is an existing root is covered: that root's `**` glob
@@ -547,12 +504,9 @@ fn derive_credential_globs(
     if let Some(endpoints) = endpoints {
         match &endpoints.index_root {
             IndexLocation::Root(url) => push_if_uncovered(&mut roots, url.as_str()),
-            IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
-                Some((_, anchor)) => push_if_uncovered(&mut roots, anchor.as_str()),
-                None => notify(AuthLoginNotice::TemplateIndexRootSkipped {
-                    template: template.to_string(),
-                }),
-            },
+            IndexLocation::Template(template) => {
+                push_if_uncovered(&mut roots, template_anchor_root(template).as_str())
+            }
         }
         if let Some(api_root) = &endpoints.api_root {
             push_if_uncovered(&mut roots, api_root.as_str());
@@ -567,17 +521,17 @@ fn derive_credential_globs(
 
 /// Anchor a URL template's literal prefix at a safe URL boundary: the
 /// prefix cut back to its last `/`, reparsed as a URL so the anchor uses
-/// the same serialization runtime request URLs will. Returns the cut
-/// position (byte index of that `/`) alongside the anchor, or `None` when
-/// no anchor at least as deep as `scheme://authority/` exists.
-fn template_anchor_root(prefix: &str) -> Option<(usize, Url)> {
-    let cut = prefix.rfind('/')?;
-    let candidate = &prefix[..=cut];
-    let url = Url::parse(candidate).ok()?;
-    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
-        return None;
-    }
-    Some((cut, url))
+/// the same serialization runtime request URLs will. Infallible:
+/// [`IndexLocation::parse`] normalized the prefix to absolute HTTP(S) URL
+/// text with an explicit path `/`, so an anchor at least as deep as
+/// `scheme://authority/` always exists.
+fn template_anchor_root(template: &IndexUrlTemplate) -> Url {
+    let prefix = template.prefix();
+    let cut = prefix
+        .rfind('/')
+        .expect("BUG: a normalized template prefix has an explicit path `/`");
+    Url::parse(&prefix[..=cut])
+        .expect("BUG: a normalized template prefix cut at a `/` parses as a URL")
 }
 
 /// Identity fields parsed from a successful `v1/whoami` response:
@@ -1097,7 +1051,7 @@ fn guidance_globs(
                 None
             }
         };
-    derive_credential_globs(primary_root, endpoints.as_ref(), notify)
+    derive_credential_globs(primary_root, endpoints.as_ref())
 }
 
 /// Store a bearer credential for the index `index_key` names. The secret
@@ -1147,7 +1101,7 @@ pub fn do_auth_login<B: BlobBackend>(
     let replacing = records.iter().any(|record| record.key == key);
 
     let endpoints = fetch_login_endpoints(client, location, &secret, runtime, &mut notify);
-    let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
+    let globs = derive_credential_globs(&primary_root, endpoints.as_ref());
 
     let outcome =
         run_validation_probes(endpoints.as_ref(), location, &secret, runtime, &mut notify);
@@ -1431,13 +1385,12 @@ pub fn do_auth_whoami<P: HTTPAuthentication>(
 
 /// The URL-glob match target of a validated index key: the key itself for
 /// a plain URL (it is normalized and ends in `/`), the literal-prefix
-/// anchor for a template key. `None` when the key does not parse or the
-/// template has no safe anchor.
+/// anchor for a template key. `None` when the key does not parse.
 fn index_key_glob_root(key: &str) -> Option<String> {
     match IndexLocation::parse(key).ok()? {
         IndexLocation::Root(url) => Some(url.as_str().to_string()),
         IndexLocation::Template(template) => {
-            template_anchor_root(template.prefix()).map(|(_, anchor)| anchor.as_str().to_string())
+            Some(template_anchor_root(&template).as_str().to_string())
         }
     }
 }

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -99,16 +99,20 @@ pub enum AuthCommandError {
     NoAdvertisedApi { index: String },
     /// More than one credential from one source matches the `v1/whoami`
     /// URL (after collapsing entries carrying the same token), so no
-    /// single identity question can be asked.
+    /// single identity question can be asked. `candidates` names every
+    /// matching credential (env variable names, or backticked stored
+    /// keys) so the error is actionable.
     #[error(
-        "{candidates} credentials from {source_name} match `{url}`;\n\
-         refine the patterns so exactly one matches"
+        "multiple credentials from {source_name} match `{url}`:\n\
+         {};\n\
+         refine the patterns so exactly one matches",
+        candidates.join(", ")
     )]
     AmbiguousWhoamiCredential {
         url: String,
         // Not `source`: thiserror reserves that name for error chaining.
         source_name: &'static str,
-        candidates: usize,
+        candidates: Vec<String>,
     },
     /// No credential of either source matches the `v1/whoami` URL. The
     /// message states the bare condition; the frontend appends its own
@@ -1238,7 +1242,11 @@ fn select_whoami_credential(
             return Err(AuthCommandError::AmbiguousWhoamiCredential {
                 url: whoami_url.as_str().to_string(),
                 source_name: "`SYSAND_CRED_*` environment variables",
-                candidates: matched.len(),
+                candidates: crate::commands::publish::dedup_in_order(
+                    matched
+                        .iter()
+                        .map(|entry| format!("SYSAND_CRED_{}", entry.label)),
+                ),
             });
         }
         BearerSelection::None => {}
@@ -1256,7 +1264,9 @@ fn select_whoami_credential(
             Err(AuthCommandError::AmbiguousWhoamiCredential {
                 url: whoami_url.as_str().to_string(),
                 source_name: "stored credentials",
-                candidates: matched.len(),
+                candidates: crate::commands::publish::dedup_in_order(
+                    matched.iter().map(|entry| format!("`{}`", entry.key())),
+                ),
             })
         }
         BearerSelection::None => Err(AuthCommandError::NoWhoamiCredential {

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -46,7 +46,7 @@ pub enum AuthCommandError {
     NoStoredCredential { index: String },
     /// The target is not an HTTP(S) index (for example a `file://` URL).
     #[error(
-        "`{url}`: not an HTTP(S) index; nothing to authenticate to \
+        "`{url}`: not an HTTP(S) index; nothing to authenticate to\n\
          (use an https:// index URL)"
     )]
     NotHttpIndex { url: String },
@@ -101,7 +101,7 @@ pub enum AuthCommandError {
     /// URL (after collapsing entries carrying the same token), so no
     /// single identity question can be asked.
     #[error(
-        "{candidates} credentials from {source_name} match `{url}`; \
+        "{candidates} credentials from {source_name} match `{url}`;\n\
          refine the patterns so exactly one matches"
     )]
     AmbiguousWhoamiCredential {
@@ -141,7 +141,7 @@ fn validation_rejected_message(
                 ""
             };
             format!(
-                "the index rejected the token for `{index}` \
+                "the index rejected the token for `{index}`\n\
                  (`{endpoint}` answered HTTP {status}){hedge}; nothing was stored"
             )
         }
@@ -154,7 +154,7 @@ fn validation_rejected_message(
                 })
                 .collect();
             format!(
-                "credential for `{index}` was rejected by {} and accepted by no surface; \
+                "credential for `{index}` was rejected by {} and accepted by no surface;\n\
                  nothing was stored",
                 surfaces.join(" and ")
             )
@@ -165,8 +165,8 @@ fn validation_rejected_message(
         // stored-anyway variant in sysand/src/commands/auth.rs
         // (render_login_notice).
         message.push_str(
-            "\nthis index uses username/password (HTTP basic) authentication; configure \
-             `SYSAND_CRED_<X>_BASIC_USER` / `SYSAND_CRED_<X>_BASIC_PASS` environment \
+            "\nthis index uses username/password (HTTP basic) authentication; configure\n\
+             `SYSAND_CRED_<X>_BASIC_USER` / `SYSAND_CRED_<X>_BASIC_PASS` environment\n\
              variables instead",
         );
     }
@@ -1213,11 +1213,11 @@ fn select_whoami_credential(
                 entry.auth.token().to_string(),
             ));
         }
-        BearerSelection::Ambiguous { candidates, .. } => {
+        BearerSelection::Ambiguous { matched, .. } => {
             return Err(AuthCommandError::AmbiguousWhoamiCredential {
                 url: whoami_url.as_str().to_string(),
                 source_name: "`SYSAND_CRED_*` environment variables",
-                candidates,
+                candidates: matched.len(),
             });
         }
         BearerSelection::None => {}
@@ -1231,11 +1231,11 @@ fn select_whoami_credential(
             },
             entry.auth().token().to_string(),
         )),
-        BearerSelection::Ambiguous { candidates, .. } => {
+        BearerSelection::Ambiguous { matched, .. } => {
             Err(AuthCommandError::AmbiguousWhoamiCredential {
                 url: whoami_url.as_str().to_string(),
                 source_name: "stored credentials",
-                candidates,
+                candidates: matched.len(),
             })
         }
         BearerSelection::None => Err(AuthCommandError::NoWhoamiCredential {

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -345,10 +345,8 @@ impl IndexKey {
             other => AuthCommandError::InvalidIndexUrl(other.to_string()),
         })?;
         let glob_root = match &location {
-            IndexLocation::Root(url) => root_anchor(url).as_str().to_string(),
-            IndexLocation::Template(template) => {
-                template_anchor_root(template).as_str().to_string()
-            }
+            IndexLocation::Root(url) => root_anchor(url).into(),
+            IndexLocation::Template(template) => template_anchor_root(template).into(),
         };
         Ok(Self {
             key: location.to_string(),
@@ -458,26 +456,26 @@ fn derive_credential_globs(
     // matches every URL under the candidate.
     let mut roots: Vec<String> = vec![primary_root.to_string()];
 
-    let push_if_uncovered = |roots: &mut Vec<String>, candidate: &str| {
+    let push_if_uncovered = |roots: &mut Vec<String>, candidate: String| {
         if !roots
             .iter()
             .any(|root| candidate.starts_with(root.as_str()))
         {
             // A candidate that prefixes an existing root subsumes it.
-            roots.retain(|root| !root.starts_with(candidate));
-            roots.push(candidate.to_string());
+            roots.retain(|root| !root.starts_with(&candidate));
+            roots.push(candidate);
         }
     };
 
     if let Some(endpoints) = endpoints {
         match &endpoints.index_root {
-            IndexLocation::Root(url) => push_if_uncovered(&mut roots, root_anchor(url).as_str()),
+            IndexLocation::Root(url) => push_if_uncovered(&mut roots, root_anchor(url).into()),
             IndexLocation::Template(template) => {
-                push_if_uncovered(&mut roots, template_anchor_root(template).as_str())
+                push_if_uncovered(&mut roots, template_anchor_root(template).into())
             }
         }
         if let Some(api_root) = &endpoints.api_root {
-            push_if_uncovered(&mut roots, root_anchor(api_root).as_str());
+            push_if_uncovered(&mut roots, root_anchor(api_root).into());
         }
     }
 
@@ -1366,10 +1364,8 @@ pub fn do_auth_whoami<P: HTTPAuthentication>(
 /// anchor for a template key. `None` when the key does not parse.
 fn index_key_glob_root(key: &str) -> Option<String> {
     match IndexLocation::parse(key).ok()? {
-        IndexLocation::Root(url) => Some(url.as_str().to_string()),
-        IndexLocation::Template(template) => {
-            Some(template_anchor_root(&template).as_str().to_string())
-        }
+        IndexLocation::Root(url) => Some(url.into()),
+        IndexLocation::Template(template) => Some(template_anchor_root(&template).into()),
     }
 }
 

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -64,7 +64,7 @@ pub enum AuthCommandError {
     TemplateWithoutAnchor { url: String },
     /// Every exercised surface rejected the credential and none accepted
     /// it, so nothing was stored.
-    #[error("{}", validation_rejected_message(.index, .rejected, *.basic_challenge))]
+    #[error("{}", validation_rejected_message(.index, .rejected, .challenge_schemes))]
     ValidationRejected {
         /// The normalized index key the login targeted.
         index: String,
@@ -73,11 +73,12 @@ pub enum AuthCommandError {
         /// the message: it can mean a rejected token, but also a URL with
         /// no index at all.
         rejected: Vec<(ProbeSurface, u16)>,
-        /// Whether the read surface answered with a `WWW-Authenticate:
-        /// Basic` challenge: the index wants username/password, not a
-        /// bearer token, and the message routes the user to
-        /// `SYSAND_CRED_*` basic credentials.
-        basic_challenge: bool,
+        /// The scheme tokens the read surface offered in its
+        /// `WWW-Authenticate` challenges, verbatim in first-seen order
+        /// (deduplicated case-insensitively). `Basic` routes the message
+        /// to `SYSAND_CRED_*` basic credentials; schemes other than
+        /// `Basic`/`Bearer` are named as unsupported.
+        challenge_schemes: Vec<String>,
     },
     /// `whoami` could not read the index configuration, so the API root
     /// (and with it the `v1/whoami` URL) could not be resolved.
@@ -126,7 +127,7 @@ pub enum AuthCommandError {
 fn validation_rejected_message(
     index: &str,
     rejected: &[(ProbeSurface, u16)],
-    basic_challenge: bool,
+    challenge_schemes: &[String],
 ) -> String {
     let mut message = match rejected {
         // A read-surface 404 is hedged: it can also mean there is simply
@@ -163,7 +164,7 @@ fn validation_rejected_message(
             )
         }
     };
-    if basic_challenge {
+    if schemes_include_basic(challenge_schemes) {
         // Keep this basic-auth routing hint consistent with the
         // stored-anyway variant in sysand/src/commands/auth.rs
         // (render_login_notice).
@@ -173,7 +174,45 @@ fn validation_rejected_message(
              variables instead",
         );
     }
+    if let Some(followup) = unsupported_schemes_followup(challenge_schemes) {
+        message.push('\n');
+        message.push_str(&followup);
+    }
     message
+}
+
+/// Whether the collected challenge schemes include HTTP `Basic`
+/// (case-insensitive): the index wants username/password, not a bearer
+/// token, and messages route the user to `SYSAND_CRED_*` basic
+/// credentials.
+pub fn schemes_include_basic(schemes: &[String]) -> bool {
+    schemes.iter().any(|s| s.eq_ignore_ascii_case("basic"))
+}
+
+/// The follow-up line naming, verbatim, the offered challenge schemes
+/// sysand does not support (anything other than `Basic` and `Bearer`),
+/// or `None` when every offered scheme is supported. Shared by the
+/// refusal message and the stored-anyway warning so both name the same
+/// schemes.
+pub fn unsupported_schemes_followup(schemes: &[String]) -> Option<String> {
+    let unsupported: Vec<String> = schemes
+        .iter()
+        .filter(|s| !s.eq_ignore_ascii_case("basic") && !s.eq_ignore_ascii_case("bearer"))
+        .map(|s| format!("`{s}`"))
+        .collect();
+    if unsupported.is_empty() {
+        return None;
+    }
+    let noun = if unsupported.len() == 1 {
+        "scheme"
+    } else {
+        "schemes"
+    };
+    Some(format!(
+        "the index requests the authentication {noun} {} in its challenge,\n\
+         which sysand does not support",
+        unsupported.join(", ")
+    ))
 }
 
 /// One `SYSAND_CRED_*` environment credential, as seen by `auth status`:
@@ -435,12 +474,13 @@ pub enum AuthLoginNotice {
     /// A surface rejected the credential but another accepted it, so it
     /// was stored anyway. `status` is the HTTP status the surface
     /// answered (a read-surface 404 hedges the warning: possibly no
-    /// `index.json` at that URL); `basic_challenge` means the read
-    /// surface answered with a `WWW-Authenticate: Basic` challenge.
+    /// `index.json` at that URL); `challenge_schemes` carries the
+    /// scheme tokens the read surface offered in `WWW-Authenticate`
+    /// (always empty for the API surface).
     SurfaceRejected {
         surface: ProbeSurface,
         status: u16,
-        basic_challenge: bool,
+        challenge_schemes: Vec<String>,
     },
 }
 
@@ -617,7 +657,9 @@ struct ProbeOutcome {
     accepted: Vec<ProbeSurface>,
     /// Each rejecting surface with the HTTP status it answered.
     rejected: Vec<(ProbeSurface, u16)>,
-    basic_challenge: bool,
+    /// The scheme tokens the read surface offered in `WWW-Authenticate`
+    /// across both probe legs, verbatim in first-seen order.
+    challenge_schemes: Vec<String>,
     identity: Option<WhoamiIdentity>,
 }
 
@@ -666,38 +708,46 @@ fn redirect_target(response: &reqwest::Response) -> String {
         .unwrap_or_else(|| "(no Location header)".to_string())
 }
 
-/// Whether any `WWW-Authenticate` challenge on the response offers the
-/// `Basic` scheme (case-insensitive, RFC 7235). Splits on top-level
-/// commas only and checks each challenge's leading scheme token, because
-/// both a substring check and a naive comma split false-positive on
-/// quoted realm values. (A quoted `\"` is not handled; this only tunes a
-/// hint message.)
-fn offers_basic_challenge(headers: &reqwest::header::HeaderMap) -> bool {
-    headers
-        .get_all(reqwest::header::WWW_AUTHENTICATE)
-        .iter()
-        .filter_map(|value| value.to_str().ok())
-        .any(header_offers_basic)
-}
-
-fn header_offers_basic(value: &str) -> bool {
-    // Split into challenges on commas outside double quotes.
-    let mut in_quotes = false;
-    value
-        .split(|c: char| {
+/// Collect into `schemes` the scheme token of every `WWW-Authenticate`
+/// challenge on the response, verbatim (original casing) in first-seen
+/// order, deduplicated case-insensitively. Splits challenges on
+/// top-level commas only, because a naive comma split false-positives
+/// on quoted realm values; a comma-continued auth-param
+/// (`charset="UTF-8"`) is not a challenge, so a leading token counts as
+/// a scheme only when it is a valid HTTP token. (A quoted `\"` is not
+/// handled; this only tunes hint messages.)
+fn collect_challenge_schemes(headers: &reqwest::header::HeaderMap, schemes: &mut Vec<String>) {
+    for value in headers.get_all(reqwest::header::WWW_AUTHENTICATE).iter() {
+        let Ok(value) = value.to_str() else { continue };
+        // Split into challenges on commas outside double quotes.
+        let mut in_quotes = false;
+        let challenges = value.split(|c: char| {
             if c == '"' {
                 in_quotes = !in_quotes;
             }
             c == ',' && !in_quotes
-        })
-        .any(|challenge| {
+        });
+        for challenge in challenges {
             let token = challenge
                 .trim_start()
                 .split([' ', '\t'])
                 .next()
                 .unwrap_or("");
-            token.eq_ignore_ascii_case("basic")
-        })
+            if token.is_empty() || !token.chars().all(is_tchar) {
+                continue;
+            }
+            if !schemes.iter().any(|s| s.eq_ignore_ascii_case(token)) {
+                schemes.push(token.to_string());
+            }
+        }
+    }
+}
+
+/// An RFC 9110 `token` character. An auth-param continuation
+/// (`charset="UTF-8"`) contains `=`/`"`, which are not tchars, so it is
+/// never mistaken for a scheme.
+fn is_tchar(c: char) -> bool {
+    c.is_ascii_alphanumeric() || "!#$%&'*+-.^_`|~".contains(c)
 }
 
 /// Probe the read surface (`index_root/index.json`): an unauthenticated
@@ -749,7 +799,8 @@ fn probe_read_surface(
         });
         return;
     }
-    let basic_challenge = offers_basic_challenge(baseline.headers());
+    let mut challenge_schemes = Vec::new();
+    collect_challenge_schemes(baseline.headers(), &mut challenge_schemes);
     let forced = match probe_request(
         runtime,
         client,
@@ -777,7 +828,8 @@ fn probe_read_surface(
         outcome.accepted.push(surface);
     } else if forced_status.is_client_error() {
         outcome.rejected.push((surface, forced_status.as_u16()));
-        outcome.basic_challenge = basic_challenge || offers_basic_challenge(forced.headers());
+        collect_challenge_schemes(forced.headers(), &mut challenge_schemes);
+        outcome.challenge_schemes = challenge_schemes;
     } else {
         notify(AuthLoginNotice::ProbeUnreachable {
             surface,
@@ -1093,7 +1145,7 @@ pub fn do_auth_login<B: BlobBackend>(
         return Err(AuthCommandError::ValidationRejected {
             index: key,
             rejected: outcome.rejected,
-            basic_challenge: outcome.basic_challenge,
+            challenge_schemes: outcome.challenge_schemes,
         });
     }
     // Stored anyway: warn about each surface that rejected.
@@ -1101,7 +1153,11 @@ pub fn do_auth_login<B: BlobBackend>(
         notify(AuthLoginNotice::SurfaceRejected {
             surface: *surface,
             status: *status,
-            basic_challenge: outcome.basic_challenge && *surface == ProbeSurface::Read,
+            challenge_schemes: if *surface == ProbeSurface::Read {
+                outcome.challenge_schemes.clone()
+            } else {
+                Vec::new()
+            },
         });
     }
     let validated = outcome.accepted;

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -2,21 +2,30 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 //! `sysand auth` command orchestration (design/credential-storage.md
-//! sections 4, 9, 14): `do_auth_logout` and `do_auth_status`, generic over
-//! [`CredentialStore`].
+//! sections 4, 8, 9, 14): `do_auth_login`, `do_auth_logout`, and
+//! `do_auth_status`, generic over [`CredentialStore`].
 //!
-//! Library calls never prompt and never print; they return data for the
-//! host (CLI or bindings) to render. Environment credentials are passed in
-//! as [`EnvCredentialEntry`] values: this module does not read the process
-//! environment.
+//! Library calls never prompt and never print; the login secret arrives as
+//! a parameter and progress is reported through [`AuthLoginNotice`] values
+//! for the host (CLI or bindings) to render. Environment credentials are
+//! passed in as [`EnvCredentialEntry`] values: this module does not read
+//! the process environment.
+
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use globset::GlobBuilder;
 use thiserror::Error;
 use url::Url;
 
-use crate::credential_store::{
-    CredentialRecord, CredentialStore, CredentialStoreError, normalize_index_key,
+use crate::{
+    auth::Unauthenticated,
+    credential_store::{
+        CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
+        normalize_index_key,
+    },
+    env::discovery::{ResolvedEndpoints, fetch_index_config},
+    index_location::{IndexLocation, is_template_syntax},
 };
 
 /// Errors from the `sysand auth` commands.
@@ -31,6 +40,15 @@ pub enum AuthCommandError {
     /// The target could not be parsed or normalized as an index URL.
     #[error("invalid index URL for credential storage: {0}")]
     InvalidIndexUrl(String),
+    /// The target is a URL-template index location, which `sysand auth`
+    /// does not support in v1 (a template does not normalize to a stable
+    /// index key). `SYSAND_CRED_*` environment variables remain the
+    /// authentication path for templated indexes.
+    #[error(
+        "`{url}`: URL-template index locations are not supported by `sysand auth`;\n\
+         use `SYSAND_CRED_*` environment variables to authenticate a templated index"
+    )]
+    TemplateIndexUrl { url: String },
     /// The credential store failed.
     #[error(transparent)]
     Store(#[from] CredentialStoreError),
@@ -93,9 +111,20 @@ pub struct AuthStatus {
     pub env: Vec<EnvCredentialEntry>,
 }
 
-/// Validate that `index_url` is an absolute HTTP(S) URL and normalize it
-/// to its credential store key form.
-fn index_key_for(index_url: &str) -> Result<String, AuthCommandError> {
+/// Validate that `index_url` is an absolute, non-template HTTP(S) URL and
+/// normalize it to its credential store key form.
+///
+/// Public so the CLI can validate the target before reading a secret (a
+/// `file://` or template target must fail before any prompt).
+pub fn validated_index_key(index_url: &str) -> Result<String, AuthCommandError> {
+    // Reject template syntax before `Url::parse`: the `url` crate would
+    // percent-encode the braces and normalization would then silently
+    // produce a mangled `%7Bpath%7D` key.
+    if is_template_syntax(index_url) {
+        return Err(AuthCommandError::TemplateIndexUrl {
+            url: index_url.to_string(),
+        });
+    }
     // Check the scheme before normalizing so a non-HTTP(S) location gets
     // the dedicated message instead of a generic normalization error.
     let url = Url::parse(index_url)
@@ -114,6 +143,200 @@ fn index_key_for(index_url: &str) -> Result<String, AuthCommandError> {
     })
 }
 
+/// Progress notice emitted by [`do_auth_login`] while it works, so the
+/// host can render it at the right moment (in particular, a replacement is
+/// reported strictly before the store write happens).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthLoginNotice {
+    /// A stored credential for the same key exists and is about to be
+    /// overwritten.
+    ReplacingExisting { key: String },
+    /// The discovery document could not be read (network failure, or an
+    /// HTTP error such as 401 on a private index); the credential is
+    /// scoped to the URL-derived pattern only.
+    DiscoveryUnreachable { error: String },
+    /// Discovery resolved a templated `index_root` whose literal prefix
+    /// cannot be anchored at a safe URL boundary (at least
+    /// `scheme://authority/`), so no glob was derived for it. Deriving one
+    /// anyway could produce a pattern matching other hosts.
+    TemplateIndexRootSkipped { template: String },
+}
+
+/// Outcome of [`do_auth_login`].
+///
+/// An absent keyring backend is an outcome rather than an error because
+/// the host still needs the derived globs: the CLI prints the exact
+/// `SYSAND_CRED_*` lines to set instead (design/credential-storage.md
+/// section 9).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthLoginOutcome {
+    /// The credential was persisted.
+    Stored { key: String, globs: Vec<String> },
+    /// No usable OS keyring backend on this host; nothing was persisted
+    /// and the secret was discarded.
+    BackendUnavailable {
+        key: String,
+        globs: Vec<String>,
+        reason: String,
+    },
+}
+
+/// Derive the escaped URL glob patterns a login for `key` covers
+/// (design/credential-storage.md section 8).
+///
+/// The primary glob anchors on the normalized user-supplied discovery URL
+/// (`globset::escape(<root ending in />)` + `**`), so the discovery fetch
+/// itself is authenticated on later runs. The resolved `index_root` and
+/// `api_root` add further globs only when not already covered by an
+/// earlier root (Case B, disjoint host or path); a root that is itself a
+/// prefix of an earlier one is also skipped, keeping the set minimal. A
+/// templated `index_root` anchors on its literal prefix cut back to the
+/// last `/` boundary: under `literal_separator(true)` a `**` crosses `/`
+/// only as a full path component, so a mid-segment anchor would not match.
+///
+/// Both derivation and runtime matching serialize URLs via
+/// `url::Url::as_str()`, so IDN/percent-encoding agree on both sides.
+fn derive_credential_globs(
+    key: &str,
+    endpoints: Option<&ResolvedEndpoints>,
+    notify: &mut impl FnMut(AuthLoginNotice),
+) -> Vec<String> {
+    // Roots already covered, each ending in `/`. A candidate root is
+    // covered when one of these is its string prefix: the corresponding
+    // `<escaped root>**` glob then matches every URL under the candidate
+    // (`**` after `/` crosses separators).
+    let mut roots: Vec<String> = vec![key.to_string()];
+
+    let push_if_uncovered = |roots: &mut Vec<String>, candidate: &str| {
+        if !roots
+            .iter()
+            .any(|root| candidate.starts_with(root.as_str()))
+        {
+            // Keep the set minimal in the other direction too: a candidate
+            // that is a prefix of an existing root subsumes it.
+            roots.retain(|root| !root.starts_with(candidate));
+            roots.push(candidate.to_string());
+        }
+    };
+
+    if let Some(endpoints) = endpoints {
+        match &endpoints.index_root {
+            IndexLocation::Root(url) => push_if_uncovered(&mut roots, url.as_str()),
+            IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
+                Some(anchor) => push_if_uncovered(&mut roots, anchor.as_str()),
+                None => notify(AuthLoginNotice::TemplateIndexRootSkipped {
+                    template: template.to_string(),
+                }),
+            },
+        }
+        if let Some(api_root) = &endpoints.api_root {
+            push_if_uncovered(&mut roots, api_root.as_str());
+        }
+    }
+
+    roots
+        .into_iter()
+        .map(|root| format!("{}**", globset::escape(&root)))
+        .collect()
+}
+
+/// Anchor a templated `index_root`'s literal prefix at a safe URL
+/// boundary: the prefix cut back to its last `/`, reparsed as a URL so the
+/// anchor uses the same serialization runtime request URLs will (host
+/// case, default port). Returns `None` when no anchor at least as deep as
+/// `scheme://authority/` exists (for example a placeholder directly in the
+/// query of a path-less URL, whose last `/` is the one in `://`).
+fn template_anchor_root(prefix: &str) -> Option<Url> {
+    let cut = prefix.rfind('/')?;
+    let candidate = &prefix[..=cut];
+    let url = Url::parse(candidate).ok()?;
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        return None;
+    }
+    Some(url)
+}
+
+/// Store a bearer credential for `index_url` (design/credential-storage.md
+/// sections 4, 8, 9). The secret arrives as a parameter: a library call
+/// never prompts.
+///
+/// Discovery is fetched best-effort with the unauthenticated policy (no
+/// credential exists for the index yet) to resolve `index_root` and
+/// `api_root` for glob scoping; when it cannot be read the credential
+/// falls back to the URL-derived glob with a
+/// [`AuthLoginNotice::DiscoveryUnreachable`] notice. Overwriting an
+/// existing record for the same key is reported through
+/// [`AuthLoginNotice::ReplacingExisting`] before the write happens.
+///
+/// No validation probe runs here yet: the `--validation` flow
+/// (design/credential-storage.md section 5) slots in between glob
+/// derivation and the store write.
+pub fn do_auth_login<S: CredentialStore>(
+    store: &mut S,
+    index_url: &str,
+    secret: String,
+    client: &reqwest_middleware::ClientWithMiddleware,
+    runtime: Arc<tokio::runtime::Runtime>,
+    mut notify: impl FnMut(AuthLoginNotice),
+) -> Result<AuthLoginOutcome, AuthCommandError> {
+    let key = validated_index_key(index_url)?;
+    let location = IndexLocation::parse(&key)
+        .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
+
+    let endpoints =
+        match runtime.block_on(fetch_index_config(client, &Unauthenticated {}, &location)) {
+            Ok(endpoints) => Some(endpoints),
+            Err(err) => {
+                notify(AuthLoginNotice::DiscoveryUnreachable {
+                    error: err.to_string(),
+                });
+                None
+            }
+        };
+    let globs = derive_credential_globs(&key, endpoints.as_ref(), &mut notify);
+
+    // Detect an existing login before writing, so the host can announce
+    // the replacement first. `list` and `upsert` are separately locked, so
+    // this is best-effort under cross-process races.
+    let records = match store.list() {
+        Ok(records) => records,
+        Err(CredentialStoreError::BackendAbsent { source }) => {
+            return Ok(AuthLoginOutcome::BackendUnavailable {
+                key,
+                globs,
+                reason: source.to_string(),
+            });
+        }
+        Err(err) => return Err(err.into()),
+    };
+    if records.iter().any(|record| record.key == key) {
+        notify(AuthLoginNotice::ReplacingExisting { key: key.clone() });
+    }
+
+    // Validation probes (design/credential-storage.md section 5) will run
+    // here, between glob derivation and the store write.
+
+    let record = CredentialRecord {
+        key: key.clone(),
+        globs: globs.clone(),
+        scheme: CredentialScheme::Bearer,
+        secret,
+        expires_at: None,
+        extra: serde_json::Map::new(),
+    };
+    match store.upsert(record) {
+        Ok(()) => Ok(AuthLoginOutcome::Stored { key, globs }),
+        Err(CredentialStoreError::BackendAbsent { source }) => {
+            Ok(AuthLoginOutcome::BackendUnavailable {
+                key,
+                globs,
+                reason: source.to_string(),
+            })
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Remove the stored login for `index_url`.
 ///
 /// Returns the normalized index key the record was stored under. Removing
@@ -123,7 +346,7 @@ pub fn do_auth_logout<S: CredentialStore>(
     store: &mut S,
     index_url: &str,
 ) -> Result<String, AuthCommandError> {
-    let key = index_key_for(index_url)?;
+    let key = validated_index_key(index_url)?;
     if store.remove(&key)? {
         Ok(key)
     } else {

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -64,16 +64,15 @@ pub enum AuthCommandError {
     TemplateWithoutAnchor { url: String },
     /// Every exercised surface rejected the credential and none accepted
     /// it, so nothing was stored.
-    #[error("{}", validation_rejected_message(.index, .rejected, *.read_status, *.basic_challenge))]
+    #[error("{}", validation_rejected_message(.index, .rejected, *.basic_challenge))]
     ValidationRejected {
         /// The normalized index key the login targeted.
         index: String,
-        /// The surfaces that exercised and rejected the credential.
-        rejected: Vec<ProbeSurface>,
-        /// The HTTP status of the read surface's rejection, when the read
-        /// surface rejected. A 404 hedges the message: it can mean a
-        /// rejected token, but also a URL with no index at all.
-        read_status: Option<u16>,
+        /// The surfaces that exercised and rejected the credential, each
+        /// with the HTTP status it answered. A read-surface 404 hedges
+        /// the message: it can mean a rejected token, but also a URL with
+        /// no index at all.
+        rejected: Vec<(ProbeSurface, u16)>,
         /// Whether the read surface answered with a `WWW-Authenticate:
         /// Basic` challenge: the index wants username/password, not a
         /// bearer token, and the message routes the user to
@@ -126,20 +125,18 @@ pub enum AuthCommandError {
 
 fn validation_rejected_message(
     index: &str,
-    rejected: &[ProbeSurface],
-    read_status: Option<u16>,
+    rejected: &[(ProbeSurface, u16)],
     basic_challenge: bool,
 ) -> String {
     let mut message = match rejected {
         // A read-surface 404 is hedged: it can also mean there is simply
         // no index at this URL, so the token must not be blamed outright.
-        [surface] => {
-            let (endpoint, status) = match surface {
-                ProbeSurface::Read => ("index.json", read_status.unwrap_or(401)),
-                // The API surface rejects only on 401.
-                ProbeSurface::Api => ("v1/whoami", 401),
+        [(surface, status)] => {
+            let endpoint = match surface {
+                ProbeSurface::Read => "index.json",
+                ProbeSurface::Api => "v1/whoami",
             };
-            let hedge = if *surface == ProbeSurface::Read && status == 404 {
+            let hedge = if *surface == ProbeSurface::Read && *status == 404 {
                 ", or no index exists at this URL"
             } else {
                 ""
@@ -150,11 +147,13 @@ fn validation_rejected_message(
             )
         }
         _ => {
-            let surfaces: Vec<&str> = rejected
+            let surfaces: Vec<String> = rejected
                 .iter()
-                .map(|surface| match surface {
-                    ProbeSurface::Read => "the index read surface (`index.json`)",
-                    ProbeSurface::Api => "the index API (`v1/whoami`)",
+                .map(|(surface, status)| match surface {
+                    ProbeSurface::Read => {
+                        format!("the index read surface (`index.json`, HTTP {status})")
+                    }
+                    ProbeSurface::Api => format!("the index API (`v1/whoami`, HTTP {status})"),
                 })
                 .collect();
             format!(
@@ -434,13 +433,13 @@ pub enum AuthLoginNotice {
     /// limiting can never refuse a credential.
     ProbeRateLimited { surface: ProbeSurface },
     /// A surface rejected the credential but another accepted it, so it
-    /// was stored anyway. `read_status` is the read surface's rejection
-    /// status (a 404 hedges the warning: possibly no `index.json` at that
-    /// URL); `basic_challenge` means the read surface answered with a
-    /// `WWW-Authenticate: Basic` challenge.
+    /// was stored anyway. `status` is the HTTP status the surface
+    /// answered (a read-surface 404 hedges the warning: possibly no
+    /// `index.json` at that URL); `basic_challenge` means the read
+    /// surface answered with a `WWW-Authenticate: Basic` challenge.
     SurfaceRejected {
         surface: ProbeSurface,
-        read_status: Option<u16>,
+        status: u16,
         basic_challenge: bool,
     },
 }
@@ -616,9 +615,8 @@ fn parse_whoami_identity(
 #[derive(Default)]
 struct ProbeOutcome {
     accepted: Vec<ProbeSurface>,
-    rejected: Vec<ProbeSurface>,
-    /// The HTTP status of the read surface's rejection, when it rejected.
-    read_status: Option<u16>,
+    /// Each rejecting surface with the HTTP status it answered.
+    rejected: Vec<(ProbeSurface, u16)>,
     basic_challenge: bool,
     identity: Option<WhoamiIdentity>,
 }
@@ -778,8 +776,7 @@ fn probe_read_surface(
     } else if forced_status.is_success() {
         outcome.accepted.push(surface);
     } else if forced_status.is_client_error() {
-        outcome.rejected.push(surface);
-        outcome.read_status = Some(forced_status.as_u16());
+        outcome.rejected.push((surface, forced_status.as_u16()));
         outcome.basic_challenge = basic_challenge || offers_basic_challenge(forced.headers());
     } else {
         notify(AuthLoginNotice::ProbeUnreachable {
@@ -838,7 +835,7 @@ fn probe_api_surface(
         outcome.accepted.push(surface);
         outcome.identity = parse_whoami_identity(runtime, response);
     } else if status == reqwest::StatusCode::UNAUTHORIZED {
-        outcome.rejected.push(surface);
+        outcome.rejected.push((surface, status.as_u16()));
     } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
         // 429 is never a verdict; the protocol explicitly
         // allows rate limiting on `v1/whoami`.
@@ -1096,19 +1093,14 @@ pub fn do_auth_login<B: BlobBackend>(
         return Err(AuthCommandError::ValidationRejected {
             index: key,
             rejected: outcome.rejected,
-            read_status: outcome.read_status,
             basic_challenge: outcome.basic_challenge,
         });
     }
     // Stored anyway: warn about each surface that rejected.
-    for surface in &outcome.rejected {
+    for (surface, status) in &outcome.rejected {
         notify(AuthLoginNotice::SurfaceRejected {
             surface: *surface,
-            read_status: if *surface == ProbeSurface::Read {
-                outcome.read_status
-            } else {
-                None
-            },
+            status: *status,
             basic_challenge: outcome.basic_challenge && *surface == ProbeSurface::Read,
         });
     }

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -241,6 +241,11 @@ pub enum AuthLoginNotice {
         surface: ProbeSurface,
         error: String,
     },
+    /// A validation probe was answered with HTTP 429. A 429 is never a
+    /// verdict (design/credential-storage.md section 5): whether it hit
+    /// the unauth baseline or the forced retry, the surface counts as not
+    /// tested, so rate limiting can never refuse a credential.
+    ProbeRateLimited { surface: ProbeSurface },
     /// A surface rejected the credential, but another surface accepted
     /// it, so the credential was stored anyway. `basic_challenge` is true
     /// when the read surface answered with a `WWW-Authenticate: Basic`
@@ -500,6 +505,13 @@ fn probe_read_surface(
         // case, not a failure).
         return;
     }
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        // Never force-retry a rate-limited surface: the retry would spend
+        // more of the rate budget, and a 429 answer to it would prove
+        // nothing either (429 is never a verdict, section 5).
+        notify(AuthLoginNotice::ProbeRateLimited { surface });
+        return;
+    }
     if !status.is_client_error() {
         notify(AuthLoginNotice::ProbeUnreachable {
             surface,
@@ -521,6 +533,12 @@ fn probe_read_surface(
             surface,
             target: redirect_target(&forced),
         });
+    } else if forced_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        // 429 is never a verdict (section 5): a rate-limited forced retry
+        // must not count as rejected, or throttling could false-refuse a
+        // valid token. A basic challenge seen on the baseline is discarded
+        // with the verdict: without a rejection there is nothing to route.
+        notify(AuthLoginNotice::ProbeRateLimited { surface });
     } else if forced_status.is_success() {
         outcome.accepted.push(surface);
     } else if forced_status.is_client_error() {
@@ -599,6 +617,10 @@ fn probe_api_surface(
         }
     } else if status == reqwest::StatusCode::UNAUTHORIZED {
         outcome.rejected.push(surface);
+    } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        // 429 is never a verdict (section 5); the protocol explicitly
+        // allows rate limiting on `v1/whoami`.
+        notify(AuthLoginNotice::ProbeRateLimited { surface });
     } else {
         notify(AuthLoginNotice::ProbeUnreachable {
             surface,

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -695,8 +695,10 @@ fn run_validation_probes(
 /// only once validation has decided the write will happen: a refused
 /// login never announces a replacement).
 ///
-/// `validation` maps the `--validation true|false` flag: `None` means the
-/// default, `true`. When enabled, the section 5 probes run between glob
+/// `validation`: `None` means the default, `true`; the CLI's
+/// `--no-validation` flag maps to `Some(false)`, and language bindings can
+/// expose this as an optional keyword. When enabled, the section 5 probes
+/// run between glob
 /// derivation and the store write, and the refusal rule applies: the
 /// credential is stored if any exercised surface accepted it, refused
 /// ([`AuthCommandError::ValidationRejected`]) when at least one exercised

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -52,20 +52,17 @@ pub enum AuthCommandError {
     /// The target could not be parsed or normalized as an index URL.
     #[error("invalid index URL for credential storage: {0}")]
     InvalidIndexUrl(String),
-    /// The target is a URL template whose literal prefix has no anchor at
-    /// a safe URL boundary (at least `scheme://authority/`), so no
-    /// credential scope glob could be derived for it (the section 8
-    /// clamp). `SYSAND_CRED_*` environment variables remain the
-    /// authentication path for such templates.
+    /// The target is a URL template with no literal prefix at a safe URL
+    /// boundary (at least `scheme://authority/`), so no credential scope
+    /// glob can be derived (the section 8 clamp).
     #[error(
         "`{url}`: this URL template has no literal prefix at a safe URL boundary\n\
          (at least `scheme://authority/`) to scope a credential to;\n\
          use `SYSAND_CRED_*` environment variables to authenticate it"
     )]
     TemplateWithoutAnchor { url: String },
-    /// Every surface that exercised the credential rejected it and none
-    /// accepted it, so nothing was stored (design/credential-storage.md
-    /// section 5 refusal rule).
+    /// Every exercised surface rejected the credential and none accepted
+    /// it, so nothing was stored (section 5 refusal rule).
     #[error("{}", validation_rejected_message(.index, .rejected, *.read_status, *.basic_challenge))]
     ValidationRejected {
         /// The normalized index key the login targeted.
@@ -89,10 +86,9 @@ pub enum AuthCommandError {
     )]
     WhoamiDiscoveryFailed { index: String, error: String },
     /// `whoami` targeted an index whose discovery configuration does not
-    /// explicitly advertise `api_root`: there is no API identity endpoint
-    /// to ask. The parenthetical matters: a private index can hide its
-    /// configuration from a client whose credentials do not cover it, which
-    /// resolves to the same unadvertised state.
+    /// advertise `api_root`: no identity endpoint to ask. The
+    /// parenthetical matters: a private index hiding its configuration
+    /// resolves to this same state.
     #[error(
         "index `{index}` does not advertise an API (`api_root`) in its\n\
          discovery configuration, so there is no identity endpoint to ask\n\
@@ -130,10 +126,8 @@ fn validation_rejected_message(
     basic_challenge: bool,
 ) -> String {
     let mut message = match rejected {
-        // Exactly one surface rejected: plain wording naming the endpoint
-        // and its answer. A read-surface 404 is hedged: it can also mean
-        // there is simply no index at this URL, so the token must not be
-        // blamed outright.
+        // A read-surface 404 is hedged: it can also mean there is simply
+        // no index at this URL, so the token must not be blamed outright.
         [surface] => {
             let (endpoint, status) = match surface {
                 ProbeSurface::Read => ("index.json", read_status.unwrap_or(401)),
@@ -239,22 +233,15 @@ pub struct StoredCredentialStatus {
     /// exercised the credential ("stored, not validated").
     pub validated: Vec<String>,
     /// Labels of `SYSAND_CRED_*` entries that may shadow this login.
-    ///
-    /// Approximate: an env entry is listed when its pattern matches this
-    /// record's key URL. Env credentials take precedence per matched
-    /// request URL, so an env pattern matching only part of the covered
-    /// URLs (or spelled so it misses the key, for example with a port
-    /// wildcard) may shadow requests without being listed here. For a
-    /// template key the match target contains the literal placeholder
-    /// text, which no request URL contains, so shadow detection is extra
-    /// approximate for templates.
+    /// Approximate: an entry is listed when its pattern matches this
+    /// record's key URL, but precedence is per request URL, so an env
+    /// pattern can shadow requests without being listed here (more so for
+    /// template keys, whose placeholder text no request URL contains).
     pub shadowed_by: Vec<String>,
     /// Whether this entry applies to the default index passed to
-    /// [`assemble_auth_status`]: its key equals the default's normalized
-    /// key, or one of its globs matches the default index root URL (an
-    /// entry can cover the default without being keyed by it, for example
-    /// via a disjoint `api_root` glob). Shares the root-URL approximation
-    /// documented on `shadowed_by`.
+    /// [`assemble_auth_status`]: key equality, or a glob matching the
+    /// default index root URL (an entry can cover the default without
+    /// being keyed by it). Shares `shadowed_by`'s approximation.
     pub applies_to_default: bool,
 }
 
@@ -280,31 +267,23 @@ pub struct AuthStatus {
 /// plain URL or a `{path}`/`{path_raw}` URL template) and normalize it to
 /// its credential store key form.
 ///
-/// A plain URL normalizes via
-/// [`normalize_index_key`]. A template's key is
-/// the template text with its anchorable literal prefix rewritten through
-/// `url::Url` serialization (lowercased scheme and host, default port
-/// stripped, IDN punycoded); the text after the prefix's last `/`, the
-/// placeholder, and the suffix stay verbatim, since they are raw template
-/// text, not a parsed URL. The result is idempotent and round-trips
-/// through [`IndexLocation::parse`] / `Display`, so `auth status` prints
-/// template keys in the exact form `auth logout` accepts. A template with
-/// no safe anchor (at least `scheme://authority/`) is rejected
-/// ([`AuthCommandError::TemplateWithoutAnchor`]): no credential scope
-/// glob could be derived for it.
+/// A plain URL normalizes via [`normalize_index_key`]. A template's key
+/// rewrites only the anchorable literal prefix through `url::Url`
+/// serialization; the rest stays verbatim (raw template text, not a
+/// parsed URL). The result is idempotent and round-trips through
+/// [`IndexLocation::parse`] / `Display`, so `auth status` prints template
+/// keys in the exact form `auth logout` accepts. A template with no safe
+/// anchor is rejected ([`AuthCommandError::TemplateWithoutAnchor`]).
 ///
-/// Public so the CLI can validate the target before reading a secret (a
-/// `file://` or unanchorable-template target must fail before any
-/// prompt).
+/// Public so the CLI can validate the target before reading a secret.
 pub fn validated_index_key(index_url: &str) -> Result<String, AuthCommandError> {
-    // Handle template syntax before `Url::parse`: the `url` crate would
-    // percent-encode the braces and normalization would then silently
-    // produce a mangled `%7Bpath%7D` key.
+    // Before `Url::parse`: it would percent-encode the braces into a
+    // mangled `%7Bpath%7D` key.
     if is_template_syntax(index_url) {
         return normalized_template_key(index_url);
     }
-    // Check the scheme before normalizing so a non-HTTP(S) location gets
-    // the dedicated message instead of a generic normalization error.
+    // Scheme check first, so a non-HTTP(S) location gets the dedicated
+    // message instead of a generic normalization error.
     let url = Url::parse(index_url)
         .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{index_url}`: {err}")))?;
     match url.scheme() {
@@ -342,10 +321,9 @@ fn normalized_template_key(index_url: &str) -> Result<String, AuthCommandError> 
             url: index_url.to_string(),
         });
     };
-    // `Display` reproduces the validated template text, so slicing off
-    // the prefix leaves the placeholder plus suffix verbatim. The rest of
-    // the prefix past its last `/` contains no `/` by construction, so
-    // reassembly keeps the anchor as the key's own anchor (idempotence).
+    // `Display` reproduces the validated template text; the prefix past
+    // its last `/` contains no `/`, so reassembly keeps the anchor as the
+    // key's own anchor (idempotence).
     let tail = location.to_string();
     Ok(format!(
         "{anchor}{}{}",
@@ -367,16 +345,13 @@ pub enum AuthLoginNotice {
     /// [`fetch_login_endpoints`]). The credential is scoped to the
     /// URL-derived pattern only.
     DiscoveryUnreachable { error: String },
-    /// Discovery resolved a templated `index_root` whose literal prefix
-    /// cannot be anchored at a safe URL boundary (at least
-    /// `scheme://authority/`), so no glob was derived for it. Deriving one
-    /// anyway could produce a pattern matching other hosts.
+    /// Discovery resolved a templated `index_root` with no safe anchor,
+    /// so no glob was derived: deriving one anyway could produce a
+    /// pattern matching other hosts.
     TemplateIndexRootSkipped { template: String },
     /// A validation probe was answered with a redirect. Probes never
-    /// follow redirects (the verdict would come from a different URL than
-    /// the surface nominally probed), so the surface counts as not
-    /// tested. `target` names the redirect target when the response
-    /// carried one.
+    /// follow redirects (the verdict would come from a different URL),
+    /// so the surface counts as not tested.
     ProbeRedirected {
         surface: ProbeSurface,
         target: String,
@@ -388,17 +363,14 @@ pub enum AuthLoginNotice {
         error: String,
     },
     /// A validation probe was answered with HTTP 429. A 429 is never a
-    /// verdict (design/credential-storage.md section 5): whether it hit
-    /// the unauth baseline or the forced retry, the surface counts as not
-    /// tested, so rate limiting can never refuse a credential.
+    /// verdict (section 5): the surface counts as not tested, so rate
+    /// limiting can never refuse a credential.
     ProbeRateLimited { surface: ProbeSurface },
-    /// A surface rejected the credential, but another surface accepted
-    /// it, so the credential was stored anyway. `read_status` is the HTTP
-    /// status of the read surface's rejection (set only when `surface` is
-    /// the read surface); a 404 hedges the warning, since it can also
-    /// mean no `index.json` exists at that URL. `basic_challenge` is true
-    /// when the read surface answered with a `WWW-Authenticate: Basic`
-    /// challenge (the index wants username/password, not a bearer token).
+    /// A surface rejected the credential but another accepted it, so it
+    /// was stored anyway. `read_status` is the read surface's rejection
+    /// status (a 404 hedges the warning: possibly no `index.json` at that
+    /// URL); `basic_challenge` means the read surface answered with a
+    /// `WWW-Authenticate: Basic` challenge.
     SurfaceRejected {
         surface: ProbeSurface,
         read_status: Option<u16>,
@@ -419,11 +391,9 @@ pub enum AuthLoginOutcome {
         key: String,
         globs: Vec<String>,
         /// The surfaces that exercised and accepted the credential, in
-        /// probe order (read before api). Empty means "stored, not
-        /// validated": nothing
-        /// exercised the credential. Hosts must scope the claim to these
-        /// surfaces and never print a bare "validated"
-        /// (design/credential-storage.md section 5).
+        /// probe order. Empty means "stored, not validated". Hosts must
+        /// scope the claim to these surfaces and never print a bare
+        /// "validated" (section 5).
         validated: Vec<ProbeSurface>,
     },
     /// No usable OS keyring backend on this host; nothing was persisted
@@ -438,30 +408,22 @@ pub enum AuthLoginOutcome {
 /// Derive the escaped URL glob patterns a login covers
 /// (design/credential-storage.md section 8).
 ///
-/// The primary glob anchors on `primary_root`: the normalized
-/// user-supplied discovery URL for a plain-URL target (so the discovery
-/// fetch itself is authenticated on later runs), or the literal-prefix
-/// anchor for a template target
-/// (`globset::escape(<root ending in />)` + `**` either way). The
-/// resolved `index_root` and
-/// `api_root` add further globs only when not already covered by an
-/// earlier root (Case B, disjoint host or path); a root that is itself a
-/// prefix of an earlier one is also skipped, keeping the set minimal. A
+/// The primary glob anchors on `primary_root`
+/// (`globset::escape(<root ending in />)` + `**`); the resolved
+/// `index_root` and `api_root` add globs only when not covered by an
+/// earlier root, and a root that prefixes an earlier one subsumes it. A
 /// templated `index_root` anchors on its literal prefix cut back to the
-/// last `/` boundary: under `literal_separator(true)` a `**` crosses `/`
-/// only as a full path component, so a mid-segment anchor would not match.
-///
-/// Both derivation and runtime matching serialize URLs via
+/// last `/`: under `literal_separator(true)` a mid-segment anchor would
+/// not match. Both derivation and runtime matching serialize URLs via
 /// `url::Url::as_str()`, so IDN/percent-encoding agree on both sides.
 fn derive_credential_globs(
     primary_root: &str,
     endpoints: Option<&ResolvedEndpoints>,
     notify: &mut impl FnMut(AuthLoginNotice),
 ) -> Vec<String> {
-    // Roots already covered, each ending in `/`. A candidate root is
-    // covered when one of these is its string prefix: the corresponding
-    // `<escaped root>**` glob then matches every URL under the candidate
-    // (`**` after `/` crosses separators).
+    // Roots already covered, each ending in `/`. A candidate whose string
+    // prefix is an existing root is covered: that root's `**` glob
+    // matches every URL under the candidate.
     let mut roots: Vec<String> = vec![primary_root.to_string()];
 
     let push_if_uncovered = |roots: &mut Vec<String>, candidate: &str| {
@@ -469,8 +431,7 @@ fn derive_credential_globs(
             .iter()
             .any(|root| candidate.starts_with(root.as_str()))
         {
-            // Keep the set minimal in the other direction too: a candidate
-            // that is a prefix of an existing root subsumes it.
+            // A candidate that prefixes an existing root subsumes it.
             roots.retain(|root| !root.starts_with(candidate));
             roots.push(candidate.to_string());
         }
@@ -499,11 +460,9 @@ fn derive_credential_globs(
 
 /// Anchor a URL template's literal prefix at a safe URL boundary: the
 /// prefix cut back to its last `/`, reparsed as a URL so the anchor uses
-/// the same serialization runtime request URLs will (host case, default
-/// port). Returns the cut position (the byte index of that last `/`)
-/// alongside the anchor. Returns `None` when no anchor at least as deep
-/// as `scheme://authority/` exists (for example a placeholder directly in
-/// the query of a path-less URL, whose last `/` is the one in `://`).
+/// the same serialization runtime request URLs will. Returns the cut
+/// position (byte index of that `/`) alongside the anchor, or `None` when
+/// no anchor at least as deep as `scheme://authority/` exists.
 fn template_anchor_root(prefix: &str) -> Option<(usize, Url)> {
     let cut = prefix.rfind('/')?;
     let candidate = &prefix[..=cut];
@@ -515,9 +474,8 @@ fn template_anchor_root(prefix: &str) -> Option<(usize, Url)> {
 }
 
 /// Identity fields parsed from a successful `v1/whoami` response:
-/// persisted on the stored record by a validating login
-/// (design/credential-storage.md sections 5, 6, 9) and rendered live by
-/// `auth whoami`. Never contains the secret.
+/// persisted on the stored record by a validating login and rendered live
+/// by `auth whoami`. Never contains the secret.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WhoamiIdentity {
     pub subject: CredentialSubject,
@@ -642,14 +600,11 @@ fn redirect_target(response: &reqwest::Response) -> String {
 }
 
 /// Whether any `WWW-Authenticate` challenge on the response offers the
-/// `Basic` scheme. Scheme tokens are case-insensitive (RFC 7235) and one
-/// header value can carry several comma-separated challenges. A plain
-/// substring check would false-positive on `Bearer realm="Basic
-/// migration"`, and splitting on every comma would false-positive on a
-/// comma inside a quoted parameter value (`Bearer realm="use, basic"`),
-/// so we split on top-level commas only and check each challenge's leading
-/// scheme token. (A quoted `\"` inside a value is not handled, but such
-/// realms do not occur in practice, and this only tunes a hint message.)
+/// `Basic` scheme (case-insensitive, RFC 7235). Splits on top-level
+/// commas only and checks each challenge's leading scheme token, because
+/// both a substring check and a naive comma split false-positive on
+/// quoted realm values. (A quoted `\"` is not handled; this only tunes a
+/// hint message.)
 fn offers_basic_challenge(headers: &reqwest::header::HeaderMap) -> bool {
     headers
         .get_all(reqwest::header::WWW_AUTHENTICATE)
@@ -659,9 +614,7 @@ fn offers_basic_challenge(headers: &reqwest::header::HeaderMap) -> bool {
 }
 
 fn header_offers_basic(value: &str) -> bool {
-    // Split into challenges on commas outside double quotes: the toggling
-    // closure flips `in_quotes` on each `"` and treats a `,` as a
-    // separator only while outside quotes.
+    // Split into challenges on commas outside double quotes.
     let mut in_quotes = false;
     value
         .split(|c: char| {
@@ -716,9 +669,8 @@ fn probe_read_surface(
         return;
     }
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        // Never force-retry a rate-limited surface: the retry would spend
-        // more of the rate budget, and a 429 answer to it would prove
-        // nothing either (429 is never a verdict, section 5).
+        // Never force-retry a rate-limited surface (429 is never a
+        // verdict, section 5).
         notify(AuthLoginNotice::ProbeRateLimited { surface });
         return;
     }
@@ -744,10 +696,8 @@ fn probe_read_surface(
             target: redirect_target(&forced),
         });
     } else if forced_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        // 429 is never a verdict (section 5): a rate-limited forced retry
-        // must not count as rejected, or throttling could false-refuse a
-        // valid token. A basic challenge seen on the baseline is discarded
-        // with the verdict: without a rejection there is nothing to route.
+        // 429 is never a verdict (section 5): counting it as rejected
+        // would let throttling false-refuse a valid token.
         notify(AuthLoginNotice::ProbeRateLimited { surface });
     } else if forced_status.is_success() {
         outcome.accepted.push(surface);
@@ -820,20 +770,16 @@ fn probe_api_surface(
 }
 
 /// Fetch discovery for a login (design/credential-storage.md sections 5,
-/// 8): an unauthenticated baseline, then, on any 4xx answer except 429,
-/// one forced-bearer retry carrying the in-hand secret, mirroring the
-/// probe mechanism (including its 429 carve-out: a throttling host gets
-/// no retry and no secret). The forced retry is what distinguishes a hidden discovery
-/// document from an absent one: a fully private index answers 401 (or, in
-/// GitLab's style, 404) to the unauthenticated fetch whether or not a
-/// document exists, and only the credentialed answer settles it, letting
-/// such an index advertise its `api_root` for glob scoping and the whoami
-/// probe.
+/// 8): an unauthenticated baseline, then one forced-bearer retry on any
+/// 4xx except 429. The forced retry distinguishes a hidden discovery
+/// document from an absent one: a fully private index answers 401 (or
+/// GitLab-style 404) unauthenticated either way, and only the
+/// credentialed answer settles it.
 ///
-/// Discovery here is about knowing the topology, not validating the
-/// credential, and its outcome never refuses a login. `None` means "no
-/// usable document"; the caller falls back to the URL-derived glob after
-/// a [`AuthLoginNotice::DiscoveryUnreachable`] notice.
+/// Discovery is about topology, not validation; its outcome never refuses
+/// a login. `None` means "no usable document" and the caller falls back
+/// to the URL-derived glob after a
+/// [`AuthLoginNotice::DiscoveryUnreachable`] notice.
 fn fetch_login_endpoints(
     client: &reqwest_middleware::ClientWithMiddleware,
     location: &IndexLocation,
@@ -841,10 +787,9 @@ fn fetch_login_endpoints(
     runtime: &tokio::runtime::Runtime,
     notify: &mut impl FnMut(AuthLoginNotice),
 ) -> Option<ResolvedEndpoints> {
-    // The baseline goes through the regular middleware client (following
-    // redirects, exactly like every other discovery fetch); the strict
-    // variant surfaces an absent document as its 404 status so the retry
-    // decision below can see it.
+    // The baseline uses the regular middleware client; the strict variant
+    // surfaces an absent document as its 404 status so the retry decision
+    // below can see it.
     match runtime.block_on(fetch_index_config_strict(
         client,
         &Unauthenticated {},
@@ -856,11 +801,9 @@ fn fetch_login_endpoints(
         {
             forced_discovery_fetch(location, secret, runtime, notify)
         }
-        // Network failures, 5xx, a 429 baseline (the retry would spend
-        // more of the rate budget and send the secret to a throttling
-        // host, mirroring the probes' 429 carve-out), and a
-        // present-but-invalid document are not "possibly hidden from me"
-        // signals: no secret is sent.
+        // Network failures, 5xx, a 429 baseline, and a present-but-invalid
+        // document are not "possibly hidden from me" signals: no secret
+        // is sent.
         Err(err) => {
             notify(AuthLoginNotice::DiscoveryUnreachable {
                 error: err.to_string(),
@@ -871,14 +814,11 @@ fn fetch_login_endpoints(
 }
 
 /// The forced leg of [`fetch_login_endpoints`]: one GET of the discovery
-/// document with a forced bearer, through the no-redirect probe client. A
-/// 200 with a valid document is used exactly like a public discovery
-/// success; a 404 is the authoritative "no document" answer to the
-/// credential and reconstructs the flat topology, like a public 404 (no
-/// notice: this is the normal discovery-less case, not a failure).
-/// Everything else (other 4xx, 429, redirect, 5xx, network failure) falls
-/// back to `None` with a notice; the validation probes still deliver the
-/// credential verdict.
+/// document with a forced bearer, through the no-redirect probe client.
+/// 200 with a valid document is used like a public discovery success; 404
+/// is the authoritative "no document" answer and reconstructs the flat
+/// topology (no notice). Everything else falls back to `None` with a
+/// notice; the validation probes still deliver the credential verdict.
 fn forced_discovery_fetch(
     location: &IndexLocation,
     secret: &str,
@@ -921,9 +861,8 @@ fn forced_discovery_fetch(
     } else if status == reqwest::StatusCode::NOT_FOUND {
         Some(ResolvedEndpoints::flat(location.clone()))
     } else if status.is_redirection() {
-        // The probe client never follows redirects (unlike the baseline's
-        // middleware client), so a redirect-fronted discovery document
-        // gains this notice instead of a forced answer.
+        // The probe client never follows redirects, so a redirect-fronted
+        // discovery document gets this notice instead of a forced answer.
         unreachable(format!(
             "the authenticated retry for `{config_url}` was redirected to `{}`",
             redirect_target(&response)
@@ -939,13 +878,11 @@ fn forced_discovery_fetch(
     }
 }
 
-/// Run the validation probes (design/credential-storage.md section 5):
-/// discovery-first (the already-fetched discovery result is reused; when
-/// it was unreachable the read surface falls back to the URL-derived
-/// `index.json`, so a fully private index still gets its read surface
-/// exercised), and the API surface only when discovery advertised
-/// `api_root` (which the protocol now requires explicitly), so a static
-/// index is not phantom-probed for an API it does not have.
+/// Run the validation probes (design/credential-storage.md section 5).
+/// When discovery was unreachable the read surface falls back to the
+/// URL-derived `index.json`; the API surface is probed only when
+/// discovery advertised `api_root`, so a static index is not
+/// phantom-probed for an API it does not have.
 fn run_validation_probes(
     endpoints: Option<&ResolvedEndpoints>,
     location: &IndexLocation,
@@ -992,41 +929,10 @@ fn run_validation_probes(
     outcome
 }
 
-/// Store a bearer credential for `index_url` (design/credential-storage.md
-/// sections 4, 5, 8, 9). The secret arrives as a parameter: a library call
-/// never prompts.
-///
-/// Discovery is fetched best-effort to resolve `index_root` and
-/// `api_root` for glob scoping: an unauthenticated baseline, retried once
-/// with the in-hand secret as a forced bearer when the baseline answers
-/// any 4xx except 429, so a fully private index can still advertise its
-/// topology
-/// ([`fetch_login_endpoints`]); only the backend-absent path stays
-/// strictly unauthenticated, since its secret is discarded. When no usable
-/// document results, the credential falls back to the URL-derived glob
-/// with a [`AuthLoginNotice::DiscoveryUnreachable`] notice. Overwriting an
-/// existing record for the same key is reported through
-/// [`AuthLoginNotice::ReplacingExisting`] before the write happens (and
-/// only once validation has decided the write will happen: a refused
-/// login never announces a replacement).
-///
-/// Validation always runs (there is no opt-out; design section 5): the
-/// probes run between glob derivation and the store write, and the
-/// refusal rule applies. The credential is stored if any exercised
-/// surface accepted it, refused
-/// ([`AuthCommandError::ValidationRejected`]) when at least one exercised
-/// surface rejected it and none accepted, and stored as "not validated"
-/// when nothing exercised it (which is how an offline or unreachable
-/// index degrades: warnings, no verdict, no refusal). An absent keyring
-/// backend returns [`AuthLoginOutcome::BackendUnavailable`] before any
-/// probe runs (no network is spent on a credential that cannot be
-/// stored), so the `SYSAND_CRED_*` guidance a no-keyring host prints
-/// always describes an unvalidated credential.
-///
 /// Best-effort discovery used only to scope the `SYSAND_CRED_*` guidance
-/// globs when the keyring backend is absent. It stays strictly
-/// unauthenticated (the secret is discarded on this path), and a discovery
-/// failure degrades to the URL-derived glob with a warning.
+/// globs when the keyring backend is absent. Strictly unauthenticated
+/// (the secret is discarded on this path); a discovery failure degrades
+/// to the URL-derived glob with a warning.
 fn guidance_globs(
     client: &reqwest_middleware::ClientWithMiddleware,
     location: &IndexLocation,
@@ -1047,6 +953,22 @@ fn guidance_globs(
     derive_credential_globs(primary_root, endpoints.as_ref(), notify)
 }
 
+/// Store a bearer credential for `index_url` (design/credential-storage.md
+/// sections 4, 5, 8, 9). The secret arrives as a parameter: a library
+/// call never prompts.
+///
+/// Discovery is fetched best-effort for glob scoping
+/// ([`fetch_login_endpoints`]); with no usable document the credential
+/// falls back to the URL-derived glob. Validation always runs, between
+/// glob derivation and the store write, with the section 5 refusal rule:
+/// stored if any exercised surface accepted, refused
+/// ([`AuthCommandError::ValidationRejected`]) when surfaces only
+/// rejected, stored "not validated" when nothing exercised the credential
+/// (how an offline index degrades). Replacement is announced via
+/// [`AuthLoginNotice::ReplacingExisting`] before the write, and only once
+/// validation has decided the write will happen. An absent keyring
+/// backend returns [`AuthLoginOutcome::BackendUnavailable`] before any
+/// probe runs: no network is spent on a credential that cannot be stored.
 pub fn do_auth_login<B: BlobBackend>(
     store: &mut LockedBlobStore<B>,
     index_url: &str,
@@ -1058,10 +980,8 @@ pub fn do_auth_login<B: BlobBackend>(
     let key = validated_index_key(index_url)?;
     let location = IndexLocation::parse(&key)
         .map_err(|err| AuthCommandError::InvalidIndexUrl(format!("`{key}`: {err}")))?;
-    // The primary glob root: the key itself for a plain URL (it ends in
-    // `/`), the literal-prefix anchor for a template target. Key
-    // validation already rejected unanchorable templates; this re-check
-    // just avoids a panic path.
+    // Key validation already rejected unanchorable templates; this
+    // re-check just avoids a panic path.
     let primary_root = match &location {
         IndexLocation::Root(_) => key.clone(),
         IndexLocation::Template(template) => match template_anchor_root(template.prefix()) {
@@ -1072,13 +992,10 @@ pub fn do_auth_login<B: BlobBackend>(
         },
     };
 
-    // Read the store before any network so an absent keyring backend is
-    // detected before the secret could be spent on a credentialed request
-    // (the BackendUnavailable outcome discards the secret, so its
-    // best-effort discovery for the `SYSAND_CRED_*` guidance globs stays
-    // strictly unauthenticated). This also detects an existing login
-    // before writing, so the host can announce the replacement before the
-    // write; `list` and `upsert` are separately locked, so that part is
+    // Read the store before any network: an absent keyring backend must
+    // be detected before the secret could be spent on a credentialed
+    // request. Also detects an existing login for the replacement notice;
+    // `list` and `upsert` are separately locked, so that part is
     // best-effort under cross-process races.
     let records = match store.list() {
         Ok(records) => records,
@@ -1097,12 +1014,9 @@ pub fn do_auth_login<B: BlobBackend>(
     let endpoints = fetch_login_endpoints(client, &location, &secret, runtime, &mut notify);
     let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
 
-    // Validation probes (design/credential-storage.md section 5), between
-    // glob derivation and the store write.
     let outcome =
         run_validation_probes(endpoints.as_ref(), &location, &secret, runtime, &mut notify);
-    // The refusal rule: refuse only when at least one exercised
-    // surface rejected the credential and none accepted it.
+    // Refuse only when an exercised surface rejected and none accepted.
     if outcome.accepted.is_empty() && !outcome.rejected.is_empty() {
         return Err(AuthCommandError::ValidationRejected {
             index: key,
@@ -1111,8 +1025,7 @@ pub fn do_auth_login<B: BlobBackend>(
             basic_challenge: outcome.basic_challenge,
         });
     }
-    // Stored anyway (some surface accepted): warn about each surface
-    // that rejected.
+    // Stored anyway: warn about each surface that rejected.
     for surface in &outcome.rejected {
         notify(AuthLoginNotice::SurfaceRejected {
             surface: *surface,
@@ -1230,13 +1143,11 @@ pub struct AuthWhoamiOutcome {
 }
 
 /// Select the credential `auth whoami` sends, mirroring the runtime and
-/// publish precedence (design/credential-storage.md sections 7, 9): a
-/// `SYSAND_CRED_*` env bearer matching the whoami URL wins over a stored
-/// login; within a source exactly one credential may match (candidates
-/// carrying the same token collapse to one, [`select_bearer`]). The
-/// stored map is built by the same [`stored_bearer_map_from_records`] the
-/// runtime's lazy layer uses, so invalid glob patterns are skipped
-/// individually: one bad pattern must not hide the other credentials.
+/// publish precedence (design/credential-storage.md sections 7, 9): env
+/// over stored, and within a source exactly one credential may match
+/// (same-token candidates collapse, [`select_bearer`]). The stored map is
+/// built by the same [`stored_bearer_map_from_records`] the runtime uses,
+/// so one bad glob pattern cannot hide the other credentials.
 fn select_whoami_credential(
     env_bearers: &GlobMap<EnvBearerAuth>,
     records: &[CredentialRecord],
@@ -1286,20 +1197,16 @@ fn select_whoami_credential(
 
 /// Query-only live identity check (design/credential-storage.md section
 /// 4): resolve the index API, select the credential the runtime would use
-/// (env over stored, [`select_whoami_credential`]), and send one
-/// forced-bearer GET to `api_root/v1/whoami` with the no-redirect probe
-/// client. Never prompts, never prints, and never touches a credential
-/// store: the caller reads the store once and passes the `records`
-/// snapshot (an absent backend passes an empty slice; a locked or denied
-/// backend is the caller's hard error). Taking records instead of a store
-/// lets the host share one store read between this selection and its
-/// discovery policy, keeping whoami at one keychain touch. Cached
+/// ([`select_whoami_credential`]), and send one forced-bearer GET to
+/// `api_root/v1/whoami` with the no-redirect probe client. Never prompts,
+/// never prints, never touches a credential store: taking a `records`
+/// snapshot lets the host share one store read between this selection and
+/// its discovery policy, keeping whoami at one keychain touch. Cached
 /// identity fields on a stored record are deliberately not refreshed.
 ///
-/// `discovery_auth` is the policy for the discovery fetch: unlike login
-/// (which is unauthenticated because no credential exists yet), whoami
-/// runs when a credential does exist, and a private index may gate its
-/// discovery document, so the CLI passes its regular read policy here.
+/// `discovery_auth` is the discovery-fetch policy: unlike login, whoami
+/// runs when a credential exists and a private index may gate its
+/// discovery document, so the CLI passes its regular read policy.
 pub fn do_auth_whoami<P: HTTPAuthentication>(
     records: &[CredentialRecord],
     index_url: &str,
@@ -1403,14 +1310,10 @@ fn lenient_glob_matches(pattern: &str, target: &str) -> bool {
 /// entries, against the given clock. Exposed for deterministic tests;
 /// [`do_auth_status`] is the store-reading entry point.
 ///
-/// `default_key` is the normalized key (see [`validated_index_key`]) of
-/// the default index, when the caller could resolve one; entries that
-/// apply to it are marked (`applies_to_default`), answering "which
-/// credential will bare commands use". A stored entry applies on key
-/// equality or when one of its globs matches the default index root URL
-/// (for a template default, its literal-prefix anchor); an env entry
-/// applies when its pattern matches that root. Purely diagnostic: `None`
-/// simply marks nothing.
+/// `default_key` is the normalized key of the default index, when the
+/// caller could resolve one; entries that apply to it are marked
+/// (`applies_to_default`), answering "which credential will bare commands
+/// use". Purely diagnostic: `None` simply marks nothing.
 pub fn assemble_auth_status(
     records: Vec<CredentialRecord>,
     env: Vec<EnvCredentialEntry>,
@@ -1427,9 +1330,8 @@ pub fn assemble_auth_status(
     for entry in &mut env {
         entry.applies_to_default = default_applies(std::slice::from_ref(&entry.pattern));
     }
-    // Compile each env pattern the same way runtime matching does
-    // (`GlobMapBuilder`, `literal_separator(true)`). An invalid pattern
-    // cannot shadow anything and is skipped.
+    // Compiled like runtime matching (`literal_separator(true)`); an
+    // invalid pattern cannot shadow anything and is skipped.
     let env_matchers: Vec<(&str, globset::GlobMatcher)> = env
         .iter()
         .filter_map(|entry| {

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -976,6 +976,31 @@ fn run_validation_probes(
 /// probe runs (no network is spent on a credential that cannot be
 /// stored), so the `SYSAND_CRED_*` guidance a no-keyring host prints
 /// always describes an unvalidated credential.
+///
+/// Best-effort discovery used only to scope the `SYSAND_CRED_*` guidance
+/// globs when the keyring backend is absent. It stays strictly
+/// unauthenticated (the secret is discarded on this path), and a discovery
+/// failure degrades to the URL-derived glob with a warning.
+fn guidance_globs(
+    client: &reqwest_middleware::ClientWithMiddleware,
+    location: &IndexLocation,
+    primary_root: &str,
+    runtime: &tokio::runtime::Runtime,
+    notify: &mut impl FnMut(AuthLoginNotice),
+) -> Vec<String> {
+    let endpoints =
+        match runtime.block_on(fetch_index_config(client, &Unauthenticated {}, location)) {
+            Ok(endpoints) => Some(endpoints),
+            Err(err) => {
+                notify(AuthLoginNotice::DiscoveryUnreachable {
+                    error: err.to_string(),
+                });
+                None
+            }
+        };
+    derive_credential_globs(primary_root, endpoints.as_ref(), notify)
+}
+
 pub fn do_auth_login<S: CredentialStore>(
     store: &mut S,
     index_url: &str,
@@ -1012,20 +1037,7 @@ pub fn do_auth_login<S: CredentialStore>(
     let records = match store.list() {
         Ok(records) => records,
         Err(CredentialStoreError::BackendAbsent { source }) => {
-            let endpoints = match runtime.block_on(fetch_index_config(
-                client,
-                &Unauthenticated {},
-                &location,
-            )) {
-                Ok(endpoints) => Some(endpoints),
-                Err(err) => {
-                    notify(AuthLoginNotice::DiscoveryUnreachable {
-                        error: err.to_string(),
-                    });
-                    None
-                }
-            };
-            let globs = derive_credential_globs(&primary_root, endpoints.as_ref(), &mut notify);
+            let globs = guidance_globs(client, &location, &primary_root, &runtime, &mut notify);
             return Ok(AuthLoginOutcome::BackendUnavailable {
                 key,
                 globs,

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -107,10 +107,7 @@ pub enum AuthCommandError {
         candidates: usize,
     },
     /// No credential of either source matches the `v1/whoami` URL.
-    #[error(
-        "no credential matches `{url}`; run `sysand auth login {index}` to \
-         store one, or set `SYSAND_CRED_*` environment variables"
-    )]
+    #[error("no credential matches `{url}`; set `SYSAND_CRED_*` environment variables")]
     NoWhoamiCredential { url: String, index: String },
     /// The credential store failed.
     #[error(transparent)]

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     credential_store::{
         CredentialRecord, CredentialScheme, CredentialStoreError, CredentialSubject,
+        ValidatedSurface,
         keyring_store::{BlobBackend, LockedBlobStore},
         normalize_index_key,
     },
@@ -206,6 +207,17 @@ impl std::fmt::Display for ProbeSurface {
     }
 }
 
+/// The persisted form of a probe surface, for the record's `validated`
+/// list.
+impl From<ProbeSurface> for ValidatedSurface {
+    fn from(surface: ProbeSurface) -> Self {
+        match surface {
+            ProbeSurface::Read => ValidatedSurface::Read,
+            ProbeSurface::Api => ValidatedSurface::Api,
+        }
+    }
+}
+
 /// Status of one stored credential, as shown by `auth status`. Never contains
 /// the secret.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -231,7 +243,7 @@ pub struct StoredCredentialStatus {
     /// The surfaces that exercised and accepted the credential at login
     /// (`"read"`, `"api"`, in probe order). Empty means nothing
     /// exercised the credential ("stored, not validated").
-    pub validated: Vec<String>,
+    pub validated: Vec<ValidatedSurface>,
     /// Labels of `SYSAND_CRED_*` entries that may shadow this login.
     /// Approximate: an entry is listed when its pattern matches this
     /// record's key URL, but precedence is per request URL, so an env
@@ -576,7 +588,9 @@ fn parse_whoami_identity(
     match parsed {
         Ok(body) => Some(WhoamiIdentity {
             subject: CredentialSubject {
-                kind: body.subject.kind,
+                // The wire value stays lenient; unknown types become
+                // `SubjectKind::Other` and round-trip verbatim.
+                kind: body.subject.kind.into(),
                 name: body.subject.name,
             },
             token_name: body.token.name,
@@ -1102,7 +1116,7 @@ pub fn do_auth_login<B: BlobBackend>(
         // (read)" and so on), so `auth status` can show it later.
         validated: validated
             .iter()
-            .map(std::string::ToString::to_string)
+            .map(|surface| ValidatedSurface::from(*surface))
             .collect(),
         extra: serde_json::Map::new(),
     };

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -191,6 +191,10 @@ pub struct StoredCredentialStatus {
     /// The token's non-secret display prefix, when a validating login
     /// learned it.
     pub token_prefix: Option<String>,
+    /// The surfaces that exercised and accepted the credential at login
+    /// (`"read"`, `"api"`, in probe order). Empty means the credential
+    /// was stored without validation.
+    pub validated: Vec<String>,
     /// Labels of `SYSAND_CRED_*` entries that may shadow this login.
     ///
     /// Approximate: an env entry is listed when its pattern matches this
@@ -917,6 +921,12 @@ pub fn do_auth_login<S: CredentialStore>(
         subject,
         token_name,
         token_prefix,
+        // Persist the same scoped claim the host prints ("validated
+        // (read)" and so on), so `auth status` can show it later.
+        validated: validated
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect(),
         extra: serde_json::Map::new(),
     };
     match store.upsert(record) {
@@ -1267,6 +1277,7 @@ pub fn assemble_auth_status(
                 expires_at: record.expires_at,
                 subject: record.subject,
                 token_prefix: record.token_prefix,
+                validated: record.validated,
                 shadowed_by,
             }
         })

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -93,7 +93,8 @@ fn logout_of_non_http_url_errors_without_touching_the_store() {
     assert!(matches!(&err, AuthCommandError::NotHttpIndex { .. }));
     assert_eq!(
         err.to_string(),
-        "`file:///srv/index`: not an HTTP(S) index; nothing to authenticate to"
+        "`file:///srv/index`: not an HTTP(S) index; nothing to authenticate to \
+         (use an https:// index URL)"
     );
     assert_eq!(store.list().unwrap().len(), 1);
 }

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -78,10 +78,6 @@ fn logout_of_missing_credential_errors() {
         &err,
         AuthCommandError::NoStoredCredential { index } if index == "https://absent.example/"
     ));
-    assert_eq!(
-        err.to_string(),
-        "no stored credential for `https://absent.example/`"
-    );
     assert_eq!(store.list().unwrap().len(), 1);
 }
 
@@ -92,21 +88,11 @@ fn logout_of_non_http_url_errors_without_touching_the_store() {
     let err = do_auth_logout(&mut store, "file:///srv/index").unwrap_err();
 
     assert!(matches!(&err, AuthCommandError::NotHttpIndex { .. }));
-    assert_eq!(
-        err.to_string(),
-        "`file:///srv/index`: not an HTTP(S) index; nothing to authenticate to \
-         (use an https:// index URL)"
+    assert!(
+        err.to_string().contains("not an HTTP(S) index"),
+        "was: {err}"
     );
     assert_eq!(store.list().unwrap().len(), 1);
-}
-
-#[test]
-fn logout_of_unparseable_url_errors() {
-    let mut store = in_memory_store();
-
-    let err = do_auth_logout(&mut store, "not a url").unwrap_err();
-
-    assert!(matches!(&err, AuthCommandError::InvalidIndexUrl(_)));
 }
 
 // do_auth_status / assemble_auth_status
@@ -453,12 +439,7 @@ mod login {
         let api_root = format!("{root}api/");
         let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let _whoami = server
-            .mock("GET", "/api/v1/whoami")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut server, "/api/v1/whoami", None);
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
@@ -479,12 +460,7 @@ mod login {
         let api_root = format!("{}/base/", api_server.url());
         let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let _whoami = api_server
-            .mock("GET", "/base/v1/whoami")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut api_server, "/base/v1/whoami", None);
         let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &root, "tok");
@@ -521,12 +497,7 @@ mod login {
             .mock("GET", "/idx/index.json")
             .with_status(200)
             .create();
-        let _whoami = api_server
-            .mock("GET", "/v1/whoami")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut api_server, "/v1/whoami", None);
         let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &root, "tok");
@@ -555,12 +526,7 @@ mod login {
             .match_query(mockito::Matcher::UrlEncoded("ref".into(), "main".into()))
             .with_status(200)
             .create();
-        let _whoami = api_server
-            .mock("GET", "/v1/whoami")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut api_server, "/v1/whoami", None);
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
@@ -612,33 +578,6 @@ mod login {
         assert!(
             !matcher(&globs).is_match("https://attacker.example/x"),
             "no derived glob may cover other hosts: {globs:?}"
-        );
-    }
-
-    #[test]
-    fn login_with_unauthorized_discovery_falls_back_with_a_notice() {
-        let mut server = mockito::Server::new();
-        let root = format!("{}/", server.url());
-        // 401 on both discovery legs (baseline and forced retry).
-        let _mock = server
-            .mock("GET", "/sysand-index-config.json")
-            .with_status(401)
-            .expect(2)
-            .create();
-        // Keep the read probe quiet: the discovery notice is the point.
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let mut store = in_memory_store();
-
-        let (outcome, notices) = run_login(&mut store, &root, "tok");
-
-        let (_, globs) = stored(outcome);
-        assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
-        assert!(
-            notices.iter().any(|n| matches!(
-                n,
-                AuthLoginNotice::DiscoveryUnreachable { error } if error.contains("401")
-            )),
-            "expected a 401 discovery notice, got {notices:?}"
         );
     }
 
@@ -727,20 +666,6 @@ mod login {
             validated_index_key(&validated_index_key(spelled).unwrap()).unwrap(),
             gitlab
         );
-    }
-
-    #[test]
-    fn template_key_rejects_an_unanchorable_template() {
-        // Placeholder directly in the query of a path-less URL: the only
-        // `/` in the literal prefix is the one in `://`.
-        let err = validated_index_key("https://files.example.com?f={path}").unwrap_err();
-
-        assert!(matches!(
-            &err,
-            AuthCommandError::TemplateWithoutAnchor { .. }
-        ));
-        let message = err.to_string();
-        assert!(message.contains("SYSAND_CRED_"), "was: {message}");
     }
 
     #[test]
@@ -878,29 +803,21 @@ mod login {
 
     #[test]
     fn login_rejects_an_unanchorable_template_target() {
+        // Placeholder directly in the query of a path-less URL: the only
+        // `/` in the literal prefix is the one in `://`.
         let mut store = in_memory_store();
 
         // Fails in key validation, before any network or store access.
         let (outcome, notices) = run_login(&mut store, "https://files.example.com?f={path}", "tok");
 
+        let err = outcome.unwrap_err();
         assert!(matches!(
-            outcome.unwrap_err(),
+            &err,
             AuthCommandError::TemplateWithoutAnchor { .. }
         ));
+        assert!(err.to_string().contains("SYSAND_CRED_"), "was: {err}");
         assert!(notices.is_empty());
         assert!(store.list().unwrap().is_empty());
-    }
-
-    #[test]
-    fn logout_rejects_an_unanchorable_template_target() {
-        let mut store = in_memory_store();
-
-        let err = do_auth_logout(&mut store, "https://files.example.com?f={path}").unwrap_err();
-
-        assert!(matches!(
-            err,
-            AuthCommandError::TemplateWithoutAnchor { .. }
-        ));
     }
 
     #[test]
@@ -960,6 +877,23 @@ mod login {
     const WHOAMI_BODY: &str = r#"{"subject":{"type":"user","name":"alice"},
         "token":{"name":"laptop","prefix":"sysand_u_1a2b3c4d",
                  "expires_at":"2026-09-01T00:00:00Z"}}"#;
+
+    /// Mock a whoami endpoint answering 200 with the standard identity
+    /// body; with `token` it also requires exactly that bearer and
+    /// expects exactly one request.
+    fn whoami_ok(server: &mut mockito::Server, path: &str, token: Option<&str>) -> mockito::Mock {
+        let mock = server.mock("GET", path);
+        let mock = match token {
+            Some(token) => mock
+                .match_header("authorization", format!("Bearer {token}").as_str())
+                .expect(1),
+            None => mock,
+        };
+        mock.with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .create()
+    }
 
     fn no_discovery_mock(server: &mut mockito::Server) -> mockito::Mock {
         server
@@ -1139,13 +1073,9 @@ mod login {
                 basic_challenge: false,
             } if index == &root && rejected == &vec![ProbeSurface::Read]
         ));
-        // Single rejecting surface: the plain wording names the endpoint
-        // and its answer.
+        // Single rejecting surface: the wording names the endpoint and
+        // its answer.
         let message = err.to_string();
-        assert!(
-            message.contains("the index rejected the token"),
-            "was: {message}"
-        );
         assert!(
             message.contains("`index.json` answered HTTP 401"),
             "was: {message}"
@@ -1172,14 +1102,7 @@ mod login {
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let whoami = server
-            .mock("GET", "/api/v1/whoami")
-            .match_header("authorization", "Bearer tok")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .expect(1)
-            .create();
+        let whoami = whoami_ok(&mut server, "/api/v1/whoami", Some("tok"));
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1228,10 +1151,6 @@ mod login {
         ));
         let message = err.to_string();
         assert!(
-            message.contains("the index rejected the token"),
-            "was: {message}"
-        );
-        assert!(
             message.contains("`v1/whoami` answered HTTP 401"),
             "was: {message}"
         );
@@ -1265,14 +1184,9 @@ mod login {
         ));
         let message = err.to_string();
         assert!(
-            message.contains("`index.json` answered HTTP 404"),
-            "was: {message}"
-        );
-        assert!(
             message.contains("or no index exists at this URL"),
             "was: {message}"
         );
-        assert!(message.contains("nothing was stored"), "was: {message}");
         assert!(store.list().unwrap().is_empty());
     }
 
@@ -1318,11 +1232,7 @@ mod login {
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
         let (_unauth, _forced) = private_index_json(&mut server, "tok", 401);
-        let _whoami = server
-            .mock("GET", "/api/v1/whoami")
-            .with_status(200)
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut server, "/api/v1/whoami", None);
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1356,11 +1266,7 @@ mod login {
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
         let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
-        let _whoami = server
-            .mock("GET", "/api/v1/whoami")
-            .with_status(200)
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut server, "/api/v1/whoami", None);
         let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
@@ -1457,7 +1363,6 @@ mod login {
             }
         ));
         let message = err.to_string();
-        assert!(message.contains("username/password"), "was: {message}");
         assert!(
             message.contains("SYSAND_CRED_<X>_BASIC_USER"),
             "was: {message}"
@@ -1617,13 +1522,7 @@ mod login {
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
         let _index = server.mock("GET", "/index.json").with_status(429).create();
-        let _whoami = server
-            .mock("GET", "/api/v1/whoami")
-            .match_header("authorization", "Bearer tok")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut server, "/api/v1/whoami", Some("tok"));
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1662,10 +1561,7 @@ mod login {
         ));
         let message = err.to_string();
         assert!(
-            message.contains(
-                "was rejected by the index read surface (`index.json`) \
-                 and the index API (`v1/whoami`) and accepted by no surface"
-            ),
+            message.contains("and accepted by no surface"),
             "was: {message}"
         );
         assert!(!message.contains("no index exists"), "was: {message}");
@@ -1696,14 +1592,7 @@ mod login {
             &format!(r#"{{"api_root": "{api_root}"}}"#),
         );
         let (unauth_index, forced_index) = private_index_json(&mut server, "tok", 200);
-        let whoami = api_server
-            .mock("GET", "/api/v1/whoami")
-            .match_header("authorization", "Bearer tok")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .expect(1)
-            .create();
+        let whoami = whoami_ok(&mut api_server, "/api/v1/whoami", Some("tok"));
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1757,14 +1646,7 @@ mod login {
             &format!(r#"{{"api_root": "{root}api/"}}"#),
         );
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let whoami = server
-            .mock("GET", "/api/v1/whoami")
-            .match_header("authorization", "Bearer tok")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .expect(1)
-            .create();
+        let whoami = whoami_ok(&mut server, "/api/v1/whoami", Some("tok"));
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1975,12 +1857,7 @@ mod login {
             .create();
         let forced = no_authed_config_mock(&mut server);
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let _whoami = server
-            .mock("GET", "/api/v1/whoami")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(WHOAMI_BODY)
-            .create();
+        let _whoami = whoami_ok(&mut server, "/api/v1/whoami", None);
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -315,21 +315,17 @@ fn status_surfaces_a_denied_backend_as_an_error() {
 // do_auth_login
 
 mod login {
-    use std::sync::Arc;
-
     use globset::{GlobBuilder, GlobSetBuilder};
 
     use super::super::{AuthLoginNotice, AuthLoginOutcome, do_auth_login};
     use super::*;
     use crate::{index_location::IndexLocation, resolve::net_utils::create_reqwest_client};
 
-    fn make_runtime() -> Arc<tokio::runtime::Runtime> {
-        Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap(),
-        )
+    fn make_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
     }
 
     /// Run `do_auth_login` against a real client/runtime, collecting the
@@ -351,7 +347,7 @@ mod login {
             index_url,
             secret.to_string(),
             &client,
-            make_runtime(),
+            &make_runtime(),
             |notice| notices.push(notice),
         );
         (outcome, notices)
@@ -1298,6 +1294,7 @@ mod login {
                 n,
                 AuthLoginNotice::SurfaceRejected {
                     surface: ProbeSurface::Api,
+                    read_status: None,
                     basic_challenge: false,
                 }
             )),
@@ -1332,6 +1329,10 @@ mod login {
                 n,
                 AuthLoginNotice::SurfaceRejected {
                     surface: ProbeSurface::Read,
+                    // The read surface carries its rejection status so
+                    // hosts can hedge a 404 (which can also mean no
+                    // `index.json` at all).
+                    read_status: Some(401),
                     basic_challenge: false,
                 }
             )),
@@ -2139,13 +2140,15 @@ mod whoami {
             matches!(&err, AuthCommandError::NoWhoamiCredential { .. }),
             "unexpected error: {err}"
         );
-        // The core message states the condition without naming a CLI
-        // command; the frontend adds the `sysand auth login` hint.
+        // The core message states the bare condition; all remediation
+        // (the `sysand auth login` hint and the `SYSAND_CRED_*` CI path)
+        // belongs to the frontend.
         let message = err.to_string();
         assert!(
             message.contains("no credential matches"),
             "message: {message}"
         );
         assert!(!message.contains("sysand auth"), "message: {message}");
+        assert!(!message.contains("SYSAND_CRED"), "message: {message}");
     }
 }

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1381,3 +1381,162 @@ mod login {
         assert_eq!(store.list().unwrap()[0].secret, "tok");
     }
 }
+
+// select_whoami_credential (auth whoami)
+
+mod whoami {
+    use url::Url;
+
+    use super::super::{AuthCommandError, WhoamiCredentialSource, select_whoami_credential};
+    use super::record;
+    use crate::auth::{EnvBearerAuth, ForceBearerAuth, GlobMap, GlobMapBuilder};
+
+    const INDEX_KEY: &str = "https://example.com/";
+
+    fn whoami_url() -> Url {
+        Url::parse("https://example.com/api/v1/whoami").unwrap()
+    }
+
+    fn env_map(entries: &[(&str, &str, &str)]) -> GlobMap<EnvBearerAuth> {
+        let mut builder = GlobMapBuilder::new();
+        for (label, pattern, token) in entries {
+            builder.add(
+                pattern,
+                EnvBearerAuth {
+                    auth: ForceBearerAuth::new(token),
+                    label: Some((*label).to_string()),
+                },
+            );
+        }
+        builder.build().unwrap()
+    }
+
+    #[test]
+    fn env_credential_wins_over_a_stored_login() {
+        let env = env_map(&[("TEAM", "https://example.com/**", "env-tok")]);
+        let records = [record(INDEX_KEY, "stored-tok")];
+
+        let (source, token) =
+            select_whoami_credential(&env, &records, &whoami_url(), INDEX_KEY).unwrap();
+
+        assert_eq!(
+            source,
+            WhoamiCredentialSource::Env {
+                label: Some("TEAM".to_string())
+            }
+        );
+        assert_eq!(token, "env-tok");
+    }
+
+    #[test]
+    fn stored_login_is_selected_when_no_env_credential_matches() {
+        let env = env_map(&[("OTHER", "https://other.example/**", "env-tok")]);
+        let records = [record(INDEX_KEY, "stored-tok")];
+
+        let (source, token) =
+            select_whoami_credential(&env, &records, &whoami_url(), INDEX_KEY).unwrap();
+
+        assert_eq!(
+            source,
+            WhoamiCredentialSource::Stored {
+                key: INDEX_KEY.to_string()
+            }
+        );
+        assert_eq!(token, "stored-tok");
+    }
+
+    #[test]
+    fn distinct_ambiguous_env_credentials_are_refused() {
+        let env = env_map(&[
+            ("A", "https://example.com/**", "tok-a"),
+            ("B", "https://example.com/api/**", "tok-b"),
+        ]);
+
+        let err = select_whoami_credential(&env, &[], &whoami_url(), INDEX_KEY).unwrap_err();
+
+        assert!(
+            matches!(
+                &err,
+                AuthCommandError::AmbiguousWhoamiCredential { candidates: 2, .. }
+            ),
+            "unexpected error: {err}"
+        );
+        assert!(err.to_string().contains("SYSAND_CRED_"));
+    }
+
+    #[test]
+    fn overlapping_env_globs_with_one_token_collapse_to_one_credential() {
+        // Overlapping patterns carrying the same token are one credential,
+        // not an ambiguity (mirrors the runtime's token dedup).
+        let env = env_map(&[
+            ("A", "https://example.com/**", "same-tok"),
+            ("B", "https://example.com/api/**", "same-tok"),
+        ]);
+
+        let (source, token) =
+            select_whoami_credential(&env, &[], &whoami_url(), INDEX_KEY).unwrap();
+
+        assert_eq!(
+            source,
+            WhoamiCredentialSource::Env {
+                label: Some("A".to_string())
+            }
+        );
+        assert_eq!(token, "same-tok");
+    }
+
+    #[test]
+    fn distinct_ambiguous_stored_logins_are_refused() {
+        let env = env_map(&[]);
+        let mut narrower = record("https://example.com/api/", "tok-b");
+        narrower.globs = vec!["https://example.com/api/**".to_string()];
+        let records = [record(INDEX_KEY, "tok-a"), narrower];
+
+        let err = select_whoami_credential(&env, &records, &whoami_url(), INDEX_KEY).unwrap_err();
+
+        assert!(
+            matches!(
+                &err,
+                AuthCommandError::AmbiguousWhoamiCredential { candidates: 2, .. }
+            ),
+            "unexpected error: {err}"
+        );
+        assert!(err.to_string().contains("stored logins"));
+    }
+
+    #[test]
+    fn invalid_stored_glob_is_skipped_without_hiding_the_record() {
+        // One bad pattern must not hide the record's other patterns (nor
+        // the other records): each glob is compiled individually.
+        let env = env_map(&[]);
+        let mut broken = record(INDEX_KEY, "stored-tok");
+        broken.globs = vec!["[invalid".to_string(), "https://example.com/**".to_string()];
+
+        let (source, token) =
+            select_whoami_credential(&env, &[broken], &whoami_url(), INDEX_KEY).unwrap();
+
+        assert_eq!(
+            source,
+            WhoamiCredentialSource::Stored {
+                key: INDEX_KEY.to_string()
+            }
+        );
+        assert_eq!(token, "stored-tok");
+    }
+
+    #[test]
+    fn no_matching_credential_suggests_login_for_the_index() {
+        let env = env_map(&[("OTHER", "https://other.example/**", "tok")]);
+
+        let err = select_whoami_credential(&env, &[], &whoami_url(), INDEX_KEY).unwrap_err();
+
+        assert!(
+            matches!(&err, AuthCommandError::NoWhoamiCredential { .. }),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("sysand auth login https://example.com/")
+        );
+    }
+}

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1020,6 +1020,128 @@ mod login {
         assert_eq!(record.expires_at, None);
     }
 
+    // 429 carve-out (design/credential-storage.md section 5): a 429 is
+    // never a verdict, so rate limiting can never refuse a credential.
+
+    #[test]
+    fn validated_login_treats_a_rate_limited_baseline_as_not_tested() {
+        // A 429 baseline sends no forced retry (it would spend more of
+        // the rate budget and prove nothing): stored, not validated.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let baseline = server
+            .mock("GET", "/index.json")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(429)
+            .expect(1)
+            .create();
+        let forced = server
+            .mock("GET", "/index.json")
+            .match_header("authorization", "Bearer tok")
+            .expect(0)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty(), "429 must not validate: {validated:?}");
+        assert_eq!(
+            notices,
+            vec![AuthLoginNotice::ProbeRateLimited {
+                surface: ProbeSurface::Read,
+            }]
+        );
+        baseline.assert();
+        forced.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_stores_when_the_forced_retry_is_rate_limited() {
+        // Formerly false-refusing sequence: baseline 401, forced 429
+        // counted as rejected and refused a possibly valid token. Now the
+        // surface is not tested and the credential is stored with a
+        // rate-limited warning.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let (unauth, forced) = private_index_json(&mut server, "tok", 429);
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty(), "429 must not validate: {validated:?}");
+        assert_eq!(
+            notices,
+            vec![AuthLoginNotice::ProbeRateLimited {
+                surface: ProbeSurface::Read,
+            }]
+        );
+        unauth.assert();
+        forced.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_treats_a_rate_limited_whoami_as_not_tested() {
+        // Public read, advertised API, whoami rate limited: nothing was
+        // tested, so the credential stores as "not validated" instead of
+        // being refused by the throttle.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(429)
+            .expect(1)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty(), "429 must not validate: {validated:?}");
+        assert_eq!(
+            notices,
+            vec![AuthLoginNotice::ProbeRateLimited {
+                surface: ProbeSurface::Api,
+            }]
+        );
+        whoami.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_validates_api_when_read_is_rate_limited() {
+        // A throttled read surface must not mask a working API probe: the
+        // stored claim is scoped to what actually accepted.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let _index = server.mock("GET", "/index.json").with_status(429).create();
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .match_header("authorization", "Bearer tok")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Api]);
+        assert_eq!(
+            notices,
+            vec![AuthLoginNotice::ProbeRateLimited {
+                surface: ProbeSurface::Read,
+            }]
+        );
+    }
+
     #[test]
     fn login_without_validation_sends_no_probe_requests() {
         // `--validation false` preserves the pre-validation behavior

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -22,6 +22,7 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
         subject: None,
         token_name: None,
         token_prefix: None,
+        validated: Vec::new(),
         extra: serde_json::Map::new(),
     }
 }
@@ -112,6 +113,7 @@ fn status_lists_stored_records_and_env_entries() {
     let mut expiring = record("https://example.com/idx/", "tok-1");
     let expiry = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
     expiring.expires_at = Some(expiry);
+    expiring.validated = vec!["read".to_string()];
     expiring.globs = vec![
         "https://example.com/idx/**".to_string(),
         "https://api.example.com/**".to_string(),
@@ -135,9 +137,11 @@ fn status_lists_stored_records_and_env_entries() {
         ]
     );
     assert_eq!(stored[0].expires_at, Some(expiry));
+    assert_eq!(stored[0].validated, vec!["read".to_string()]);
     assert_eq!(stored[1].key, "https://other.example/");
     assert_eq!(stored[1].expires_at, None);
     assert!(!stored[1].expired);
+    assert!(stored[1].validated.is_empty());
 }
 
 #[test]
@@ -374,7 +378,10 @@ mod login {
         assert!(notices.is_empty(), "unexpected notices: {notices:?}");
         // Flat topology: every surface lives under the discovery root.
         assert_surface_coverage(&globs, &root, &root, &root);
-        assert_eq!(store.list().unwrap()[0].secret, "tok");
+        let record = &store.list().unwrap()[0];
+        assert_eq!(record.secret, "tok");
+        // Validation was disabled: the record carries no claim.
+        assert!(record.validated.is_empty());
     }
 
     #[test]
@@ -910,6 +917,8 @@ mod login {
         assert_eq!(record.secret, "tok");
         assert_eq!(record.subject, None);
         assert_eq!(record.expires_at, None);
+        // The scoped claim is persisted for `auth status`.
+        assert_eq!(record.validated, vec!["read".to_string()]);
     }
 
     #[test]
@@ -1086,7 +1095,12 @@ mod login {
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Read, ProbeSurface::Api]);
-        assert!(store.list().unwrap()[0].subject.is_some());
+        let record = &store.list().unwrap()[0];
+        assert!(record.subject.is_some());
+        assert_eq!(
+            record.validated,
+            vec!["read".to_string(), "api".to_string()]
+        );
     }
 
     #[test]

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -19,6 +19,9 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
         scheme: CredentialScheme::Bearer,
         secret: secret.to_string(),
         expires_at: None,
+        subject: None,
+        token_name: None,
+        token_prefix: None,
         extra: serde_json::Map::new(),
     }
 }
@@ -254,12 +257,13 @@ mod login {
         )
     }
 
-    /// Run `do_auth_login` against a real client/runtime, collecting the
-    /// notices in order.
-    fn run_login<S: CredentialStore>(
+    /// Run `do_auth_login` with the given `validation` argument against a
+    /// real client/runtime, collecting the notices in order.
+    fn run_login_with<S: CredentialStore>(
         store: &mut S,
         index_url: &str,
         secret: &str,
+        validation: Option<bool>,
     ) -> (
         Result<AuthLoginOutcome, AuthCommandError>,
         Vec<AuthLoginNotice>,
@@ -270,11 +274,26 @@ mod login {
             store,
             index_url,
             secret.to_string(),
+            validation,
             &client,
             make_runtime(),
             |notice| notices.push(notice),
         );
         (outcome, notices)
+    }
+
+    /// Run `do_auth_login` with validation disabled: these tests cover
+    /// glob derivation and store behavior, which `--validation false`
+    /// preserves exactly, without needing probe mocks.
+    fn run_login<S: CredentialStore>(
+        store: &mut S,
+        index_url: &str,
+        secret: &str,
+    ) -> (
+        Result<AuthLoginOutcome, AuthCommandError>,
+        Vec<AuthLoginNotice>,
+    ) {
+        run_login_with(store, index_url, secret, Some(false))
     }
 
     /// Compile globs exactly the way runtime matching does
@@ -293,8 +312,19 @@ mod login {
     }
 
     fn stored(outcome: Result<AuthLoginOutcome, AuthCommandError>) -> (String, Vec<String>) {
+        let (key, globs, _) = stored_validated(outcome);
+        (key, globs)
+    }
+
+    fn stored_validated(
+        outcome: Result<AuthLoginOutcome, AuthCommandError>,
+    ) -> (String, Vec<String>, Vec<super::super::ProbeSurface>) {
         match outcome.unwrap() {
-            AuthLoginOutcome::Stored { key, globs } => (key, globs),
+            AuthLoginOutcome::Stored {
+                key,
+                globs,
+                validated,
+            } => (key, globs, validated),
             other => panic!("expected Stored, got {other:?}"),
         }
     }
@@ -572,5 +602,450 @@ mod login {
         let err = do_auth_logout(&mut store, "https://files.example.com/{path}").unwrap_err();
 
         assert!(matches!(err, AuthCommandError::TemplateIndexUrl { .. }));
+    }
+
+    // Validation probes (design/credential-storage.md section 5).
+    //
+    // All tests follow the existing pattern: a sync `mockito::Server`
+    // created before any `runtime.block_on` (never `#[tokio::test]`, which
+    // would nest runtimes).
+
+    use super::super::ProbeSurface;
+
+    const WHOAMI_BODY: &str = r#"{"subject":{"type":"user","name":"alice"},
+        "token":{"name":"laptop","prefix":"sysand_u_1a2b3c4d",
+                 "expires_at":"2026-09-01T00:00:00Z"}}"#;
+
+    fn no_discovery_mock(server: &mut mockito::Server) -> mockito::Mock {
+        server
+            .mock("GET", "/sysand-index-config.json")
+            .with_status(404)
+            .create()
+    }
+
+    /// Mock a private `index.json`: 401 without credentials,
+    /// `forced_status` with exactly the expected bearer token.
+    fn private_index_json(
+        server: &mut mockito::Server,
+        token: &str,
+        forced_status: usize,
+    ) -> (mockito::Mock, mockito::Mock) {
+        let unauth = server
+            .mock("GET", "/index.json")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(401)
+            .create();
+        let forced = server
+            .mock("GET", "/index.json")
+            .match_header("authorization", format!("Bearer {token}").as_str())
+            .with_status(forced_status)
+            .create();
+        (unauth, forced)
+    }
+
+    #[test]
+    fn validated_login_on_public_index_without_api_stores_not_validated() {
+        // S1: public read, no API. Nothing exercises the credential, and
+        // the flat/defaulted api_root must never be phantom-probed.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty(), "nothing was exercised: {validated:?}");
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        whoami.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_does_not_probe_a_defaulted_api_root() {
+        // A discovery document without `api_root` defaults the API to the
+        // discovery root at runtime, but that default is not an
+        // advertisement: no whoami probe.
+        let mut server = mockito::Server::new();
+        let _config = config_mock(&mut server, "{}".to_string());
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        whoami.assert();
+    }
+
+    #[test]
+    fn validated_login_on_private_read_index_validates_read() {
+        // S2: private static index. The read baseline 401s, the forced
+        // retry succeeds: validated (read).
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let (unauth, forced) = private_index_json(&mut server, "tok", 200);
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Read]);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        unauth.assert();
+        forced.assert();
+        let record = &store.list().unwrap()[0];
+        assert_eq!(record.secret, "tok");
+        assert_eq!(record.subject, None);
+        assert_eq!(record.expires_at, None);
+    }
+
+    #[test]
+    fn validated_login_probes_read_when_discovery_is_private() {
+        // A fully private index rejects even the discovery fetch; the
+        // read probe falls back to the URL-derived `index.json` so the
+        // credential still gets exercised.
+        let mut server = mockito::Server::new();
+        let _config = server
+            .mock("GET", "/sysand-index-config.json")
+            .with_status(401)
+            .create();
+        let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Read]);
+        assert!(
+            notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::DiscoveryUnreachable { .. }))
+        );
+    }
+
+    #[test]
+    fn validated_login_refuses_when_the_only_exercised_surface_rejects() {
+        // The refusal rule: read rejected, nothing else exercised. An
+        // existing login for the same key must survive untouched, and no
+        // replacement may be announced.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = no_discovery_mock(&mut server);
+        let _index = server
+            .mock("GET", "/index.json")
+            .with_status(401)
+            .expect(2)
+            .create();
+        let mut store = store_with(&[record(&root, "old-tok")]);
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "bad-tok", None);
+
+        let err = outcome.unwrap_err();
+        assert!(matches!(
+            &err,
+            AuthCommandError::ValidationRejected {
+                index,
+                rejected,
+                basic_challenge: false,
+            } if index == &root && rejected == &vec![ProbeSurface::Read]
+        ));
+        assert!(err.to_string().contains("nothing was stored"));
+        assert!(
+            !notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::ReplacingExisting { .. })),
+            "a refused login must not announce a replacement: {notices:?}"
+        );
+        assert_eq!(store.list().unwrap()[0].secret, "old-tok");
+    }
+
+    #[test]
+    fn validated_login_validates_an_advertised_api_and_persists_identity() {
+        // S3: public read, advertised API. whoami 200 validates (api) and
+        // its identity fields are persisted on the record.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .match_header("authorization", "Bearer tok")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .expect(1)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Api]);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        whoami.assert();
+        let record = &store.list().unwrap()[0];
+        assert_eq!(
+            record.subject,
+            Some(crate::credential_store::CredentialSubject {
+                kind: "user".to_string(),
+                name: "alice".to_string(),
+            })
+        );
+        assert_eq!(record.token_name.as_deref(), Some("laptop"));
+        assert_eq!(record.token_prefix.as_deref(), Some("sysand_u_1a2b3c4d"));
+        assert_eq!(
+            record.expires_at,
+            Some(Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn validated_login_refuses_when_whoami_rejects_on_a_public_index() {
+        // Public read never tests the token, so whoami is the only real
+        // test; a 401 there refuses, keeping the publish flow protected.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(401)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        assert!(matches!(
+            outcome.unwrap_err(),
+            AuthCommandError::ValidationRejected { rejected, .. }
+                if rejected == vec![ProbeSurface::Api]
+        ));
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn validated_login_stores_with_a_warning_when_read_accepts_and_api_rejects() {
+        // Private index, read works, API rejects: store with an
+        // "API access failed" warning (the token still reads).
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(401)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Read]);
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::SurfaceRejected {
+                    surface: ProbeSurface::Api,
+                    basic_challenge: false,
+                }
+            )),
+            "expected an api rejection notice, got {notices:?}"
+        );
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_validates_both_surfaces() {
+        // S4: private read accepts and whoami accepts: validated
+        // (read, api), in probe order.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(200)
+            .with_body(WHOAMI_BODY)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Read, ProbeSurface::Api]);
+        assert!(store.list().unwrap()[0].subject.is_some());
+    }
+
+    #[test]
+    fn validated_login_stores_not_validated_when_probes_are_unreachable() {
+        // 5xx is not a verdict: the surface was not tested, and with
+        // nothing else exercised the login stores as not validated.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server.mock("GET", "/index.json").with_status(500).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::ProbeUnreachable {
+                    surface: ProbeSurface::Read,
+                    ..
+                }
+            )),
+            "expected an unreachable notice, got {notices:?}"
+        );
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_treats_a_redirected_probe_as_not_tested() {
+        // Probes never follow redirects; the verdict would come from a
+        // different URL than the surface nominally probed.
+        let target = "https://elsewhere.example/idx/index.json";
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server
+            .mock("GET", "/index.json")
+            .with_status(302)
+            .with_header("location", target)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::ProbeRedirected {
+                    surface: ProbeSurface::Read,
+                    target: t,
+                } if t == target
+            )),
+            "expected a redirect notice naming `{target}`, got {notices:?}"
+        );
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_refusal_names_basic_authentication() {
+        // A basic-auth index must not dead-end: the refusal routes the
+        // user to the `SYSAND_CRED_*` basic credentials.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server
+            .mock("GET", "/index.json")
+            .with_status(401)
+            .with_header("www-authenticate", r#"Basic realm="idx""#)
+            .expect(2)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let err = outcome.unwrap_err();
+        assert!(matches!(
+            &err,
+            AuthCommandError::ValidationRejected {
+                basic_challenge: true,
+                ..
+            }
+        ));
+        let message = err.to_string();
+        assert!(message.contains("username/password"), "was: {message}");
+        assert!(
+            message.contains("SYSAND_CRED_<X>_BASIC_USER"),
+            "was: {message}"
+        );
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn validated_login_ignores_a_bearer_challenge_mentioning_basic() {
+        // Scheme detection must not be a substring check: a `Bearer`
+        // challenge whose realm mentions Basic is not a basic challenge.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server
+            .mock("GET", "/index.json")
+            .with_status(401)
+            .with_header("www-authenticate", r#"Bearer realm="Basic migration""#)
+            .expect(2)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        assert!(matches!(
+            outcome.unwrap_err(),
+            AuthCommandError::ValidationRejected {
+                basic_challenge: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validated_login_accepts_whoami_with_an_unparseable_body() {
+        // The 200 status is the acceptance verdict; a body this client
+        // cannot parse only loses the identity fields.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(200)
+            .with_body("not json")
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Api]);
+        let record = &store.list().unwrap()[0];
+        assert_eq!(record.subject, None);
+        assert_eq!(record.token_name, None);
+        assert_eq!(record.token_prefix, None);
+        assert_eq!(record.expires_at, None);
+    }
+
+    #[test]
+    fn login_without_validation_sends_no_probe_requests() {
+        // `--validation false` preserves the pre-validation behavior
+        // exactly: discovery is still fetched for glob scoping, but no
+        // probe request is ever made.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let config = server
+            .mock("GET", "/sysand-index-config.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(r#"{{"api_root": "{root}api/"}}"#))
+            .expect(1)
+            .create();
+        let index = server.mock("GET", "/index.json").expect(0).create();
+        let whoami = server.mock("GET", "/api/v1/whoami").expect(0).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", Some(false));
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        config.assert();
+        index.assert();
+        whoami.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
     }
 }

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1085,9 +1085,8 @@ mod login {
             AuthCommandError::ValidationRejected {
                 index,
                 rejected,
-                read_status: Some(401),
                 basic_challenge: false,
-            } if index == &root && rejected == &vec![ProbeSurface::Read]
+            } if index == &root && rejected == &vec![(ProbeSurface::Read, 401)]
         ));
         // Single rejecting surface: the wording names the endpoint and
         // its answer.
@@ -1163,7 +1162,7 @@ mod login {
         assert!(matches!(
             &err,
             AuthCommandError::ValidationRejected { rejected, .. }
-                if rejected == &vec![ProbeSurface::Api]
+                if rejected == &vec![(ProbeSurface::Api, 401)]
         ));
         let message = err.to_string();
         assert!(
@@ -1192,16 +1191,47 @@ mod login {
         let err = outcome.unwrap_err();
         assert!(matches!(
             &err,
-            AuthCommandError::ValidationRejected {
-                rejected,
-                read_status: Some(404),
-                ..
-            } if rejected == &vec![ProbeSurface::Read]
+            AuthCommandError::ValidationRejected { rejected, .. }
+                if rejected == &vec![(ProbeSurface::Read, 404)]
         ));
         let message = err.to_string();
         assert!(
+            message.contains("`index.json` answered HTTP 404"),
+            "was: {message}"
+        );
+        assert!(
             message.contains("or no index exists at this URL"),
             "was: {message}"
+        );
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn validated_login_refusal_reports_the_actual_read_rejection_status() {
+        // The read surface rejects on any non-429 4xx, not just 401; the
+        // refusal must report the status the surface actually answered
+        // (a 403 here), and only a 404 gets the no-index hedge.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let (_unauth, _forced) = private_index_json(&mut server, "tok", 403);
+        let mut store = in_memory_store();
+
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
+
+        let err = outcome.unwrap_err();
+        assert!(matches!(
+            &err,
+            AuthCommandError::ValidationRejected { rejected, .. }
+                if rejected == &vec![(ProbeSurface::Read, 403)]
+        ));
+        let message = err.to_string();
+        assert!(
+            message.contains("`index.json` answered HTTP 403"),
+            "was: {message}"
+        );
+        assert!(
+            !message.contains("no index exists"),
+            "a 403 must not be hedged: {message}"
         );
         assert!(store.list().unwrap().is_empty());
     }
@@ -1229,7 +1259,7 @@ mod login {
                 n,
                 AuthLoginNotice::SurfaceRejected {
                     surface: ProbeSurface::Api,
-                    read_status: None,
+                    status: 401,
                     basic_challenge: false,
                 }
             )),
@@ -1260,10 +1290,10 @@ mod login {
                 n,
                 AuthLoginNotice::SurfaceRejected {
                     surface: ProbeSurface::Read,
-                    // The read surface carries its rejection status so
-                    // hosts can hedge a 404 (which can also mean no
-                    // `index.json` at all).
-                    read_status: Some(401),
+                    // The surface carries its rejection status so hosts
+                    // can report it and hedge a read 404 (which can also
+                    // mean no `index.json` at all).
+                    status: 401,
                     basic_challenge: false,
                 }
             )),
@@ -1573,13 +1603,16 @@ mod login {
         assert!(matches!(
             &err,
             AuthCommandError::ValidationRejected { rejected, .. }
-                if rejected == &vec![ProbeSurface::Read, ProbeSurface::Api]
+                if rejected == &vec![(ProbeSurface::Read, 404), (ProbeSurface::Api, 401)]
         ));
         let message = err.to_string();
         assert!(
             message.contains("and accepted by no surface"),
             "was: {message}"
         );
+        // The enumeration names each surface's own answer.
+        assert!(message.contains("`index.json`, HTTP 404"), "was: {message}");
+        assert!(message.contains("`v1/whoami`, HTTP 401"), "was: {message}");
         assert!(!message.contains("no index exists"), "was: {message}");
         assert!(store.list().unwrap().is_empty());
     }
@@ -1724,7 +1757,7 @@ mod login {
         assert!(matches!(
             outcome.unwrap_err(),
             AuthCommandError::ValidationRejected { rejected, .. }
-                if rejected == vec![ProbeSurface::Read]
+                if rejected == vec![(ProbeSurface::Read, 401)]
         ));
         assert!(
             notices.iter().any(|n| matches!(

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1968,9 +1968,13 @@ mod whoami {
             matches!(&err, AuthCommandError::NoWhoamiCredential { .. }),
             "unexpected error: {err}"
         );
+        // The core message states the condition without naming a CLI
+        // command; the frontend adds the `sysand auth login` hint.
+        let message = err.to_string();
         assert!(
-            err.to_string()
-                .contains("sysand auth login https://example.com/")
+            message.contains("no credential matches"),
+            "message: {message}"
         );
+        assert!(!message.contains("sysand auth"), "message: {message}");
     }
 }

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -560,23 +560,26 @@ mod login {
     }
 
     #[test]
-    fn login_skips_an_unanchorable_template_index_root() {
+    fn login_anchors_a_query_only_template_index_root_at_the_host() {
         let mut server = mockito::Server::new();
         let mut files_server = mockito::Server::new();
         let root = format!("{}/", server.url());
-        // Placeholder directly in the query of a path-less URL: the only
-        // `/` in the literal prefix is the one in `://`, so anchoring
-        // would produce a glob matching every URL of the scheme.
+        // Placeholder directly in the query of a path-less URL: template
+        // parsing normalizes the prefix to an explicit `/` path, so the
+        // anchor is the host root (which is exactly the surface such a
+        // template can address).
         let template = format!("{}?f={{path}}", files_server.url());
         let _mock = config_mock(&mut server, format!(r#"{{"index_root": "{template}"}}"#));
-        // The read probe still expands the unanchorable template (only
-        // the glob was skipped), landing on the host root.
-        let _index = files_server
+        // The read probe expands the template, landing on the host root.
+        let index_query = mockito::Matcher::UrlEncoded("f".into(), "index.json".into());
+        let _index_head = files_server
+            .mock("HEAD", "/")
+            .match_query(index_query.clone())
+            .with_status(200)
+            .create();
+        let _index_get = files_server
             .mock("GET", "/")
-            .match_query(mockito::Matcher::UrlEncoded(
-                "f".into(),
-                "index.json".into(),
-            ))
+            .match_query(index_query)
             .with_status(200)
             .create();
         let mut store = in_memory_store();
@@ -584,12 +587,17 @@ mod login {
         let (outcome, notices) = run_login(&mut store, &root, "tok");
 
         let (_, globs) = stored(outcome);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        let anchor = format!("{}/", files_server.url());
         assert!(
-            notices
-                .iter()
-                .any(|n| matches!(n, AuthLoginNotice::TemplateIndexRootSkipped { .. })),
-            "expected a skip notice, got {notices:?}"
+            globs.contains(&format!("{}**", globset::escape(&anchor))),
+            "expected a host-root glob for the templated index_root: {globs:?}"
         );
+        // The templated index.json URL (placeholder expansion) matches.
+        let index_json = IndexLocation::parse(&template)
+            .unwrap()
+            .resolve(["index.json"]);
+        assert!(matcher(&globs).is_match(index_json.as_str()));
         assert!(
             !matcher(&globs).is_match("https://attacker.example/x"),
             "no derived glob may cover other hosts: {globs:?}"
@@ -662,17 +670,17 @@ mod login {
     // Template targets: templated login targets are supported, anchored
     // on their literal URL prefix.
 
-    /// The motivating GitLab-shaped target: the key is the template text
-    /// itself (already canonical), with the anchor normalizing only the
-    /// URL-parsed part of the literal prefix.
+    /// The motivating GitLab-shaped target: the key is the template's
+    /// canonical `Display` text, with the literal prefix normalized at
+    /// parse time.
     #[test]
-    fn template_key_is_the_template_with_a_normalized_anchor() {
+    fn template_key_is_the_template_with_a_normalized_prefix() {
         let gitlab =
             "https://gitlab.com/api/v4/projects/84113019/repository/files/{path}/raw?ref=index";
 
         assert_eq!(IndexKey::validate(gitlab).unwrap().as_str(), gitlab);
-        // Scheme/host case and the default port normalize through the
-        // anchor; the placeholder and suffix stay verbatim.
+        // Scheme/host case and the default port normalize into the
+        // prefix; the placeholder and suffix stay verbatim.
         let spelled =
             "HTTPS://GitLab.COM:443/api/v4/projects/84113019/repository/files/{path}/raw?ref=index";
         assert_eq!(IndexKey::validate(spelled).unwrap().as_str(), gitlab);
@@ -818,21 +826,28 @@ mod login {
     }
 
     #[test]
-    fn login_rejects_an_unanchorable_template_target() {
-        // Placeholder directly in the query of a path-less URL: the only
-        // `/` in the literal prefix is the one in `://`.
+    fn login_normalizes_a_query_only_template_target_to_the_host_root() {
+        // Placeholder directly in the query of a path-less URL: the key
+        // gains the explicit root `/` and the glob anchors on the host
+        // root. Port 1 answers nothing, so discovery is unreachable and
+        // the glob set is the anchor-derived fallback.
         let mut store = in_memory_store();
 
-        // Fails in key validation, before any network or store access.
-        let (outcome, notices) = run_login(&mut store, "https://files.example.com?f={path}", "tok");
+        let (outcome, notices) = run_login(&mut store, "http://127.0.0.1:1?f={path}", "tok");
 
-        let err = outcome.unwrap_err();
-        assert!(matches!(
-            &err,
-            AuthCommandError::TemplateWithoutAnchor { .. }
-        ));
-        assert!(err.to_string().contains("SYSAND_CRED_"), "was: {err}");
-        assert!(notices.is_empty());
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, "http://127.0.0.1:1/?f={path}");
+        assert_eq!(
+            globs,
+            vec![format!("{}**", globset::escape("http://127.0.0.1:1/"))]
+        );
+        assert!(
+            notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::DiscoveryUnreachable { .. }))
+        );
+        // `logout` accepts the normalized key `status` would print.
+        assert_eq!(logout(&mut store, &key).unwrap(), key);
         assert!(store.list().unwrap().is_empty());
     }
 

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -331,13 +331,14 @@ mod login {
         )
     }
 
-    /// Run `do_auth_login` with the given `validation` argument against a
-    /// real client/runtime, collecting the notices in order.
-    fn run_login_with<S: CredentialStore>(
+    /// Run `do_auth_login` against a real client/runtime, collecting the
+    /// notices in order. Validation always runs, so tests mock every
+    /// surface a probe would touch (or point at an unreachable local
+    /// port, where the probes degrade to warnings).
+    fn run_login<S: CredentialStore>(
         store: &mut S,
         index_url: &str,
         secret: &str,
-        validation: Option<bool>,
     ) -> (
         Result<AuthLoginOutcome, AuthCommandError>,
         Vec<AuthLoginNotice>,
@@ -348,26 +349,11 @@ mod login {
             store,
             index_url,
             secret.to_string(),
-            validation,
             &client,
             make_runtime(),
             |notice| notices.push(notice),
         );
         (outcome, notices)
-    }
-
-    /// Run `do_auth_login` with validation disabled: these tests cover
-    /// glob derivation and store behavior, which `--validation false`
-    /// preserves exactly, without needing probe mocks.
-    fn run_login<S: CredentialStore>(
-        store: &mut S,
-        index_url: &str,
-        secret: &str,
-    ) -> (
-        Result<AuthLoginOutcome, AuthCommandError>,
-        Vec<AuthLoginNotice>,
-    ) {
-        run_login_with(store, index_url, secret, Some(false))
     }
 
     /// Compile globs exactly the way runtime matching does
@@ -434,10 +420,14 @@ mod login {
     fn login_without_discovery_document_derives_a_single_glob() {
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
+        // 404 on both discovery legs (baseline and forced retry).
         let _mock = server
             .mock("GET", "/sysand-index-config.json")
             .with_status(404)
+            .expect(2)
             .create();
+        // Public read surface: probed, but never exercises the token.
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
         let mut store = InMemoryCredentialStore::new();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -450,7 +440,7 @@ mod login {
         assert_surface_coverage(&globs, &root, &root, &root);
         let record = &store.list().unwrap()[0];
         assert_eq!(record.secret, "tok");
-        // Validation was disabled: the record carries no claim.
+        // Nothing exercised the token: the record carries no claim.
         assert!(record.validated.is_empty());
     }
 
@@ -460,6 +450,13 @@ mod login {
         let root = format!("{}/", server.url());
         let api_root = format!("{root}api/");
         let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .create();
         let mut store = InMemoryCredentialStore::new();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
@@ -473,9 +470,19 @@ mod login {
     #[test]
     fn login_with_disjoint_api_root_adds_a_second_glob() {
         let mut server = mockito::Server::new();
+        // A second server stands in for the disjoint API host, so the
+        // advertised-api whoami probe has somewhere real to go.
+        let mut api_server = mockito::Server::new();
         let root = format!("{}/", server.url());
-        let api_root = "https://api.example.com/base/";
+        let api_root = format!("{}/base/", api_server.url());
         let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _whoami = api_server
+            .mock("GET", "/base/v1/whoami")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .create();
         let mut store = InMemoryCredentialStore::new();
 
         let (outcome, _) = run_login(&mut store, &root, "tok");
@@ -485,10 +492,10 @@ mod login {
             globs,
             vec![
                 format!("{}**", globset::escape(&root)),
-                format!("{}**", globset::escape(api_root)),
+                format!("{}**", globset::escape(&api_root)),
             ]
         );
-        assert_surface_coverage(&globs, &root, &root, api_root);
+        assert_surface_coverage(&globs, &root, &root, &api_root);
         // Non-overlapping: the api glob stays host-scoped.
         assert!(!matcher(&globs[1..]).is_match(format!("{root}index.json")));
     }
@@ -496,61 +503,99 @@ mod login {
     #[test]
     fn login_with_divergent_index_and_api_roots_adds_three_globs() {
         let mut server = mockito::Server::new();
+        // Real stand-ins for the divergent hosts, since the read probe
+        // follows the resolved index_root and whoami the advertised
+        // api_root.
+        let mut files_server = mockito::Server::new();
+        let mut api_server = mockito::Server::new();
         let root = format!("{}/", server.url());
-        let index_root = "https://files.example.com/idx/";
-        let api_root = "https://api.example.com/";
+        let index_root = format!("{}/idx/", files_server.url());
+        let api_root = format!("{}/", api_server.url());
         let _mock = config_mock(
             &mut server,
             format!(r#"{{"index_root": "{index_root}", "api_root": "{api_root}"}}"#),
         );
+        let _index = files_server
+            .mock("GET", "/idx/index.json")
+            .with_status(200)
+            .create();
+        let _whoami = api_server
+            .mock("GET", "/v1/whoami")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .create();
         let mut store = InMemoryCredentialStore::new();
 
         let (outcome, _) = run_login(&mut store, &root, "tok");
 
         let (_, globs) = stored(outcome);
         assert_eq!(globs.len(), 3, "Case B twice over: {globs:?}");
-        assert_surface_coverage(&globs, &root, index_root, api_root);
+        assert_surface_coverage(&globs, &root, &index_root, &api_root);
     }
 
     #[test]
     fn login_with_templated_index_root_anchors_before_the_placeholder() {
         let mut server = mockito::Server::new();
+        let mut files_server = mockito::Server::new();
+        let mut api_server = mockito::Server::new();
         let root = format!("{}/", server.url());
-        let template = "https://files.example.com/repo/{path}/raw?ref=main";
-        let api_root = "https://api.example.com/";
+        let template = format!("{}/repo/{{path}}/raw?ref=main", files_server.url());
+        let anchor = format!("{}/repo/", files_server.url());
+        let api_root = format!("{}/", api_server.url());
         let _mock = config_mock(
             &mut server,
             format!(r#"{{"index_root": "{template}", "api_root": "{api_root}"}}"#),
         );
+        // The read probe expands the template exactly like runtime reads.
+        let _index = files_server
+            .mock("GET", "/repo/index.json/raw")
+            .match_query(mockito::Matcher::UrlEncoded("ref".into(), "main".into()))
+            .with_status(200)
+            .create();
+        let _whoami = api_server
+            .mock("GET", "/v1/whoami")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .create();
         let mut store = InMemoryCredentialStore::new();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
 
         let (_, globs) = stored(outcome);
         assert!(notices.is_empty(), "unexpected notices: {notices:?}");
-        assert_eq!(
-            globs[1],
-            format!("{}**", globset::escape("https://files.example.com/repo/"))
-        );
+        assert_eq!(globs[1], format!("{}**", globset::escape(&anchor)));
         // The templated index.json URL (placeholder expansion) matches.
-        let index_json = IndexLocation::parse(template).unwrap().resolve([
+        let index_json = IndexLocation::parse(&template).unwrap().resolve([
             "some-publisher",
             "some.name",
             "index.json",
         ]);
         assert!(matcher(&globs).is_match(index_json.as_str()));
-        assert_surface_coverage(&globs, &root, "https://files.example.com/repo/", api_root);
+        assert_surface_coverage(&globs, &root, &anchor, &api_root);
     }
 
     #[test]
     fn login_skips_an_unanchorable_template_index_root() {
         let mut server = mockito::Server::new();
+        let mut files_server = mockito::Server::new();
         let root = format!("{}/", server.url());
         // Placeholder directly in the query of a path-less URL: the only
         // `/` in the literal prefix is the one in `://`, so anchoring
-        // would produce a glob matching every https URL.
-        let template = "https://files.example.com?f={path}";
+        // would produce a glob matching every URL of the scheme.
+        let template = format!("{}?f={{path}}", files_server.url());
         let _mock = config_mock(&mut server, format!(r#"{{"index_root": "{template}"}}"#));
+        // The read probe still expands the unanchorable template (only
+        // the glob was skipped), landing on the host root.
+        let _index = files_server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "f".into(),
+                "index.json".into(),
+            ))
+            .with_status(200)
+            .create();
         let mut store = InMemoryCredentialStore::new();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
@@ -572,10 +617,14 @@ mod login {
     fn login_with_unauthorized_discovery_falls_back_with_a_notice() {
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
+        // 401 on both discovery legs (baseline and forced retry).
         let _mock = server
             .mock("GET", "/sysand-index-config.json")
             .with_status(401)
+            .expect(2)
             .create();
+        // Keep the read probe quiet: the discovery notice is the point.
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
         let mut store = InMemoryCredentialStore::new();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
@@ -711,6 +760,13 @@ mod login {
             .mock("GET", "/repo/files/sysand-index-config.json/raw")
             .match_query(mockito::Matcher::UrlEncoded("ref".into(), "index".into()))
             .with_status(404)
+            .expect(2)
+            .create();
+        // Public read surface, so the probe leaves no notice.
+        let _index = server
+            .mock("GET", "/repo/files/index.json/raw")
+            .match_query(mockito::Matcher::UrlEncoded("ref".into(), "index".into()))
+            .with_status(200)
             .create();
         let mut store = InMemoryCredentialStore::new();
 
@@ -879,7 +935,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &template, "tok", None);
+        let (outcome, notices) = run_login(&mut store, &template, "tok");
 
         let (key, _, validated) = stored_validated(outcome);
         assert_eq!(key, template);
@@ -930,6 +986,45 @@ mod login {
         (unauth, forced)
     }
 
+    /// Mock the unauthenticated discovery baseline: `status` when no
+    /// credential is sent.
+    fn unauth_config_mock(server: &mut mockito::Server, status: usize) -> mockito::Mock {
+        server
+            .mock("GET", "/sysand-index-config.json")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(status)
+            .expect(1)
+            .create()
+    }
+
+    /// Mock the forced discovery retry: `status`/`body` for exactly the
+    /// expected bearer token.
+    fn forced_config_mock(
+        server: &mut mockito::Server,
+        token: &str,
+        status: usize,
+        body: &str,
+    ) -> mockito::Mock {
+        server
+            .mock("GET", "/sysand-index-config.json")
+            .match_header("authorization", format!("Bearer {token}").as_str())
+            .with_status(status)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .expect(1)
+            .create()
+    }
+
+    /// Mock matching any credentialed discovery request, for
+    /// `expect(0)` "the secret never went out" assertions.
+    fn no_authed_config_mock(server: &mut mockito::Server) -> mockito::Mock {
+        server
+            .mock("GET", "/sysand-index-config.json")
+            .match_header("authorization", mockito::Matcher::Regex(".+".to_string()))
+            .expect(0)
+            .create()
+    }
+
     #[test]
     fn validated_login_on_public_index_without_api_stores_not_validated() {
         // S1: public read, no API. Nothing exercises the credential, and
@@ -940,7 +1035,7 @@ mod login {
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert!(validated.is_empty(), "nothing was exercised: {validated:?}");
@@ -960,7 +1055,7 @@ mod login {
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert!(validated.is_empty());
@@ -976,7 +1071,7 @@ mod login {
         let (unauth, forced) = private_index_json(&mut server, "tok", 200);
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Read]);
@@ -1004,7 +1099,7 @@ mod login {
         let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Read]);
@@ -1030,7 +1125,7 @@ mod login {
             .create();
         let mut store = store_with(&[record(&root, "old-tok")]);
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "bad-tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "bad-tok");
 
         let err = outcome.unwrap_err();
         assert!(matches!(
@@ -1069,7 +1164,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Api]);
@@ -1105,7 +1200,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
         assert!(matches!(
             outcome.unwrap_err(),
@@ -1129,7 +1224,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Read]);
@@ -1161,7 +1256,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Read, ProbeSurface::Api]);
@@ -1182,7 +1277,7 @@ mod login {
         let _index = server.mock("GET", "/index.json").with_status(500).create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert!(validated.is_empty());
@@ -1213,7 +1308,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert!(validated.is_empty());
@@ -1244,7 +1339,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
         let err = outcome.unwrap_err();
         assert!(matches!(
@@ -1277,7 +1372,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
         assert!(matches!(
             outcome.unwrap_err(),
@@ -1303,7 +1398,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, _) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Api]);
@@ -1336,7 +1431,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert!(validated.is_empty(), "429 must not validate: {validated:?}");
@@ -1362,7 +1457,7 @@ mod login {
         let (unauth, forced) = private_index_json(&mut server, "tok", 429);
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert!(validated.is_empty(), "429 must not validate: {validated:?}");
@@ -1393,7 +1488,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert!(validated.is_empty(), "429 must not validate: {validated:?}");
@@ -1424,7 +1519,7 @@ mod login {
             .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", None);
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
         assert_eq!(validated, vec![ProbeSurface::Api]);
@@ -1436,33 +1531,288 @@ mod login {
         );
     }
 
+    // Authenticated discovery (design/credential-storage.md section 5):
+    // the login discovery fetch is an unauth baseline retried once with a
+    // forced bearer on any 4xx (scoping is knowing the topology, not
+    // validating the credential, so its outcome never refuses a login).
+
     #[test]
-    fn login_without_validation_sends_no_probe_requests() {
-        // `--validation false` preserves the pre-validation behavior
-        // exactly: discovery is still fetched for glob scoping, but no
-        // probe request is ever made.
+    fn validated_login_uses_authed_discovery_on_a_private_index() {
+        // S4: fully private index with a disjoint api_root. The
+        // unauthenticated discovery baseline 401s; the forced retry reads
+        // the document, so the login learns the disjoint api_root, covers
+        // it with a glob, and probes whoami there.
+        let mut server = mockito::Server::new();
+        let mut api_server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let api_root = format!("{}/api/", api_server.url());
+        let unauth_config = unauth_config_mock(&mut server, 401);
+        let forced_config = forced_config_mock(
+            &mut server,
+            "tok",
+            200,
+            &format!(r#"{{"api_root": "{api_root}"}}"#),
+        );
+        let (unauth_index, forced_index) = private_index_json(&mut server, "tok", 200);
+        let whoami = api_server
+            .mock("GET", "/api/v1/whoami")
+            .match_header("authorization", "Bearer tok")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .expect(1)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, globs, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Read, ProbeSurface::Api]);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        assert_eq!(
+            globs.len(),
+            2,
+            "disjoint api_root must add a glob: {globs:?}"
+        );
+        assert_surface_coverage(&globs, &root, &root, &api_root);
+        for mock in [
+            unauth_config,
+            forced_config,
+            unauth_index,
+            forced_index,
+            whoami,
+        ] {
+            mock.assert();
+        }
+        let record = &store.list().unwrap()[0];
+        assert_eq!(
+            record.validated,
+            vec!["read".to_string(), "api".to_string()]
+        );
+        // The whoami identity fields are persisted on the record.
+        assert_eq!(
+            record.subject,
+            Some(crate::credential_store::CredentialSubject {
+                kind: "user".to_string(),
+                name: "alice".to_string(),
+            })
+        );
+        assert_eq!(record.token_prefix.as_deref(), Some("sysand_u_1a2b3c4d"));
+    }
+
+    #[test]
+    fn validated_login_uses_authed_discovery_after_a_404_baseline() {
+        // GitLab answers 404, not 401, when auth is missing, so a 404
+        // baseline can hide a real document; the forced retry uncovers
+        // it, proven by the whoami probe at the advertised api_root.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let unauth_config = unauth_config_mock(&mut server, 404);
+        let forced_config = forced_config_mock(
+            &mut server,
+            "tok",
+            200,
+            &format!(r#"{{"api_root": "{root}api/"}}"#),
+        );
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .match_header("authorization", "Bearer tok")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .expect(1)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Api]);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        unauth_config.assert();
+        forced_config.assert();
+        whoami.assert();
+    }
+
+    #[test]
+    fn validated_login_treats_a_forced_404_as_no_document() {
+        // A 404 to the credentialed retry is the authoritative "no
+        // document" answer: flat topology, no warning (this is the normal
+        // discovery-less case), nothing advertised, so no whoami probe.
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
         let config = server
             .mock("GET", "/sysand-index-config.json")
+            .with_status(404)
+            .expect(2)
+            .create();
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, globs, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
+        config.assert();
+        whoami.assert();
+    }
+
+    #[test]
+    fn validated_login_refuses_a_bad_token_on_a_fully_private_index() {
+        // A bad token on S4: the forced discovery retry is rejected too
+        // (fallback with a notice), the read probe then rejects, and the
+        // refusal rule ends the login with nothing stored.
+        let mut server = mockito::Server::new();
+        let config = server
+            .mock("GET", "/sysand-index-config.json")
+            .with_status(401)
+            .expect(2)
+            .create();
+        let index = server
+            .mock("GET", "/index.json")
+            .with_status(401)
+            .expect(2)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "bad-tok");
+
+        assert!(matches!(
+            outcome.unwrap_err(),
+            AuthCommandError::ValidationRejected { rejected, .. }
+                if rejected == vec![ProbeSurface::Read]
+        ));
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::DiscoveryUnreachable { error } if error.contains("401")
+            )),
+            "expected a discovery notice naming the 401, got {notices:?}"
+        );
+        assert!(store.list().unwrap().is_empty());
+        config.assert();
+        index.assert();
+    }
+
+    #[test]
+    fn validated_login_falls_back_when_forced_discovery_is_rate_limited() {
+        // 429 on the forced retry is never a verdict and never a
+        // document: fall back with the unreachable-style warning; the
+        // probes still run against the URL-derived surface.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let unauth_config = unauth_config_mock(&mut server, 401);
+        let forced_config = forced_config_mock(&mut server, "tok", 429, "");
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, globs, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::DiscoveryUnreachable { error } if error.contains("rate limited")
+            )),
+            "expected a rate-limited discovery notice, got {notices:?}"
+        );
+        unauth_config.assert();
+        forced_config.assert();
+        whoami.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn validated_login_falls_back_when_the_forced_document_is_unparseable() {
+        // The forced retry accepted the request but the body is not a
+        // discovery document: no topology was learned, fall back with a
+        // notice; the read probe still exercises the credential.
+        let mut server = mockito::Server::new();
+        let _unauth_config = unauth_config_mock(&mut server, 401);
+        let _forced_config = forced_config_mock(&mut server, "tok", 200, "not json");
+        let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Read]);
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::DiscoveryUnreachable { error } if error.contains("parse")
+            )),
+            "expected a parse-failure discovery notice, got {notices:?}"
+        );
+    }
+
+    #[test]
+    fn validated_login_sends_no_credential_when_the_baseline_is_not_4xx() {
+        // A non-4xx baseline (here 5xx) is not a "possibly hidden from
+        // me" signal: the forced retry never happens and the secret never
+        // reaches the wire for discovery.
+        let mut server = mockito::Server::new();
+        let baseline = server
+            .mock("GET", "/sysand-index-config.json")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(500)
+            .expect(1)
+            .create();
+        let forced = no_authed_config_mock(&mut server);
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        assert!(
+            notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::DiscoveryUnreachable { .. }))
+        );
+        baseline.assert();
+        forced.assert();
+    }
+
+    #[test]
+    fn login_with_public_discovery_sends_no_forced_request() {
+        // A public discovery success is used as-is: the forced retry
+        // never fires and the secret is never sent to the discovery URL.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let baseline = server
+            .mock("GET", "/sysand-index-config.json")
+            .match_header("authorization", mockito::Matcher::Missing)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(format!(r#"{{"api_root": "{root}api/"}}"#))
             .expect(1)
             .create();
-        let index = server.mock("GET", "/index.json").expect(0).create();
-        let whoami = server.mock("GET", "/api/v1/whoami").expect(0).create();
+        let forced = no_authed_config_mock(&mut server);
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(WHOAMI_BODY)
+            .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login_with(&mut store, &server.url(), "tok", Some(false));
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, vec![ProbeSurface::Api]);
         assert!(notices.is_empty(), "unexpected notices: {notices:?}");
-        config.assert();
-        index.assert();
-        whoami.assert();
-        assert_eq!(store.list().unwrap()[0].secret, "tok");
+        baseline.assert();
+        forced.assert();
     }
 }
 

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1085,8 +1085,10 @@ mod login {
             AuthCommandError::ValidationRejected {
                 index,
                 rejected,
-                basic_challenge: false,
-            } if index == &root && rejected == &vec![(ProbeSurface::Read, 401)]
+                challenge_schemes,
+            } if index == &root
+                && rejected == &vec![(ProbeSurface::Read, 401)]
+                && challenge_schemes.is_empty()
         ));
         // Single rejecting surface: the wording names the endpoint and
         // its answer.
@@ -1260,8 +1262,8 @@ mod login {
                 AuthLoginNotice::SurfaceRejected {
                     surface: ProbeSurface::Api,
                     status: 401,
-                    basic_challenge: false,
-                }
+                    challenge_schemes,
+                } if challenge_schemes.is_empty()
             )),
             "expected an api rejection notice, got {notices:?}"
         );
@@ -1294,8 +1296,8 @@ mod login {
                     // can report it and hedge a read 404 (which can also
                     // mean no `index.json` at all).
                     status: 401,
-                    basic_challenge: false,
-                }
+                    challenge_schemes,
+                } if challenge_schemes.is_empty()
             )),
             "expected a read rejection notice, got {notices:?}"
         );
@@ -1404,14 +1406,18 @@ mod login {
         assert!(matches!(
             &err,
             AuthCommandError::ValidationRejected {
-                basic_challenge: true,
+                challenge_schemes,
                 ..
-            }
+            } if challenge_schemes == &vec!["Basic".to_string()]
         ));
         let message = err.to_string();
         assert!(
             message.contains("SYSAND_CRED_<X>_BASIC_USER"),
             "was: {message}"
+        );
+        assert!(
+            !message.contains("does not support"),
+            "Basic is routed, not reported as unsupported: {message}"
         );
         assert!(store.list().unwrap().is_empty());
     }
@@ -1432,13 +1438,128 @@ mod login {
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
+        let err = outcome.unwrap_err();
         assert!(matches!(
-            outcome.unwrap_err(),
+            &err,
             AuthCommandError::ValidationRejected {
-                basic_challenge: false,
+                challenge_schemes,
                 ..
-            }
+            } if challenge_schemes == &vec!["Bearer".to_string()]
         ));
+        // Bearer is the expected scheme: no basic routing and no
+        // unsupported-scheme follow-up.
+        let message = err.to_string();
+        assert!(!message.contains("BASIC_USER"), "was: {message}");
+        assert!(!message.contains("does not support"), "was: {message}");
+    }
+
+    #[test]
+    fn validated_login_refusal_names_an_unsupported_scheme_verbatim() {
+        // A scheme sysand cannot satisfy (neither Basic nor Bearer) must
+        // be reported to the user verbatim, not silently dropped.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server
+            .mock("HEAD", "/index.json")
+            .with_status(401)
+            .with_header("www-authenticate", r#"Negotiate"#)
+            .expect(2)
+            .create();
+        let mut store = in_memory_store();
+
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
+
+        let err = outcome.unwrap_err();
+        assert!(matches!(
+            &err,
+            AuthCommandError::ValidationRejected {
+                challenge_schemes,
+                ..
+            } if challenge_schemes == &vec!["Negotiate".to_string()]
+        ));
+        let message = err.to_string();
+        assert!(
+            message.contains("the authentication scheme `Negotiate`"),
+            "was: {message}"
+        );
+        assert!(message.contains("does not support"), "was: {message}");
+        assert!(
+            !message.contains("BASIC_USER"),
+            "no basic routing without a Basic challenge: {message}"
+        );
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn validated_login_refusal_reports_basic_and_unsupported_schemes_together() {
+        // A mixed challenge gets both follow-ups: the basic routing hint
+        // and the unsupported scheme named verbatim. The top-level comma
+        // split separates the two challenges in one header.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server
+            .mock("HEAD", "/index.json")
+            .with_status(401)
+            .with_header("www-authenticate", r#"Negotiate, Basic realm="idx""#)
+            .expect(2)
+            .create();
+        let mut store = in_memory_store();
+
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
+
+        let err = outcome.unwrap_err();
+        assert!(matches!(
+            &err,
+            AuthCommandError::ValidationRejected {
+                challenge_schemes,
+                ..
+            } if challenge_schemes == &vec!["Negotiate".to_string(), "Basic".to_string()]
+        ));
+        let message = err.to_string();
+        assert!(
+            message.contains("SYSAND_CRED_<X>_BASIC_USER"),
+            "was: {message}"
+        );
+        assert!(
+            message.contains("the authentication scheme `Negotiate`"),
+            "was: {message}"
+        );
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn challenge_scheme_collection_handles_quoting_params_and_casing() {
+        // Behavior matrix for the header parsing: top-level comma split,
+        // auth-param continuations filtered, casing preserved verbatim
+        // but deduplicated case-insensitively across headers.
+        let cases: &[(&[&str], &[&str])] = &[
+            // A quoted realm containing a comma and a scheme name is
+            // neither a split point nor a scheme.
+            (&[r#"Bearer realm="Basic, or not""#], &["Bearer"]),
+            // A comma-continued auth-param is not a new challenge.
+            (&[r#"Basic realm="idx", charset="UTF-8""#], &["Basic"]),
+            (&["Basic realm=idx, foo=bar"], &["Basic"]),
+            // Two challenges in one header, one bare and one with params.
+            (
+                &[r#"Negotiate, Bearer realm="a""#],
+                &["Negotiate", "Bearer"],
+            ),
+            // Across headers: first-seen casing wins, dedup is
+            // case-insensitive.
+            (
+                &["basic", r#"Basic realm="idx", Negotiate"#],
+                &["basic", "Negotiate"],
+            ),
+        ];
+        for (values, expected) in cases {
+            let mut headers = reqwest::header::HeaderMap::new();
+            for value in *values {
+                headers.append(reqwest::header::WWW_AUTHENTICATE, value.parse().unwrap());
+            }
+            let mut schemes = Vec::new();
+            super::super::collect_challenge_schemes(&headers, &mut schemes);
+            assert_eq!(schemes, *expected, "headers: {values:?}");
+        }
     }
 
     #[test]

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1908,7 +1908,7 @@ mod whoami {
                 pattern,
                 EnvBearerAuth {
                     auth: ForceBearerAuth::new(token),
-                    label: Some((*label).to_string()),
+                    label: (*label).to_string(),
                 },
             );
         }
@@ -1926,7 +1926,7 @@ mod whoami {
         assert_eq!(
             source,
             WhoamiCredentialSource::Env {
-                label: Some("TEAM".to_string())
+                label: "TEAM".to_string()
             }
         );
         assert_eq!(token, "env-tok");
@@ -1983,7 +1983,7 @@ mod whoami {
         assert_eq!(
             source,
             WhoamiCredentialSource::Env {
-                label: Some("A".to_string())
+                label: "A".to_string()
             }
         );
         assert_eq!(token, "same-tok");

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -5,7 +5,7 @@ use chrono::{TimeZone, Utc};
 
 use super::{
     AuthCommandError, EnvCredentialEntry, StoredCredentialsStatus, assemble_auth_status,
-    do_auth_logout, do_auth_status,
+    do_auth_logout, do_auth_status, validated_index_key,
 };
 use crate::credential_store::{
     CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
@@ -577,31 +577,241 @@ mod login {
         }
     }
 
+    // Template targets (design/credential-storage.md section 4: templated
+    // login targets are supported, anchored per section 8).
+
+    /// The motivating GitLab-shaped target: the key is the template text
+    /// itself (already canonical), with the anchor normalizing only the
+    /// URL-parsed part of the literal prefix.
     #[test]
-    fn login_rejects_a_template_target() {
+    fn template_key_is_the_template_with_a_normalized_anchor() {
+        let gitlab =
+            "https://gitlab.com/api/v4/projects/84113019/repository/files/{path}/raw?ref=index";
+
+        assert_eq!(validated_index_key(gitlab).unwrap(), gitlab);
+        // Scheme/host case and the default port normalize through the
+        // anchor; the placeholder and suffix stay verbatim.
+        let spelled =
+            "HTTPS://GitLab.COM:443/api/v4/projects/84113019/repository/files/{path}/raw?ref=index";
+        assert_eq!(validated_index_key(spelled).unwrap(), gitlab);
+        // Idempotent: the key is its own key.
+        assert_eq!(
+            validated_index_key(&validated_index_key(spelled).unwrap()).unwrap(),
+            gitlab
+        );
+    }
+
+    #[test]
+    fn template_key_rejects_an_unanchorable_template() {
+        // Placeholder directly in the query of a path-less URL: the only
+        // `/` in the literal prefix is the one in `://`.
+        let err = validated_index_key("https://files.example.com?f={path}").unwrap_err();
+
+        assert!(matches!(
+            &err,
+            AuthCommandError::TemplateWithoutAnchor { .. }
+        ));
+        let message = err.to_string();
+        assert!(message.contains("SYSAND_CRED_"), "was: {message}");
+    }
+
+    #[test]
+    fn template_key_keeps_the_non_http_rejection() {
+        let err = validated_index_key("ftp://files.example.com/{path}").unwrap_err();
+
+        assert!(matches!(&err, AuthCommandError::NotHttpIndex { .. }));
+    }
+
+    #[test]
+    fn login_with_a_template_target_anchors_and_covers_expanded_urls() {
+        let mut server = mockito::Server::new();
+        let template = format!("{}/repo/files/{{path}}/raw?ref=index", server.url());
+        let anchor = format!("{}/repo/files/", server.url());
+        // No discovery document: the fetch goes through the template
+        // (asserted indirectly: a missed mock would answer 501, which is
+        // a DiscoveryUnreachable notice, and notices must stay empty).
+        let _config = server
+            .mock("GET", "/repo/files/sysand-index-config.json/raw")
+            .match_query(mockito::Matcher::UrlEncoded("ref".into(), "index".into()))
+            .with_status(404)
+            .create();
         let mut store = InMemoryCredentialStore::new();
 
-        let (outcome, notices) = run_login(
-            &mut store,
-            "https://files.example.com/repo/{path}/raw",
-            "tok",
+        let (outcome, notices) = run_login(&mut store, &template, "tok");
+
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, template);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        assert_eq!(globs, vec![format!("{}**", globset::escape(&anchor))]);
+        // Section 8 coverage for a template without an api_root: the
+        // template-resolved discovery URL, `index.json` URL, and an
+        // encoded-`{path}` project-file URL all match the derived set.
+        let location = IndexLocation::parse(&template).unwrap();
+        let set = matcher(&globs);
+        let kpar = location.resolve(["some-publisher", "some.name", "1.0.0", "project.kpar"]);
+        for url in [
+            location.resolve(["sysand-index-config.json"]),
+            location.resolve(["index.json"]),
+            kpar.clone(),
+        ] {
+            assert!(set.is_match(url.as_str()), "`{url}` must match {globs:?}");
+        }
+        // The `{path}` expansion really is one encoded segment.
+        assert!(kpar.as_str().contains("some-publisher%2Fsome.name"));
+        assert!(!set.is_match(format!("{}/elsewhere", server.url())));
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn login_and_logout_round_trip_a_template_key() {
+        // Port 1 answers nothing: discovery is unreachable and the glob
+        // set is the anchor-derived fallback.
+        let template = "http://127.0.0.1:1/files/{path}/raw?ref=main";
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, template, "tok");
+
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, template);
+        assert_eq!(
+            globs,
+            vec![format!(
+                "{}**",
+                globset::escape("http://127.0.0.1:1/files/")
+            )]
         );
+        assert!(
+            notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::DiscoveryUnreachable { .. }))
+        );
+        // `status` reports the key in the exact form `logout` accepts.
+        let status = do_auth_status(&store, vec![]).unwrap();
+        let StoredCredentialsStatus::Available(stored) = status.stored else {
+            panic!("expected stored credentials");
+        };
+        assert_eq!(stored[0].key, template);
+        // A differently-spelled scheme normalizes to the same key.
+        let removed =
+            do_auth_logout(&mut store, "HTTP://127.0.0.1:1/files/{path}/raw?ref=main").unwrap();
+        assert_eq!(removed, template);
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn login_with_a_query_placeholder_template_anchors_at_the_path() {
+        // Anchorable query-position placeholder: the anchor cuts back to
+        // the last `/` of the literal prefix, shallower than the whole
+        // prefix.
+        let template = "http://127.0.0.1:1/repo/download?file={path}&ref=main";
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login(&mut store, template, "tok");
+
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, template);
+        assert_eq!(
+            globs,
+            vec![format!("{}**", globset::escape("http://127.0.0.1:1/repo/"))]
+        );
+        let expanded = IndexLocation::parse(template)
+            .unwrap()
+            .resolve(["index.json"]);
+        assert!(matcher(&globs).is_match(expanded.as_str()));
+        assert!(!matcher(&globs).is_match("http://127.0.0.1:1/other"));
+    }
+
+    #[test]
+    fn login_with_a_path_raw_template_target_round_trips() {
+        let template = "http://127.0.0.1:1/raw/{path_raw}?ref=main";
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login(&mut store, template, "tok");
+
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, template);
+        // `{path_raw}` keeps literal `/` separators; `**` after `/`
+        // crosses them.
+        let expanded =
+            IndexLocation::parse(template)
+                .unwrap()
+                .resolve(["pub", "name", "versions.json"]);
+        assert!(expanded.as_str().contains("/raw/pub/name/versions.json"));
+        assert!(matcher(&globs).is_match(expanded.as_str()));
+        assert_eq!(do_auth_logout(&mut store, template).unwrap(), template);
+    }
+
+    #[test]
+    fn login_rejects_an_unanchorable_template_target() {
+        let mut store = InMemoryCredentialStore::new();
+
+        // Fails in key validation, before any network or store access.
+        let (outcome, notices) = run_login(&mut store, "https://files.example.com?f={path}", "tok");
 
         assert!(matches!(
             outcome.unwrap_err(),
-            AuthCommandError::TemplateIndexUrl { .. }
+            AuthCommandError::TemplateWithoutAnchor { .. }
         ));
         assert!(notices.is_empty());
         assert!(store.list().unwrap().is_empty());
     }
 
     #[test]
-    fn logout_rejects_a_template_target() {
+    fn logout_rejects_an_unanchorable_template_target() {
         let mut store = InMemoryCredentialStore::new();
 
-        let err = do_auth_logout(&mut store, "https://files.example.com/{path}").unwrap_err();
+        let err = do_auth_logout(&mut store, "https://files.example.com?f={path}").unwrap_err();
 
-        assert!(matches!(err, AuthCommandError::TemplateIndexUrl { .. }));
+        assert!(matches!(
+            err,
+            AuthCommandError::TemplateWithoutAnchor { .. }
+        ));
+    }
+
+    #[test]
+    fn validated_login_on_a_private_template_index_validates_read() {
+        // The GitLab reality check: unauthenticated GET answers 404 on a
+        // private repo, the forced bearer retry 200s; that is the
+        // accepted-read path. A template without a discovery document
+        // has no api_root, so whoami is never probed.
+        let mut server = mockito::Server::new();
+        let template = format!("{}/repo/files/{{path}}/raw?ref=index", server.url());
+        let ref_query = mockito::Matcher::UrlEncoded("ref".into(), "index".into());
+        let _config = server
+            .mock("GET", "/repo/files/sysand-index-config.json/raw")
+            .match_query(ref_query.clone())
+            .with_status(404)
+            .create();
+        let unauth = server
+            .mock("GET", "/repo/files/index.json/raw")
+            .match_query(ref_query.clone())
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(404)
+            .expect(1)
+            .create();
+        let forced = server
+            .mock("GET", "/repo/files/index.json/raw")
+            .match_query(ref_query)
+            .match_header("authorization", "Bearer tok")
+            .with_status(200)
+            .expect(1)
+            .create();
+        let whoami = server
+            .mock("GET", mockito::Matcher::Regex("whoami".to_string()))
+            .expect(0)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login_with(&mut store, &template, "tok", None);
+
+        let (key, _, validated) = stored_validated(outcome);
+        assert_eq!(key, template);
+        assert_eq!(validated, vec![ProbeSurface::Read]);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        unauth.assert();
+        forced.assert();
+        whoami.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
     }
 
     // Validation probes (design/credential-storage.md section 5).

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1243,6 +1243,42 @@ mod login {
     }
 
     #[test]
+    fn validated_login_stores_with_a_warning_when_api_accepts_and_read_rejects() {
+        // API-only token (the mirror of the read-accepts/api-rejects case):
+        // the read surface rejects even with the token, but the advertised
+        // whoami accepts. Store as validated (api) with a read-rejection
+        // warning; the token still authenticates the API.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let (_unauth, _forced) = private_index_json(&mut server, "tok", 401);
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(200)
+            .with_body(WHOAMI_BODY)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, _, validated) = stored_validated(outcome);
+        assert_eq!(validated, vec![ProbeSurface::Api]);
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::SurfaceRejected {
+                    surface: ProbeSurface::Read,
+                    basic_challenge: false,
+                }
+            )),
+            "expected a read rejection notice, got {notices:?}"
+        );
+        let record = &store.list().unwrap()[0];
+        assert_eq!(record.secret, "tok");
+        assert!(record.subject.is_some());
+    }
+
+    #[test]
     fn validated_login_validates_both_surfaces() {
         // S4: private read accepts and whoami accepts: validated
         // (read, api), in probe order.

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -233,3 +233,344 @@ fn status_surfaces_a_denied_backend_as_an_error() {
         AuthCommandError::Store(CredentialStoreError::BackendDenied { .. })
     ));
 }
+
+// do_auth_login
+
+mod login {
+    use std::sync::Arc;
+
+    use globset::{GlobBuilder, GlobSetBuilder};
+
+    use super::super::{AuthLoginNotice, AuthLoginOutcome, do_auth_login};
+    use super::*;
+    use crate::{index_location::IndexLocation, resolve::net_utils::create_reqwest_client};
+
+    fn make_runtime() -> Arc<tokio::runtime::Runtime> {
+        Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        )
+    }
+
+    /// Run `do_auth_login` against a real client/runtime, collecting the
+    /// notices in order.
+    fn run_login<S: CredentialStore>(
+        store: &mut S,
+        index_url: &str,
+        secret: &str,
+    ) -> (
+        Result<AuthLoginOutcome, AuthCommandError>,
+        Vec<AuthLoginNotice>,
+    ) {
+        let client = create_reqwest_client().unwrap();
+        let mut notices = Vec::new();
+        let outcome = do_auth_login(
+            store,
+            index_url,
+            secret.to_string(),
+            &client,
+            make_runtime(),
+            |notice| notices.push(notice),
+        );
+        (outcome, notices)
+    }
+
+    /// Compile globs exactly the way runtime matching does
+    /// (`GlobMapBuilder`: `literal_separator(true)`).
+    fn matcher(globs: &[String]) -> globset::GlobSet {
+        let mut builder = GlobSetBuilder::new();
+        for glob in globs {
+            builder.add(
+                GlobBuilder::new(glob)
+                    .literal_separator(true)
+                    .build()
+                    .unwrap_or_else(|err| panic!("glob `{glob}` must compile: {err}")),
+            );
+        }
+        builder.build().unwrap()
+    }
+
+    fn stored(outcome: Result<AuthLoginOutcome, AuthCommandError>) -> (String, Vec<String>) {
+        match outcome.unwrap() {
+            AuthLoginOutcome::Stored { key, globs } => (key, globs),
+            other => panic!("expected Stored, got {other:?}"),
+        }
+    }
+
+    /// The section 8 coverage guarantee: the discovery-document URL, the
+    /// `index.json` URL, and the upload URL each match the derived set.
+    fn assert_surface_coverage(
+        globs: &[String],
+        discovery_root: &str,
+        index_root: &str,
+        api_root: &str,
+    ) {
+        let set = matcher(globs);
+        for url in [
+            format!("{discovery_root}sysand-index-config.json"),
+            format!("{index_root}index.json"),
+            format!("{api_root}v1/upload"),
+        ] {
+            assert!(set.is_match(&url), "`{url}` must match globs {globs:?}");
+        }
+    }
+
+    fn config_mock(server: &mut mockito::Server, body: String) -> mockito::Mock {
+        server
+            .mock("GET", "/sysand-index-config.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create()
+    }
+
+    #[test]
+    fn login_without_discovery_document_derives_a_single_glob() {
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _mock = server
+            .mock("GET", "/sysand-index-config.json")
+            .with_status(404)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, root);
+        assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        // Flat topology: every surface lives under the discovery root.
+        assert_surface_coverage(&globs, &root, &root, &root);
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
+    }
+
+    #[test]
+    fn login_with_nested_api_root_keeps_one_glob() {
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let api_root = format!("{root}api/");
+        let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &root, "tok");
+
+        let (_, globs) = stored(outcome);
+        assert_eq!(globs.len(), 1, "Case A must not add a glob: {globs:?}");
+        assert!(notices.is_empty());
+        assert_surface_coverage(&globs, &root, &root, &api_root);
+    }
+
+    #[test]
+    fn login_with_disjoint_api_root_adds_a_second_glob() {
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let api_root = "https://api.example.com/base/";
+        let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login(&mut store, &root, "tok");
+
+        let (_, globs) = stored(outcome);
+        assert_eq!(
+            globs,
+            vec![
+                format!("{}**", globset::escape(&root)),
+                format!("{}**", globset::escape(api_root)),
+            ]
+        );
+        assert_surface_coverage(&globs, &root, &root, api_root);
+        // Non-overlapping: the api glob stays host-scoped.
+        assert!(!matcher(&globs[1..]).is_match(format!("{root}index.json")));
+    }
+
+    #[test]
+    fn login_with_divergent_index_and_api_roots_adds_three_globs() {
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let index_root = "https://files.example.com/idx/";
+        let api_root = "https://api.example.com/";
+        let _mock = config_mock(
+            &mut server,
+            format!(r#"{{"index_root": "{index_root}", "api_root": "{api_root}"}}"#),
+        );
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login(&mut store, &root, "tok");
+
+        let (_, globs) = stored(outcome);
+        assert_eq!(globs.len(), 3, "Case B twice over: {globs:?}");
+        assert_surface_coverage(&globs, &root, index_root, api_root);
+    }
+
+    #[test]
+    fn login_with_templated_index_root_anchors_before_the_placeholder() {
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let template = "https://files.example.com/repo/{path}/raw?ref=main";
+        let api_root = "https://api.example.com/";
+        let _mock = config_mock(
+            &mut server,
+            format!(r#"{{"index_root": "{template}", "api_root": "{api_root}"}}"#),
+        );
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &root, "tok");
+
+        let (_, globs) = stored(outcome);
+        assert!(notices.is_empty(), "unexpected notices: {notices:?}");
+        assert_eq!(
+            globs[1],
+            format!("{}**", globset::escape("https://files.example.com/repo/"))
+        );
+        // The templated index.json URL (placeholder expansion) matches.
+        let index_json = IndexLocation::parse(template).unwrap().resolve([
+            "some-publisher",
+            "some.name",
+            "index.json",
+        ]);
+        assert!(matcher(&globs).is_match(index_json.as_str()));
+        assert_surface_coverage(&globs, &root, "https://files.example.com/repo/", api_root);
+    }
+
+    #[test]
+    fn login_skips_an_unanchorable_template_index_root() {
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        // Placeholder directly in the query of a path-less URL: the only
+        // `/` in the literal prefix is the one in `://`, so anchoring
+        // would produce a glob matching every https URL.
+        let template = "https://files.example.com?f={path}";
+        let _mock = config_mock(&mut server, format!(r#"{{"index_root": "{template}"}}"#));
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &root, "tok");
+
+        let (_, globs) = stored(outcome);
+        assert!(
+            notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::TemplateIndexRootSkipped { .. })),
+            "expected a skip notice, got {notices:?}"
+        );
+        assert!(
+            !matcher(&globs).is_match("https://attacker.example/x"),
+            "no derived glob may cover other hosts: {globs:?}"
+        );
+    }
+
+    #[test]
+    fn login_with_unauthorized_discovery_falls_back_with_a_notice() {
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _mock = server
+            .mock("GET", "/sysand-index-config.json")
+            .with_status(401)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &root, "tok");
+
+        let (_, globs) = stored(outcome);
+        assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::DiscoveryUnreachable { error } if error.contains("401")
+            )),
+            "expected a 401 discovery notice, got {notices:?}"
+        );
+    }
+
+    #[test]
+    fn login_with_unreachable_ipv6_literal_derives_an_escaped_glob() {
+        // Port 1 answers nothing, so discovery is unreachable and the
+        // URL-derived fallback glob is used. The IPv6 literal would read
+        // as a globset character class without escaping.
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, "https://[::1]:1", "tok");
+
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, "https://[::1]:1/");
+        assert!(
+            notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::DiscoveryUnreachable { .. }))
+        );
+        let set = matcher(&globs);
+        assert!(set.is_match("https://[::1]:1/index.json"));
+        assert!(set.is_match("https://[::1]:1/sysand-index-config.json"));
+        assert!(!set.is_match("https://[x1]:1/index.json"));
+    }
+
+    #[test]
+    fn login_over_an_existing_key_notifies_replacement_and_overwrites() {
+        let mut store = InMemoryCredentialStore::new();
+        let (first, first_notices) = run_login(&mut store, "http://127.0.0.1:1", "old-tok");
+        stored(first);
+        assert!(
+            !first_notices
+                .iter()
+                .any(|n| matches!(n, AuthLoginNotice::ReplacingExisting { .. }))
+        );
+
+        let (second, second_notices) = run_login(&mut store, "http://127.0.0.1:1/", "new-tok");
+
+        stored(second);
+        assert!(second_notices.iter().any(|n| matches!(
+            n,
+            AuthLoginNotice::ReplacingExisting { key } if key == "http://127.0.0.1:1/"
+        )));
+        let records = store.list().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].secret, "new-tok");
+    }
+
+    #[test]
+    fn login_reports_an_absent_backend_with_the_derived_globs() {
+        let mut store = FailingStore(|| CredentialStoreError::BackendAbsent {
+            source: "no secret service".into(),
+        });
+
+        let (outcome, _) = run_login(&mut store, "http://127.0.0.1:1", "tok");
+
+        match outcome.unwrap() {
+            AuthLoginOutcome::BackendUnavailable { key, globs, reason } => {
+                assert_eq!(key, "http://127.0.0.1:1/");
+                assert_eq!(globs, vec![format!("{}**", globset::escape(&key))]);
+                assert_eq!(reason, "no secret service");
+            }
+            other => panic!("expected BackendUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_rejects_a_template_target() {
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(
+            &mut store,
+            "https://files.example.com/repo/{path}/raw",
+            "tok",
+        );
+
+        assert!(matches!(
+            outcome.unwrap_err(),
+            AuthCommandError::TemplateIndexUrl { .. }
+        ));
+        assert!(notices.is_empty());
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn logout_rejects_a_template_target() {
+        let mut store = InMemoryCredentialStore::new();
+
+        let err = do_auth_logout(&mut store, "https://files.example.com/{path}").unwrap_err();
+
+        assert!(matches!(err, AuthCommandError::TemplateIndexUrl { .. }));
+    }
+}

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -806,6 +806,32 @@ mod login {
     }
 
     #[test]
+    fn login_with_a_query_root_target_anchors_without_the_query() {
+        // A plain root may carry a query (`?ref=main` on a raw-file
+        // host). Resolved request URLs continue the path before the
+        // query, so the glob anchors on the query-stripped root while
+        // the key keeps the query.
+        let mut store = in_memory_store();
+
+        let (outcome, _) = run_login(&mut store, "http://127.0.0.1:1/idx?ref=main", "tok");
+
+        let (key, globs) = stored(outcome);
+        assert_eq!(key, "http://127.0.0.1:1/idx/?ref=main");
+        assert_eq!(
+            globs,
+            vec![format!("{}**", globset::escape("http://127.0.0.1:1/idx/"))]
+        );
+        let expanded = IndexLocation::parse(&key).unwrap().resolve(["index.json"]);
+        assert_eq!(
+            expanded.as_str(),
+            "http://127.0.0.1:1/idx/index.json?ref=main"
+        );
+        assert!(matcher(&globs).is_match(expanded.as_str()));
+        // `logout` accepts the normalized key `status` would print.
+        assert_eq!(logout(&mut store, &key).unwrap(), key);
+    }
+
+    #[test]
     fn login_with_a_path_raw_template_target_round_trips() {
         let template = "http://127.0.0.1:1/raw/{path_raw}?ref=main";
         let mut store = in_memory_store();

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1134,10 +1134,26 @@ mod login {
             AuthCommandError::ValidationRejected {
                 index,
                 rejected,
+                read_status: Some(401),
                 basic_challenge: false,
             } if index == &root && rejected == &vec![ProbeSurface::Read]
         ));
-        assert!(err.to_string().contains("nothing was stored"));
+        // Single rejecting surface: the plain wording names the endpoint
+        // and its answer.
+        let message = err.to_string();
+        assert!(
+            message.contains("the index rejected the token"),
+            "was: {message}"
+        );
+        assert!(
+            message.contains("`index.json` answered HTTP 401"),
+            "was: {message}"
+        );
+        assert!(message.contains("nothing was stored"), "was: {message}");
+        assert!(
+            !message.contains("no index exists"),
+            "a 401 must not be hedged: {message}"
+        );
         assert!(
             !notices
                 .iter()
@@ -1203,11 +1219,59 @@ mod login {
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
+        let err = outcome.unwrap_err();
         assert!(matches!(
-            outcome.unwrap_err(),
+            &err,
             AuthCommandError::ValidationRejected { rejected, .. }
-                if rejected == vec![ProbeSurface::Api]
+                if rejected == &vec![ProbeSurface::Api]
         ));
+        let message = err.to_string();
+        assert!(
+            message.contains("the index rejected the token"),
+            "was: {message}"
+        );
+        assert!(
+            message.contains("`v1/whoami` answered HTTP 401"),
+            "was: {message}"
+        );
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn validated_login_refusal_hedges_a_read_404() {
+        // A valid token against a URL with no index.json at all: the read
+        // baseline and forced retry both 404. The refusal must not blame
+        // only the credential; the message allows the no-index reading.
+        let mut server = mockito::Server::new();
+        let _config = no_discovery_mock(&mut server);
+        let _index = server
+            .mock("GET", "/index.json")
+            .with_status(404)
+            .expect(2)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
+
+        let err = outcome.unwrap_err();
+        assert!(matches!(
+            &err,
+            AuthCommandError::ValidationRejected {
+                rejected,
+                read_status: Some(404),
+                ..
+            } if rejected == &vec![ProbeSurface::Read]
+        ));
+        let message = err.to_string();
+        assert!(
+            message.contains("`index.json` answered HTTP 404"),
+            "was: {message}"
+        );
+        assert!(
+            message.contains("or no index exists at this URL"),
+            "was: {message}"
+        );
+        assert!(message.contains("nothing was stored"), "was: {message}");
         assert!(store.list().unwrap().is_empty());
     }
 
@@ -1568,10 +1632,45 @@ mod login {
         );
     }
 
+    #[test]
+    fn validated_login_refusal_enumerates_both_rejecting_surfaces() {
+        // Two rejecting surfaces keep the enumeration form (and no
+        // hedge: the API's 401 is authoritative about the credential).
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
+        let (_unauth, _forced) = private_index_json(&mut server, "tok", 404);
+        let _whoami = server
+            .mock("GET", "/api/v1/whoami")
+            .with_status(401)
+            .create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, _) = run_login(&mut store, &server.url(), "tok");
+
+        let err = outcome.unwrap_err();
+        assert!(matches!(
+            &err,
+            AuthCommandError::ValidationRejected { rejected, .. }
+                if rejected == &vec![ProbeSurface::Read, ProbeSurface::Api]
+        ));
+        let message = err.to_string();
+        assert!(
+            message.contains(
+                "was rejected by the index read surface (`index.json`) \
+                 and the index API (`v1/whoami`) and accepted by no surface"
+            ),
+            "was: {message}"
+        );
+        assert!(!message.contains("no index exists"), "was: {message}");
+        assert!(store.list().unwrap().is_empty());
+    }
+
     // Authenticated discovery (design/credential-storage.md section 5):
     // the login discovery fetch is an unauth baseline retried once with a
-    // forced bearer on any 4xx (scoping is knowing the topology, not
-    // validating the credential, so its outcome never refuses a login).
+    // forced bearer on any 4xx except 429 (scoping is knowing the
+    // topology, not validating the credential, so its outcome never
+    // refuses a login).
 
     #[test]
     fn validated_login_uses_authed_discovery_on_a_private_index() {
@@ -1817,6 +1916,41 @@ mod login {
         );
         baseline.assert();
         forced.assert();
+    }
+
+    #[test]
+    fn validated_login_sends_no_credential_when_the_baseline_is_rate_limited() {
+        // A 429 discovery baseline gets no forced retry, mirroring the
+        // probes' 429 carve-out: the retry would spend more of the rate
+        // budget and hand the secret to a throttling host. Discovery
+        // degrades to the URL-derived glob with the unreachable notice.
+        let mut server = mockito::Server::new();
+        let root = format!("{}/", server.url());
+        let baseline = server
+            .mock("GET", "/sysand-index-config.json")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(429)
+            .expect(1)
+            .create();
+        let forced = no_authed_config_mock(&mut server);
+        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let mut store = InMemoryCredentialStore::new();
+
+        let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
+
+        let (_, globs, validated) = stored_validated(outcome);
+        assert!(validated.is_empty());
+        assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
+        assert!(
+            notices.iter().any(|n| matches!(
+                n,
+                AuthLoginNotice::DiscoveryUnreachable { error } if error.contains("429")
+            )),
+            "expected a 429 discovery notice, got {notices:?}"
+        );
+        baseline.assert();
+        forced.assert();
+        assert_eq!(store.list().unwrap()[0].secret, "tok");
     }
 
     #[test]

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1958,14 +1958,17 @@ mod whoami {
 
         let err = select_whoami_credential(&env, &[], &whoami_url(), INDEX_KEY).unwrap_err();
 
-        assert!(
-            matches!(
-                &err,
-                AuthCommandError::AmbiguousWhoamiCredential { candidates: 2, .. }
-            ),
-            "unexpected error: {err}"
-        );
-        assert!(err.to_string().contains("SYSAND_CRED_"));
+        match &err {
+            AuthCommandError::AmbiguousWhoamiCredential { candidates, .. } => {
+                assert_eq!(
+                    candidates,
+                    &["SYSAND_CRED_A".to_string(), "SYSAND_CRED_B".to_string()]
+                );
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        let rendered = err.to_string();
+        assert!(rendered.contains("SYSAND_CRED_A, SYSAND_CRED_B"));
     }
 
     #[test]
@@ -1998,14 +2001,22 @@ mod whoami {
 
         let err = select_whoami_credential(&env, &records, &whoami_url(), INDEX_KEY).unwrap_err();
 
+        match &err {
+            AuthCommandError::AmbiguousWhoamiCredential { candidates, .. } => {
+                assert_eq!(
+                    candidates.len(),
+                    2,
+                    "both stored keys named: {candidates:?}"
+                );
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        let rendered = err.to_string();
+        assert!(rendered.contains("stored credentials"));
         assert!(
-            matches!(
-                &err,
-                AuthCommandError::AmbiguousWhoamiCredential { candidates: 2, .. }
-            ),
-            "unexpected error: {err}"
+            rendered.contains("example.com/api/"),
+            "keys named in the message: {rendered}"
         );
-        assert!(err.to_string().contains("stored credentials"));
     }
 
     #[test]

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -377,7 +377,7 @@ mod login {
         }
     }
 
-    /// The section 8 coverage guarantee: the discovery-document URL, the
+    /// The coverage guarantee: the discovery-document URL, the
     /// `index.json` URL, and the upload URL each match the derived set.
     fn assert_surface_coverage(
         globs: &[String],
@@ -644,8 +644,8 @@ mod login {
         }
     }
 
-    // Template targets (design/credential-storage.md section 4: templated
-    // login targets are supported, anchored per section 8).
+    // Template targets: templated login targets are supported, anchored
+    // on their literal URL prefix.
 
     /// The motivating GitLab-shaped target: the key is the template text
     /// itself (already canonical), with the anchor normalizing only the
@@ -866,7 +866,7 @@ mod login {
         assert_eq!(store.list().unwrap()[0].secret, "tok");
     }
 
-    // Validation probes (design/credential-storage.md section 5).
+    // Validation probes.
     //
     // All tests follow the existing pattern: a sync `mockito::Server`
     // created before any `runtime.block_on` (never `#[tokio::test]`, which
@@ -1421,8 +1421,8 @@ mod login {
         assert_eq!(record.expires_at, None);
     }
 
-    // 429 carve-out (design/credential-storage.md section 5): a 429 is
-    // never a verdict, so rate limiting can never refuse a credential.
+    // The 429 carve-out: a 429 is never a verdict, so rate limiting can
+    // never refuse a credential.
 
     #[test]
     fn validated_login_treats_a_rate_limited_baseline_as_not_tested() {
@@ -1568,8 +1568,8 @@ mod login {
         assert!(store.list().unwrap().is_empty());
     }
 
-    // Authenticated discovery (design/credential-storage.md section 5):
-    // the login discovery fetch is an unauth baseline retried once with a
+    // Authenticated discovery: the login discovery fetch is an
+    // unauthenticated baseline retried once with a
     // forced bearer on any 4xx except 429 (scoping is knowing the
     // topology, not validating the credential, so its outcome never
     // refuses a login).

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -11,7 +11,9 @@ use crate::credential_store::keyring_store::{BlobBackend, LockedBlobStore};
 use crate::credential_store::test_support::{
     InMemoryBlobBackend, in_memory_store, unique_lock_path,
 };
-use crate::credential_store::{CredentialRecord, CredentialScheme, CredentialStoreError};
+use crate::credential_store::{
+    CredentialRecord, CredentialScheme, CredentialStoreError, SubjectKind, ValidatedSurface,
+};
 
 fn record(key: &str, secret: &str) -> CredentialRecord {
     CredentialRecord {
@@ -110,7 +112,7 @@ fn status_lists_stored_records_and_env_entries() {
     let mut expiring = record("https://example.com/idx/", "tok-1");
     let expiry = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
     expiring.expires_at = Some(expiry);
-    expiring.validated = vec!["read".to_string()];
+    expiring.validated = vec![ValidatedSurface::Read];
     expiring.globs = vec![
         "https://example.com/idx/**".to_string(),
         "https://api.example.com/**".to_string(),
@@ -134,7 +136,7 @@ fn status_lists_stored_records_and_env_entries() {
         ]
     );
     assert_eq!(stored[0].expires_at, Some(expiry));
-    assert_eq!(stored[0].validated, vec!["read".to_string()]);
+    assert_eq!(stored[0].validated, vec![ValidatedSurface::Read]);
     assert_eq!(stored[1].key, "https://other.example/");
     assert_eq!(stored[1].expires_at, None);
     assert!(!stored[1].expired);
@@ -1033,7 +1035,7 @@ mod login {
         assert_eq!(record.subject, None);
         assert_eq!(record.expires_at, None);
         // The scoped claim is persisted for `auth status`.
-        assert_eq!(record.validated, vec!["read".to_string()]);
+        assert_eq!(record.validated, vec![ValidatedSurface::Read]);
     }
 
     #[test]
@@ -1129,7 +1131,7 @@ mod login {
         assert_eq!(
             record.subject,
             Some(crate::credential_store::CredentialSubject {
-                kind: "user".to_string(),
+                kind: SubjectKind::User,
                 name: "alice".to_string(),
             })
         );
@@ -1291,7 +1293,7 @@ mod login {
         assert!(record.subject.is_some());
         assert_eq!(
             record.validated,
-            vec!["read".to_string(), "api".to_string()]
+            vec![ValidatedSurface::Read, ValidatedSurface::Api]
         );
     }
 
@@ -1632,13 +1634,13 @@ mod login {
         let record = &store.list().unwrap()[0];
         assert_eq!(
             record.validated,
-            vec!["read".to_string(), "api".to_string()]
+            vec![ValidatedSurface::Read, ValidatedSurface::Api]
         );
         // The whoami identity fields are persisted on the record.
         assert_eq!(
             record.subject,
             Some(crate::credential_store::CredentialSubject {
-                kind: "user".to_string(),
+                kind: SubjectKind::User,
                 name: "alice".to_string(),
             })
         );

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1935,7 +1935,7 @@ mod whoami {
             ),
             "unexpected error: {err}"
         );
-        assert!(err.to_string().contains("stored logins"));
+        assert!(err.to_string().contains("stored credentials"));
     }
 
     #[test]

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -7,10 +7,11 @@ use super::{
     AuthCommandError, EnvCredentialEntry, StoredCredentialsStatus, assemble_auth_status,
     do_auth_logout, do_auth_status, validated_index_key,
 };
-use crate::credential_store::{
-    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
-    InMemoryCredentialStore,
+use crate::credential_store::keyring_store::{BlobBackend, LockedBlobStore};
+use crate::credential_store::test_support::{
+    InMemoryBlobBackend, in_memory_store, unique_lock_path,
 };
+use crate::credential_store::{CredentialRecord, CredentialScheme, CredentialStoreError};
 
 fn record(key: &str, secret: &str) -> CredentialRecord {
     CredentialRecord {
@@ -27,8 +28,8 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
     }
 }
 
-fn store_with(records: &[CredentialRecord]) -> InMemoryCredentialStore {
-    let mut store = InMemoryCredentialStore::new();
+fn store_with(records: &[CredentialRecord]) -> LockedBlobStore<InMemoryBlobBackend> {
+    let mut store = in_memory_store();
     for record in records {
         store.upsert(record.clone()).unwrap();
     }
@@ -101,7 +102,7 @@ fn logout_of_non_http_url_errors_without_touching_the_store() {
 
 #[test]
 fn logout_of_unparseable_url_errors() {
-    let mut store = InMemoryCredentialStore::new();
+    let mut store = in_memory_store();
 
     let err = do_auth_logout(&mut store, "not a url").unwrap_err();
 
@@ -264,27 +265,31 @@ fn status_marks_entries_for_a_template_default_index() {
     assert!(status.env[0].applies_to_default);
 }
 
-/// A store whose reads fail with a configurable error, for the error
+/// A backend whose accesses fail with a configurable error, for the error
 /// taxonomy paths.
-struct FailingStore(fn() -> CredentialStoreError);
+struct FailingBackend(fn() -> CredentialStoreError);
 
-impl CredentialStore for FailingStore {
-    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+impl BlobBackend for FailingBackend {
+    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
         Err((self.0)())
     }
 
-    fn upsert(&mut self, _record: CredentialRecord) -> Result<(), CredentialStoreError> {
+    fn write(&self, _raw: &str) -> Result<(), CredentialStoreError> {
         Err((self.0)())
     }
 
-    fn remove(&mut self, _key: &str) -> Result<bool, CredentialStoreError> {
+    fn delete(&self) -> Result<(), CredentialStoreError> {
         Err((self.0)())
     }
 }
 
+fn failing_store(error: fn() -> CredentialStoreError) -> LockedBlobStore<FailingBackend> {
+    LockedBlobStore::new(FailingBackend(error), unique_lock_path())
+}
+
 #[test]
 fn status_degrades_to_env_only_when_the_backend_is_absent() {
-    let store = FailingStore(|| CredentialStoreError::BackendAbsent {
+    let store = failing_store(|| CredentialStoreError::BackendAbsent {
         source: "no secret service".into(),
     });
     let env = vec![env_entry("SYSAND_CRED_CI", "https://ci.example/**")];
@@ -300,7 +305,7 @@ fn status_degrades_to_env_only_when_the_backend_is_absent() {
 
 #[test]
 fn status_surfaces_a_denied_backend_as_an_error() {
-    let store = FailingStore(|| CredentialStoreError::BackendDenied {
+    let store = failing_store(|| CredentialStoreError::BackendDenied {
         source: "collection is locked".into(),
     });
 
@@ -332,8 +337,8 @@ mod login {
     /// notices in order. Validation always runs, so tests mock every
     /// surface a probe would touch (or point at an unreachable local
     /// port, where the probes degrade to warnings).
-    fn run_login<S: CredentialStore>(
-        store: &mut S,
+    fn run_login<B: BlobBackend>(
+        store: &mut LockedBlobStore<B>,
         index_url: &str,
         secret: &str,
     ) -> (
@@ -425,7 +430,7 @@ mod login {
             .create();
         // Public read surface: probed, but never exercises the token.
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -454,7 +459,7 @@ mod login {
             .with_header("content-type", "application/json")
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
 
@@ -480,7 +485,7 @@ mod login {
             .with_header("content-type", "application/json")
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &root, "tok");
 
@@ -522,7 +527,7 @@ mod login {
             .with_header("content-type", "application/json")
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &root, "tok");
 
@@ -556,7 +561,7 @@ mod login {
             .with_header("content-type", "application/json")
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
 
@@ -593,7 +598,7 @@ mod login {
             ))
             .with_status(200)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
 
@@ -622,7 +627,7 @@ mod login {
             .create();
         // Keep the read probe quiet: the discovery notice is the point.
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &root, "tok");
 
@@ -642,7 +647,7 @@ mod login {
         // Port 1 answers nothing, so discovery is unreachable and the
         // URL-derived fallback glob is used. The IPv6 literal would read
         // as a globset character class without escaping.
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, "https://[::1]:1", "tok");
 
@@ -661,7 +666,7 @@ mod login {
 
     #[test]
     fn login_over_an_existing_key_notifies_replacement_and_overwrites() {
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
         let (first, first_notices) = run_login(&mut store, "http://127.0.0.1:1", "old-tok");
         stored(first);
         assert!(
@@ -684,7 +689,7 @@ mod login {
 
     #[test]
     fn login_reports_an_absent_backend_with_the_derived_globs() {
-        let mut store = FailingStore(|| CredentialStoreError::BackendAbsent {
+        let mut store = failing_store(|| CredentialStoreError::BackendAbsent {
             source: "no secret service".into(),
         });
 
@@ -765,7 +770,7 @@ mod login {
             .match_query(mockito::Matcher::UrlEncoded("ref".into(), "index".into()))
             .with_status(200)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &template, "tok");
 
@@ -797,7 +802,7 @@ mod login {
         // Port 1 answers nothing: discovery is unreachable and the glob
         // set is the anchor-derived fallback.
         let template = "http://127.0.0.1:1/files/{path}/raw?ref=main";
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, template, "tok");
 
@@ -834,7 +839,7 @@ mod login {
         // the last `/` of the literal prefix, shallower than the whole
         // prefix.
         let template = "http://127.0.0.1:1/repo/download?file={path}&ref=main";
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, template, "tok");
 
@@ -854,7 +859,7 @@ mod login {
     #[test]
     fn login_with_a_path_raw_template_target_round_trips() {
         let template = "http://127.0.0.1:1/raw/{path_raw}?ref=main";
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, template, "tok");
 
@@ -873,7 +878,7 @@ mod login {
 
     #[test]
     fn login_rejects_an_unanchorable_template_target() {
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         // Fails in key validation, before any network or store access.
         let (outcome, notices) = run_login(&mut store, "https://files.example.com?f={path}", "tok");
@@ -888,7 +893,7 @@ mod login {
 
     #[test]
     fn logout_rejects_an_unanchorable_template_target() {
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let err = do_auth_logout(&mut store, "https://files.example.com?f={path}").unwrap_err();
 
@@ -930,7 +935,7 @@ mod login {
             .mock("GET", mockito::Matcher::Regex("whoami".to_string()))
             .expect(0)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &template, "tok");
 
@@ -1030,7 +1035,7 @@ mod login {
         let _config = no_discovery_mock(&mut server);
         let _index = server.mock("GET", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1050,7 +1055,7 @@ mod login {
         let _config = config_mock(&mut server, "{}".to_string());
         let _index = server.mock("GET", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1066,7 +1071,7 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let (unauth, forced) = private_index_json(&mut server, "tok", 200);
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1094,7 +1099,7 @@ mod login {
             .with_status(401)
             .create();
         let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1175,7 +1180,7 @@ mod login {
             .with_body(WHOAMI_BODY)
             .expect(1)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1211,7 +1216,7 @@ mod login {
             .mock("GET", "/api/v1/whoami")
             .with_status(401)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1245,7 +1250,7 @@ mod login {
             .with_status(404)
             .expect(2)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1283,7 +1288,7 @@ mod login {
             .mock("GET", "/api/v1/whoami")
             .with_status(401)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1318,7 +1323,7 @@ mod login {
             .with_status(200)
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1356,7 +1361,7 @@ mod login {
             .with_status(200)
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1377,7 +1382,7 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let _index = server.mock("GET", "/index.json").with_status(500).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1408,7 +1413,7 @@ mod login {
             .with_status(302)
             .with_header("location", target)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1439,7 +1444,7 @@ mod login {
             .with_header("www-authenticate", r#"Basic realm="idx""#)
             .expect(2)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1472,7 +1477,7 @@ mod login {
             .with_header("www-authenticate", r#"Bearer realm="Basic migration""#)
             .expect(2)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1498,7 +1503,7 @@ mod login {
             .with_status(200)
             .with_body("not json")
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1531,7 +1536,7 @@ mod login {
             .match_header("authorization", "Bearer tok")
             .expect(0)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1557,7 +1562,7 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let (unauth, forced) = private_index_json(&mut server, "tok", 429);
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1588,7 +1593,7 @@ mod login {
             .with_status(429)
             .expect(1)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1619,7 +1624,7 @@ mod login {
             .with_header("content-type", "application/json")
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1645,7 +1650,7 @@ mod login {
             .mock("GET", "/api/v1/whoami")
             .with_status(401)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
@@ -1699,7 +1704,7 @@ mod login {
             .with_body(WHOAMI_BODY)
             .expect(1)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1760,7 +1765,7 @@ mod login {
             .with_body(WHOAMI_BODY)
             .expect(1)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1786,7 +1791,7 @@ mod login {
             .create();
         let _index = server.mock("GET", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1814,7 +1819,7 @@ mod login {
             .with_status(401)
             .expect(2)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "bad-tok");
 
@@ -1846,7 +1851,7 @@ mod login {
         let forced_config = forced_config_mock(&mut server, "tok", 429, "");
         let _index = server.mock("GET", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1875,7 +1880,7 @@ mod login {
         let _unauth_config = unauth_config_mock(&mut server, 401);
         let _forced_config = forced_config_mock(&mut server, "tok", 200, "not json");
         let (_unauth, _forced) = private_index_json(&mut server, "tok", 200);
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1904,7 +1909,7 @@ mod login {
             .create();
         let forced = no_authed_config_mock(&mut server);
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1935,7 +1940,7 @@ mod login {
             .create();
         let forced = no_authed_config_mock(&mut server);
         let _index = server.mock("GET", "/index.json").with_status(200).create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
@@ -1976,7 +1981,7 @@ mod login {
             .with_header("content-type", "application/json")
             .with_body(WHOAMI_BODY)
             .create();
-        let mut store = InMemoryCredentialStore::new();
+        let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -39,6 +39,7 @@ fn env_entry(label: &str, pattern: &str) -> EnvCredentialEntry {
     EnvCredentialEntry {
         label: label.to_string(),
         pattern: pattern.to_string(),
+        applies_to_default: false,
     }
 }
 
@@ -121,7 +122,7 @@ fn status_lists_stored_records_and_env_entries() {
     let store = store_with(&[expiring, record("https://other.example/", "tok-2")]);
     let env = vec![env_entry("SYSAND_CRED_CI", "https://ci.example/**")];
 
-    let status = do_auth_status(&store, env.clone()).unwrap();
+    let status = do_auth_status(&store, env.clone(), None).unwrap();
 
     assert_eq!(status.env, env);
     let StoredCredentialsStatus::Available(stored) = status.stored else {
@@ -154,11 +155,13 @@ fn status_marks_expiry_against_the_given_clock() {
         vec![record.clone()],
         vec![],
         Utc.with_ymd_and_hms(2026, 8, 31, 0, 0, 0).unwrap(),
+        None,
     );
     let after = assemble_auth_status(
         vec![record],
         vec![],
         Utc.with_ymd_and_hms(2026, 9, 2, 0, 0, 0).unwrap(),
+        None,
     );
 
     let StoredCredentialsStatus::Available(before) = before.stored else {
@@ -184,13 +187,80 @@ fn status_reports_env_entries_shadowing_a_stored_key() {
         env_entry("SYSAND_CRED_BROKEN", "https://example.com/[invalid"),
     ];
 
-    let status = assemble_auth_status(records, env, Utc::now());
+    let status = assemble_auth_status(records, env, Utc::now(), None);
 
     let StoredCredentialsStatus::Available(stored) = status.stored else {
         panic!("expected stored credentials");
     };
     assert_eq!(stored[0].shadowed_by, vec!["SYSAND_CRED_TEAM".to_string()]);
     assert!(stored[1].shadowed_by.is_empty());
+}
+
+#[test]
+fn status_marks_entries_applying_to_the_default_index() {
+    let mut by_key = record("https://sysand.com/", "tok-1");
+    // One invalid glob must not break marking (or status); key equality
+    // still applies.
+    by_key.globs = vec!["https://sysand.com/[invalid".to_string()];
+    let mut by_glob = record("https://other.example/", "tok-2");
+    // Keyed elsewhere, but a disjoint glob (the `api_root` shape) covers
+    // the default index root.
+    by_glob.globs = vec![
+        "https://other.example/**".to_string(),
+        "https://sysand.com/**".to_string(),
+    ];
+    let records = vec![
+        by_key,
+        by_glob,
+        record("https://unrelated.example/", "tok-3"),
+    ];
+    let env = vec![
+        env_entry("SYSAND_CRED_HIT", "https://sysand.com/**"),
+        env_entry("SYSAND_CRED_MISS", "https://elsewhere.example/**"),
+    ];
+
+    let status = assemble_auth_status(records, env, Utc::now(), Some("https://sysand.com/"));
+
+    let StoredCredentialsStatus::Available(stored) = status.stored else {
+        panic!("expected stored credentials");
+    };
+    assert!(stored[0].applies_to_default, "marked by key equality");
+    assert!(stored[1].applies_to_default, "marked by glob cover");
+    assert!(!stored[2].applies_to_default);
+    assert!(status.env[0].applies_to_default);
+    assert!(!status.env[1].applies_to_default);
+}
+
+#[test]
+fn status_marks_entries_for_a_template_default_index() {
+    // Equality uses the template key form; glob matching uses the
+    // template's literal-prefix anchor (`https://git.example/repo/files/`).
+    let template_key = "https://git.example/repo/files/{path}/raw?ref=index";
+    let mut template_entry = record(template_key, "tok-1");
+    template_entry.globs = vec!["https://git.example/repo/files/**".to_string()];
+    let mut host_entry = record("https://git.example/", "tok-2");
+    host_entry.globs = vec!["https://git.example/**".to_string()];
+    let env = vec![env_entry("SYSAND_CRED_GIT", "https://git.example/**")];
+
+    let status = assemble_auth_status(
+        vec![template_entry, host_entry],
+        env,
+        Utc::now(),
+        Some(template_key),
+    );
+
+    let StoredCredentialsStatus::Available(stored) = status.stored else {
+        panic!("expected stored credentials");
+    };
+    assert!(
+        stored[0].applies_to_default,
+        "marked by template key equality"
+    );
+    assert!(
+        stored[1].applies_to_default,
+        "glob covers the template anchor"
+    );
+    assert!(status.env[0].applies_to_default);
 }
 
 /// A store whose reads fail with a configurable error, for the error
@@ -218,7 +288,7 @@ fn status_degrades_to_env_only_when_the_backend_is_absent() {
     });
     let env = vec![env_entry("SYSAND_CRED_CI", "https://ci.example/**")];
 
-    let status = do_auth_status(&store, env.clone()).unwrap();
+    let status = do_auth_status(&store, env.clone(), None).unwrap();
 
     assert_eq!(status.env, env);
     assert!(matches!(
@@ -233,7 +303,7 @@ fn status_surfaces_a_denied_backend_as_an_error() {
         source: "collection is locked".into(),
     });
 
-    let err = do_auth_status(&store, vec![]).unwrap_err();
+    let err = do_auth_status(&store, vec![], None).unwrap_err();
 
     assert!(matches!(
         err,
@@ -693,7 +763,7 @@ mod login {
                 .any(|n| matches!(n, AuthLoginNotice::DiscoveryUnreachable { .. }))
         );
         // `status` reports the key in the exact form `logout` accepts.
-        let status = do_auth_status(&store, vec![]).unwrap();
+        let status = do_auth_status(&store, vec![], None).unwrap();
         let StoredCredentialsStatus::Available(stored) = status.stored else {
             panic!("expected stored credentials");
         };

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use chrono::{TimeZone, Utc};
+
+use super::{
+    AuthCommandError, EnvCredentialEntry, StoredCredentialsStatus, assemble_auth_status,
+    do_auth_logout, do_auth_status,
+};
+use crate::credential_store::{
+    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
+    InMemoryCredentialStore,
+};
+
+fn record(key: &str, secret: &str) -> CredentialRecord {
+    CredentialRecord {
+        key: key.to_string(),
+        globs: vec![format!("{key}**")],
+        scheme: CredentialScheme::Bearer,
+        secret: secret.to_string(),
+        expires_at: None,
+        extra: serde_json::Map::new(),
+    }
+}
+
+fn store_with(records: &[CredentialRecord]) -> InMemoryCredentialStore {
+    let mut store = InMemoryCredentialStore::new();
+    for record in records {
+        store.upsert(record.clone()).unwrap();
+    }
+    store
+}
+
+fn env_entry(label: &str, pattern: &str) -> EnvCredentialEntry {
+    EnvCredentialEntry {
+        label: label.to_string(),
+        pattern: pattern.to_string(),
+    }
+}
+
+// do_auth_logout
+
+#[test]
+fn logout_removes_only_the_matching_record() {
+    let keep = record("https://other.example/", "tok-keep");
+    let mut store = store_with(&[record("https://example.com/idx/", "tok-gone"), keep.clone()]);
+
+    let key = do_auth_logout(&mut store, "https://example.com/idx/").unwrap();
+
+    assert_eq!(key, "https://example.com/idx/");
+    assert_eq!(store.list().unwrap(), vec![keep]);
+}
+
+#[test]
+fn logout_normalizes_url_spellings_to_the_stored_key() {
+    // Uppercase host, no trailing slash, default port: all the same key.
+    let mut store = store_with(&[record("https://example.com/idx/", "tok")]);
+
+    let key = do_auth_logout(&mut store, "HTTPS://Example.COM:443/idx").unwrap();
+
+    assert_eq!(key, "https://example.com/idx/");
+    assert!(store.list().unwrap().is_empty());
+}
+
+#[test]
+fn logout_of_missing_credential_errors() {
+    let mut store = store_with(&[record("https://example.com/idx/", "tok")]);
+
+    let err = do_auth_logout(&mut store, "https://absent.example/").unwrap_err();
+
+    assert!(matches!(
+        &err,
+        AuthCommandError::NoStoredCredential { index } if index == "https://absent.example/"
+    ));
+    assert_eq!(
+        err.to_string(),
+        "no stored credential for `https://absent.example/`"
+    );
+    assert_eq!(store.list().unwrap().len(), 1);
+}
+
+#[test]
+fn logout_of_non_http_url_errors_without_touching_the_store() {
+    let mut store = store_with(&[record("https://example.com/idx/", "tok")]);
+
+    let err = do_auth_logout(&mut store, "file:///srv/index").unwrap_err();
+
+    assert!(matches!(&err, AuthCommandError::NotHttpIndex { .. }));
+    assert_eq!(
+        err.to_string(),
+        "`file:///srv/index`: not an HTTP(S) index; nothing to authenticate to"
+    );
+    assert_eq!(store.list().unwrap().len(), 1);
+}
+
+#[test]
+fn logout_of_unparseable_url_errors() {
+    let mut store = InMemoryCredentialStore::new();
+
+    let err = do_auth_logout(&mut store, "not a url").unwrap_err();
+
+    assert!(matches!(&err, AuthCommandError::InvalidIndexUrl(_)));
+}
+
+// do_auth_status / assemble_auth_status
+
+#[test]
+fn status_lists_stored_records_and_env_entries() {
+    let mut expiring = record("https://example.com/idx/", "tok-1");
+    let expiry = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
+    expiring.expires_at = Some(expiry);
+    expiring.globs = vec![
+        "https://example.com/idx/**".to_string(),
+        "https://api.example.com/**".to_string(),
+    ];
+    let store = store_with(&[expiring, record("https://other.example/", "tok-2")]);
+    let env = vec![env_entry("SYSAND_CRED_CI", "https://ci.example/**")];
+
+    let status = do_auth_status(&store, env.clone()).unwrap();
+
+    assert_eq!(status.env, env);
+    let StoredCredentialsStatus::Available(stored) = status.stored else {
+        panic!("expected stored credentials to be available");
+    };
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored[0].key, "https://example.com/idx/");
+    assert_eq!(
+        stored[0].globs,
+        vec![
+            "https://example.com/idx/**".to_string(),
+            "https://api.example.com/**".to_string(),
+        ]
+    );
+    assert_eq!(stored[0].expires_at, Some(expiry));
+    assert_eq!(stored[1].key, "https://other.example/");
+    assert_eq!(stored[1].expires_at, None);
+    assert!(!stored[1].expired);
+}
+
+#[test]
+fn status_marks_expiry_against_the_given_clock() {
+    let mut record = record("https://example.com/idx/", "tok");
+    let expiry = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
+    record.expires_at = Some(expiry);
+
+    let before = assemble_auth_status(
+        vec![record.clone()],
+        vec![],
+        Utc.with_ymd_and_hms(2026, 8, 31, 0, 0, 0).unwrap(),
+    );
+    let after = assemble_auth_status(
+        vec![record],
+        vec![],
+        Utc.with_ymd_and_hms(2026, 9, 2, 0, 0, 0).unwrap(),
+    );
+
+    let StoredCredentialsStatus::Available(before) = before.stored else {
+        panic!("expected stored credentials");
+    };
+    let StoredCredentialsStatus::Available(after) = after.stored else {
+        panic!("expected stored credentials");
+    };
+    assert!(!before[0].expired);
+    assert!(after[0].expired);
+}
+
+#[test]
+fn status_reports_env_entries_shadowing_a_stored_key() {
+    let records = vec![
+        record("https://example.com/idx/", "tok-1"),
+        record("https://other.example/", "tok-2"),
+    ];
+    let env = vec![
+        env_entry("SYSAND_CRED_TEAM", "https://example.com/**"),
+        env_entry("SYSAND_CRED_ELSEWHERE", "https://unrelated.example/**"),
+        // Invalid pattern: cannot shadow, must be skipped, not panic.
+        env_entry("SYSAND_CRED_BROKEN", "https://example.com/[invalid"),
+    ];
+
+    let status = assemble_auth_status(records, env, Utc::now());
+
+    let StoredCredentialsStatus::Available(stored) = status.stored else {
+        panic!("expected stored credentials");
+    };
+    assert_eq!(stored[0].shadowed_by, vec!["SYSAND_CRED_TEAM".to_string()]);
+    assert!(stored[1].shadowed_by.is_empty());
+}
+
+/// A store whose reads fail with a configurable error, for the error
+/// taxonomy paths.
+struct FailingStore(fn() -> CredentialStoreError);
+
+impl CredentialStore for FailingStore {
+    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+        Err((self.0)())
+    }
+
+    fn upsert(&mut self, _record: CredentialRecord) -> Result<(), CredentialStoreError> {
+        Err((self.0)())
+    }
+
+    fn remove(&mut self, _key: &str) -> Result<bool, CredentialStoreError> {
+        Err((self.0)())
+    }
+}
+
+#[test]
+fn status_degrades_to_env_only_when_the_backend_is_absent() {
+    let store = FailingStore(|| CredentialStoreError::BackendAbsent {
+        source: "no secret service".into(),
+    });
+    let env = vec![env_entry("SYSAND_CRED_CI", "https://ci.example/**")];
+
+    let status = do_auth_status(&store, env.clone()).unwrap();
+
+    assert_eq!(status.env, env);
+    assert!(matches!(
+        status.stored,
+        StoredCredentialsStatus::BackendUnavailable { reason } if reason == "no secret service"
+    ));
+}
+
+#[test]
+fn status_surfaces_a_denied_backend_as_an_error() {
+    let store = FailingStore(|| CredentialStoreError::BackendDenied {
+        source: "collection is locked".into(),
+    });
+
+    let err = do_auth_status(&store, vec![]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        AuthCommandError::Store(CredentialStoreError::BackendDenied { .. })
+    ));
+}

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -430,7 +430,7 @@ mod login {
             .expect(2)
             .create();
         // Public read surface: probed, but never exercises the token.
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -453,7 +453,7 @@ mod login {
         let root = format!("{}/", server.url());
         let api_root = format!("{root}api/");
         let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let _whoami = whoami_ok(&mut server, "/api/v1/whoami", None);
         let mut store = in_memory_store();
 
@@ -474,7 +474,7 @@ mod login {
         let root = format!("{}/", server.url());
         let api_root = format!("{}/base/", api_server.url());
         let _mock = config_mock(&mut server, format!(r#"{{"api_root": "{api_root}"}}"#));
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let _whoami = whoami_ok(&mut api_server, "/base/v1/whoami", None);
         let mut store = in_memory_store();
 
@@ -509,7 +509,7 @@ mod login {
             format!(r#"{{"index_root": "{index_root}", "api_root": "{api_root}"}}"#),
         );
         let _index = files_server
-            .mock("GET", "/idx/index.json")
+            .mock("HEAD", "/idx/index.json")
             .with_status(200)
             .create();
         let _whoami = whoami_ok(&mut api_server, "/v1/whoami", None);
@@ -537,7 +537,7 @@ mod login {
         );
         // The read probe expands the template exactly like runtime reads.
         let _index = files_server
-            .mock("GET", "/repo/index.json/raw")
+            .mock("HEAD", "/repo/index.json/raw")
             .match_query(mockito::Matcher::UrlEncoded("ref".into(), "main".into()))
             .with_status(200)
             .create();
@@ -708,7 +708,7 @@ mod login {
             .create();
         // Public read surface, so the probe leaves no notice.
         let _index = server
-            .mock("GET", "/repo/files/index.json/raw")
+            .mock("HEAD", "/repo/files/index.json/raw")
             .match_query(mockito::Matcher::UrlEncoded("ref".into(), "index".into()))
             .with_status(200)
             .create();
@@ -851,14 +851,14 @@ mod login {
             .with_status(404)
             .create();
         let unauth = server
-            .mock("GET", "/repo/files/index.json/raw")
+            .mock("HEAD", "/repo/files/index.json/raw")
             .match_query(ref_query.clone())
             .match_header("authorization", mockito::Matcher::Missing)
             .with_status(404)
             .expect(1)
             .create();
         let forced = server
-            .mock("GET", "/repo/files/index.json/raw")
+            .mock("HEAD", "/repo/files/index.json/raw")
             .match_query(ref_query)
             .match_header("authorization", "Bearer tok")
             .with_status(200)
@@ -926,12 +926,12 @@ mod login {
         forced_status: usize,
     ) -> (mockito::Mock, mockito::Mock) {
         let unauth = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .match_header("authorization", mockito::Matcher::Missing)
             .with_status(401)
             .create();
         let forced = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .match_header("authorization", format!("Bearer {token}").as_str())
             .with_status(forced_status)
             .create();
@@ -983,7 +983,7 @@ mod login {
         // the flat/defaulted api_root must never be phantom-probed.
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
         let mut store = in_memory_store();
 
@@ -1003,7 +1003,7 @@ mod login {
         // advertisement: no whoami probe.
         let mut server = mockito::Server::new();
         let _config = config_mock(&mut server, "{}".to_string());
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
         let mut store = in_memory_store();
 
@@ -1071,7 +1071,7 @@ mod login {
         let root = format!("{}/", server.url());
         let _config = no_discovery_mock(&mut server);
         let _index = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .with_status(401)
             .expect(2)
             .create();
@@ -1117,7 +1117,7 @@ mod login {
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let whoami = whoami_ok(&mut server, "/api/v1/whoami", Some("tok"));
         let mut store = in_memory_store();
 
@@ -1150,7 +1150,7 @@ mod login {
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let _whoami = server
             .mock("GET", "/api/v1/whoami")
             .with_status(401)
@@ -1181,7 +1181,7 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let _index = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .with_status(404)
             .expect(2)
             .create();
@@ -1303,7 +1303,7 @@ mod login {
         // nothing else exercised the login stores as not validated.
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
-        let _index = server.mock("GET", "/index.json").with_status(500).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(500).create();
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1331,7 +1331,7 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let _index = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .with_status(302)
             .with_header("location", target)
             .create();
@@ -1361,7 +1361,7 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let _index = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .with_status(401)
             .with_header("www-authenticate", r#"Basic realm="idx""#)
             .expect(2)
@@ -1393,7 +1393,7 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let _index = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .with_status(401)
             .with_header("www-authenticate", r#"Bearer realm="Basic migration""#)
             .expect(2)
@@ -1418,7 +1418,7 @@ mod login {
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let _whoami = server
             .mock("GET", "/api/v1/whoami")
             .with_status(200)
@@ -1447,13 +1447,13 @@ mod login {
         let mut server = mockito::Server::new();
         let _config = no_discovery_mock(&mut server);
         let baseline = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .match_header("authorization", mockito::Matcher::Missing)
             .with_status(429)
             .expect(1)
             .create();
         let forced = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .match_header("authorization", "Bearer tok")
             .expect(0)
             .create();
@@ -1508,7 +1508,7 @@ mod login {
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let whoami = server
             .mock("GET", "/api/v1/whoami")
             .with_status(429)
@@ -1537,7 +1537,7 @@ mod login {
         let mut server = mockito::Server::new();
         let root = format!("{}/", server.url());
         let _config = config_mock(&mut server, format!(r#"{{"api_root": "{root}api/"}}"#));
-        let _index = server.mock("GET", "/index.json").with_status(429).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(429).create();
         let _whoami = whoami_ok(&mut server, "/api/v1/whoami", Some("tok"));
         let mut store = in_memory_store();
 
@@ -1661,7 +1661,7 @@ mod login {
             200,
             &format!(r#"{{"api_root": "{root}api/"}}"#),
         );
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let whoami = whoami_ok(&mut server, "/api/v1/whoami", Some("tok"));
         let mut store = in_memory_store();
 
@@ -1687,7 +1687,7 @@ mod login {
             .with_status(404)
             .expect(2)
             .create();
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
         let mut store = in_memory_store();
 
@@ -1713,7 +1713,7 @@ mod login {
             .expect(2)
             .create();
         let index = server
-            .mock("GET", "/index.json")
+            .mock("HEAD", "/index.json")
             .with_status(401)
             .expect(2)
             .create();
@@ -1747,7 +1747,7 @@ mod login {
         let root = format!("{}/", server.url());
         let unauth_config = unauth_config_mock(&mut server, 401);
         let forced_config = forced_config_mock(&mut server, "tok", 429, "");
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let whoami = server.mock("GET", "/v1/whoami").expect(0).create();
         let mut store = in_memory_store();
 
@@ -1806,7 +1806,7 @@ mod login {
             .expect(1)
             .create();
         let forced = no_authed_config_mock(&mut server);
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1837,7 +1837,7 @@ mod login {
             .expect(1)
             .create();
         let forced = no_authed_config_mock(&mut server);
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let mut store = in_memory_store();
 
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
@@ -1872,7 +1872,7 @@ mod login {
             .expect(1)
             .create();
         let forced = no_authed_config_mock(&mut server);
-        let _index = server.mock("GET", "/index.json").with_status(200).create();
+        let _index = server.mock("HEAD", "/index.json").with_status(200).create();
         let _whoami = whoami_ok(&mut server, "/api/v1/whoami", None);
         let mut store = in_memory_store();
 

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -4,8 +4,8 @@
 use chrono::{TimeZone, Utc};
 
 use super::{
-    AuthCommandError, EnvCredentialEntry, StoredCredentialsStatus, assemble_auth_status,
-    do_auth_logout, do_auth_status, validated_index_key,
+    AuthCommandError, EnvCredentialEntry, IndexKey, StoredCredentialsStatus, assemble_auth_status,
+    do_auth_logout, do_auth_status,
 };
 use crate::credential_store::keyring_store::{BlobBackend, LockedBlobStore};
 use crate::credential_store::test_support::{
@@ -36,6 +36,14 @@ fn store_with(records: &[CredentialRecord]) -> LockedBlobStore<InMemoryBlobBacke
     store
 }
 
+/// Logout through the same validate-then-call path the CLI uses.
+fn logout<B: BlobBackend>(
+    store: &mut LockedBlobStore<B>,
+    index_url: &str,
+) -> Result<String, AuthCommandError> {
+    do_auth_logout(store, &IndexKey::validate(index_url)?)
+}
+
 fn env_entry(label: &str, pattern: &str) -> EnvCredentialEntry {
     EnvCredentialEntry {
         label: label.to_string(),
@@ -51,7 +59,7 @@ fn logout_removes_only_the_matching_record() {
     let keep = record("https://other.example/", "tok-keep");
     let mut store = store_with(&[record("https://example.com/idx/", "tok-gone"), keep.clone()]);
 
-    let key = do_auth_logout(&mut store, "https://example.com/idx/").unwrap();
+    let key = logout(&mut store, "https://example.com/idx/").unwrap();
 
     assert_eq!(key, "https://example.com/idx/");
     assert_eq!(store.list().unwrap(), vec![keep]);
@@ -62,7 +70,7 @@ fn logout_normalizes_url_spellings_to_the_stored_key() {
     // Uppercase host, no trailing slash, default port: all the same key.
     let mut store = store_with(&[record("https://example.com/idx/", "tok")]);
 
-    let key = do_auth_logout(&mut store, "HTTPS://Example.COM:443/idx").unwrap();
+    let key = logout(&mut store, "HTTPS://Example.COM:443/idx").unwrap();
 
     assert_eq!(key, "https://example.com/idx/");
     assert!(store.list().unwrap().is_empty());
@@ -72,7 +80,7 @@ fn logout_normalizes_url_spellings_to_the_stored_key() {
 fn logout_of_missing_credential_errors() {
     let mut store = store_with(&[record("https://example.com/idx/", "tok")]);
 
-    let err = do_auth_logout(&mut store, "https://absent.example/").unwrap_err();
+    let err = logout(&mut store, "https://absent.example/").unwrap_err();
 
     assert!(matches!(
         &err,
@@ -85,7 +93,7 @@ fn logout_of_missing_credential_errors() {
 fn logout_of_non_http_url_errors_without_touching_the_store() {
     let mut store = store_with(&[record("https://example.com/idx/", "tok")]);
 
-    let err = do_auth_logout(&mut store, "file:///srv/index").unwrap_err();
+    let err = logout(&mut store, "file:///srv/index").unwrap_err();
 
     assert!(matches!(&err, AuthCommandError::NotHttpIndex { .. }));
     assert!(
@@ -333,9 +341,14 @@ mod login {
     ) {
         let client = create_reqwest_client().unwrap();
         let mut notices = Vec::new();
+        // Validate here, like the CLI does before calling core.
+        let index_key = match IndexKey::validate(index_url) {
+            Ok(key) => key,
+            Err(err) => return (Err(err), notices),
+        };
         let outcome = do_auth_login(
             store,
-            index_url,
+            &index_key,
             secret.to_string(),
             &client,
             &make_runtime(),
@@ -655,22 +668,24 @@ mod login {
         let gitlab =
             "https://gitlab.com/api/v4/projects/84113019/repository/files/{path}/raw?ref=index";
 
-        assert_eq!(validated_index_key(gitlab).unwrap(), gitlab);
+        assert_eq!(IndexKey::validate(gitlab).unwrap().as_str(), gitlab);
         // Scheme/host case and the default port normalize through the
         // anchor; the placeholder and suffix stay verbatim.
         let spelled =
             "HTTPS://GitLab.COM:443/api/v4/projects/84113019/repository/files/{path}/raw?ref=index";
-        assert_eq!(validated_index_key(spelled).unwrap(), gitlab);
+        assert_eq!(IndexKey::validate(spelled).unwrap().as_str(), gitlab);
         // Idempotent: the key is its own key.
         assert_eq!(
-            validated_index_key(&validated_index_key(spelled).unwrap()).unwrap(),
+            IndexKey::validate(IndexKey::validate(spelled).unwrap().as_str())
+                .unwrap()
+                .as_str(),
             gitlab
         );
     }
 
     #[test]
     fn template_key_keeps_the_non_http_rejection() {
-        let err = validated_index_key("ftp://files.example.com/{path}").unwrap_err();
+        let err = IndexKey::validate("ftp://files.example.com/{path}").unwrap_err();
 
         assert!(matches!(&err, AuthCommandError::NotHttpIndex { .. }));
     }
@@ -752,8 +767,7 @@ mod login {
         };
         assert_eq!(stored[0].key, template);
         // A differently-spelled scheme normalizes to the same key.
-        let removed =
-            do_auth_logout(&mut store, "HTTP://127.0.0.1:1/files/{path}/raw?ref=main").unwrap();
+        let removed = logout(&mut store, "HTTP://127.0.0.1:1/files/{path}/raw?ref=main").unwrap();
         assert_eq!(removed, template);
         assert!(store.list().unwrap().is_empty());
     }
@@ -798,7 +812,7 @@ mod login {
                 .resolve(["pub", "name", "versions.json"]);
         assert!(expanded.as_str().contains("/raw/pub/name/versions.json"));
         assert!(matcher(&globs).is_match(expanded.as_str()));
-        assert_eq!(do_auth_logout(&mut store, template).unwrap(), template);
+        assert_eq!(logout(&mut store, template).unwrap(), template);
     }
 
     #[test]

--- a/core/src/commands/mod.rs
+++ b/core/src/commands/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 pub mod add;
+#[cfg(all(feature = "filesystem", feature = "networking"))]
+pub mod auth;
 #[cfg(feature = "filesystem")]
 pub mod build;
 pub mod env;

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -875,8 +875,7 @@ pub enum PublishError {
 
     #[error(
         "no bearer token credentials configured for publish URL `{upload_url}`;\n\
-         run `sysand auth login <index-url>` to store one, or set `SYSAND_CRED_<X>`\n\
-         and `SYSAND_CRED_<X>_BEARER_TOKEN` with a matching URL pattern"
+         set `SYSAND_CRED_<X>` and `SYSAND_CRED_<X>_BEARER_TOKEN` with a matching URL pattern"
     )]
     NoPublishBearer { upload_url: Box<str> },
 
@@ -986,9 +985,9 @@ pub enum PublishError {
     },
 
     #[error(
-        "the stored login for `{key}` expired at {expires_at}, so publish stopped\n\
-         before uploading; re-run `sysand auth login {key}` to store a fresh token\n\
-         (a matching `SYSAND_CRED_*` environment credential would take precedence instead)"
+        "the stored credential for `{key}` expired at {expires_at}, so publish stopped\n\
+         before uploading (a matching `SYSAND_CRED_*` environment credential would take\n\
+         precedence instead)"
     )]
     StoredCredentialExpired {
         key: String,
@@ -1424,12 +1423,13 @@ fn publish_auth_error(
 }
 
 /// The source-named upload auth-failure message (design section 7):
-/// because env credentials shadow stored logins, "re-run `sysand auth
-/// login`" would be the wrong fix for a stale `SYSAND_CRED_*` bearer, so
-/// the message states where the selected bearer came from and tailors the
-/// remediation. A 403 is authorization, not authentication: it
-/// additionally points at `sysand auth status`, whose stored `subject`
-/// catches a token for a different project or account.
+/// because env credentials shadow stored credentials, replacing the stored
+/// credential alone would be the wrong fix for a stale `SYSAND_CRED_*`
+/// bearer, so the message states where the selected bearer came from. A 403
+/// is authorization, not authentication, so it adds that a wrong-project or
+/// wrong-account token cannot publish. The message states the situation
+/// only; the remediation commands (`sysand auth login` / `status`) are the
+/// frontend's to add, so no CLI command name appears here.
 fn publish_auth_failed_message(
     status: u16,
     detail: &str,
@@ -1445,30 +1445,26 @@ fn publish_auth_failed_message(
             message.push_str(&format!(
                 "\nthe publish credential came from `SYSAND_CRED_{label}`; unset it or rotate\n\
                  `SYSAND_CRED_{label}_BEARER_TOKEN` (environment credentials take precedence\n\
-                 over stored logins, so `sysand auth login` alone cannot replace it)"
+                 over stored credentials, so re-authenticating alone cannot replace it)"
             ));
         }
         PublishBearerProvenance::Env { label: None } => {
             message.push_str(
                 "\nthe publish credential came from a `SYSAND_CRED_*` environment variable;\n\
                  unset it or rotate its `_BEARER_TOKEN` value (environment credentials take\n\
-                 precedence over stored logins, so `sysand auth login` alone cannot replace it)",
+                 precedence over stored credentials, so re-authenticating alone cannot replace it)",
             );
         }
         PublishBearerProvenance::Stored { key, .. } => {
             message.push_str(&format!(
-                "\nthe publish credential came from your stored login for `{key}`;\n\
-                 re-run `sysand auth login {key}` to store a fresh token"
+                "\nthe publish credential came from the stored credential for `{key}`"
             ));
         }
         // `publish_auth_error` never routes trusted publishing here.
         PublishBearerProvenance::TrustedPublishing => {}
     }
     if status == 403 {
-        message.push_str(
-            "\nrun `sysand auth status` to check which subject the credential authenticates\n\
-             as; a token for a different project or account cannot publish here",
-        );
+        message.push_str("\na token for a different project or account cannot publish here");
     }
     message
 }

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -308,6 +308,13 @@ fn stored_bearer_clearly_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) 
     now.signed_duration_since(expires_at) > TimeDelta::hours(1)
 }
 
+/// Render an expiry timestamp for display, without chrono's sub-second
+/// noise (`11:39:28.149443` reads as `11:39:28`), matching how `auth status`
+/// renders expiry timestamps.
+fn format_expiry_utc(expires_at: &DateTime<Utc>) -> String {
+    expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+}
+
 /// Validate the shape of the resolved `api_root` that comes back from
 /// discovery before the upload step. The user-supplied discovery root is an
 /// [`IndexLocation`], which already enforces the HTTP(S)/no-userinfo
@@ -463,7 +470,11 @@ fn resolve_publish_bearer_from_config(
     stored_bearers: impl FnOnce() -> GlobMap<StoredBearerAuth>,
     upload_url: &Url,
 ) -> Result<SelectedPublishBearer, PublishError> {
-    if let Some(entry) = lookup_publish_bearer(env_bearers, PublishBearerSource::Env, upload_url)? {
+    if let Some(entry) =
+        lookup_publish_bearer(env_bearers, PublishBearerSource::Env, upload_url, |entry| {
+            entry.auth.token()
+        })?
+    {
         return Ok(SelectedPublishBearer {
             auth: entry.auth.clone(),
             provenance: PublishBearerProvenance::Env {
@@ -472,7 +483,11 @@ fn resolve_publish_bearer_from_config(
         });
     }
     let stored = stored_bearers();
-    if let Some(entry) = lookup_publish_bearer(&stored, PublishBearerSource::Keyring, upload_url)? {
+    if let Some(entry) =
+        lookup_publish_bearer(&stored, PublishBearerSource::Keyring, upload_url, |entry| {
+            entry.auth().token()
+        })?
+    {
         return Ok(SelectedPublishBearer {
             auth: entry.auth().clone(),
             provenance: PublishBearerProvenance::Stored {
@@ -488,19 +503,31 @@ fn resolve_publish_bearer_from_config(
 
 /// Look `upload_url` up in one source's bearer map: a unique match wins, an
 /// ambiguous match errors naming the source, and no match returns `None` so
-/// the caller can fall through to the next source.
+/// the caller can fall through to the next source. Like the whoami and
+/// runtime selection flows, candidates that carry the identical token are
+/// one credential in effect (for example two stored globs of one login both
+/// matching the upload URL), so they collapse to a single match instead of
+/// erroring; `token` extracts the token to compare.
 fn lookup_publish_bearer<'a, T>(
     map: &'a GlobMap<T>,
     source: PublishBearerSource,
     upload_url: &Url,
+    token: impl Fn(&T) -> &str,
 ) -> Result<Option<&'a T>, PublishError> {
     match map.lookup(upload_url.as_str()) {
         GlobMapResult::Found(_, entry) => Ok(Some(entry)),
-        GlobMapResult::Ambiguous(candidates) => Err(PublishError::AmbiguousPublishBearer {
-            upload_url: upload_url.as_str().into(),
-            bearer_source: source,
-            candidates: candidates.len(),
-        }),
+        GlobMapResult::Ambiguous(candidates) => {
+            if let Some(((_, first), rest)) = candidates.split_first()
+                && rest.iter().all(|(_, entry)| token(entry) == token(first))
+            {
+                return Ok(Some(first));
+            }
+            Err(PublishError::AmbiguousPublishBearer {
+                upload_url: upload_url.as_str().into(),
+                bearer_source: source,
+                candidates: candidates.len(),
+            })
+        }
         GlobMapResult::NotFound => Ok(None),
     }
 }
@@ -985,9 +1012,10 @@ pub enum PublishError {
     },
 
     #[error(
-        "the stored credential for `{key}` expired at {expires_at}, so publish stopped\n\
+        "the stored credential for `{key}` expired at {}, so publish stopped\n\
          before uploading (a matching `SYSAND_CRED_*` environment credential would take\n\
-         precedence instead)"
+         precedence instead)",
+        format_expiry_utc(.expires_at)
     )]
     StoredCredentialExpired {
         key: String,

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -317,8 +317,8 @@ pub fn build_upload_url(api_root: &Url) -> Url {
 pub enum PublishBearerSource {
     /// `SYSAND_CRED_*` environment variables.
     Env,
-    /// Stored logins (keyring). Not populated yet; `sysand auth login` will
-    /// fill this source in a later phase.
+    /// Stored logins (the credential store), read lazily and only when no
+    /// env bearer matches the upload URL.
     Keyring,
 }
 
@@ -342,40 +342,22 @@ impl PublishBearerSource {
     }
 }
 
-/// Publish bearer credentials grouped by source, in precedence order:
-/// env before keyring, so a CI `SYSAND_CRED_*` variable overrides an
-/// interactive login. The keyring map is currently always empty; a later
-/// phase populates it from stored logins (design/credential-storage.md,
-/// section 7).
-#[derive(Debug, Clone)]
-pub struct PublishBearerSources {
-    env: GlobMap<ForceBearerAuth>,
-    keyring: GlobMap<ForceBearerAuth>,
-}
-
-impl PublishBearerSources {
-    /// Bearer credentials from `SYSAND_CRED_*` only, with no stored logins.
-    pub fn from_env(env: GlobMap<ForceBearerAuth>) -> Self {
-        Self::new(env, GlobMap::default())
-    }
-
-    // Crate-private on purpose: the keyring side must stay lazily read (one
-    // keychain access, only when env has no match), so the eager two-map
-    // shape is not a public commitment. The task that populates the keyring
-    // source owns reshaping this constructor.
-    pub(crate) fn new(env: GlobMap<ForceBearerAuth>, keyring: GlobMap<ForceBearerAuth>) -> Self {
-        Self { env, keyring }
-    }
-}
-
 /// Resolve the bearer token used for publishing.
 ///
 /// In `auto` mode, publish uses trusted publishing in supported CI
 /// environments and uses configured bearer credentials elsewhere. In `always`
 /// mode, publish requires trusted publishing and ignores configured bearer
 /// credentials. In `never` mode, publish uses configured bearer credentials.
+///
+/// Configured credentials come from two sources in precedence order: the
+/// eager `env_bearers` map (`SYSAND_CRED_*`) and `stored_bearers`, a lazy
+/// provider for stored logins that is invoked only when no env bearer
+/// matches the upload URL, so a publish resolved from env (or via trusted
+/// publishing) never touches the credential store
+/// (design/credential-storage.md, section 7).
 pub fn resolve_publish_bearer(
-    bearer_sources: &PublishBearerSources,
+    env_bearers: &GlobMap<ForceBearerAuth>,
+    stored_bearers: impl FnOnce() -> GlobMap<ForceBearerAuth>,
     api_root: &Url,
     mode: TrustedPublishingMode,
     env: &TrustedPublishingEnvironment,
@@ -388,46 +370,57 @@ pub fn resolve_publish_bearer(
             if let Some(provider) = env.trusted_publishing_provider()? {
                 return acquire_trusted_publishing_bearer(provider, api_root, client, runtime);
             }
-            resolve_publish_bearer_from_config(bearer_sources, &upload_url)
+            resolve_publish_bearer_from_config(env_bearers, stored_bearers, &upload_url)
         }
         TrustedPublishingMode::Always => {
             let provider = env.require_trusted_publishing_provider()?;
             acquire_trusted_publishing_bearer(provider, api_root, client, runtime)
         }
         TrustedPublishingMode::Never => {
-            resolve_publish_bearer_from_config(bearer_sources, &upload_url)
+            resolve_publish_bearer_from_config(env_bearers, stored_bearers, &upload_url)
         }
     }
 }
 
 /// Select the configured bearer for `upload_url` with source precedence:
 /// a single env match wins outright; an ambiguous env match errors without
-/// consulting the keyring; only when env has no match at all is the keyring
-/// source tried, under the same single-match rule.
+/// consulting the keyring; only when env has no match at all is the
+/// `stored_bearers` provider invoked and its map tried, under the same
+/// single-match rule.
 fn resolve_publish_bearer_from_config(
-    bearer_sources: &PublishBearerSources,
+    env_bearers: &GlobMap<ForceBearerAuth>,
+    stored_bearers: impl FnOnce() -> GlobMap<ForceBearerAuth>,
     upload_url: &Url,
 ) -> Result<ForceBearerAuth, PublishError> {
-    let sources = [
-        (PublishBearerSource::Env, &bearer_sources.env),
-        (PublishBearerSource::Keyring, &bearer_sources.keyring),
-    ];
-    for (source, map) in sources {
-        match map.lookup(upload_url.as_str()) {
-            GlobMapResult::Found(_, token) => return Ok(token.clone()),
-            GlobMapResult::Ambiguous(candidates) => {
-                return Err(PublishError::AmbiguousPublishBearer {
-                    upload_url: upload_url.as_str().into(),
-                    bearer_source: source,
-                    candidates: candidates.len(),
-                });
-            }
-            GlobMapResult::NotFound => {}
-        }
+    if let Some(token) = lookup_publish_bearer(env_bearers, PublishBearerSource::Env, upload_url)? {
+        return Ok(token);
+    }
+    let stored = stored_bearers();
+    if let Some(token) = lookup_publish_bearer(&stored, PublishBearerSource::Keyring, upload_url)? {
+        return Ok(token);
     }
     Err(PublishError::NoPublishBearer {
         upload_url: upload_url.as_str().into(),
     })
+}
+
+/// Look `upload_url` up in one source's bearer map: a unique match wins, an
+/// ambiguous match errors naming the source, and no match returns `None` so
+/// the caller can fall through to the next source.
+fn lookup_publish_bearer(
+    map: &GlobMap<ForceBearerAuth>,
+    source: PublishBearerSource,
+    upload_url: &Url,
+) -> Result<Option<ForceBearerAuth>, PublishError> {
+    match map.lookup(upload_url.as_str()) {
+        GlobMapResult::Found(_, token) => Ok(Some(token.clone())),
+        GlobMapResult::Ambiguous(candidates) => Err(PublishError::AmbiguousPublishBearer {
+            upload_url: upload_url.as_str().into(),
+            bearer_source: source,
+            candidates: candidates.len(),
+        }),
+        GlobMapResult::NotFound => Ok(None),
+    }
 }
 
 fn acquire_trusted_publishing_bearer(

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -17,8 +17,13 @@ use thiserror::Error;
 use url::Url;
 use zip::result::ZipError;
 
+use chrono::{DateTime, TimeDelta, Utc};
+
 use crate::{
-    auth::{ForceBearerAuth, GlobMap, GlobMapResult, HTTPAuthentication},
+    auth::{
+        EnvBearerAuth, ForceBearerAuth, GlobMap, GlobMapResult, HTTPAuthentication,
+        StoredBearerAuth,
+    },
     env::discovery::{HttpBaseUrlShapeError, validate_http_base_url_shape},
     include::{IncludeError, extract_symbols},
     index_location::IndexLocation,
@@ -207,10 +212,26 @@ pub fn do_publish(
     prepared: PublishPreparation,
     discovery_root: IndexLocation,
     api_root: Url,
-    auth: ForceBearerAuth,
+    bearer: SelectedPublishBearer,
     client: reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
 ) -> Result<PublishResponse, PublishError> {
+    // Fail fast on a clearly expired stored login before uploading the
+    // archive (design/credential-storage.md section 7). The server's 401
+    // remains the authority: only an expiry past the skew margin stops
+    // here, and an env credential (no known expiry) always proceeds.
+    if let PublishBearerProvenance::Stored {
+        key,
+        expires_at: Some(expires_at),
+    } = &bearer.provenance
+        && stored_bearer_clearly_expired(*expires_at, Utc::now())
+    {
+        return Err(PublishError::StoredCredentialExpired {
+            key: key.clone(),
+            expires_at: *expires_at,
+        });
+    }
+
     let header = crate::style::get_style_config().header;
     // Caller is expected to have run discovery and passed the resolved
     // `api_root`. `discovery_root` is the user-facing URL (what was
@@ -253,8 +274,12 @@ pub fn do_publish(
         c.post(upload_url.clone()).multipart(form)
     };
 
-    let response =
-        runtime.block_on(async { auth.with_authentication(&client, &build_request).await })?;
+    let response = runtime.block_on(async {
+        bearer
+            .auth
+            .with_authentication(&client, &build_request)
+            .await
+    })?;
 
     let status = response.status().as_u16();
     let response_url = response.url().to_string();
@@ -268,7 +293,14 @@ pub fn do_publish(
         status
     );
 
-    map_publish_response(status, &body_bytes)
+    map_publish_response(status, &body_bytes, &bearer.provenance)
+}
+
+/// Whether a stored login's known expiry is clearly past: beyond a small
+/// skew margin, so a fast client clock cannot false-trip the pre-upload
+/// stop (design/credential-storage.md section 7).
+fn stored_bearer_clearly_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    now.signed_duration_since(expires_at) > TimeDelta::seconds(60)
 }
 
 /// Validate the shape of the resolved `api_root` that comes back from
@@ -322,6 +354,40 @@ pub enum PublishBearerSource {
     Keyring,
 }
 
+/// The bearer credential publish selected for the upload, with the
+/// provenance an auth failure must name (design/credential-storage.md
+/// section 7).
+#[derive(Clone)]
+pub struct SelectedPublishBearer {
+    pub auth: ForceBearerAuth,
+    pub provenance: PublishBearerProvenance,
+}
+
+impl std::fmt::Debug for SelectedPublishBearer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redacts the token: only the non-secret provenance is shown.
+        f.debug_struct("SelectedPublishBearer")
+            .field("provenance", &self.provenance)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Where the selected publish bearer came from, carrying the non-secret
+/// fields the auth-failure messages and the pre-upload expiry check need.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishBearerProvenance {
+    /// A `SYSAND_CRED_*` environment credential; `label` is the
+    /// `SYSAND_CRED_<LABEL>` stem when known.
+    Env { label: Option<String> },
+    /// A stored login (`sysand auth login`) for the given index key.
+    Stored {
+        key: String,
+        expires_at: Option<DateTime<Utc>>,
+    },
+    /// A short-lived token acquired via CI trusted publishing.
+    TrustedPublishing,
+}
+
 impl PublishBearerSource {
     fn name(self) -> &'static str {
         match self {
@@ -356,14 +422,14 @@ impl PublishBearerSource {
 /// publishing) never touches the credential store
 /// (design/credential-storage.md, section 7).
 pub fn resolve_publish_bearer(
-    env_bearers: &GlobMap<ForceBearerAuth>,
-    stored_bearers: impl FnOnce() -> GlobMap<ForceBearerAuth>,
+    env_bearers: &GlobMap<EnvBearerAuth>,
+    stored_bearers: impl FnOnce() -> GlobMap<StoredBearerAuth>,
     api_root: &Url,
     mode: TrustedPublishingMode,
     env: &TrustedPublishingEnvironment,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: &Arc<tokio::runtime::Runtime>,
-) -> Result<ForceBearerAuth, PublishError> {
+) -> Result<SelectedPublishBearer, PublishError> {
     let upload_url = build_upload_url(api_root);
     match mode {
         TrustedPublishingMode::Auto => {
@@ -388,16 +454,27 @@ pub fn resolve_publish_bearer(
 /// `stored_bearers` provider invoked and its map tried, under the same
 /// single-match rule.
 fn resolve_publish_bearer_from_config(
-    env_bearers: &GlobMap<ForceBearerAuth>,
-    stored_bearers: impl FnOnce() -> GlobMap<ForceBearerAuth>,
+    env_bearers: &GlobMap<EnvBearerAuth>,
+    stored_bearers: impl FnOnce() -> GlobMap<StoredBearerAuth>,
     upload_url: &Url,
-) -> Result<ForceBearerAuth, PublishError> {
-    if let Some(token) = lookup_publish_bearer(env_bearers, PublishBearerSource::Env, upload_url)? {
-        return Ok(token);
+) -> Result<SelectedPublishBearer, PublishError> {
+    if let Some(entry) = lookup_publish_bearer(env_bearers, PublishBearerSource::Env, upload_url)? {
+        return Ok(SelectedPublishBearer {
+            auth: entry.auth.clone(),
+            provenance: PublishBearerProvenance::Env {
+                label: entry.label.clone(),
+            },
+        });
     }
     let stored = stored_bearers();
-    if let Some(token) = lookup_publish_bearer(&stored, PublishBearerSource::Keyring, upload_url)? {
-        return Ok(token);
+    if let Some(entry) = lookup_publish_bearer(&stored, PublishBearerSource::Keyring, upload_url)? {
+        return Ok(SelectedPublishBearer {
+            auth: entry.auth().clone(),
+            provenance: PublishBearerProvenance::Stored {
+                key: entry.key().to_string(),
+                expires_at: entry.expires_at(),
+            },
+        });
     }
     Err(PublishError::NoPublishBearer {
         upload_url: upload_url.as_str().into(),
@@ -407,13 +484,13 @@ fn resolve_publish_bearer_from_config(
 /// Look `upload_url` up in one source's bearer map: a unique match wins, an
 /// ambiguous match errors naming the source, and no match returns `None` so
 /// the caller can fall through to the next source.
-fn lookup_publish_bearer(
-    map: &GlobMap<ForceBearerAuth>,
+fn lookup_publish_bearer<'a, T>(
+    map: &'a GlobMap<T>,
     source: PublishBearerSource,
     upload_url: &Url,
-) -> Result<Option<ForceBearerAuth>, PublishError> {
+) -> Result<Option<&'a T>, PublishError> {
     match map.lookup(upload_url.as_str()) {
-        GlobMapResult::Found(_, token) => Ok(Some(token.clone())),
+        GlobMapResult::Found(_, entry) => Ok(Some(entry)),
         GlobMapResult::Ambiguous(candidates) => Err(PublishError::AmbiguousPublishBearer {
             upload_url: upload_url.as_str().into(),
             bearer_source: source,
@@ -428,7 +505,7 @@ fn acquire_trusted_publishing_bearer(
     api_root: &Url,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: &Arc<tokio::runtime::Runtime>,
-) -> Result<ForceBearerAuth, PublishError> {
+) -> Result<SelectedPublishBearer, PublishError> {
     log::debug!("trusted publishing: using {provider:?}");
     let provider_token = match provider {
         SelectedTrustedPublishingProvider::Github {
@@ -440,7 +517,10 @@ fn acquire_trusted_publishing_bearer(
     let index_token =
         exchange_oidc_token_for_index_token(api_root, &provider_token, client, runtime)?;
 
-    Ok(ForceBearerAuth::new(index_token))
+    Ok(SelectedPublishBearer {
+        auth: ForceBearerAuth::new(index_token),
+        provenance: PublishBearerProvenance::TrustedPublishing,
+    })
 }
 
 /// Ask the GitHub Actions runner OIDC endpoint for a token with the `sysand`
@@ -892,6 +972,23 @@ pub enum PublishError {
     #[error("authentication failed: {0}")]
     AuthError(String),
 
+    #[error("{}", publish_auth_failed_message(*.status, .detail, .provenance))]
+    PublishAuthFailed {
+        status: u16,
+        detail: String,
+        provenance: PublishBearerProvenance,
+    },
+
+    #[error(
+        "the stored login for `{key}` expired at {expires_at}, so publish stopped\n\
+         before uploading; re-run `sysand auth login {key}` to store a fresh token\n\
+         (a matching `SYSAND_CRED_*` environment credential would take precedence instead)"
+    )]
+    StoredCredentialExpired {
+        key: String,
+        expires_at: DateTime<Utc>,
+    },
+
     #[error("conflict: package version already exists: {0}")]
     Conflict(String),
 
@@ -1270,7 +1367,11 @@ fn check_metamodel(metamodel: &str) -> Result<AllowedMetamodelKind, PublishError
 }
 
 /// Maps an HTTP status and body to a `PublishResponse` or `PublishError`.
-fn map_publish_response(status: u16, body_bytes: &[u8]) -> Result<PublishResponse, PublishError> {
+fn map_publish_response(
+    status: u16,
+    body_bytes: &[u8],
+    provenance: &PublishBearerProvenance,
+) -> Result<PublishResponse, PublishError> {
     match status {
         200 => Ok(PublishResponse {
             status,
@@ -1283,7 +1384,11 @@ fn map_publish_response(status: u16, body_bytes: &[u8]) -> Result<PublishRespons
             is_new_project: true,
         }),
         400 => Err(PublishError::BadRequest(error_body_to_string(body_bytes))),
-        401 | 403 => Err(PublishError::AuthError(error_body_to_string(body_bytes))),
+        401 | 403 => Err(publish_auth_error(
+            status,
+            error_body_to_string(body_bytes),
+            provenance,
+        )),
         404 => Err(PublishError::NotFound(error_body_to_string(body_bytes))),
         409 => Err(PublishError::Conflict(error_body_to_string(body_bytes))),
         _ => Err(PublishError::ServerError {
@@ -1291,6 +1396,75 @@ fn map_publish_response(status: u16, body_bytes: &[u8]) -> Result<PublishRespons
             body: error_body_to_string(body_bytes),
         }),
     }
+}
+
+/// Build the error for a 401/403 upload response. Configured credentials
+/// get the source-named message (design/credential-storage.md section 7);
+/// a trusted-publishing token has no user-fixable source, so it keeps the
+/// generic wording.
+fn publish_auth_error(
+    status: u16,
+    detail: String,
+    provenance: &PublishBearerProvenance,
+) -> PublishError {
+    match provenance {
+        PublishBearerProvenance::TrustedPublishing => PublishError::AuthError(detail),
+        _ => PublishError::PublishAuthFailed {
+            status,
+            detail,
+            provenance: provenance.clone(),
+        },
+    }
+}
+
+/// The source-named upload auth-failure message (design section 7):
+/// because env credentials shadow stored logins, "re-run `sysand auth
+/// login`" would be the wrong fix for a stale `SYSAND_CRED_*` bearer, so
+/// the message states where the selected bearer came from and tailors the
+/// remediation. A 403 is authorization, not authentication: it
+/// additionally points at `sysand auth status`, whose stored `subject`
+/// catches a token for a different project or account.
+fn publish_auth_failed_message(
+    status: u16,
+    detail: &str,
+    provenance: &PublishBearerProvenance,
+) -> String {
+    let mut message = if status == 401 {
+        format!("authentication failed (HTTP 401): {detail}")
+    } else {
+        format!("authorization failed (HTTP {status}): {detail}")
+    };
+    match provenance {
+        PublishBearerProvenance::Env { label: Some(label) } => {
+            message.push_str(&format!(
+                "\nthe publish credential came from `SYSAND_CRED_{label}`; unset it or rotate\n\
+                 `SYSAND_CRED_{label}_BEARER_TOKEN` (environment credentials take precedence\n\
+                 over stored logins, so `sysand auth login` alone cannot replace it)"
+            ));
+        }
+        PublishBearerProvenance::Env { label: None } => {
+            message.push_str(
+                "\nthe publish credential came from a `SYSAND_CRED_*` environment variable;\n\
+                 unset it or rotate its `_BEARER_TOKEN` value (environment credentials take\n\
+                 precedence over stored logins, so `sysand auth login` alone cannot replace it)",
+            );
+        }
+        PublishBearerProvenance::Stored { key, .. } => {
+            message.push_str(&format!(
+                "\nthe publish credential came from your stored login for `{key}`;\n\
+                 re-run `sysand auth login {key}` to store a fresh token"
+            ));
+        }
+        // `publish_auth_error` never routes trusted publishing here.
+        PublishBearerProvenance::TrustedPublishing => {}
+    }
+    if status == 403 {
+        message.push_str(
+            "\nrun `sysand auth status` to check which subject the credential authenticates\n\
+             as; a token for a different project or account cannot publish here",
+        );
+    }
+    message
 }
 
 #[derive(Deserialize)]

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -21,8 +21,8 @@ use chrono::{DateTime, TimeDelta, Utc};
 
 use crate::{
     auth::{
-        EnvBearerAuth, ForceBearerAuth, GlobMap, GlobMapResult, HTTPAuthentication,
-        StoredBearerAuth,
+        BearerSelection, EnvBearerAuth, ForceBearerAuth, GlobMap, HTTPAuthentication,
+        StoredBearerAuth, select_bearer,
     },
     env::discovery::{HttpBaseUrlShapeError, validate_http_base_url_shape},
     include::{IncludeError, extract_symbols},
@@ -501,34 +501,26 @@ fn resolve_publish_bearer_from_config(
     })
 }
 
-/// Look `upload_url` up in one source's bearer map: a unique match wins, an
-/// ambiguous match errors naming the source, and no match returns `None` so
-/// the caller can fall through to the next source. Like the whoami and
-/// runtime selection flows, candidates that carry the identical token are
-/// one credential in effect (for example two stored globs of one login both
-/// matching the upload URL), so they collapse to a single match instead of
-/// erroring; `token` extracts the token to compare.
+/// Look `upload_url` up in one source's bearer map: a unique match wins
+/// (candidates carrying the identical token collapse to one,
+/// [`select_bearer`]), an ambiguous match errors naming the source, and no
+/// match returns `None` so the caller can fall through to the next source.
 fn lookup_publish_bearer<'a, T>(
     map: &'a GlobMap<T>,
     source: PublishBearerSource,
     upload_url: &Url,
     token: impl Fn(&T) -> &str,
 ) -> Result<Option<&'a T>, PublishError> {
-    match map.lookup(upload_url.as_str()) {
-        GlobMapResult::Found(_, entry) => Ok(Some(entry)),
-        GlobMapResult::Ambiguous(candidates) => {
-            if let Some(((_, first), rest)) = candidates.split_first()
-                && rest.iter().all(|(_, entry)| token(entry) == token(first))
-            {
-                return Ok(Some(first));
-            }
+    match select_bearer(map, upload_url.as_str(), token) {
+        BearerSelection::Unique(entry) => Ok(Some(entry)),
+        BearerSelection::Ambiguous { candidates, .. } => {
             Err(PublishError::AmbiguousPublishBearer {
                 upload_url: upload_url.as_str().into(),
                 bearer_source: source,
-                candidates: candidates.len(),
+                candidates,
             })
         }
-        GlobMapResult::NotFound => Ok(None),
+        BearerSelection::None => Ok(None),
     }
 }
 

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -397,7 +397,7 @@ impl PublishBearerSource {
     fn name(self) -> &'static str {
         match self {
             PublishBearerSource::Env => "`SYSAND_CRED_*` environment variables",
-            PublishBearerSource::Keyring => "stored logins",
+            PublishBearerSource::Keyring => "stored credentials",
         }
     }
 

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -529,7 +529,7 @@ fn lookup_publish_bearer<'a, T>(
 /// Collect an iterator of candidate names, dropping repeats while keeping
 /// first-seen order (a stored login matching through several of its own
 /// URL patterns still names its key once).
-fn dedup_in_order(names: impl Iterator<Item = String>) -> Vec<String> {
+pub(crate) fn dedup_in_order(names: impl Iterator<Item = String>) -> Vec<String> {
     let mut seen = Vec::new();
     for name in names {
         if !seen.contains(&name) {

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -309,6 +309,65 @@ pub fn build_upload_url(api_root: &Url) -> Url {
     api_root.join(UPLOAD_ENDPOINT_PATH).unwrap()
 }
 
+/// Where a configured publish bearer credential came from. Selection tries
+/// sources in precedence order (env before keyring), and ambiguity errors
+/// name the source so the remediation can be accurate
+/// (see design/credential-storage.md, sections 7 and 8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishBearerSource {
+    /// `SYSAND_CRED_*` environment variables.
+    Env,
+    /// Stored logins (keyring). Not populated yet; `sysand auth login` will
+    /// fill this source in a later phase.
+    Keyring,
+}
+
+impl PublishBearerSource {
+    fn name(self) -> &'static str {
+        match self {
+            PublishBearerSource::Env => "`SYSAND_CRED_*` environment variables",
+            PublishBearerSource::Keyring => "stored logins",
+        }
+    }
+
+    fn ambiguity_hint(self) -> &'static str {
+        match self {
+            PublishBearerSource::Env => {
+                "refine `SYSAND_CRED_<X>` URL patterns so exactly one bearer token matches"
+            }
+            PublishBearerSource::Keyring => {
+                "remove or narrow overlapping stored credentials so exactly one bearer token matches"
+            }
+        }
+    }
+}
+
+/// Publish bearer credentials grouped by source, in precedence order:
+/// env before keyring, so a CI `SYSAND_CRED_*` variable overrides an
+/// interactive login. The keyring map is currently always empty; a later
+/// phase populates it from stored logins (design/credential-storage.md,
+/// section 7).
+#[derive(Debug, Clone)]
+pub struct PublishBearerSources {
+    env: GlobMap<ForceBearerAuth>,
+    keyring: GlobMap<ForceBearerAuth>,
+}
+
+impl PublishBearerSources {
+    /// Bearer credentials from `SYSAND_CRED_*` only, with no stored logins.
+    pub fn from_env(env: GlobMap<ForceBearerAuth>) -> Self {
+        Self::new(env, GlobMap::default())
+    }
+
+    // Crate-private on purpose: the keyring side must stay lazily read (one
+    // keychain access, only when env has no match), so the eager two-map
+    // shape is not a public commitment. The task that populates the keyring
+    // source owns reshaping this constructor.
+    pub(crate) fn new(env: GlobMap<ForceBearerAuth>, keyring: GlobMap<ForceBearerAuth>) -> Self {
+        Self { env, keyring }
+    }
+}
+
 /// Resolve the bearer token used for publishing.
 ///
 /// In `auto` mode, publish uses trusted publishing in supported CI
@@ -316,7 +375,7 @@ pub fn build_upload_url(api_root: &Url) -> Url {
 /// mode, publish requires trusted publishing and ignores configured bearer
 /// credentials. In `never` mode, publish uses configured bearer credentials.
 pub fn resolve_publish_bearer(
-    bearer_map: &GlobMap<ForceBearerAuth>,
+    bearer_sources: &PublishBearerSources,
     api_root: &Url,
     mode: TrustedPublishingMode,
     env: &TrustedPublishingEnvironment,
@@ -329,30 +388,46 @@ pub fn resolve_publish_bearer(
             if let Some(provider) = env.trusted_publishing_provider()? {
                 return acquire_trusted_publishing_bearer(provider, api_root, client, runtime);
             }
-            resolve_publish_bearer_from_config(bearer_map, &upload_url)
+            resolve_publish_bearer_from_config(bearer_sources, &upload_url)
         }
         TrustedPublishingMode::Always => {
             let provider = env.require_trusted_publishing_provider()?;
             acquire_trusted_publishing_bearer(provider, api_root, client, runtime)
         }
-        TrustedPublishingMode::Never => resolve_publish_bearer_from_config(bearer_map, &upload_url),
+        TrustedPublishingMode::Never => {
+            resolve_publish_bearer_from_config(bearer_sources, &upload_url)
+        }
     }
 }
 
+/// Select the configured bearer for `upload_url` with source precedence:
+/// a single env match wins outright; an ambiguous env match errors without
+/// consulting the keyring; only when env has no match at all is the keyring
+/// source tried, under the same single-match rule.
 fn resolve_publish_bearer_from_config(
-    bearer_map: &GlobMap<ForceBearerAuth>,
+    bearer_sources: &PublishBearerSources,
     upload_url: &Url,
 ) -> Result<ForceBearerAuth, PublishError> {
-    match bearer_map.lookup(upload_url.as_str()) {
-        GlobMapResult::Found(_, token) => Ok(token.clone()),
-        GlobMapResult::Ambiguous(candidates) => Err(PublishError::AmbiguousPublishBearer {
-            upload_url: upload_url.as_str().into(),
-            candidates: candidates.len(),
-        }),
-        GlobMapResult::NotFound => Err(PublishError::NoPublishBearer {
-            upload_url: upload_url.as_str().into(),
-        }),
+    let sources = [
+        (PublishBearerSource::Env, &bearer_sources.env),
+        (PublishBearerSource::Keyring, &bearer_sources.keyring),
+    ];
+    for (source, map) in sources {
+        match map.lookup(upload_url.as_str()) {
+            GlobMapResult::Found(_, token) => return Ok(token.clone()),
+            GlobMapResult::Ambiguous(candidates) => {
+                return Err(PublishError::AmbiguousPublishBearer {
+                    upload_url: upload_url.as_str().into(),
+                    bearer_source: source,
+                    candidates: candidates.len(),
+                });
+            }
+            GlobMapResult::NotFound => {}
+        }
     }
+    Err(PublishError::NoPublishBearer {
+        upload_url: upload_url.as_str().into(),
+    })
 }
 
 fn acquire_trusted_publishing_bearer(
@@ -727,11 +802,16 @@ pub enum PublishError {
     NoPublishBearer { upload_url: Box<str> },
 
     #[error(
-        "multiple bearer token credentials configured for publish URL `{upload_url}`;\n\
-         refine `SYSAND_CRED_<X>` URL patterns so exactly one bearer token matches ({candidates} candidates found)"
+        "multiple bearer token credentials from {} configured for publish URL `{upload_url}`;\n\
+         {} ({candidates} candidates found)",
+        bearer_source.name(),
+        bearer_source.ambiguity_hint()
     )]
+    // The field is `bearer_source`, not `source`, because thiserror gives a
+    // field named `source` error-chaining semantics.
     AmbiguousPublishBearer {
         upload_url: Box<str>,
+        bearer_source: PublishBearerSource,
         candidates: usize,
     },
 

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -216,8 +216,8 @@ pub fn do_publish(
     client: reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
 ) -> Result<PublishResponse, PublishError> {
-    // Fail fast on a clearly expired stored credential before uploading the
-    // archive (design/credential-storage.md section 7). The server's 401
+    // Fail fast on a clearly expired stored credential before uploading
+    // the archive. The server's 401
     // remains the authority: only an expiry past the skew margin stops
     // here, and an env credential (no known expiry) always proceeds.
     if let PublishBearerProvenance::Stored {
@@ -297,8 +297,7 @@ pub fn do_publish(
 /// Whether a stored credential's known expiry is clearly past: beyond a
 /// generous clock-skew margin, so a skewed client clock cannot false-trip
 /// the pre-upload stop. The stop is only an optimization; the server's 401
-/// is the real authority, so the margin errs toward attempting
-/// (design/credential-storage.md section 7).
+/// is the real authority, so the margin errs toward attempting.
 fn stored_bearer_clearly_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
     now.signed_duration_since(expires_at) > TimeDelta::hours(1)
 }
@@ -348,8 +347,7 @@ pub fn build_upload_url(api_root: &Url) -> Url {
 
 /// Where a configured publish bearer credential came from. Selection tries
 /// sources in precedence order (env before keyring), and ambiguity errors
-/// name the source so the remediation can be accurate
-/// (see design/credential-storage.md, sections 7 and 8).
+/// name the source so the remediation can be accurate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PublishBearerSource {
     /// `SYSAND_CRED_*` environment variables.
@@ -360,8 +358,7 @@ pub enum PublishBearerSource {
 }
 
 /// The bearer credential publish selected for the upload, with the
-/// provenance an auth failure must name (design/credential-storage.md
-/// section 7).
+/// provenance an auth failure must name.
 #[derive(Clone)]
 pub struct SelectedPublishBearer {
     pub auth: ForceBearerAuth,
@@ -424,7 +421,7 @@ impl PublishBearerSource {
 /// `env_bearers` (`SYSAND_CRED_*`), then the lazy `stored_bearers`
 /// provider, invoked only when no env bearer matches the upload URL, so a
 /// publish resolved from env (or trusted publishing) never touches the
-/// credential store (design/credential-storage.md section 7).
+/// credential store.
 pub fn resolve_publish_bearer(
     env_bearers: &GlobMap<EnvBearerAuth>,
     stored_bearers: impl FnOnce() -> GlobMap<StoredBearerAuth>,
@@ -1416,7 +1413,7 @@ fn map_publish_response(
 }
 
 /// Build the error for a 401/403 upload response. Configured credentials
-/// get the source-named message (design/credential-storage.md section 7);
+/// get the source-named message;
 /// a trusted-publishing token has no user-fixable source, so it keeps the
 /// generic wording.
 fn publish_auth_error(
@@ -1434,7 +1431,7 @@ fn publish_auth_error(
     }
 }
 
-/// The source-named upload auth-failure message (design section 7): env
+/// The source-named upload auth-failure message: env
 /// credentials shadow stored ones, so re-authenticating would be the
 /// wrong fix for a stale `SYSAND_CRED_*` bearer and the message must name
 /// where the selected bearer came from. States the situation only; the

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -367,8 +367,8 @@ impl std::fmt::Debug for SelectedPublishBearer {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PublishBearerProvenance {
     /// A `SYSAND_CRED_*` environment credential; `label` is the
-    /// `SYSAND_CRED_<LABEL>` stem when known.
-    Env { label: Option<String> },
+    /// `SYSAND_CRED_<LABEL>` stem.
+    Env { label: String },
     /// A stored credential (`sysand auth login`) for the given index key.
     Stored {
         key: String,
@@ -1435,19 +1435,12 @@ fn publish_auth_failed_message(
         format!("authorization failed (HTTP {status}): {detail}")
     };
     match provenance {
-        PublishBearerProvenance::Env { label: Some(label) } => {
+        PublishBearerProvenance::Env { label } => {
             message.push_str(&format!(
                 "\nthe publish credential came from `SYSAND_CRED_{label}`; unset it or rotate\n\
                  `SYSAND_CRED_{label}_BEARER_TOKEN` (environment credentials take precedence\n\
                  over stored credentials, so re-authenticating alone cannot replace it)"
             ));
-        }
-        PublishBearerProvenance::Env { label: None } => {
-            message.push_str(
-                "\nthe publish credential came from a `SYSAND_CRED_*` environment variable;\n\
-                 unset it or rotate its `_BEARER_TOKEN` value (environment credentials take\n\
-                 precedence over stored credentials, so re-authenticating alone cannot replace it)",
-            );
         }
         PublishBearerProvenance::Stored { key, .. } => {
             message.push_str(&format!(

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -870,7 +870,8 @@ pub enum PublishError {
 
     #[error(
         "no bearer token credentials configured for publish URL `{upload_url}`;\n\
-         set `SYSAND_CRED_<X>` and `SYSAND_CRED_<X>_BEARER_TOKEN` with a matching URL pattern"
+         run `sysand auth login <index-url>` to store one, or set `SYSAND_CRED_<X>`\n\
+         and `SYSAND_CRED_<X>_BEARER_TOKEN` with a matching URL pattern"
     )]
     NoPublishBearer { upload_url: Box<str> },
 

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -333,16 +333,52 @@ pub fn build_upload_url(api_root: &Url) -> Url {
     api_root.join(UPLOAD_ENDPOINT_PATH).unwrap()
 }
 
-/// Where a configured publish bearer credential came from. Selection tries
-/// sources in precedence order (env before keyring), and ambiguity errors
-/// name the source so the remediation can be accurate.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PublishBearerSource {
-    /// `SYSAND_CRED_*` environment variables.
-    Env,
-    /// Stored logins (the credential store), read lazily and only when no
-    /// env bearer matches the upload URL.
-    Keyring,
+/// The conflicting candidates behind an ambiguous publish bearer
+/// selection, per source (selection tries env before keyring, and never
+/// mixes the two). Each variant names every matching credential so the
+/// error tells the user exactly what to reconcile, and the remediation can
+/// be source-accurate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishBearerConflict {
+    /// Conflicting `SYSAND_CRED_*` environment credentials; each entry is
+    /// a full `SYSAND_CRED_<LABEL>` variable name.
+    Env { variables: Vec<String> },
+    /// Conflicting stored logins (the credential store, read lazily and
+    /// only when no env bearer matches the upload URL), by index key.
+    Stored { keys: Vec<String> },
+}
+
+impl PublishBearerConflict {
+    fn source_name(&self) -> &'static str {
+        match self {
+            PublishBearerConflict::Env { .. } => "`SYSAND_CRED_*` environment variables",
+            PublishBearerConflict::Stored { .. } => "stored credentials",
+        }
+    }
+
+    /// The matching credentials, comma-separated: bare variable names for
+    /// env, backticked index keys for stored logins.
+    fn candidate_list(&self) -> String {
+        match self {
+            PublishBearerConflict::Env { variables } => variables.join(", "),
+            PublishBearerConflict::Stored { keys } => keys
+                .iter()
+                .map(|key| format!("`{key}`"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        }
+    }
+
+    fn hint(&self) -> &'static str {
+        match self {
+            PublishBearerConflict::Env { .. } => {
+                "refine `SYSAND_CRED_<X>` URL patterns so exactly one bearer token matches"
+            }
+            PublishBearerConflict::Stored { .. } => {
+                "remove or narrow overlapping stored credentials so exactly one bearer token matches"
+            }
+        }
+    }
 }
 
 /// The bearer credential publish selected for the upload, with the
@@ -376,26 +412,6 @@ pub enum PublishBearerProvenance {
     },
     /// A short-lived token acquired via CI trusted publishing.
     TrustedPublishing,
-}
-
-impl PublishBearerSource {
-    fn name(self) -> &'static str {
-        match self {
-            PublishBearerSource::Env => "`SYSAND_CRED_*` environment variables",
-            PublishBearerSource::Keyring => "stored credentials",
-        }
-    }
-
-    fn ambiguity_hint(self) -> &'static str {
-        match self {
-            PublishBearerSource::Env => {
-                "refine `SYSAND_CRED_<X>` URL patterns so exactly one bearer token matches"
-            }
-            PublishBearerSource::Keyring => {
-                "remove or narrow overlapping stored credentials so exactly one bearer token matches"
-            }
-        }
-    }
 }
 
 /// Resolve the bearer token used for publishing.
@@ -447,11 +463,18 @@ fn resolve_publish_bearer_from_config(
     stored_bearers: impl FnOnce() -> GlobMap<StoredBearerAuth>,
     upload_url: &Url,
 ) -> Result<SelectedPublishBearer, PublishError> {
-    if let Some(entry) =
-        lookup_publish_bearer(env_bearers, PublishBearerSource::Env, upload_url, |entry| {
-            entry.auth.token()
-        })?
-    {
+    if let Some(entry) = lookup_publish_bearer(
+        env_bearers,
+        upload_url,
+        |entry| entry.auth.token(),
+        |matched| PublishBearerConflict::Env {
+            variables: dedup_in_order(
+                matched
+                    .iter()
+                    .map(|entry| format!("SYSAND_CRED_{}", entry.label)),
+            ),
+        },
+    )? {
         return Ok(SelectedPublishBearer {
             auth: entry.auth.clone(),
             provenance: PublishBearerProvenance::Env {
@@ -460,11 +483,14 @@ fn resolve_publish_bearer_from_config(
         });
     }
     let stored = stored_bearers();
-    if let Some(entry) =
-        lookup_publish_bearer(&stored, PublishBearerSource::Keyring, upload_url, |entry| {
-            entry.auth().token()
-        })?
-    {
+    if let Some(entry) = lookup_publish_bearer(
+        &stored,
+        upload_url,
+        |entry| entry.auth().token(),
+        |matched| PublishBearerConflict::Stored {
+            keys: dedup_in_order(matched.iter().map(|entry| entry.key().to_string())),
+        },
+    )? {
         return Ok(SelectedPublishBearer {
             auth: entry.auth().clone(),
             provenance: PublishBearerProvenance::Stored {
@@ -480,25 +506,37 @@ fn resolve_publish_bearer_from_config(
 
 /// Look `upload_url` up in one source's bearer map: a unique match wins
 /// (candidates carrying the identical token collapse to one,
-/// [`select_bearer`]), an ambiguous match errors naming the source, and no
-/// match returns `None` so the caller can fall through to the next source.
+/// [`select_bearer`]), an ambiguous match errors naming every matching
+/// credential (`conflict` builds the per-source naming from the matched
+/// entries), and no match returns `None` so the caller can fall through to
+/// the next source.
 fn lookup_publish_bearer<'a, T>(
     map: &'a GlobMap<T>,
-    source: PublishBearerSource,
     upload_url: &Url,
     token: impl Fn(&T) -> &str,
+    conflict: impl FnOnce(&[&T]) -> PublishBearerConflict,
 ) -> Result<Option<&'a T>, PublishError> {
     match select_bearer(map, upload_url.as_str(), token) {
         BearerSelection::Unique(entry) => Ok(Some(entry)),
-        BearerSelection::Ambiguous { candidates, .. } => {
-            Err(PublishError::AmbiguousPublishBearer {
-                upload_url: upload_url.as_str().into(),
-                bearer_source: source,
-                candidates,
-            })
-        }
+        BearerSelection::Ambiguous { matched, .. } => Err(PublishError::AmbiguousPublishBearer {
+            upload_url: upload_url.as_str().into(),
+            conflict: conflict(&matched),
+        }),
         BearerSelection::None => Ok(None),
     }
+}
+
+/// Collect an iterator of candidate names, dropping repeats while keeping
+/// first-seen order (a stored login matching through several of its own
+/// URL patterns still names its key once).
+fn dedup_in_order(names: impl Iterator<Item = String>) -> Vec<String> {
+    let mut seen = Vec::new();
+    for name in names {
+        if !seen.contains(&name) {
+            seen.push(name);
+        }
+    }
+    seen
 }
 
 fn acquire_trusted_publishing_bearer(
@@ -876,17 +914,16 @@ pub enum PublishError {
     NoPublishBearer { upload_url: Box<str> },
 
     #[error(
-        "multiple bearer token credentials from {} configured for publish URL `{upload_url}`;\n\
-         {} ({candidates} candidates found)",
-        bearer_source.name(),
-        bearer_source.ambiguity_hint()
+        "multiple bearer token credentials from {} configured for publish URL `{upload_url}`:\n\
+         {};\n\
+         {}",
+        conflict.source_name(),
+        conflict.candidate_list(),
+        conflict.hint()
     )]
-    // The field is `bearer_source`, not `source`, because thiserror gives a
-    // field named `source` error-chaining semantics.
     AmbiguousPublishBearer {
         upload_url: Box<str>,
-        bearer_source: PublishBearerSource,
-        candidates: usize,
+        conflict: PublishBearerConflict,
     },
 
     #[error(

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -233,10 +233,8 @@ pub fn do_publish(
     }
 
     let header = crate::style::get_style_config().header;
-    // Caller is expected to have run discovery and passed the resolved
-    // `api_root`. `discovery_root` is the user-facing URL (what was
-    // passed as `--index`) and is kept only so log messages match what
-    // the user configured — the actual upload targets `api_root`.
+    // `discovery_root` is the user-facing `--index` URL, kept only for
+    // log messages; the actual upload targets the resolved `api_root`.
     let upload_url = build_upload_url(&api_root);
     let PublishPreparation {
         norm_publisher: publisher,
@@ -296,13 +294,10 @@ pub fn do_publish(
     map_publish_response(status, &body_bytes, &bearer.provenance)
 }
 
-/// Whether a stored credential's known expiry is clearly past: beyond a generous
-/// clock-skew margin, so a skewed client clock (real skew is often minutes,
-/// not seconds) cannot false-trip the pre-upload stop and refuse a token the
-/// server would still accept. The stop is only an optimization to avoid
-/// uploading with a known-dead token; the server's 401 is the real authority,
-/// so the margin errs toward attempting. A clock wrong by more than an hour
-/// has larger problems and a request would likely fail regardless
+/// Whether a stored credential's known expiry is clearly past: beyond a
+/// generous clock-skew margin, so a skewed client clock cannot false-trip
+/// the pre-upload stop. The stop is only an optimization; the server's 401
+/// is the real authority, so the margin errs toward attempting
 /// (design/credential-storage.md section 7).
 fn stored_bearer_clearly_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
     now.signed_duration_since(expires_at) > TimeDelta::hours(1)
@@ -343,12 +338,10 @@ pub fn validate_api_root_url_shape(url: &Url) -> Result<(), PublishError> {
 }
 
 /// Build the `POST` URL for the publish endpoint from a resolved
-/// `api_root`. Precondition: `api_root` has already been checked with
-/// [`validate_api_root_url_shape`] (done once per publish) and normalized
-/// to end with `/` — both hold for a resolved API root from discovery — so
-/// it is an HTTP(S) base and the endpoint path appends rather than replaces
-/// its last segment. Does not prepend any `/api/` segment; that belongs to
-/// the API root itself.
+/// `api_root`. Precondition: `api_root` was checked with
+/// [`validate_api_root_url_shape`] and ends with `/`, so the endpoint
+/// path appends rather than replaces its last segment. Never prepends an
+/// `/api/` segment; that belongs to the API root itself.
 pub fn build_upload_url(api_root: &Url) -> Url {
     api_root.join(UPLOAD_ENDPOINT_PATH).unwrap()
 }
@@ -427,12 +420,11 @@ impl PublishBearerSource {
 /// mode, publish requires trusted publishing and ignores configured bearer
 /// credentials. In `never` mode, publish uses configured bearer credentials.
 ///
-/// Configured credentials come from two sources in precedence order: the
-/// eager `env_bearers` map (`SYSAND_CRED_*`) and `stored_bearers`, a lazy
-/// provider for stored credentials that is invoked only when no env bearer
-/// matches the upload URL, so a publish resolved from env (or via trusted
-/// publishing) never touches the credential store
-/// (design/credential-storage.md, section 7).
+/// Configured credentials come from two sources in precedence order:
+/// `env_bearers` (`SYSAND_CRED_*`), then the lazy `stored_bearers`
+/// provider, invoked only when no env bearer matches the upload URL, so a
+/// publish resolved from env (or trusted publishing) never touches the
+/// credential store (design/credential-storage.md section 7).
 pub fn resolve_publish_bearer(
     env_bearers: &GlobMap<EnvBearerAuth>,
     stored_bearers: impl FnOnce() -> GlobMap<StoredBearerAuth>,
@@ -1442,14 +1434,11 @@ fn publish_auth_error(
     }
 }
 
-/// The source-named upload auth-failure message (design section 7):
-/// because env credentials shadow stored credentials, replacing the stored
-/// credential alone would be the wrong fix for a stale `SYSAND_CRED_*`
-/// bearer, so the message states where the selected bearer came from. A 403
-/// is authorization, not authentication, so it adds that a wrong-project or
-/// wrong-account token cannot publish. The message states the situation
-/// only; the remediation commands (`sysand auth login` / `status`) are the
-/// frontend's to add, so no CLI command name appears here.
+/// The source-named upload auth-failure message (design section 7): env
+/// credentials shadow stored ones, so re-authenticating would be the
+/// wrong fix for a stale `SYSAND_CRED_*` bearer and the message must name
+/// where the selected bearer came from. States the situation only; the
+/// remediation commands are the frontend's to add.
 fn publish_auth_failed_message(
     status: u16,
     detail: &str,

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -272,12 +272,7 @@ pub fn do_publish(
         c.post(upload_url.clone()).multipart(form)
     };
 
-    let response = runtime.block_on(async {
-        bearer
-            .auth
-            .with_authentication(&client, &build_request)
-            .await
-    })?;
+    let response = runtime.block_on(bearer.auth.with_authentication(&client, &build_request))?;
 
     let status = response.status().as_u16();
     let response_url = response.url().to_string();
@@ -300,13 +295,6 @@ pub fn do_publish(
 /// is the real authority, so the margin errs toward attempting.
 fn stored_bearer_clearly_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
     now.signed_duration_since(expires_at) > TimeDelta::hours(1)
-}
-
-/// Render an expiry timestamp for display, without chrono's sub-second
-/// noise (`11:39:28.149443` reads as `11:39:28`), matching how `auth status`
-/// renders expiry timestamps.
-fn format_expiry_utc(expires_at: &DateTime<Utc>) -> String {
-    expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string()
 }
 
 /// Validate the shape of the resolved `api_root` that comes back from
@@ -996,7 +984,7 @@ pub enum PublishError {
         "the stored credential for `{key}` expired at {}, so publish stopped\n\
          before uploading (a matching `SYSAND_CRED_*` environment credential would take\n\
          precedence instead)",
-        format_expiry_utc(.expires_at)
+        crate::utils::format_expiry_utc(.expires_at)
     )]
     StoredCredentialExpired {
         key: String,

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -216,7 +216,7 @@ pub fn do_publish(
     client: reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
 ) -> Result<PublishResponse, PublishError> {
-    // Fail fast on a clearly expired stored login before uploading the
+    // Fail fast on a clearly expired stored credential before uploading the
     // archive (design/credential-storage.md section 7). The server's 401
     // remains the authority: only an expiry past the skew margin stops
     // here, and an env credential (no known expiry) always proceeds.
@@ -296,7 +296,7 @@ pub fn do_publish(
     map_publish_response(status, &body_bytes, &bearer.provenance)
 }
 
-/// Whether a stored login's known expiry is clearly past: beyond a generous
+/// Whether a stored credential's known expiry is clearly past: beyond a generous
 /// clock-skew margin, so a skewed client clock (real skew is often minutes,
 /// not seconds) cannot false-trip the pre-upload stop and refuse a token the
 /// server would still accept. The stop is only an optimization to avoid
@@ -384,7 +384,7 @@ pub enum PublishBearerProvenance {
     /// A `SYSAND_CRED_*` environment credential; `label` is the
     /// `SYSAND_CRED_<LABEL>` stem when known.
     Env { label: Option<String> },
-    /// A stored login (`sysand auth login`) for the given index key.
+    /// A stored credential (`sysand auth login`) for the given index key.
     Stored {
         key: String,
         expires_at: Option<DateTime<Utc>>,
@@ -422,7 +422,7 @@ impl PublishBearerSource {
 ///
 /// Configured credentials come from two sources in precedence order: the
 /// eager `env_bearers` map (`SYSAND_CRED_*`) and `stored_bearers`, a lazy
-/// provider for stored logins that is invoked only when no env bearer
+/// provider for stored credentials that is invoked only when no env bearer
 /// matches the upload URL, so a publish resolved from env (or via trusted
 /// publishing) never touches the credential store
 /// (design/credential-storage.md, section 7).

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -296,11 +296,16 @@ pub fn do_publish(
     map_publish_response(status, &body_bytes, &bearer.provenance)
 }
 
-/// Whether a stored login's known expiry is clearly past: beyond a small
-/// skew margin, so a fast client clock cannot false-trip the pre-upload
-/// stop (design/credential-storage.md section 7).
+/// Whether a stored login's known expiry is clearly past: beyond a generous
+/// clock-skew margin, so a skewed client clock (real skew is often minutes,
+/// not seconds) cannot false-trip the pre-upload stop and refuse a token the
+/// server would still accept. The stop is only an optimization to avoid
+/// uploading with a known-dead token; the server's 401 is the real authority,
+/// so the margin errs toward attempting. A clock wrong by more than an hour
+/// has larger problems and a request would likely fail regardless
+/// (design/credential-storage.md section 7).
 fn stored_bearer_clearly_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-    now.signed_duration_since(expires_at) > TimeDelta::seconds(60)
+    now.signed_duration_since(expires_at) > TimeDelta::hours(1)
 }
 
 /// Validate the shape of the resolved `api_root` that comes back from

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -15,7 +15,7 @@ use crate::{
     resolve::net_utils::create_reqwest_client,
 };
 use bytes::Bytes;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, Timelike, Utc};
 use mockito::Matcher;
 use std::assert_matches;
 use std::sync::Arc;
@@ -188,6 +188,55 @@ fn publish_bearer_falls_through_to_keyring_when_env_has_no_match() {
     .unwrap();
 
     assert_eq!(selected.auth, ForceBearerAuth::new("keyring-token"));
+    assert_eq!(
+        selected.provenance,
+        PublishBearerProvenance::Stored {
+            key: STORED_KEY.to_string(),
+            expires_at: None,
+        }
+    );
+}
+
+#[test]
+fn publish_bearer_env_identical_token_candidates_collapse() {
+    // Two env patterns carrying the same token are one credential in
+    // effect, so they collapse to a match instead of erroring, mirroring
+    // the whoami and runtime selection flows.
+    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
+    let env = env_sources(&[
+        ("https://example.org/**", "shared-env-token"),
+        ("https://example.org/api/**", "shared-env-token"),
+    ]);
+
+    let selected = resolve_publish_bearer_from_config(&env, stored_unreached, &upload_url).unwrap();
+
+    assert_eq!(selected.auth, ForceBearerAuth::new("shared-env-token"));
+    assert_eq!(
+        selected.provenance,
+        PublishBearerProvenance::Env { label: None }
+    );
+}
+
+#[test]
+fn publish_bearer_keyring_identical_token_candidates_collapse() {
+    // The typical shape: one stored login whose glob set matches the
+    // upload URL through more than one pattern. Same token, so publish
+    // selects it instead of reporting ambiguity.
+    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
+
+    let selected = resolve_publish_bearer_from_config(
+        &empty_sources(),
+        || {
+            stored_sources(&[
+                ("https://example.org/**", "shared-keyring-token"),
+                ("https://example.org/api/**", "shared-keyring-token"),
+            ])
+        },
+        &upload_url,
+    )
+    .unwrap();
+
+    assert_eq!(selected.auth, ForceBearerAuth::new("shared-keyring-token"));
     assert_eq!(
         selected.provenance,
         PublishBearerProvenance::Stored {
@@ -910,7 +959,11 @@ fn publish_stops_before_upload_when_the_stored_bearer_is_expired() {
     let mut server = mockito::Server::new();
     let mock = server.mock("POST", "/api/v1/upload").expect(0).create();
 
-    let expires_at = Utc::now() - Duration::days(1);
+    // A sub-second component that must not leak into the message
+    // (timestamps are shown without sub-second precision).
+    let expires_at = (Utc::now() - Duration::days(1))
+        .with_nanosecond(123_456_789)
+        .unwrap();
     let err = publish_to(&server, stored_bearer(Some(expires_at))).unwrap_err();
 
     assert_matches!(
@@ -920,7 +973,12 @@ fn publish_stops_before_upload_when_the_stored_bearer_is_expired() {
     let message = err.to_string();
     // The core message states the condition without naming a CLI command;
     // the frontend adds the `sysand auth login` remediation.
-    assert!(message.contains("expired at"), "message: {message}");
+    let expected_timestamp = expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string();
+    assert!(
+        message.contains(&format!("expired at {expected_timestamp}")),
+        "message: {message}"
+    );
+    assert!(!message.contains(".123"), "message: {message}");
     assert!(!message.contains("sysand auth"), "message: {message}");
     // The archive was never uploaded.
     mock.assert();

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -162,7 +162,7 @@ fn resolve_publish_bearer_never_rejects_ambiguous_bearer() {
 #[test]
 fn publish_bearer_env_match_wins_without_reading_stored_credentials() {
     // With an env match the stored-credential provider must not run at
-    // all (never read the keyring when env already works, section 7).
+    // all (never read the keyring when env already works).
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
     let env = env_sources(&[("https://example.org/api/**", "env-token")]);
 
@@ -229,9 +229,8 @@ fn publish_bearer_keyring_identical_token_candidates_collapse() {
 
 #[test]
 fn publish_bearer_env_ambiguity_errors_without_keyring_fallback() {
-    // An ambiguous env match must error, not fall back to a unique keyring
-    // match (design/credential-storage.md, section 8), and must not read
-    // the stored credentials at all.
+    // An ambiguous env match must error, not fall back to a unique
+    // keyring match, and must not read the stored credentials at all.
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
     let env = env_sources(&[
         ("https://example.org/**", "broad-env-token"),
@@ -787,8 +786,7 @@ fn map_publish_response_201_is_ok_new_project() {
     assert_eq!(resp.status, 201);
 }
 
-// --- source-named auth failures and the pre-upload expiry stop
-//     (design/credential-storage.md section 7) ---
+// --- source-named auth failures and the pre-upload expiry stop ---
 
 fn preparation() -> PublishPreparation {
     PublishPreparation {

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -2,10 +2,10 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::{
-    AllowedMetamodelKind, PublishBearerSource, PublishBearerSources, PublishError,
-    TrustedPublishingEnvironment, TrustedPublishingMode, build_upload_url, check_metamodel,
-    check_usage, error_body_to_string, map_publish_response, resolve_publish_bearer,
-    resolve_publish_bearer_from_config, validate_api_root_url_shape,
+    AllowedMetamodelKind, PublishBearerSource, PublishError, TrustedPublishingEnvironment,
+    TrustedPublishingMode, build_upload_url, check_metamodel, check_usage, error_body_to_string,
+    map_publish_response, resolve_publish_bearer, resolve_publish_bearer_from_config,
+    validate_api_root_url_shape,
 };
 use crate::{
     auth::{ForceBearerAuth, GlobMap, GlobMapBuilder},
@@ -35,16 +35,18 @@ fn glob_map(entries: &[(&str, &str)]) -> GlobMap<ForceBearerAuth> {
     builder.build().unwrap()
 }
 
-fn empty_sources() -> PublishBearerSources {
-    PublishBearerSources::from_env(GlobMap::default())
+fn empty_sources() -> GlobMap<ForceBearerAuth> {
+    GlobMap::default()
 }
 
-fn env_sources(entries: &[(&str, &str)]) -> PublishBearerSources {
-    PublishBearerSources::from_env(glob_map(entries))
+fn env_sources(entries: &[(&str, &str)]) -> GlobMap<ForceBearerAuth> {
+    glob_map(entries)
 }
 
-fn sources(env: &[(&str, &str)], keyring: &[(&str, &str)]) -> PublishBearerSources {
-    PublishBearerSources::new(glob_map(env), glob_map(keyring))
+/// A stored-credential provider for paths that must never consult the
+/// store (env matched, or the flow errors before configured credentials).
+fn stored_unreached() -> GlobMap<ForceBearerAuth> {
+    panic!("stored credentials must not be read on this path");
 }
 
 fn gitlab_env(token: &str) -> TrustedPublishingEnvironment {
@@ -86,6 +88,7 @@ fn resolve_publish_bearer_auto_uses_bearer_when_trusted_publishing_unavailable()
 
     resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Auto,
         &TrustedPublishingEnvironment::new(None, None, None),
@@ -107,6 +110,7 @@ fn resolve_publish_bearer_never_rejects_ambiguous_bearer() {
 
     let err = resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Never,
         &gitlab_env("gitlab-oidc-token"),
@@ -126,14 +130,13 @@ fn resolve_publish_bearer_never_rejects_ambiguous_bearer() {
 }
 
 #[test]
-fn publish_bearer_env_match_wins_over_keyring_match() {
+fn publish_bearer_env_match_wins_without_reading_stored_credentials() {
+    // With an env match the stored-credential provider must not run at
+    // all (never read the keyring when env already works, section 7).
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
-    let map = sources(
-        &[("https://example.org/api/**", "env-token")],
-        &[("https://example.org/api/**", "keyring-token")],
-    );
+    let env = env_sources(&[("https://example.org/api/**", "env-token")]);
 
-    let token = resolve_publish_bearer_from_config(&map, &upload_url).unwrap();
+    let token = resolve_publish_bearer_from_config(&env, stored_unreached, &upload_url).unwrap();
 
     assert_eq!(token, ForceBearerAuth::new("env-token"));
 }
@@ -141,12 +144,14 @@ fn publish_bearer_env_match_wins_over_keyring_match() {
 #[test]
 fn publish_bearer_falls_through_to_keyring_when_env_has_no_match() {
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
-    let map = sources(
-        &[("https://other.example.com/**", "env-token")],
-        &[("https://example.org/api/**", "keyring-token")],
-    );
+    let env = env_sources(&[("https://other.example.com/**", "env-token")]);
 
-    let token = resolve_publish_bearer_from_config(&map, &upload_url).unwrap();
+    let token = resolve_publish_bearer_from_config(
+        &env,
+        || glob_map(&[("https://example.org/api/**", "keyring-token")]),
+        &upload_url,
+    )
+    .unwrap();
 
     assert_eq!(token, ForceBearerAuth::new("keyring-token"));
 }
@@ -154,17 +159,15 @@ fn publish_bearer_falls_through_to_keyring_when_env_has_no_match() {
 #[test]
 fn publish_bearer_env_ambiguity_errors_without_keyring_fallback() {
     // An ambiguous env match must error, not fall back to a unique keyring
-    // match (design/credential-storage.md, section 8).
+    // match (design/credential-storage.md, section 8), and must not read
+    // the stored credentials at all.
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
-    let map = sources(
-        &[
-            ("https://example.org/**", "broad-env-token"),
-            ("https://example.org/api/**", "specific-env-token"),
-        ],
-        &[("https://example.org/api/**", "keyring-token")],
-    );
+    let env = env_sources(&[
+        ("https://example.org/**", "broad-env-token"),
+        ("https://example.org/api/**", "specific-env-token"),
+    ]);
 
-    let err = resolve_publish_bearer_from_config(&map, &upload_url).unwrap_err();
+    let err = resolve_publish_bearer_from_config(&env, stored_unreached, &upload_url).unwrap_err();
 
     assert_matches!(
         err,
@@ -180,15 +183,18 @@ fn publish_bearer_env_ambiguity_errors_without_keyring_fallback() {
 #[test]
 fn publish_bearer_keyring_ambiguity_errors() {
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
-    let map = sources(
-        &[],
-        &[
-            ("https://example.org/**", "broad-keyring-token"),
-            ("https://example.org/api/**", "specific-keyring-token"),
-        ],
-    );
 
-    let err = resolve_publish_bearer_from_config(&map, &upload_url).unwrap_err();
+    let err = resolve_publish_bearer_from_config(
+        &empty_sources(),
+        || {
+            glob_map(&[
+                ("https://example.org/**", "broad-keyring-token"),
+                ("https://example.org/api/**", "specific-keyring-token"),
+            ])
+        },
+        &upload_url,
+    )
+    .unwrap_err();
 
     assert_matches!(
         err,
@@ -204,12 +210,14 @@ fn publish_bearer_keyring_ambiguity_errors() {
 #[test]
 fn publish_bearer_no_match_in_any_source_errors() {
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
-    let map = sources(
-        &[("https://other.example.com/**", "env-token")],
-        &[("https://another.example.com/**", "keyring-token")],
-    );
+    let env = env_sources(&[("https://other.example.com/**", "env-token")]);
 
-    let err = resolve_publish_bearer_from_config(&map, &upload_url).unwrap_err();
+    let err = resolve_publish_bearer_from_config(
+        &env,
+        || glob_map(&[("https://another.example.com/**", "keyring-token")]),
+        &upload_url,
+    )
+    .unwrap_err();
 
     assert_matches!(err, PublishError::NoPublishBearer { .. });
     // The hint must stay truthful about what exists today: `SYSAND_CRED_*`
@@ -236,6 +244,7 @@ fn trusted_publishing_environment_treats_empty_values_as_unset() {
 
     let err = resolve_publish_bearer(
         &map,
+        GlobMap::default,
         &api_root,
         TrustedPublishingMode::Auto,
         &env,
@@ -261,6 +270,7 @@ fn resolve_publish_bearer_auto_rejects_multiple_supported_providers() {
 
     let err = resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Auto,
         &env,
@@ -283,6 +293,7 @@ fn resolve_publish_bearer_always_reports_partial_github_env() {
 
     let err = resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Always,
         &env,
@@ -307,6 +318,7 @@ fn resolve_publish_bearer_always_requires_supported_env() {
 
     let err = resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Always,
         &TrustedPublishingEnvironment::new(None, None, None),
@@ -330,6 +342,7 @@ fn resolve_publish_bearer_invalid_github_url_makes_no_exchange_request() {
 
     let err = resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Always,
         &env,
@@ -382,6 +395,7 @@ fn resolve_publish_bearer_github_preserves_existing_oidc_query_params() {
 
     resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Auto,
         &env,
@@ -415,6 +429,7 @@ fn resolve_publish_bearer_gitlab_exchange_success() {
 
     resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Auto,
         &gitlab_env("gitlab-oidc-token"),
@@ -443,6 +458,7 @@ fn resolve_publish_bearer_exchange_non_success_errors() {
 
     let err = resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Auto,
         &gitlab_env("gitlab-oidc-token"),
@@ -482,6 +498,7 @@ fn resolve_publish_bearer_exchange_malformed_response_errors() {
 
     let err = resolve_publish_bearer(
         &map,
+        stored_unreached,
         &api_root,
         TrustedPublishingMode::Auto,
         &gitlab_env("gitlab-oidc-token"),

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -42,7 +42,7 @@ fn env_sources(entries: &[(&str, &str)]) -> GlobMap<EnvBearerAuth> {
             *pattern,
             EnvBearerAuth {
                 auth: ForceBearerAuth::new(*token),
-                label: None,
+                label: "ENVIDX".to_string(),
             },
         );
     }
@@ -171,7 +171,9 @@ fn publish_bearer_env_match_wins_without_reading_stored_credentials() {
     assert_eq!(selected.auth, ForceBearerAuth::new("env-token"));
     assert_eq!(
         selected.provenance,
-        PublishBearerProvenance::Env { label: None }
+        PublishBearerProvenance::Env {
+            label: "ENVIDX".to_string()
+        }
     );
 }
 
@@ -817,11 +819,11 @@ fn publish_to(
     )
 }
 
-fn env_bearer(label: Option<&str>) -> SelectedPublishBearer {
+fn env_bearer(label: &str) -> SelectedPublishBearer {
     SelectedPublishBearer {
         auth: ForceBearerAuth::new("env-token"),
         provenance: PublishBearerProvenance::Env {
-            label: label.map(str::to_string),
+            label: label.to_string(),
         },
     }
 }
@@ -850,7 +852,7 @@ fn publish_env_auth_failure_names_the_env_var() {
     let mut server = mockito::Server::new();
     let mock = upload_mock(&mut server, 401, "unauthorized");
 
-    let err = publish_to(&server, env_bearer(Some("TEAMIDX"))).unwrap_err();
+    let err = publish_to(&server, env_bearer("TEAMIDX")).unwrap_err();
 
     let message = err.to_string();
     assert!(message.contains("HTTP 401"), "message: {message}");
@@ -947,7 +949,7 @@ fn publish_uploads_normally_without_a_known_expiry() {
     let mut server = mockito::Server::new();
     let mock = upload_mock(&mut server, 201, "created");
 
-    let response = publish_to(&server, env_bearer(Some("TEAMIDX"))).unwrap();
+    let response = publish_to(&server, env_bearer("TEAMIDX")).unwrap();
 
     assert!(response.is_new_project);
     mock.assert();

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -2,16 +2,20 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::{
-    AllowedMetamodelKind, PublishBearerSource, PublishError, TrustedPublishingEnvironment,
-    TrustedPublishingMode, build_upload_url, check_metamodel, check_usage, error_body_to_string,
+    AllowedMetamodelKind, PublishBearerProvenance, PublishBearerSource, PublishError,
+    PublishPreparation, SelectedPublishBearer, TrustedPublishingEnvironment, TrustedPublishingMode,
+    build_upload_url, check_metamodel, check_usage, do_publish, error_body_to_string,
     map_publish_response, resolve_publish_bearer, resolve_publish_bearer_from_config,
-    validate_api_root_url_shape,
+    stored_bearer_clearly_expired, validate_api_root_url_shape,
 };
 use crate::{
-    auth::{ForceBearerAuth, GlobMap, GlobMapBuilder},
+    auth::{EnvBearerAuth, ForceBearerAuth, GlobMap, GlobMapBuilder, StoredBearerAuth},
+    index_location::IndexLocation,
     model::InterchangeProjectUsageRaw,
     resolve::net_utils::create_reqwest_client,
 };
+use bytes::Bytes;
+use chrono::{DateTime, Duration, Utc};
 use mockito::Matcher;
 use std::assert_matches;
 use std::sync::Arc;
@@ -27,25 +31,51 @@ fn runtime() -> Arc<tokio::runtime::Runtime> {
     )
 }
 
-fn glob_map(entries: &[(&str, &str)]) -> GlobMap<ForceBearerAuth> {
+fn empty_sources() -> GlobMap<EnvBearerAuth> {
+    GlobMap::default()
+}
+
+fn env_sources(entries: &[(&str, &str)]) -> GlobMap<EnvBearerAuth> {
     let mut builder = GlobMapBuilder::new();
     for (pattern, token) in entries {
-        builder.add(*pattern, ForceBearerAuth::new(*token));
+        builder.add(
+            *pattern,
+            EnvBearerAuth {
+                auth: ForceBearerAuth::new(*token),
+                label: None,
+            },
+        );
     }
     builder.build().unwrap()
 }
 
-fn empty_sources() -> GlobMap<ForceBearerAuth> {
-    GlobMap::default()
+const STORED_KEY: &str = "https://example.org/";
+
+fn stored_sources(entries: &[(&str, &str)]) -> GlobMap<StoredBearerAuth> {
+    stored_sources_expiring(entries, None)
 }
 
-fn env_sources(entries: &[(&str, &str)]) -> GlobMap<ForceBearerAuth> {
-    glob_map(entries)
+fn stored_sources_expiring(
+    entries: &[(&str, &str)],
+    expires_at: Option<DateTime<Utc>>,
+) -> GlobMap<StoredBearerAuth> {
+    let mut builder = GlobMapBuilder::new();
+    for (pattern, token) in entries {
+        builder.add(
+            *pattern,
+            StoredBearerAuth::new(
+                ForceBearerAuth::new(*token),
+                STORED_KEY.to_string(),
+                expires_at,
+            ),
+        );
+    }
+    builder.build().unwrap()
 }
 
 /// A stored-credential provider for paths that must never consult the
 /// store (env matched, or the flow errors before configured credentials).
-fn stored_unreached() -> GlobMap<ForceBearerAuth> {
+fn stored_unreached() -> GlobMap<StoredBearerAuth> {
     panic!("stored credentials must not be read on this path");
 }
 
@@ -136,9 +166,13 @@ fn publish_bearer_env_match_wins_without_reading_stored_credentials() {
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
     let env = env_sources(&[("https://example.org/api/**", "env-token")]);
 
-    let token = resolve_publish_bearer_from_config(&env, stored_unreached, &upload_url).unwrap();
+    let selected = resolve_publish_bearer_from_config(&env, stored_unreached, &upload_url).unwrap();
 
-    assert_eq!(token, ForceBearerAuth::new("env-token"));
+    assert_eq!(selected.auth, ForceBearerAuth::new("env-token"));
+    assert_eq!(
+        selected.provenance,
+        PublishBearerProvenance::Env { label: None }
+    );
 }
 
 #[test]
@@ -146,14 +180,21 @@ fn publish_bearer_falls_through_to_keyring_when_env_has_no_match() {
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
     let env = env_sources(&[("https://other.example.com/**", "env-token")]);
 
-    let token = resolve_publish_bearer_from_config(
+    let selected = resolve_publish_bearer_from_config(
         &env,
-        || glob_map(&[("https://example.org/api/**", "keyring-token")]),
+        || stored_sources(&[("https://example.org/api/**", "keyring-token")]),
         &upload_url,
     )
     .unwrap();
 
-    assert_eq!(token, ForceBearerAuth::new("keyring-token"));
+    assert_eq!(selected.auth, ForceBearerAuth::new("keyring-token"));
+    assert_eq!(
+        selected.provenance,
+        PublishBearerProvenance::Stored {
+            key: STORED_KEY.to_string(),
+            expires_at: None,
+        }
+    );
 }
 
 #[test]
@@ -187,7 +228,7 @@ fn publish_bearer_keyring_ambiguity_errors() {
     let err = resolve_publish_bearer_from_config(
         &empty_sources(),
         || {
-            glob_map(&[
+            stored_sources(&[
                 ("https://example.org/**", "broad-keyring-token"),
                 ("https://example.org/api/**", "specific-keyring-token"),
             ])
@@ -214,7 +255,7 @@ fn publish_bearer_no_match_in_any_source_errors() {
 
     let err = resolve_publish_bearer_from_config(
         &env,
-        || glob_map(&[("https://another.example.com/**", "keyring-token")]),
+        || stored_sources(&[("https://another.example.com/**", "keyring-token")]),
         &upload_url,
     )
     .unwrap_err();
@@ -689,22 +730,227 @@ fn check_usage_rejects_directory_usage_with_version_constraint() {
 
 #[test]
 fn map_publish_response_400_maps_to_bad_request() {
-    let err = map_publish_response(400, b"bad field").unwrap_err();
+    let err = map_publish_response(
+        400,
+        b"bad field",
+        &PublishBearerProvenance::TrustedPublishing,
+    )
+    .unwrap_err();
     assert_matches!(err, PublishError::BadRequest(_));
 }
 
 #[test]
 fn map_publish_response_200_is_ok_not_new_project() {
-    let resp = map_publish_response(200, b"ok").unwrap();
+    let resp =
+        map_publish_response(200, b"ok", &PublishBearerProvenance::TrustedPublishing).unwrap();
     assert!(!resp.is_new_project);
     assert_eq!(resp.status, 200);
 }
 
 #[test]
 fn map_publish_response_201_is_ok_new_project() {
-    let resp = map_publish_response(201, b"created").unwrap();
+    let resp =
+        map_publish_response(201, b"created", &PublishBearerProvenance::TrustedPublishing).unwrap();
     assert!(resp.is_new_project);
     assert_eq!(resp.status, 201);
+}
+
+// --- source-named auth failures and the pre-upload expiry stop
+//     (design/credential-storage.md section 7) ---
+
+fn preparation() -> PublishPreparation {
+    PublishPreparation {
+        norm_publisher: "acme".to_string(),
+        norm_name: "widgets".to_string(),
+        version: "1.0.0".to_string(),
+        metadata: "{}".to_string(),
+        kpar_bytes: Bytes::from_static(b"not a real kpar"),
+    }
+}
+
+/// Run `do_publish` against `server`'s `/api/v1/upload` with the given
+/// selected bearer.
+fn publish_to(
+    server: &mockito::Server,
+    bearer: SelectedPublishBearer,
+) -> Result<super::PublishResponse, PublishError> {
+    let discovery_root = IndexLocation::parse(&server.url()).unwrap();
+    let api_root = Url::parse(&format!("{}/api/", server.url())).unwrap();
+    let client = create_reqwest_client().unwrap();
+    do_publish(
+        preparation(),
+        discovery_root,
+        api_root,
+        bearer,
+        client,
+        runtime(),
+    )
+}
+
+fn env_bearer(label: Option<&str>) -> SelectedPublishBearer {
+    SelectedPublishBearer {
+        auth: ForceBearerAuth::new("env-token"),
+        provenance: PublishBearerProvenance::Env {
+            label: label.map(str::to_string),
+        },
+    }
+}
+
+fn stored_bearer(expires_at: Option<DateTime<Utc>>) -> SelectedPublishBearer {
+    SelectedPublishBearer {
+        auth: ForceBearerAuth::new("stored-token"),
+        provenance: PublishBearerProvenance::Stored {
+            key: STORED_KEY.to_string(),
+            expires_at,
+        },
+    }
+}
+
+fn upload_mock(server: &mut mockito::Server, status: usize, body: &str) -> mockito::Mock {
+    server
+        .mock("POST", "/api/v1/upload")
+        .with_status(status)
+        .with_body(body)
+        .expect(1)
+        .create()
+}
+
+#[test]
+fn publish_env_auth_failure_names_the_env_var() {
+    let mut server = mockito::Server::new();
+    let mock = upload_mock(&mut server, 401, "unauthorized");
+
+    let err = publish_to(&server, env_bearer(Some("TEAMIDX"))).unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains("authentication failed (HTTP 401): unauthorized"),
+        "message: {message}"
+    );
+    assert!(
+        message.contains("came from `SYSAND_CRED_TEAMIDX`"),
+        "message: {message}"
+    );
+    assert!(
+        message.contains("`SYSAND_CRED_TEAMIDX_BEARER_TOKEN`"),
+        "message: {message}"
+    );
+    // Env shadows stored logins, so re-login must not be the suggested fix.
+    assert!(
+        message.contains("`sysand auth login` alone cannot replace it"),
+        "message: {message}"
+    );
+    assert!(!message.contains("auth status"), "message: {message}");
+    mock.assert();
+}
+
+#[test]
+fn publish_stored_auth_failure_names_the_login() {
+    let mut server = mockito::Server::new();
+    let mock = upload_mock(&mut server, 401, "unauthorized");
+
+    let err = publish_to(&server, stored_bearer(None)).unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains(&format!("your stored login for `{STORED_KEY}`")),
+        "message: {message}"
+    );
+    assert!(
+        message.contains(&format!("re-run `sysand auth login {STORED_KEY}`")),
+        "message: {message}"
+    );
+    assert!(!message.contains("SYSAND_CRED_"), "message: {message}");
+    mock.assert();
+}
+
+#[test]
+fn publish_403_points_at_auth_status() {
+    // 403 is authorization, not authentication: `sysand auth status`
+    // shows the stored subject, catching a wrong-project token.
+    let mut server = mockito::Server::new();
+    let mock = upload_mock(&mut server, 403, "forbidden");
+
+    let err = publish_to(&server, stored_bearer(None)).unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains("authorization failed (HTTP 403): forbidden"),
+        "message: {message}"
+    );
+    assert!(
+        message.contains("run `sysand auth status`"),
+        "message: {message}"
+    );
+    mock.assert();
+}
+
+#[test]
+fn publish_trusted_publishing_auth_failure_stays_generic() {
+    // A trusted-publishing token has no user-fixable source: neither env
+    // nor stored-login remediation applies.
+    let mut server = mockito::Server::new();
+    let _mock = upload_mock(&mut server, 401, "unauthorized");
+
+    let bearer = SelectedPublishBearer {
+        auth: ForceBearerAuth::new("exchanged-token"),
+        provenance: PublishBearerProvenance::TrustedPublishing,
+    };
+    let err = publish_to(&server, bearer).unwrap_err();
+
+    assert_matches!(&err, PublishError::AuthError(detail) if detail == "unauthorized");
+}
+
+#[test]
+fn publish_stops_before_upload_when_the_stored_bearer_is_expired() {
+    let mut server = mockito::Server::new();
+    let mock = server.mock("POST", "/api/v1/upload").expect(0).create();
+
+    let expires_at = Utc::now() - Duration::days(1);
+    let err = publish_to(&server, stored_bearer(Some(expires_at))).unwrap_err();
+
+    assert_matches!(
+        &err,
+        PublishError::StoredCredentialExpired { key, .. } if key == STORED_KEY
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains(&format!("re-run `sysand auth login {STORED_KEY}`")),
+        "message: {message}"
+    );
+    // The archive was never uploaded.
+    mock.assert();
+}
+
+#[test]
+fn publish_uploads_normally_without_a_known_expiry() {
+    // An env bearer carries no expiry and must never trip the stop.
+    let mut server = mockito::Server::new();
+    let mock = upload_mock(&mut server, 201, "created");
+
+    let response = publish_to(&server, env_bearer(Some("TEAMIDX"))).unwrap();
+
+    assert!(response.is_new_project);
+    mock.assert();
+}
+
+#[test]
+fn stored_bearer_clearly_expired_allows_a_skew_margin() {
+    let now = Utc::now();
+    // Within the 60 s margin: a fast client clock must not false-trip;
+    // the server's 401 stays the authority.
+    assert!(!stored_bearer_clearly_expired(
+        now - Duration::seconds(30),
+        now
+    ));
+    assert!(stored_bearer_clearly_expired(
+        now - Duration::seconds(120),
+        now
+    ));
+    assert!(!stored_bearer_clearly_expired(
+        now + Duration::hours(1),
+        now
+    ));
 }
 
 // --- validate_api_root_url_shape ---

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::{
-    AllowedMetamodelKind, PublishError, TrustedPublishingEnvironment, TrustedPublishingMode,
-    build_upload_url, check_metamodel, check_usage, error_body_to_string, map_publish_response,
-    resolve_publish_bearer, validate_api_root_url_shape,
+    AllowedMetamodelKind, PublishBearerSource, PublishBearerSources, PublishError,
+    TrustedPublishingEnvironment, TrustedPublishingMode, build_upload_url, check_metamodel,
+    check_usage, error_body_to_string, map_publish_response, resolve_publish_bearer,
+    resolve_publish_bearer_from_config, validate_api_root_url_shape,
 };
 use crate::{
     auth::{ForceBearerAuth, GlobMap, GlobMapBuilder},
@@ -26,16 +27,24 @@ fn runtime() -> Arc<tokio::runtime::Runtime> {
     )
 }
 
-fn empty_bearer_map() -> GlobMap<ForceBearerAuth> {
-    GlobMapBuilder::new().build().unwrap()
-}
-
-fn bearer_map(entries: &[(&str, &str)]) -> GlobMap<ForceBearerAuth> {
+fn glob_map(entries: &[(&str, &str)]) -> GlobMap<ForceBearerAuth> {
     let mut builder = GlobMapBuilder::new();
     for (pattern, token) in entries {
         builder.add(*pattern, ForceBearerAuth::new(*token));
     }
     builder.build().unwrap()
+}
+
+fn empty_sources() -> PublishBearerSources {
+    PublishBearerSources::from_env(GlobMap::default())
+}
+
+fn env_sources(entries: &[(&str, &str)]) -> PublishBearerSources {
+    PublishBearerSources::from_env(glob_map(entries))
+}
+
+fn sources(env: &[(&str, &str)], keyring: &[(&str, &str)]) -> PublishBearerSources {
+    PublishBearerSources::new(glob_map(env), glob_map(keyring))
 }
 
 fn gitlab_env(token: &str) -> TrustedPublishingEnvironment {
@@ -71,7 +80,7 @@ fn build_upload_url_appends_endpoint_path() {
 #[test]
 fn resolve_publish_bearer_auto_uses_bearer_when_trusted_publishing_unavailable() {
     let api_root = Url::parse("https://example.org/api/").unwrap();
-    let map = bearer_map(&[("https://example.org/api/**", "explicit-token")]);
+    let map = env_sources(&[("https://example.org/api/**", "explicit-token")]);
     let client = create_reqwest_client().unwrap();
     let runtime = runtime();
 
@@ -89,7 +98,7 @@ fn resolve_publish_bearer_auto_uses_bearer_when_trusted_publishing_unavailable()
 #[test]
 fn resolve_publish_bearer_never_rejects_ambiguous_bearer() {
     let api_root = Url::parse("https://example.org/api/").unwrap();
-    let map = bearer_map(&[
+    let map = env_sources(&[
         ("https://example.org/**", "broad-token"),
         ("https://example.org/api/**", "specific-token"),
     ]);
@@ -108,14 +117,115 @@ fn resolve_publish_bearer_never_rejects_ambiguous_bearer() {
 
     assert_matches!(
         err,
-        PublishError::AmbiguousPublishBearer { candidates: 2, .. }
+        PublishError::AmbiguousPublishBearer {
+            bearer_source: PublishBearerSource::Env,
+            candidates: 2,
+            ..
+        }
+    );
+}
+
+#[test]
+fn publish_bearer_env_match_wins_over_keyring_match() {
+    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
+    let map = sources(
+        &[("https://example.org/api/**", "env-token")],
+        &[("https://example.org/api/**", "keyring-token")],
+    );
+
+    let token = resolve_publish_bearer_from_config(&map, &upload_url).unwrap();
+
+    assert_eq!(token, ForceBearerAuth::new("env-token"));
+}
+
+#[test]
+fn publish_bearer_falls_through_to_keyring_when_env_has_no_match() {
+    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
+    let map = sources(
+        &[("https://other.example.com/**", "env-token")],
+        &[("https://example.org/api/**", "keyring-token")],
+    );
+
+    let token = resolve_publish_bearer_from_config(&map, &upload_url).unwrap();
+
+    assert_eq!(token, ForceBearerAuth::new("keyring-token"));
+}
+
+#[test]
+fn publish_bearer_env_ambiguity_errors_without_keyring_fallback() {
+    // An ambiguous env match must error, not fall back to a unique keyring
+    // match (design/credential-storage.md, section 8).
+    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
+    let map = sources(
+        &[
+            ("https://example.org/**", "broad-env-token"),
+            ("https://example.org/api/**", "specific-env-token"),
+        ],
+        &[("https://example.org/api/**", "keyring-token")],
+    );
+
+    let err = resolve_publish_bearer_from_config(&map, &upload_url).unwrap_err();
+
+    assert_matches!(
+        err,
+        PublishError::AmbiguousPublishBearer {
+            bearer_source: PublishBearerSource::Env,
+            candidates: 2,
+            ref upload_url,
+            ..
+        } if upload_url.as_ref() == "https://example.org/api/v1/upload"
+    );
+}
+
+#[test]
+fn publish_bearer_keyring_ambiguity_errors() {
+    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
+    let map = sources(
+        &[],
+        &[
+            ("https://example.org/**", "broad-keyring-token"),
+            ("https://example.org/api/**", "specific-keyring-token"),
+        ],
+    );
+
+    let err = resolve_publish_bearer_from_config(&map, &upload_url).unwrap_err();
+
+    assert_matches!(
+        err,
+        PublishError::AmbiguousPublishBearer {
+            bearer_source: PublishBearerSource::Keyring,
+            candidates: 2,
+            ref upload_url,
+            ..
+        } if upload_url.as_ref() == "https://example.org/api/v1/upload"
+    );
+}
+
+#[test]
+fn publish_bearer_no_match_in_any_source_errors() {
+    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
+    let map = sources(
+        &[("https://other.example.com/**", "env-token")],
+        &[("https://another.example.com/**", "keyring-token")],
+    );
+
+    let err = resolve_publish_bearer_from_config(&map, &upload_url).unwrap_err();
+
+    assert_matches!(err, PublishError::NoPublishBearer { .. });
+    // The hint must stay truthful about what exists today: `SYSAND_CRED_*`
+    // configuration, not the yet-unimplemented `sysand auth login`.
+    let message = err.to_string();
+    assert!(message.contains("SYSAND_CRED_<X>"), "message: {message}");
+    assert!(
+        message.contains("https://example.org/api/v1/upload"),
+        "message: {message}"
     );
 }
 
 #[test]
 fn trusted_publishing_environment_treats_empty_values_as_unset() {
     let api_root = Url::parse("https://example.org/api/").unwrap();
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let env = TrustedPublishingEnvironment::new(
         Some(String::new()),
         Some(String::new()),
@@ -140,7 +250,7 @@ fn trusted_publishing_environment_treats_empty_values_as_unset() {
 #[test]
 fn resolve_publish_bearer_auto_rejects_multiple_supported_providers() {
     let api_root = Url::parse("https://example.org/api/").unwrap();
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let env = TrustedPublishingEnvironment::new(
         Some("github-request-token".to_owned()),
         Some("https://github.example/oidc".to_owned()),
@@ -165,7 +275,7 @@ fn resolve_publish_bearer_auto_rejects_multiple_supported_providers() {
 #[test]
 fn resolve_publish_bearer_always_reports_partial_github_env() {
     let api_root = Url::parse("https://example.org/api/").unwrap();
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let env =
         TrustedPublishingEnvironment::new(Some("github-request-token".to_owned()), None, None);
     let client = create_reqwest_client().unwrap();
@@ -191,7 +301,7 @@ fn resolve_publish_bearer_always_reports_partial_github_env() {
 #[test]
 fn resolve_publish_bearer_always_requires_supported_env() {
     let api_root = Url::parse("https://example.org/api/").unwrap();
-    let map = bearer_map(&[("https://example.org/api/**", "explicit-token")]);
+    let map = env_sources(&[("https://example.org/api/**", "explicit-token")]);
     let client = create_reqwest_client().unwrap();
     let runtime = runtime();
 
@@ -213,7 +323,7 @@ fn resolve_publish_bearer_invalid_github_url_makes_no_exchange_request() {
     let mut server = mockito::Server::new();
     let exchange_mock = server.mock("POST", "/api/v1/oidc/token").expect(0).create();
     let api_root = Url::parse(&format!("{}/api/", server.url())).unwrap();
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let env = github_env("github-request-token", "not a url");
     let client = create_reqwest_client().unwrap();
     let runtime = runtime();
@@ -262,7 +372,7 @@ fn resolve_publish_bearer_github_preserves_existing_oidc_query_params() {
         .expect(1)
         .create();
 
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let env = github_env(
         "github-request-token",
         &format!("{}/oidc?existing=1", github_server.url()),
@@ -299,7 +409,7 @@ fn resolve_publish_bearer_gitlab_exchange_success() {
         .expect(1)
         .create();
     let api_root = Url::parse(&format!("{}/api/", server.url())).unwrap();
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let client = create_reqwest_client().unwrap();
     let runtime = runtime();
 
@@ -327,7 +437,7 @@ fn resolve_publish_bearer_exchange_non_success_errors() {
         .expect(1)
         .create();
     let api_root = Url::parse(&format!("{}/api/", server.url())).unwrap();
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let client = create_reqwest_client().unwrap();
     let runtime = runtime();
 
@@ -366,7 +476,7 @@ fn resolve_publish_bearer_exchange_malformed_response_errors() {
         .expect(1)
         .create();
     let api_root = Url::parse(&format!("{}/api/", server.url())).unwrap();
-    let map = empty_bearer_map();
+    let map = empty_sources();
     let client = create_reqwest_client().unwrap();
     let runtime = runtime();
 

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -938,16 +938,16 @@ fn publish_uploads_normally_without_a_known_expiry() {
 #[test]
 fn stored_bearer_clearly_expired_allows_a_skew_margin() {
     let now = Utc::now();
-    // Within the 60 s margin: a fast client clock must not false-trip;
-    // the server's 401 stays the authority.
+    // Within the one-hour margin: a skewed client clock must not false-trip
+    // and refuse a token the server would accept; the server's 401 stays the
+    // authority.
     assert!(!stored_bearer_clearly_expired(
-        now - Duration::seconds(30),
+        now - Duration::minutes(30),
         now
     ));
-    assert!(stored_bearer_clearly_expired(
-        now - Duration::seconds(120),
-        now
-    ));
+    // Well past the margin: skip uploading with a known-dead token.
+    assert!(stored_bearer_clearly_expired(now - Duration::hours(2), now));
+    // Not yet expired.
     assert!(!stored_bearer_clearly_expired(
         now + Duration::hours(1),
         now

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -261,10 +261,11 @@ fn publish_bearer_no_match_in_any_source_errors() {
     .unwrap_err();
 
     assert_matches!(err, PublishError::NoPublishBearer { .. });
-    // The hint points at both remedies: `sysand auth login` to store a
-    // credential, and the `SYSAND_CRED_*` environment fallback.
+    // The core message names no CLI command (the `sysand auth login` hint
+    // is added by the frontend); it states the condition and the
+    // `SYSAND_CRED_*` environment fallback.
     let message = err.to_string();
-    assert!(message.contains("sysand auth login"), "message: {message}");
+    assert!(!message.contains("sysand auth"), "message: {message}");
     assert!(message.contains("SYSAND_CRED_<X>"), "message: {message}");
     assert!(
         message.contains("https://example.org/api/v1/upload"),
@@ -836,39 +837,40 @@ fn publish_env_auth_failure_names_the_env_var() {
         message.contains("`SYSAND_CRED_TEAMIDX_BEARER_TOKEN`"),
         "message: {message}"
     );
-    // Env shadows stored logins, so re-login must not be the suggested fix.
+    // Env shadows stored credentials, so re-authenticating must not be the
+    // suggested fix. The core message names no CLI command.
     assert!(
-        message.contains("`sysand auth login` alone cannot replace it"),
+        message.contains("re-authenticating alone cannot replace it"),
         "message: {message}"
     );
-    assert!(!message.contains("auth status"), "message: {message}");
+    assert!(!message.contains("sysand auth"), "message: {message}");
     mock.assert();
 }
 
 #[test]
-fn publish_stored_auth_failure_names_the_login() {
+fn publish_stored_auth_failure_names_the_credential() {
     let mut server = mockito::Server::new();
     let mock = upload_mock(&mut server, 401, "unauthorized");
 
     let err = publish_to(&server, stored_bearer(None)).unwrap_err();
 
     let message = err.to_string();
+    // The core message states the source only; the frontend adds the
+    // `sysand auth login` remediation.
     assert!(
-        message.contains(&format!("your stored login for `{STORED_KEY}`")),
+        message.contains(&format!("the stored credential for `{STORED_KEY}`")),
         "message: {message}"
     );
-    assert!(
-        message.contains(&format!("re-run `sysand auth login {STORED_KEY}`")),
-        "message: {message}"
-    );
+    assert!(!message.contains("sysand auth"), "message: {message}");
     assert!(!message.contains("SYSAND_CRED_"), "message: {message}");
     mock.assert();
 }
 
 #[test]
-fn publish_403_points_at_auth_status() {
-    // 403 is authorization, not authentication: `sysand auth status`
-    // shows the stored subject, catching a wrong-project token.
+fn publish_403_points_at_the_credential_subject() {
+    // 403 is authorization, not authentication: the message points at the
+    // credential's subject, catching a wrong-project token, without naming
+    // a CLI command.
     let mut server = mockito::Server::new();
     let mock = upload_mock(&mut server, 403, "forbidden");
 
@@ -880,9 +882,10 @@ fn publish_403_points_at_auth_status() {
         "message: {message}"
     );
     assert!(
-        message.contains("run `sysand auth status`"),
+        message.contains("a token for a different project or account cannot publish here"),
         "message: {message}"
     );
+    assert!(!message.contains("sysand auth"), "message: {message}");
     mock.assert();
 }
 
@@ -915,10 +918,10 @@ fn publish_stops_before_upload_when_the_stored_bearer_is_expired() {
         PublishError::StoredCredentialExpired { key, .. } if key == STORED_KEY
     );
     let message = err.to_string();
-    assert!(
-        message.contains(&format!("re-run `sysand auth login {STORED_KEY}`")),
-        "message: {message}"
-    );
+    // The core message states the condition without naming a CLI command;
+    // the frontend adds the `sysand auth login` remediation.
+    assert!(message.contains("expired at"), "message: {message}");
+    assert!(!message.contains("sysand auth"), "message: {message}");
     // The archive was never uploaded.
     mock.assert();
 }

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -955,6 +955,17 @@ fn stored_bearer_clearly_expired_allows_a_skew_margin() {
         now + Duration::hours(1),
         now
     ));
+    // Exactly at the one-hour boundary: the comparison is strict (`>`), so
+    // this is still within the margin; one second past it flips to expired.
+    // Pins the boundary against an accidental `>=`.
+    assert!(!stored_bearer_clearly_expired(
+        now - Duration::hours(1),
+        now
+    ));
+    assert!(stored_bearer_clearly_expired(
+        now - Duration::hours(1) - Duration::seconds(1),
+        now
+    ));
 }
 
 // --- validate_api_root_url_shape ---

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -15,7 +15,7 @@ use crate::{
     resolve::net_utils::create_reqwest_client,
 };
 use bytes::Bytes;
-use chrono::{DateTime, Duration, Timelike, Utc};
+use chrono::{DateTime, Duration, Utc};
 use mockito::Matcher;
 use std::assert_matches;
 use std::sync::Arc;
@@ -198,30 +198,11 @@ fn publish_bearer_falls_through_to_keyring_when_env_has_no_match() {
 }
 
 #[test]
-fn publish_bearer_env_identical_token_candidates_collapse() {
-    // Two env patterns carrying the same token are one credential in
-    // effect, so they collapse to a match instead of erroring, mirroring
-    // the whoami and runtime selection flows.
-    let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
-    let env = env_sources(&[
-        ("https://example.org/**", "shared-env-token"),
-        ("https://example.org/api/**", "shared-env-token"),
-    ]);
-
-    let selected = resolve_publish_bearer_from_config(&env, stored_unreached, &upload_url).unwrap();
-
-    assert_eq!(selected.auth, ForceBearerAuth::new("shared-env-token"));
-    assert_eq!(
-        selected.provenance,
-        PublishBearerProvenance::Env { label: None }
-    );
-}
-
-#[test]
 fn publish_bearer_keyring_identical_token_candidates_collapse() {
     // The typical shape: one stored login whose glob set matches the
     // upload URL through more than one pattern. Same token, so publish
-    // selects it instead of reporting ambiguity.
+    // selects it instead of reporting ambiguity (the collapse rule itself
+    // is pinned per-source in the `select_bearer` tests).
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
 
     let selected = resolve_publish_bearer_from_config(
@@ -874,24 +855,14 @@ fn publish_env_auth_failure_names_the_env_var() {
     let err = publish_to(&server, env_bearer(Some("TEAMIDX"))).unwrap_err();
 
     let message = err.to_string();
-    assert!(
-        message.contains("authentication failed (HTTP 401): unauthorized"),
-        "message: {message}"
-    );
-    assert!(
-        message.contains("came from `SYSAND_CRED_TEAMIDX`"),
-        "message: {message}"
-    );
+    assert!(message.contains("HTTP 401"), "message: {message}");
     assert!(
         message.contains("`SYSAND_CRED_TEAMIDX_BEARER_TOKEN`"),
         "message: {message}"
     );
     // Env shadows stored credentials, so re-authenticating must not be the
     // suggested fix. The core message names no CLI command.
-    assert!(
-        message.contains("re-authenticating alone cannot replace it"),
-        "message: {message}"
-    );
+    assert!(message.contains("cannot replace it"), "message: {message}");
     assert!(!message.contains("sysand auth"), "message: {message}");
     mock.assert();
 }
@@ -926,12 +897,9 @@ fn publish_403_points_at_the_credential_subject() {
     let err = publish_to(&server, stored_bearer(None)).unwrap_err();
 
     let message = err.to_string();
+    assert!(message.contains("HTTP 403"), "message: {message}");
     assert!(
-        message.contains("authorization failed (HTTP 403): forbidden"),
-        "message: {message}"
-    );
-    assert!(
-        message.contains("a token for a different project or account cannot publish here"),
+        message.contains("a token for a different project"),
         "message: {message}"
     );
     assert!(!message.contains("sysand auth"), "message: {message}");
@@ -959,11 +927,7 @@ fn publish_stops_before_upload_when_the_stored_bearer_is_expired() {
     let mut server = mockito::Server::new();
     let mock = server.mock("POST", "/api/v1/upload").expect(0).create();
 
-    // A sub-second component that must not leak into the message
-    // (timestamps are shown without sub-second precision).
-    let expires_at = (Utc::now() - Duration::days(1))
-        .with_nanosecond(123_456_789)
-        .unwrap();
+    let expires_at = Utc::now() - Duration::days(1);
     let err = publish_to(&server, stored_bearer(Some(expires_at))).unwrap_err();
 
     assert_matches!(
@@ -973,12 +937,7 @@ fn publish_stops_before_upload_when_the_stored_bearer_is_expired() {
     let message = err.to_string();
     // The core message states the condition without naming a CLI command;
     // the frontend adds the `sysand auth login` remediation.
-    let expected_timestamp = expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string();
-    assert!(
-        message.contains(&format!("expired at {expected_timestamp}")),
-        "message: {message}"
-    );
-    assert!(!message.contains(".123"), "message: {message}");
+    assert!(message.contains("expired at"), "message: {message}");
     assert!(!message.contains("sysand auth"), "message: {message}");
     // The archive was never uploaded.
     mock.assert();

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -261,9 +261,10 @@ fn publish_bearer_no_match_in_any_source_errors() {
     .unwrap_err();
 
     assert_matches!(err, PublishError::NoPublishBearer { .. });
-    // The hint must stay truthful about what exists today: `SYSAND_CRED_*`
-    // configuration, not the yet-unimplemented `sysand auth login`.
+    // The hint points at both remedies: `sysand auth login` to store a
+    // credential, and the `SYSAND_CRED_*` environment fallback.
     let message = err.to_string();
+    assert!(message.contains("sysand auth login"), "message: {message}");
     assert!(message.contains("SYSAND_CRED_<X>"), "message: {message}");
     assert!(
         message.contains("https://example.org/api/v1/upload"),

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::{
-    AllowedMetamodelKind, PublishBearerProvenance, PublishBearerSource, PublishError,
+    AllowedMetamodelKind, PublishBearerConflict, PublishBearerProvenance, PublishError,
     PublishPreparation, SelectedPublishBearer, TrustedPublishingEnvironment, TrustedPublishingMode,
     build_upload_url, check_metamodel, check_usage, do_publish, error_body_to_string,
     map_publish_response, resolve_publish_bearer, resolve_publish_bearer_from_config,
@@ -36,13 +36,22 @@ fn empty_sources() -> GlobMap<EnvBearerAuth> {
 }
 
 fn env_sources(entries: &[(&str, &str)]) -> GlobMap<EnvBearerAuth> {
+    env_sources_labeled(
+        &entries
+            .iter()
+            .map(|(pattern, token)| (*pattern, *token, "ENVIDX"))
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn env_sources_labeled(entries: &[(&str, &str, &str)]) -> GlobMap<EnvBearerAuth> {
     let mut builder = GlobMapBuilder::new();
-    for (pattern, token) in entries {
+    for (pattern, token, label) in entries {
         builder.add(
             *pattern,
             EnvBearerAuth {
                 auth: ForceBearerAuth::new(*token),
-                label: "ENVIDX".to_string(),
+                label: (*label).to_string(),
             },
         );
     }
@@ -68,6 +77,17 @@ fn stored_sources_expiring(
                 STORED_KEY.to_string(),
                 expires_at,
             ),
+        );
+    }
+    builder.build().unwrap()
+}
+
+fn stored_sources_keyed(entries: &[(&str, &str, &str)]) -> GlobMap<StoredBearerAuth> {
+    let mut builder = GlobMapBuilder::new();
+    for (pattern, token, key) in entries {
+        builder.add(
+            *pattern,
+            StoredBearerAuth::new(ForceBearerAuth::new(*token), (*key).to_string(), None),
         );
     }
     builder.build().unwrap()
@@ -149,13 +169,14 @@ fn resolve_publish_bearer_never_rejects_ambiguous_bearer() {
     )
     .unwrap_err();
 
+    // Both entries share the ENVIDX label, so the conflict names the one
+    // variable once.
     assert_matches!(
         err,
         PublishError::AmbiguousPublishBearer {
-            bearer_source: PublishBearerSource::Env,
-            candidates: 2,
+            conflict: PublishBearerConflict::Env { ref variables },
             ..
-        }
+        } if variables == &["SYSAND_CRED_ENVIDX"]
     );
 }
 
@@ -234,22 +255,25 @@ fn publish_bearer_env_ambiguity_errors_without_keyring_fallback() {
     // An ambiguous env match must error, not fall back to a unique
     // keyring match, and must not read the stored credentials at all.
     let upload_url = Url::parse("https://example.org/api/v1/upload").unwrap();
-    let env = env_sources(&[
-        ("https://example.org/**", "broad-env-token"),
-        ("https://example.org/api/**", "specific-env-token"),
+    let env = env_sources_labeled(&[
+        ("https://example.org/**", "broad-env-token", "BROAD"),
+        ("https://example.org/api/**", "specific-env-token", "NARROW"),
     ]);
 
     let err = resolve_publish_bearer_from_config(&env, stored_unreached, &upload_url).unwrap_err();
 
+    // The conflict names every matching `SYSAND_CRED_<LABEL>` variable.
     assert_matches!(
         err,
         PublishError::AmbiguousPublishBearer {
-            bearer_source: PublishBearerSource::Env,
-            candidates: 2,
+            conflict: PublishBearerConflict::Env { ref variables },
             ref upload_url,
-            ..
-        } if upload_url.as_ref() == "https://example.org/api/v1/upload"
+        } if variables == &["SYSAND_CRED_BROAD", "SYSAND_CRED_NARROW"]
+            && upload_url.as_ref() == "https://example.org/api/v1/upload"
     );
+    let message = err.to_string();
+    assert!(message.contains("SYSAND_CRED_BROAD"), "message: {message}");
+    assert!(message.contains("SYSAND_CRED_NARROW"), "message: {message}");
 }
 
 #[test]
@@ -259,23 +283,37 @@ fn publish_bearer_keyring_ambiguity_errors() {
     let err = resolve_publish_bearer_from_config(
         &empty_sources(),
         || {
-            stored_sources(&[
-                ("https://example.org/**", "broad-keyring-token"),
-                ("https://example.org/api/**", "specific-keyring-token"),
+            stored_sources_keyed(&[
+                (
+                    "https://example.org/**",
+                    "broad-keyring-token",
+                    "https://example.org/",
+                ),
+                (
+                    "https://example.org/api/**",
+                    "specific-keyring-token",
+                    "https://example.org/api/",
+                ),
             ])
         },
         &upload_url,
     )
     .unwrap_err();
 
+    // The conflict names every matching stored login by its key.
     assert_matches!(
         err,
         PublishError::AmbiguousPublishBearer {
-            bearer_source: PublishBearerSource::Keyring,
-            candidates: 2,
+            conflict: PublishBearerConflict::Stored { ref keys },
             ref upload_url,
-            ..
-        } if upload_url.as_ref() == "https://example.org/api/v1/upload"
+        } if keys == &["https://example.org/", "https://example.org/api/"]
+            && upload_url.as_ref() == "https://example.org/api/v1/upload"
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("`https://example.org/`")
+            && message.contains("`https://example.org/api/`"),
+        "message: {message}"
     );
 }
 

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -138,30 +138,15 @@ fn musl_backend_absent() -> CredentialStoreError {
 
 /// UTF-16 byte length of a string: the unit Windows measures credential
 /// blobs in.
-#[cfg(any(windows, test))]
 pub(crate) fn utf16_byte_len(raw: &str) -> usize {
     raw.encode_utf16().count() * 2
 }
 
 /// Check a blob byte length against a platform limit.
-#[cfg(any(windows, test))]
 pub(crate) fn check_blob_size(byte_len: usize, limit: usize) -> Result<(), CredentialStoreError> {
     if byte_len > limit {
         Err(CredentialStoreError::BlobTooLarge)
     } else {
-        Ok(())
-    }
-}
-
-/// Enforce the platform blob size limit. Only Windows has one.
-fn enforce_platform_blob_limit(raw: &str) -> Result<(), CredentialStoreError> {
-    #[cfg(windows)]
-    {
-        check_blob_size(utf16_byte_len(raw), WINDOWS_MAX_BLOB_BYTES)
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = raw;
         Ok(())
     }
 }
@@ -201,6 +186,24 @@ pub struct LockedBlobStore<B> {
     lock_path: PathBuf,
     lock_timeout: Duration,
     lock_poll_interval: Duration,
+    /// Max serialized blob size before a write is refused as
+    /// [`CredentialStoreError::BlobTooLarge`]. `None` means unbounded;
+    /// defaults to the platform limit (only Windows has one). Overridable
+    /// so the enforcement path is testable off Windows.
+    size_limit: Option<usize>,
+}
+
+/// The serialized-blob size limit that applies on this platform, if any.
+/// Only Windows caps credential blobs.
+fn default_platform_blob_limit() -> Option<usize> {
+    #[cfg(windows)]
+    {
+        Some(WINDOWS_MAX_BLOB_BYTES)
+    }
+    #[cfg(not(windows))]
+    {
+        None
+    }
 }
 
 /// The OS-keyring-backed credential store.
@@ -220,6 +223,7 @@ impl<B: BlobBackend> LockedBlobStore<B> {
             lock_path,
             lock_timeout: DEFAULT_LOCK_TIMEOUT,
             lock_poll_interval: DEFAULT_LOCK_POLL_INTERVAL,
+            size_limit: default_platform_blob_limit(),
         }
     }
 
@@ -227,6 +231,14 @@ impl<B: BlobBackend> LockedBlobStore<B> {
     pub fn with_lock_timing(mut self, timeout: Duration, poll_interval: Duration) -> Self {
         self.lock_timeout = timeout;
         self.lock_poll_interval = poll_interval;
+        self
+    }
+
+    /// Override the blob size limit so the platform-cap enforcement path
+    /// (otherwise Windows-only) can be exercised on any platform.
+    #[cfg(test)]
+    pub fn with_size_limit(mut self, size_limit: Option<usize>) -> Self {
+        self.size_limit = size_limit;
         self
     }
 
@@ -297,16 +309,21 @@ fn load_blob<B: BlobBackend>(backend: &B) -> Result<CredentialBlob, CredentialSt
 }
 
 /// Write the blob back, deleting the entry when nothing is left so a
-/// logged-out store keeps the cheap "no entry" fast path.
+/// logged-out store keeps the cheap "no entry" fast path. `size_limit`
+/// refuses an oversized serialized blob before the write (the platform cap
+/// on Windows).
 fn store_blob<B: BlobBackend>(
     backend: &B,
     blob: &CredentialBlob,
+    size_limit: Option<usize>,
 ) -> Result<(), CredentialStoreError> {
     if blob.credentials.is_empty() && blob.extra.is_empty() {
         return backend.delete();
     }
     let raw = serialize_blob(blob)?;
-    enforce_platform_blob_limit(&raw)?;
+    if let Some(limit) = size_limit {
+        check_blob_size(utf16_byte_len(&raw), limit)?;
+    }
     backend.write(&raw)
 }
 
@@ -316,19 +333,21 @@ impl<B: BlobBackend> CredentialStore for LockedBlobStore<B> {
     }
 
     fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
+        let size_limit = self.size_limit;
         self.with_lock(|backend| {
             let mut blob = load_blob(backend)?;
             upsert_record(&mut blob.credentials, record);
-            store_blob(backend, &blob)
+            store_blob(backend, &blob, size_limit)
         })
     }
 
     fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
+        let size_limit = self.size_limit;
         self.with_lock(|backend| {
             let mut blob = load_blob(backend)?;
             let removed = remove_record(&mut blob.credentials, key);
             if removed {
-                store_blob(backend, &blob)?;
+                store_blob(backend, &blob, size_limit)?;
             }
             Ok(removed)
         })

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -372,7 +372,7 @@ fn store_blob<B: BlobBackend>(
     if blob.credentials.is_empty() && blob.extra.is_empty() {
         return backend.delete();
     }
-    let raw = serialize_blob(blob)?;
+    let raw = serialize_blob(blob);
     if let Some(limit) = size_limit {
         check_blob_size(utf16_byte_len(&raw), limit)?;
     }

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -109,11 +109,11 @@ impl BlobBackend for OsKeyringBackend {
     }
 }
 
-/// On musl targets the `keyring` crate is not built at all: its Linux
-/// Secret Service backend needs dbus, whose vendored C build does not
-/// link there. The backend reports "absent", so every caller takes the
-/// documented `SYSAND_CRED_*` fallback path (design/credential-storage.md
-/// section 9 taxonomy).
+/// On musl targets the `keyring` crate is not built at all (excluded by
+/// policy in Cargo.toml: musl builds are containers/CI where the env-var
+/// credential path is the norm). The backend reports "absent", so every
+/// caller takes the documented `SYSAND_CRED_*` fallback path
+/// (design/credential-storage.md section 9 taxonomy).
 #[cfg(all(target_os = "linux", target_env = "musl"))]
 impl BlobBackend for OsKeyringBackend {
     fn read(&self) -> Result<Option<String>, CredentialStoreError> {
@@ -178,8 +178,8 @@ pub fn default_lock_path() -> Result<PathBuf, CredentialStoreError> {
 }
 
 /// A [`CredentialStore`] over a [`BlobBackend`], guarding every operation
-/// with a cross-process advisory file lock (`flock`/`LockFileEx` via
-/// `fd-lock`) and a bounded wait.
+/// with a cross-process advisory file lock (`flock`/`LockFileEx` via the
+/// stable [`std::fs::File`] locking API) and a bounded wait.
 #[derive(Debug)]
 pub struct LockedBlobStore<B> {
     backend: B,
@@ -263,16 +263,19 @@ impl<B: BlobBackend> LockedBlobStore<B> {
         body: impl FnOnce(&B) -> Result<T, CredentialStoreError>,
     ) -> Result<T, CredentialStoreError> {
         let file = self.open_lock_file()?;
-        let mut lock = fd_lock::RwLock::new(file);
         let deadline = Instant::now() + self.lock_timeout;
         loop {
-            match lock.try_write() {
-                Ok(guard) => {
+            match file.try_lock() {
+                Ok(()) => {
                     let result = body(&self.backend);
-                    drop(guard);
+                    // Release the advisory lock. The file also unlocks on
+                    // drop, matching the previous guard-drop behavior; the
+                    // explicit call keeps the release visible and lets the
+                    // backend result stand.
+                    let _ = file.unlock();
                     return result;
                 }
-                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                Err(fs::TryLockError::WouldBlock) => {
                     if Instant::now() >= deadline {
                         return Err(CredentialStoreError::LockTimeout {
                             path: self.lock_path.display().to_string(),
@@ -280,7 +283,7 @@ impl<B: BlobBackend> LockedBlobStore<B> {
                     }
                     std::thread::sleep(self.lock_poll_interval);
                 }
-                Err(err) => return Err(CredentialStoreError::Lock(err)),
+                Err(fs::TryLockError::Error(err)) => return Err(CredentialStoreError::Lock(err)),
             }
         }
     }

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -268,10 +268,8 @@ impl<B: BlobBackend> LockedBlobStore<B> {
             match file.try_lock() {
                 Ok(()) => {
                     let result = body(&self.backend);
-                    // Release the advisory lock. The file also unlocks on
-                    // drop, matching the previous guard-drop behavior; the
-                    // explicit call keeps the release visible and lets the
-                    // backend result stand.
+                    // Release explicitly (it would also unlock on drop) so
+                    // the release is visible and the backend result stands.
                     let _ = file.unlock();
                     return result;
                 }

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 //! The credential store: [`LockedBlobStore`], a persistent store of
-//! credential records over a [`BlobBackend`] (design/credential-storage.md
-//! §9).
+//! credential records over a [`BlobBackend`]; the storage design is in
+//! design/credential-storage.md.
 //!
 //! All persisted credentials live in one backend entry holding the
 //! versioned JSON blob from the parent module. Read-modify-write is
@@ -135,8 +135,7 @@ impl BlobBackend for OsKeyringBackend {
 /// On musl targets the `keyring` crate is not built at all (excluded by
 /// policy in Cargo.toml: musl builds are containers/CI where the env-var
 /// credential path is the norm). The backend reports "absent", so every
-/// caller takes the documented `SYSAND_CRED_*` fallback path
-/// (design/credential-storage.md section 9 taxonomy).
+/// caller takes the documented `SYSAND_CRED_*` fallback path.
 #[cfg(all(feature = "keyring", target_os = "linux", target_env = "musl"))]
 impl BlobBackend for OsKeyringBackend {
     fn read(&self) -> Result<Option<String>, CredentialStoreError> {

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -23,14 +23,16 @@ use super::{
 };
 
 /// Keyring service name of the single sysand credential entry.
-pub const KEYRING_SERVICE: &str = "sysand";
+pub(crate) const KEYRING_SERVICE: &str = "sysand";
 /// Keyring account name of the single sysand credential entry.
-pub const KEYRING_ACCOUNT: &str = "credentials";
+pub(crate) const KEYRING_ACCOUNT: &str = "credentials";
 
 /// Windows `CRED_MAX_CREDENTIAL_BLOB_SIZE`: the Credential Manager caps a
 /// credential blob at 2560 bytes, measured against the UTF-16 encoding the
-/// keyring crate stores on Windows.
-pub const WINDOWS_MAX_BLOB_BYTES: usize = 2560;
+/// keyring crate stores on Windows. Only the Windows enforcement path and
+/// the (platform-independent) size-logic tests use it.
+#[cfg(any(windows, test))]
+pub(crate) const WINDOWS_MAX_BLOB_BYTES: usize = 2560;
 
 const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -136,12 +138,14 @@ fn musl_backend_absent() -> CredentialStoreError {
 
 /// UTF-16 byte length of a string: the unit Windows measures credential
 /// blobs in.
-pub fn utf16_byte_len(raw: &str) -> usize {
+#[cfg(any(windows, test))]
+pub(crate) fn utf16_byte_len(raw: &str) -> usize {
     raw.encode_utf16().count() * 2
 }
 
 /// Check a blob byte length against a platform limit.
-pub fn check_blob_size(byte_len: usize, limit: usize) -> Result<(), CredentialStoreError> {
+#[cfg(any(windows, test))]
+pub(crate) fn check_blob_size(byte_len: usize, limit: usize) -> Result<(), CredentialStoreError> {
     if byte_len > limit {
         Err(CredentialStoreError::BlobTooLarge)
     } else {

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -11,8 +11,8 @@
 //! existence-based lock file) and reads by its shared counterpart, both
 //! with a bounded wait.
 //!
-//! The blob handling is generic over [`BlobBackend`] so the lock,
-//! fail-closed, and size-limit logic is testable without a real OS
+//! The blob handling is generic over [`BlobBackend`] so the lock and
+//! fail-closed logic is testable without a real OS
 //! keyring, and so hosts can substitute backends (the CLI's debug-only
 //! test seam). The production backend, [`OsKeyringBackend`] (one keyring
 //! entry: service `sysand`, account `credentials`), sits behind the
@@ -37,13 +37,6 @@ const KEYRING_SERVICE: &str = "sysand";
     not(all(target_os = "linux", target_env = "musl"))
 ))]
 const KEYRING_ACCOUNT: &str = "credentials";
-
-/// Windows `CRED_MAX_CREDENTIAL_BLOB_SIZE`: the Credential Manager caps a
-/// credential blob at 2560 bytes, measured against the UTF-16 encoding the
-/// keyring crate stores on Windows. Only the Windows enforcement path and
-/// the (platform-independent) size-logic tests use it.
-#[cfg(any(windows, test))]
-pub(crate) const WINDOWS_MAX_BLOB_BYTES: usize = 2560;
 
 const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -75,8 +68,8 @@ fn map_keyring_error(err: keyring::Error) -> CredentialStoreError {
     match err {
         keyring::Error::PlatformFailure(source) => CredentialStoreError::BackendAbsent { source },
         keyring::Error::NoStorageAccess(source) => CredentialStoreError::BackendDenied { source },
-        // The platform store refused the value size (Windows); the blob
-        // size gate should catch this first, this is the backstop.
+        // The platform store refused the value size (Windows caps
+        // credential blobs); size limits are the platform's to enforce.
         keyring::Error::TooLong(_, _) => CredentialStoreError::BlobTooLarge,
         // A corrupt or ambiguous entry reads as an unreadable store, with
         // the same reset remediation as a corrupt blob.
@@ -156,21 +149,6 @@ fn musl_backend_absent() -> CredentialStoreError {
     }
 }
 
-/// UTF-16 byte length of a string: the unit Windows measures credential
-/// blobs in.
-pub(crate) fn utf16_byte_len(raw: &str) -> usize {
-    raw.encode_utf16().count() * 2
-}
-
-/// Check a blob byte length against a platform limit.
-pub(crate) fn check_blob_size(byte_len: usize, limit: usize) -> Result<(), CredentialStoreError> {
-    if byte_len > limit {
-        Err(CredentialStoreError::BlobTooLarge)
-    } else {
-        Ok(())
-    }
-}
-
 /// Per-user path for the credential store lock file.
 ///
 /// Linux: `XDG_STATE_HOME` (via `dirs`, defaulting to `~/.local/state`),
@@ -215,24 +193,6 @@ pub struct LockedBlobStore<B> {
     lock_path: PathBuf,
     lock_timeout: Duration,
     lock_poll_interval: Duration,
-    /// Max serialized blob size before a write is refused as
-    /// [`CredentialStoreError::BlobTooLarge`]. `None` means unbounded;
-    /// defaults to the platform limit (only Windows has one). Overridable
-    /// so the enforcement path is testable off Windows.
-    size_limit: Option<usize>,
-}
-
-/// The serialized-blob size limit that applies on this platform, if any.
-/// Only Windows caps credential blobs.
-fn default_platform_blob_limit() -> Option<usize> {
-    #[cfg(windows)]
-    {
-        Some(WINDOWS_MAX_BLOB_BYTES)
-    }
-    #[cfg(not(windows))]
-    {
-        None
-    }
 }
 
 /// The OS-keyring-backed credential store.
@@ -254,7 +214,6 @@ impl<B: BlobBackend> LockedBlobStore<B> {
             lock_path,
             lock_timeout: DEFAULT_LOCK_TIMEOUT,
             lock_poll_interval: DEFAULT_LOCK_POLL_INTERVAL,
-            size_limit: default_platform_blob_limit(),
         }
     }
 
@@ -262,14 +221,6 @@ impl<B: BlobBackend> LockedBlobStore<B> {
     pub fn with_lock_timing(mut self, timeout: Duration, poll_interval: Duration) -> Self {
         self.lock_timeout = timeout;
         self.lock_poll_interval = poll_interval;
-        self
-    }
-
-    /// Override the blob size limit so the platform-cap enforcement path
-    /// (otherwise Windows-only) can be exercised on any platform.
-    #[cfg(test)]
-    pub fn with_size_limit(mut self, size_limit: Option<usize>) -> Self {
-        self.size_limit = size_limit;
         self
     }
 
@@ -369,22 +320,18 @@ fn load_blob<B: BlobBackend>(backend: &B) -> Result<CredentialBlob, CredentialSt
 }
 
 /// Write the blob back, deleting the entry when nothing is left so a
-/// logged-out store keeps the cheap "no entry" fast path. `size_limit`
-/// refuses an oversized serialized blob before the write (the platform cap
-/// on Windows).
+/// logged-out store keeps the cheap "no entry" fast path. Size limits are
+/// the platform's to enforce: an oversized write surfaces as the
+/// backend's error (Windows caps blobs, mapped to
+/// [`CredentialStoreError::BlobTooLarge`]).
 fn store_blob<B: BlobBackend>(
     backend: &B,
     blob: &CredentialBlob,
-    size_limit: Option<usize>,
 ) -> Result<(), CredentialStoreError> {
     if blob.credentials.is_empty() && blob.extra.is_empty() {
         return backend.delete();
     }
-    let raw = serialize_blob(blob);
-    if let Some(limit) = size_limit {
-        check_blob_size(utf16_byte_len(&raw), limit)?;
-    }
-    backend.write(&raw)
+    backend.write(&serialize_blob(blob))
 }
 
 impl<B: BlobBackend> LockedBlobStore<B> {
@@ -397,7 +344,6 @@ impl<B: BlobBackend> LockedBlobStore<B> {
 
     /// Insert a record, replacing any existing record with the same `key`.
     pub fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
-        let size_limit = self.size_limit;
         self.with_lock(LockMode::Exclusive, |backend| {
             let mut blob = load_blob(backend)?;
             match blob
@@ -408,21 +354,20 @@ impl<B: BlobBackend> LockedBlobStore<B> {
                 Some(existing) => *existing = record,
                 None => blob.credentials.push(record),
             }
-            store_blob(backend, &blob, size_limit)
+            store_blob(backend, &blob)
         })
     }
 
     /// Remove the record with the given `key`. Returns whether a record
     /// was removed.
     pub fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
-        let size_limit = self.size_limit;
         self.with_lock(LockMode::Exclusive, |backend| {
             let mut blob = load_blob(backend)?;
             let before = blob.credentials.len();
             blob.credentials.retain(|record| record.key != key);
             let removed = blob.credentials.len() != before;
             if removed {
-                store_blob(backend, &blob, size_limit)?;
+                store_blob(backend, &blob)?;
             }
             Ok(removed)
         })

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -19,7 +19,11 @@
 //! `keyring` cargo feature; everything else here is unconditional.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+// `PathBuf` feeds only the gated lock-path selection below.
+#[cfg(any(feature = "keyring", test))]
+use std::path::PathBuf;
+
+use camino::{Utf8Path, Utf8PathBuf};
 use std::time::{Duration, Instant};
 
 use super::{CredentialBlob, CredentialRecord, CredentialStoreError, parse_blob, serialize_blob};
@@ -160,7 +164,7 @@ fn musl_backend_absent() -> CredentialStoreError {
 /// different environments could lock different files while
 /// read-modify-writing the same keyring entry, silently losing a record.
 #[cfg(feature = "keyring")]
-pub fn default_lock_path() -> Result<PathBuf, CredentialStoreError> {
+pub fn default_lock_path() -> Result<Utf8PathBuf, CredentialStoreError> {
     lock_path_from_dirs(dirs::state_dir(), dirs::data_local_dir(), dirs::home_dir())
 }
 
@@ -172,11 +176,14 @@ fn lock_path_from_dirs(
     state_dir: Option<PathBuf>,
     data_local_dir: Option<PathBuf>,
     home_dir: Option<PathBuf>,
-) -> Result<PathBuf, CredentialStoreError> {
-    if let Some(base) = state_dir.or(data_local_dir) {
+) -> Result<Utf8PathBuf, CredentialStoreError> {
+    // A non-UTF-8 candidate directory is exceedingly unlikely (these come
+    // from the `dirs` crate); treat one like an unset candidate.
+    let utf8 = |dir: Option<PathBuf>| dir.and_then(|d| Utf8PathBuf::from_path_buf(d).ok());
+    if let Some(base) = utf8(state_dir).or_else(|| utf8(data_local_dir)) {
         return Ok(base.join("sysand").join("credentials.lock"));
     }
-    match home_dir {
+    match utf8(home_dir) {
         Some(home) => Ok(home.join(".sysand").join("credentials.lock")),
         None => Err(CredentialStoreError::NoLockDir),
     }
@@ -190,7 +197,7 @@ fn lock_path_from_dirs(
 #[derive(Debug)]
 pub struct LockedBlobStore<B> {
     backend: B,
-    lock_path: PathBuf,
+    lock_path: Utf8PathBuf,
     lock_timeout: Duration,
     lock_poll_interval: Duration,
 }
@@ -208,7 +215,7 @@ impl KeyringCredentialStore {
 }
 
 impl<B: BlobBackend> LockedBlobStore<B> {
-    pub fn new(backend: B, lock_path: PathBuf) -> Self {
+    pub fn new(backend: B, lock_path: Utf8PathBuf) -> Self {
         LockedBlobStore {
             backend,
             lock_path,
@@ -237,7 +244,7 @@ impl<B: BlobBackend> LockedBlobStore<B> {
         }
         options
             .open(&self.lock_path)
-            .map_err(|err| FsIoError::OpenFile(utf8_lossy(&self.lock_path), err).into())
+            .map_err(|err| FsIoError::OpenFile(self.lock_path.clone(), err).into())
     }
 
     /// Run `body` under the cross-process lock, waiting at most the
@@ -267,13 +274,13 @@ impl<B: BlobBackend> LockedBlobStore<B> {
                 Err(fs::TryLockError::WouldBlock) => {
                     if Instant::now() >= deadline {
                         return Err(CredentialStoreError::LockTimeout {
-                            path: self.lock_path.display().to_string(),
+                            path: self.lock_path.to_string(),
                         });
                     }
                     std::thread::sleep(self.lock_poll_interval);
                 }
                 Err(fs::TryLockError::Error(err)) => {
-                    return Err(FsIoError::LockFile(utf8_lossy(&self.lock_path), err).into());
+                    return Err(FsIoError::LockFile(self.lock_path.clone(), err).into());
                 }
             }
         }
@@ -290,7 +297,7 @@ enum LockMode {
 
 /// Create a directory chain, with the final directory private (0700) on
 /// unix.
-fn create_private_dir_all(dir: &Path) -> Result<(), CredentialStoreError> {
+fn create_private_dir_all(dir: &Utf8Path) -> Result<(), CredentialStoreError> {
     let mut builder = fs::DirBuilder::new();
     builder.recursive(true);
     #[cfg(unix)]
@@ -300,14 +307,8 @@ fn create_private_dir_all(dir: &Path) -> Result<(), CredentialStoreError> {
     }
     builder
         .create(dir)
-        .map_err(|err| FsIoError::MkDir(utf8_lossy(dir), err))?;
+        .map_err(|err| FsIoError::MkDir(dir.to_owned(), err))?;
     Ok(())
-}
-
-/// Render a path for error context; lock paths come from the `dirs`
-/// crate, so a non-UTF-8 path is rare and lossy display is fine.
-fn utf8_lossy(path: &Path) -> camino::Utf8PathBuf {
-    camino::Utf8PathBuf::from(path.display().to_string())
 }
 
 /// Read and parse the blob; `None` (no entry) is an empty store, but a

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -266,8 +266,7 @@ impl<B: BlobBackend> LockedBlobStore<B> {
             match attempt {
                 Ok(()) => {
                     let result = body(&self.backend);
-                    // Release explicitly (it would also unlock on drop) so
-                    // the release is visible and the backend result stands.
+                    // Release explicitly (it would also unlock on `file` drop)
                     let _ = file.unlock();
                     return result;
                 }

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -19,8 +19,6 @@
 //! `keyring` cargo feature; everything else here is unconditional.
 
 use std::fs;
-// Only the gated lock-path fallback error uses `io` directly.
-#[cfg(any(feature = "keyring", test))]
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! OS-keyring-backed [`CredentialStore`] (design/credential-storage.md §9).
+//!
+//! All persisted credentials live in one keyring entry (service `sysand`,
+//! account `credentials`) holding the versioned JSON blob from the parent
+//! module. Read-modify-write is guarded by a cross-process advisory OS
+//! file lock (never an existence-based lock file), with a bounded wait.
+//!
+//! The blob handling is generic over [`BlobBackend`] so the lock,
+//! fail-closed, and size-limit logic is testable without a real OS
+//! keyring.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use super::{
+    CredentialBlob, CredentialRecord, CredentialStore, CredentialStoreError, parse_blob,
+    remove_record, serialize_blob, upsert_record,
+};
+
+/// Keyring service name of the single sysand credential entry.
+pub const KEYRING_SERVICE: &str = "sysand";
+/// Keyring account name of the single sysand credential entry.
+pub const KEYRING_ACCOUNT: &str = "credentials";
+
+/// Windows `CRED_MAX_CREDENTIAL_BLOB_SIZE`: the Credential Manager caps a
+/// credential blob at 2560 bytes, measured against the UTF-16 encoding the
+/// keyring crate stores on Windows.
+pub const WINDOWS_MAX_BLOB_BYTES: usize = 2560;
+
+const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Storage for the raw credential blob. Implemented by the OS keyring; an
+/// in-memory implementation serves headless tests.
+pub trait BlobBackend {
+    /// The stored blob, or `None` when no entry exists.
+    fn read(&self) -> Result<Option<String>, CredentialStoreError>;
+    /// Store the blob, replacing any existing entry.
+    fn write(&self, raw: &str) -> Result<(), CredentialStoreError>;
+    /// Remove the entry entirely. Succeeds when no entry exists, so an
+    /// empty store keeps the cheap "no entry" fast path for later reads.
+    fn delete(&self) -> Result<(), CredentialStoreError>;
+}
+
+/// Map a keyring crate error into the store's error taxonomy.
+///
+/// The mapping is best-effort: the keyring crate does not cleanly separate
+/// "no backend" from "backend refused". `PlatformFailure` (for example no
+/// Secret Service daemon to talk to) is treated as an absent backend, so
+/// callers may fall back to `SYSAND_CRED_*`; `NoStorageAccess` (locked or
+/// denied collection) and other errors must be surfaced.
+#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+fn map_keyring_error(err: keyring::Error) -> CredentialStoreError {
+    match err {
+        keyring::Error::PlatformFailure(source) => CredentialStoreError::BackendAbsent { source },
+        keyring::Error::NoStorageAccess(source) => CredentialStoreError::BackendDenied { source },
+        // The platform store refused the value size (Windows); the blob
+        // size gate should catch this first, this is the backstop.
+        keyring::Error::TooLong(_, _) => CredentialStoreError::BlobTooLarge,
+        // A corrupt or ambiguous entry reads as an unreadable store, with
+        // the same reset remediation as a corrupt blob.
+        keyring::Error::BadEncoding(_) | keyring::Error::Ambiguous(_) => {
+            CredentialStoreError::Unreadable
+        }
+        other => CredentialStoreError::BackendDenied {
+            source: Box::new(other),
+        },
+    }
+}
+
+/// The real OS keyring entry (macOS Keychain, Windows Credential Manager,
+/// Linux Secret Service).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OsKeyringBackend;
+
+#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+impl OsKeyringBackend {
+    fn entry() -> Result<keyring::Entry, CredentialStoreError> {
+        keyring::Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT).map_err(map_keyring_error)
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+impl BlobBackend for OsKeyringBackend {
+    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
+        match Self::entry()?.get_password() {
+            Ok(raw) => Ok(Some(raw)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(err) => Err(map_keyring_error(err)),
+        }
+    }
+
+    fn write(&self, raw: &str) -> Result<(), CredentialStoreError> {
+        Self::entry()?.set_password(raw).map_err(map_keyring_error)
+    }
+
+    fn delete(&self) -> Result<(), CredentialStoreError> {
+        match Self::entry()?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(err) => Err(map_keyring_error(err)),
+        }
+    }
+}
+
+/// On musl targets the `keyring` crate is not built at all: its Linux
+/// Secret Service backend needs dbus, whose vendored C build does not
+/// link there. The backend reports "absent", so every caller takes the
+/// documented `SYSAND_CRED_*` fallback path (design/credential-storage.md
+/// section 9 taxonomy).
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+impl BlobBackend for OsKeyringBackend {
+    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
+        Err(musl_backend_absent())
+    }
+
+    fn write(&self, _raw: &str) -> Result<(), CredentialStoreError> {
+        Err(musl_backend_absent())
+    }
+
+    fn delete(&self) -> Result<(), CredentialStoreError> {
+        Err(musl_backend_absent())
+    }
+}
+
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+fn musl_backend_absent() -> CredentialStoreError {
+    CredentialStoreError::BackendAbsent {
+        source: "OS keyring support is not built on musl targets".into(),
+    }
+}
+
+/// UTF-16 byte length of a string: the unit Windows measures credential
+/// blobs in.
+pub fn utf16_byte_len(raw: &str) -> usize {
+    raw.encode_utf16().count() * 2
+}
+
+/// Check a blob byte length against a platform limit.
+pub fn check_blob_size(byte_len: usize, limit: usize) -> Result<(), CredentialStoreError> {
+    if byte_len > limit {
+        Err(CredentialStoreError::BlobTooLarge)
+    } else {
+        Ok(())
+    }
+}
+
+/// Enforce the platform blob size limit. Only Windows has one.
+fn enforce_platform_blob_limit(raw: &str) -> Result<(), CredentialStoreError> {
+    #[cfg(windows)]
+    {
+        check_blob_size(utf16_byte_len(raw), WINDOWS_MAX_BLOB_BYTES)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = raw;
+        Ok(())
+    }
+}
+
+/// Per-user path for the credential store lock file.
+///
+/// Unix: `XDG_RUNTIME_DIR`, then `XDG_STATE_HOME` (via `dirs`), then the
+/// local data dir (covers macOS, where the XDG dirs are unset), falling
+/// back to a dotdir in the home directory. Windows: `%LOCALAPPDATA%`,
+/// falling back to the home directory. Never a world-writable shared path.
+pub fn default_lock_path() -> Result<PathBuf, CredentialStoreError> {
+    #[cfg(windows)]
+    let base = dirs::data_local_dir();
+    #[cfg(not(windows))]
+    let base = dirs::runtime_dir()
+        .or_else(dirs::state_dir)
+        .or_else(dirs::data_local_dir);
+
+    if let Some(base) = base {
+        return Ok(base.join("sysand").join("credentials.lock"));
+    }
+    match dirs::home_dir() {
+        Some(home) => Ok(home.join(".sysand").join("credentials.lock")),
+        None => Err(CredentialStoreError::Lock(io::Error::new(
+            io::ErrorKind::NotFound,
+            "could not determine a per-user directory for the credential store lock file",
+        ))),
+    }
+}
+
+/// A [`CredentialStore`] over a [`BlobBackend`], guarding every operation
+/// with a cross-process advisory file lock (`flock`/`LockFileEx` via
+/// `fd-lock`) and a bounded wait.
+#[derive(Debug)]
+pub struct LockedBlobStore<B> {
+    backend: B,
+    lock_path: PathBuf,
+    lock_timeout: Duration,
+    lock_poll_interval: Duration,
+}
+
+/// The OS-keyring-backed credential store.
+pub type KeyringCredentialStore = LockedBlobStore<OsKeyringBackend>;
+
+impl KeyringCredentialStore {
+    /// The OS keyring store with the default per-user lock path.
+    pub fn open_default() -> Result<Self, CredentialStoreError> {
+        Ok(LockedBlobStore::new(OsKeyringBackend, default_lock_path()?))
+    }
+}
+
+impl<B: BlobBackend> LockedBlobStore<B> {
+    pub fn new(backend: B, lock_path: PathBuf) -> Self {
+        LockedBlobStore {
+            backend,
+            lock_path,
+            lock_timeout: DEFAULT_LOCK_TIMEOUT,
+            lock_poll_interval: DEFAULT_LOCK_POLL_INTERVAL,
+        }
+    }
+
+    /// Override the bounded lock wait (mainly for tests).
+    pub fn with_lock_timing(mut self, timeout: Duration, poll_interval: Duration) -> Self {
+        self.lock_timeout = timeout;
+        self.lock_poll_interval = poll_interval;
+        self
+    }
+
+    fn open_lock_file(&self) -> Result<fs::File, CredentialStoreError> {
+        if let Some(parent) = self.lock_path.parent() {
+            create_private_dir_all(parent)?;
+        }
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        Ok(options.open(&self.lock_path)?)
+    }
+
+    /// Run `body` under the exclusive cross-process lock, waiting at most
+    /// the configured timeout.
+    fn with_lock<T>(
+        &self,
+        body: impl FnOnce(&B) -> Result<T, CredentialStoreError>,
+    ) -> Result<T, CredentialStoreError> {
+        let file = self.open_lock_file()?;
+        let mut lock = fd_lock::RwLock::new(file);
+        let deadline = Instant::now() + self.lock_timeout;
+        loop {
+            match lock.try_write() {
+                Ok(guard) => {
+                    let result = body(&self.backend);
+                    drop(guard);
+                    return result;
+                }
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return Err(CredentialStoreError::LockTimeout {
+                            path: self.lock_path.display().to_string(),
+                        });
+                    }
+                    std::thread::sleep(self.lock_poll_interval);
+                }
+                Err(err) => return Err(CredentialStoreError::Lock(err)),
+            }
+        }
+    }
+}
+
+/// Create a directory chain, with the final directory private (0700) on
+/// unix.
+fn create_private_dir_all(dir: &Path) -> Result<(), CredentialStoreError> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    Ok(builder.create(dir)?)
+}
+
+/// Read and parse the blob; `None` (no entry) is an empty store, but a
+/// present-yet-unparsable blob fails closed.
+fn load_blob<B: BlobBackend>(backend: &B) -> Result<CredentialBlob, CredentialStoreError> {
+    match backend.read()? {
+        Some(raw) => parse_blob(&raw),
+        None => Ok(CredentialBlob::empty()),
+    }
+}
+
+/// Write the blob back, deleting the entry when nothing is left so a
+/// logged-out store keeps the cheap "no entry" fast path.
+fn store_blob<B: BlobBackend>(
+    backend: &B,
+    blob: &CredentialBlob,
+) -> Result<(), CredentialStoreError> {
+    if blob.credentials.is_empty() && blob.extra.is_empty() {
+        return backend.delete();
+    }
+    let raw = serialize_blob(blob)?;
+    enforce_platform_blob_limit(&raw)?;
+    backend.write(&raw)
+}
+
+impl<B: BlobBackend> CredentialStore for LockedBlobStore<B> {
+    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+        self.with_lock(|backend| Ok(load_blob(backend)?.credentials))
+    }
+
+    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
+        self.with_lock(|backend| {
+            let mut blob = load_blob(backend)?;
+            upsert_record(&mut blob.credentials, record);
+            store_blob(backend, &blob)
+        })
+    }
+
+    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
+        self.with_lock(|backend| {
+            let mut blob = load_blob(backend)?;
+            let removed = remove_record(&mut blob.credentials, key);
+            if removed {
+                store_blob(backend, &blob)?;
+            }
+            Ok(removed)
+        })
+    }
+}
+
+// Private tests
+
+#[cfg(test)]
+#[path = "./keyring_store_tests.rs"]
+mod tests;

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -21,11 +21,11 @@
 use std::fs;
 // Only the gated lock-path fallback error uses `io` directly.
 #[cfg(any(feature = "keyring", test))]
-use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use super::{CredentialBlob, CredentialRecord, CredentialStoreError, parse_blob, serialize_blob};
+use crate::project::utils::FsIoError;
 
 /// Keyring service name of the single sysand credential entry.
 #[cfg(all(
@@ -202,10 +202,7 @@ fn lock_path_from_dirs(
     }
     match home_dir {
         Some(home) => Ok(home.join(".sysand").join("credentials.lock")),
-        None => Err(CredentialStoreError::Lock(io::Error::new(
-            io::ErrorKind::NotFound,
-            "could not determine a per-user directory for the credential store lock file",
-        ))),
+        None => Err(CredentialStoreError::NoLockDir),
     }
 }
 
@@ -289,7 +286,9 @@ impl<B: BlobBackend> LockedBlobStore<B> {
             use std::os::unix::fs::OpenOptionsExt;
             options.mode(0o600);
         }
-        Ok(options.open(&self.lock_path)?)
+        options
+            .open(&self.lock_path)
+            .map_err(|err| FsIoError::OpenFile(utf8_lossy(&self.lock_path), err).into())
     }
 
     /// Run `body` under the cross-process lock, waiting at most the
@@ -324,7 +323,9 @@ impl<B: BlobBackend> LockedBlobStore<B> {
                     }
                     std::thread::sleep(self.lock_poll_interval);
                 }
-                Err(fs::TryLockError::Error(err)) => return Err(CredentialStoreError::Lock(err)),
+                Err(fs::TryLockError::Error(err)) => {
+                    return Err(FsIoError::LockFile(utf8_lossy(&self.lock_path), err).into());
+                }
             }
         }
     }
@@ -348,7 +349,16 @@ fn create_private_dir_all(dir: &Path) -> Result<(), CredentialStoreError> {
         use std::os::unix::fs::DirBuilderExt;
         builder.mode(0o700);
     }
-    Ok(builder.create(dir)?)
+    builder
+        .create(dir)
+        .map_err(|err| FsIoError::MkDir(utf8_lossy(dir), err))?;
+    Ok(())
+}
+
+/// Render a path for error context; lock paths come from the `dirs`
+/// crate, so a non-UTF-8 path is rare and lossy display is fine.
+fn utf8_lossy(path: &Path) -> camino::Utf8PathBuf {
+    camino::Utf8PathBuf::from(path.display().to_string())
 }
 
 /// Read and parse the blob; `None` (no entry) is an empty store, but a

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -5,8 +5,9 @@
 //!
 //! All persisted credentials live in one keyring entry (service `sysand`,
 //! account `credentials`) holding the versioned JSON blob from the parent
-//! module. Read-modify-write is guarded by a cross-process advisory OS
-//! file lock (never an existence-based lock file), with a bounded wait.
+//! module. Read-modify-write is guarded by an exclusive cross-process
+//! advisory OS file lock (never an existence-based lock file) and reads by
+//! its shared counterpart, both with a bounded wait.
 //!
 //! The blob handling is generic over [`BlobBackend`] so the lock,
 //! fail-closed, and size-limit logic is testable without a real OS
@@ -153,22 +154,30 @@ pub(crate) fn check_blob_size(byte_len: usize, limit: usize) -> Result<(), Crede
 
 /// Per-user path for the credential store lock file.
 ///
-/// Unix: `XDG_RUNTIME_DIR`, then `XDG_STATE_HOME` (via `dirs`), then the
-/// local data dir (covers macOS, where the XDG dirs are unset), falling
-/// back to a dotdir in the home directory. Windows: `%LOCALAPPDATA%`,
-/// falling back to the home directory. Never a world-writable shared path.
+/// Linux: `XDG_STATE_HOME` (via `dirs`, defaulting to `~/.local/state`),
+/// then the local data dir. macOS and Windows: the local data dir (the
+/// state dir is unset there). Both fall back to a dotdir in the home
+/// directory. Never a world-writable shared path, and deliberately never
+/// the session-scoped `XDG_RUNTIME_DIR`: it is often unset for cron,
+/// systemd, and container processes, so two same-user processes with
+/// different environments could lock different files while
+/// read-modify-writing the same keyring entry, silently losing a record.
 pub fn default_lock_path() -> Result<PathBuf, CredentialStoreError> {
-    #[cfg(windows)]
-    let base = dirs::data_local_dir();
-    #[cfg(not(windows))]
-    let base = dirs::runtime_dir()
-        .or_else(dirs::state_dir)
-        .or_else(dirs::data_local_dir);
+    lock_path_from_dirs(dirs::state_dir(), dirs::data_local_dir(), dirs::home_dir())
+}
 
-    if let Some(base) = base {
+/// Pure path selection behind [`default_lock_path`], taking the candidate
+/// directories as arguments so the precedence is testable without touching
+/// the process environment.
+fn lock_path_from_dirs(
+    state_dir: Option<PathBuf>,
+    data_local_dir: Option<PathBuf>,
+    home_dir: Option<PathBuf>,
+) -> Result<PathBuf, CredentialStoreError> {
+    if let Some(base) = state_dir.or(data_local_dir) {
         return Ok(base.join("sysand").join("credentials.lock"));
     }
-    match dirs::home_dir() {
+    match home_dir {
         Some(home) => Ok(home.join(".sysand").join("credentials.lock")),
         None => Err(CredentialStoreError::Lock(io::Error::new(
             io::ErrorKind::NotFound,
@@ -256,16 +265,23 @@ impl<B: BlobBackend> LockedBlobStore<B> {
         Ok(options.open(&self.lock_path)?)
     }
 
-    /// Run `body` under the exclusive cross-process lock, waiting at most
-    /// the configured timeout.
+    /// Run `body` under the cross-process lock, waiting at most the
+    /// configured timeout. Read-only operations take the shared lock so
+    /// concurrent readers do not serialize; read-modify-write takes the
+    /// exclusive lock.
     fn with_lock<T>(
         &self,
+        mode: LockMode,
         body: impl FnOnce(&B) -> Result<T, CredentialStoreError>,
     ) -> Result<T, CredentialStoreError> {
         let file = self.open_lock_file()?;
         let deadline = Instant::now() + self.lock_timeout;
         loop {
-            match file.try_lock() {
+            let attempt = match mode {
+                LockMode::Shared => file.try_lock_shared(),
+                LockMode::Exclusive => file.try_lock(),
+            };
+            match attempt {
                 Ok(()) => {
                     let result = body(&self.backend);
                     // Release explicitly (it would also unlock on drop) so
@@ -285,6 +301,14 @@ impl<B: BlobBackend> LockedBlobStore<B> {
             }
         }
     }
+}
+
+/// Which cross-process lock [`LockedBlobStore::with_lock`] takes: shared
+/// for read-only operations, exclusive for read-modify-write.
+#[derive(Clone, Copy)]
+enum LockMode {
+    Shared,
+    Exclusive,
 }
 
 /// Create a directory chain, with the final directory private (0700) on
@@ -330,12 +354,14 @@ fn store_blob<B: BlobBackend>(
 
 impl<B: BlobBackend> CredentialStore for LockedBlobStore<B> {
     fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
-        self.with_lock(|backend| Ok(load_blob(backend)?.credentials))
+        self.with_lock(LockMode::Shared, |backend| {
+            Ok(load_blob(backend)?.credentials)
+        })
     }
 
     fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
         let size_limit = self.size_limit;
-        self.with_lock(|backend| {
+        self.with_lock(LockMode::Exclusive, |backend| {
             let mut blob = load_blob(backend)?;
             upsert_record(&mut blob.credentials, record);
             store_blob(backend, &blob, size_limit)
@@ -344,7 +370,7 @@ impl<B: BlobBackend> CredentialStore for LockedBlobStore<B> {
 
     fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
         let size_limit = self.size_limit;
-        self.with_lock(|backend| {
+        self.with_lock(LockMode::Exclusive, |backend| {
             let mut blob = load_blob(backend)?;
             let removed = remove_record(&mut blob.credentials, key);
             if removed {

--- a/core/src/credential_store/keyring_store.rs
+++ b/core/src/credential_store/keyring_store.rs
@@ -1,32 +1,44 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-//! OS-keyring-backed [`CredentialStore`] (design/credential-storage.md §9).
+//! The credential store: [`LockedBlobStore`], a persistent store of
+//! credential records over a [`BlobBackend`] (design/credential-storage.md
+//! §9).
 //!
-//! All persisted credentials live in one keyring entry (service `sysand`,
-//! account `credentials`) holding the versioned JSON blob from the parent
-//! module. Read-modify-write is guarded by an exclusive cross-process
-//! advisory OS file lock (never an existence-based lock file) and reads by
-//! its shared counterpart, both with a bounded wait.
+//! All persisted credentials live in one backend entry holding the
+//! versioned JSON blob from the parent module. Read-modify-write is
+//! guarded by an exclusive cross-process advisory OS file lock (never an
+//! existence-based lock file) and reads by its shared counterpart, both
+//! with a bounded wait.
 //!
 //! The blob handling is generic over [`BlobBackend`] so the lock,
 //! fail-closed, and size-limit logic is testable without a real OS
-//! keyring.
+//! keyring, and so hosts can substitute backends (the CLI's debug-only
+//! test seam). The production backend, [`OsKeyringBackend`] (one keyring
+//! entry: service `sysand`, account `credentials`), sits behind the
+//! `keyring` cargo feature; everything else here is unconditional.
 
 use std::fs;
+// Only the gated lock-path fallback error uses `io` directly.
+#[cfg(any(feature = "keyring", test))]
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use super::{
-    CredentialBlob, CredentialRecord, CredentialStore, CredentialStoreError, parse_blob,
-    remove_record, serialize_blob, upsert_record,
-};
+use super::{CredentialBlob, CredentialRecord, CredentialStoreError, parse_blob, serialize_blob};
 
 /// Keyring service name of the single sysand credential entry.
-pub(crate) const KEYRING_SERVICE: &str = "sysand";
+#[cfg(all(
+    feature = "keyring",
+    not(all(target_os = "linux", target_env = "musl"))
+))]
+const KEYRING_SERVICE: &str = "sysand";
 /// Keyring account name of the single sysand credential entry.
-pub(crate) const KEYRING_ACCOUNT: &str = "credentials";
+#[cfg(all(
+    feature = "keyring",
+    not(all(target_os = "linux", target_env = "musl"))
+))]
+const KEYRING_ACCOUNT: &str = "credentials";
 
 /// Windows `CRED_MAX_CREDENTIAL_BLOB_SIZE`: the Credential Manager caps a
 /// credential blob at 2560 bytes, measured against the UTF-16 encoding the
@@ -57,7 +69,10 @@ pub trait BlobBackend {
 /// Secret Service daemon to talk to) is treated as an absent backend, so
 /// callers may fall back to `SYSAND_CRED_*`; `NoStorageAccess` (locked or
 /// denied collection) and other errors must be surfaced.
-#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+#[cfg(all(
+    feature = "keyring",
+    not(all(target_os = "linux", target_env = "musl"))
+))]
 fn map_keyring_error(err: keyring::Error) -> CredentialStoreError {
     match err {
         keyring::Error::PlatformFailure(source) => CredentialStoreError::BackendAbsent { source },
@@ -78,17 +93,24 @@ fn map_keyring_error(err: keyring::Error) -> CredentialStoreError {
 
 /// The real OS keyring entry (macOS Keychain, Windows Credential Manager,
 /// Linux Secret Service).
+#[cfg(feature = "keyring")]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct OsKeyringBackend;
 
-#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+#[cfg(all(
+    feature = "keyring",
+    not(all(target_os = "linux", target_env = "musl"))
+))]
 impl OsKeyringBackend {
     fn entry() -> Result<keyring::Entry, CredentialStoreError> {
         keyring::Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT).map_err(map_keyring_error)
     }
 }
 
-#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+#[cfg(all(
+    feature = "keyring",
+    not(all(target_os = "linux", target_env = "musl"))
+))]
 impl BlobBackend for OsKeyringBackend {
     fn read(&self) -> Result<Option<String>, CredentialStoreError> {
         match Self::entry()?.get_password() {
@@ -115,7 +137,7 @@ impl BlobBackend for OsKeyringBackend {
 /// credential path is the norm). The backend reports "absent", so every
 /// caller takes the documented `SYSAND_CRED_*` fallback path
 /// (design/credential-storage.md section 9 taxonomy).
-#[cfg(all(target_os = "linux", target_env = "musl"))]
+#[cfg(all(feature = "keyring", target_os = "linux", target_env = "musl"))]
 impl BlobBackend for OsKeyringBackend {
     fn read(&self) -> Result<Option<String>, CredentialStoreError> {
         Err(musl_backend_absent())
@@ -130,7 +152,7 @@ impl BlobBackend for OsKeyringBackend {
     }
 }
 
-#[cfg(all(target_os = "linux", target_env = "musl"))]
+#[cfg(all(feature = "keyring", target_os = "linux", target_env = "musl"))]
 fn musl_backend_absent() -> CredentialStoreError {
     CredentialStoreError::BackendAbsent {
         source: "OS keyring support is not built on musl targets".into(),
@@ -162,6 +184,7 @@ pub(crate) fn check_blob_size(byte_len: usize, limit: usize) -> Result<(), Crede
 /// systemd, and container processes, so two same-user processes with
 /// different environments could lock different files while
 /// read-modify-writing the same keyring entry, silently losing a record.
+#[cfg(feature = "keyring")]
 pub fn default_lock_path() -> Result<PathBuf, CredentialStoreError> {
     lock_path_from_dirs(dirs::state_dir(), dirs::data_local_dir(), dirs::home_dir())
 }
@@ -169,6 +192,7 @@ pub fn default_lock_path() -> Result<PathBuf, CredentialStoreError> {
 /// Pure path selection behind [`default_lock_path`], taking the candidate
 /// directories as arguments so the precedence is testable without touching
 /// the process environment.
+#[cfg(any(feature = "keyring", test))]
 fn lock_path_from_dirs(
     state_dir: Option<PathBuf>,
     data_local_dir: Option<PathBuf>,
@@ -186,9 +210,11 @@ fn lock_path_from_dirs(
     }
 }
 
-/// A [`CredentialStore`] over a [`BlobBackend`], guarding every operation
-/// with a cross-process advisory file lock (`flock`/`LockFileEx` via the
-/// stable [`std::fs::File`] locking API) and a bounded wait.
+/// A persistent store of credential records over a [`BlobBackend`],
+/// guarding every operation with a cross-process advisory file lock
+/// (`flock`/`LockFileEx` via the stable [`std::fs::File`] locking API) and
+/// a bounded wait, so each operation is atomic with respect to other
+/// processes.
 #[derive(Debug)]
 pub struct LockedBlobStore<B> {
     backend: B,
@@ -216,8 +242,10 @@ fn default_platform_blob_limit() -> Option<usize> {
 }
 
 /// The OS-keyring-backed credential store.
+#[cfg(feature = "keyring")]
 pub type KeyringCredentialStore = LockedBlobStore<OsKeyringBackend>;
 
+#[cfg(feature = "keyring")]
 impl KeyringCredentialStore {
     /// The OS keyring store with the default per-user lock path.
     pub fn open_default() -> Result<Self, CredentialStoreError> {
@@ -352,27 +380,40 @@ fn store_blob<B: BlobBackend>(
     backend.write(&raw)
 }
 
-impl<B: BlobBackend> CredentialStore for LockedBlobStore<B> {
-    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+impl<B: BlobBackend> LockedBlobStore<B> {
+    /// All stored records.
+    pub fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
         self.with_lock(LockMode::Shared, |backend| {
             Ok(load_blob(backend)?.credentials)
         })
     }
 
-    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
+    /// Insert a record, replacing any existing record with the same `key`.
+    pub fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
         let size_limit = self.size_limit;
         self.with_lock(LockMode::Exclusive, |backend| {
             let mut blob = load_blob(backend)?;
-            upsert_record(&mut blob.credentials, record);
+            match blob
+                .credentials
+                .iter_mut()
+                .find(|existing| existing.key == record.key)
+            {
+                Some(existing) => *existing = record,
+                None => blob.credentials.push(record),
+            }
             store_blob(backend, &blob, size_limit)
         })
     }
 
-    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
+    /// Remove the record with the given `key`. Returns whether a record
+    /// was removed.
+    pub fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
         let size_limit = self.size_limit;
         self.with_lock(LockMode::Exclusive, |backend| {
             let mut blob = load_blob(backend)?;
-            let removed = remove_record(&mut blob.credentials, key);
+            let before = blob.credentials.len();
+            blob.credentials.retain(|record| record.key != key);
+            let removed = blob.credentials.len() != before;
             if removed {
                 store_blob(backend, &blob, size_limit)?;
             }

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -151,7 +151,7 @@ fn lock_path_prefers_state_then_data_local_then_home() {
     );
     assert!(matches!(
         lock_path_from_dirs(None, None, None).unwrap_err(),
-        CredentialStoreError::Lock(_)
+        CredentialStoreError::NoLockDir
     ));
 }
 

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -53,7 +53,7 @@ fn read_modify_write_persists_records() {
         .unwrap();
 
     // A second store over the same backend sees the same records.
-    let other = store_at(backend, &dir);
+    let other = store_at(backend.clone(), &dir);
     let records = other.list().unwrap();
     assert_eq!(records.len(), 2);
     assert_eq!(records[0].secret, "tok-a2");
@@ -63,17 +63,9 @@ fn read_modify_write_persists_records() {
     assert!(!store.remove("https://a.example/").unwrap());
     assert_eq!(store.list().unwrap().len(), 1);
     assert_eq!(store.list().unwrap()[0].key, "https://b.example/");
-}
 
-#[test]
-fn removing_last_record_deletes_the_entry() {
-    let dir = tempdir().unwrap();
-    let backend = InMemoryBlobBackend::default();
-    let mut store = store_at(backend.clone(), &dir);
-
-    store.upsert(record("https://a.example/", "tok")).unwrap();
-    assert!(backend.contents().is_some());
-    assert!(store.remove("https://a.example/").unwrap());
+    // Removing the last record deletes the backend entry outright.
+    assert!(store.remove("https://b.example/").unwrap());
     assert_eq!(
         backend.contents(),
         None,
@@ -293,10 +285,9 @@ fn blob_size_check_uses_utf16_length() {
     assert_eq!(utf16_byte_len(&blob), 2600);
     let err = check_blob_size(utf16_byte_len(&blob), WINDOWS_MAX_BLOB_BYTES).unwrap_err();
     assert!(matches!(err, CredentialStoreError::BlobTooLarge));
-    assert_eq!(
-        err.to_string(),
-        "credential store full on this platform (Windows ~2.5 KB limit); \
-         remove an unused credential or use a smaller token"
+    assert!(
+        err.to_string().contains("Windows"),
+        "message must name the platform limit: {err}"
     );
 
     let small = "a".repeat(1280);

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -156,14 +156,13 @@ fn lock_wait_is_bounded() {
         .truncate(false)
         .open(&lock_path)
         .unwrap();
-    let mut held = fd_lock::RwLock::new(file);
-    let guard = held.try_write().unwrap();
+    file.try_lock().unwrap();
 
     let err = store
         .upsert(record("https://a.example/", "tok"))
         .unwrap_err();
     assert!(matches!(err, CredentialStoreError::LockTimeout { .. }));
-    drop(guard);
+    file.unlock().unwrap();
 
     // Once released, the operation succeeds.
     store.upsert(record("https://a.example/", "tok")).unwrap();

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -58,6 +58,9 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
         scheme: CredentialScheme::Bearer,
         secret: secret.to_string(),
         expires_at: None,
+        subject: None,
+        token_name: None,
+        token_prefix: None,
         extra: serde_json::Map::new(),
     }
 }

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -212,9 +212,39 @@ fn blob_size_check_uses_utf16_length() {
     assert_eq!(
         err.to_string(),
         "credential store full on this platform (Windows ~2.5 KB limit); \
-         remove an unused login or use a smaller token"
+         remove an unused credential or use a smaller token"
     );
 
     let small = "a".repeat(1280);
     check_blob_size(utf16_byte_len(&small), WINDOWS_MAX_BLOB_BYTES).unwrap();
+}
+
+#[test]
+fn upsert_enforces_the_size_limit_and_does_not_write_when_exceeded() {
+    // The platform-cap enforcement (store_blob -> upsert) is Windows-only
+    // in production, so CI never runs it. Inject a tiny limit to drive the
+    // same wiring on any platform: prove the gate is connected, not just
+    // that the `check_blob_size` helper works, and that an over-limit write
+    // is refused before it reaches the backend.
+    let dir = tempdir().unwrap();
+    let backend = MemoryBackend::default();
+    let mut store = store_at(backend.clone(), &dir).with_size_limit(Some(16));
+
+    let err = store
+        .upsert(record(
+            "https://a.example/",
+            "a-token-well-over-sixteen-bytes",
+        ))
+        .unwrap_err();
+    assert!(matches!(err, CredentialStoreError::BlobTooLarge));
+    // The oversized blob never reached the backend.
+    assert!(backend.read().unwrap().is_none());
+
+    // A generous limit lets the same write through, so the gate is the
+    // size check, not an unconditional refusal.
+    let mut ok_store = store_at(backend.clone(), &dir).with_size_limit(Some(100_000));
+    ok_store
+        .upsert(record("https://a.example/", "tok"))
+        .unwrap();
+    assert!(backend.read().unwrap().is_some());
 }

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -4,7 +4,6 @@
 //! Tests of the locked blob store logic against an in-memory backend, so
 //! they run headlessly without a real OS keyring.
 
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use camino_tempfile::tempdir;
@@ -15,44 +14,8 @@ use super::{
     BlobBackend, LockedBlobStore, WINDOWS_MAX_BLOB_BYTES, check_blob_size, lock_path_from_dirs,
     utf16_byte_len,
 };
-use crate::credential_store::{
-    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
-};
-
-/// In-memory [`BlobBackend`] sharing its contents across clones, standing
-/// in for the single OS keyring entry.
-#[derive(Debug, Clone, Default)]
-struct MemoryBackend {
-    blob: Arc<Mutex<Option<String>>>,
-}
-
-impl MemoryBackend {
-    fn with_contents(raw: &str) -> Self {
-        MemoryBackend {
-            blob: Arc::new(Mutex::new(Some(raw.to_string()))),
-        }
-    }
-
-    fn contents(&self) -> Option<String> {
-        self.blob.lock().unwrap().clone()
-    }
-}
-
-impl BlobBackend for MemoryBackend {
-    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
-        Ok(self.blob.lock().unwrap().clone())
-    }
-
-    fn write(&self, raw: &str) -> Result<(), CredentialStoreError> {
-        *self.blob.lock().unwrap() = Some(raw.to_string());
-        Ok(())
-    }
-
-    fn delete(&self) -> Result<(), CredentialStoreError> {
-        *self.blob.lock().unwrap() = None;
-        Ok(())
-    }
-}
+use crate::credential_store::test_support::InMemoryBlobBackend;
+use crate::credential_store::{CredentialRecord, CredentialScheme, CredentialStoreError};
 
 fn record(key: &str, secret: &str) -> CredentialRecord {
     CredentialRecord {
@@ -70,16 +33,16 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
 }
 
 fn store_at(
-    backend: MemoryBackend,
+    backend: InMemoryBlobBackend,
     dir: &camino_tempfile::Utf8TempDir,
-) -> LockedBlobStore<MemoryBackend> {
+) -> LockedBlobStore<InMemoryBlobBackend> {
     LockedBlobStore::new(backend, dir.path().join("credentials.lock").into())
 }
 
 #[test]
 fn read_modify_write_persists_records() {
     let dir = tempdir().unwrap();
-    let backend = MemoryBackend::default();
+    let backend = InMemoryBlobBackend::default();
     let mut store = store_at(backend.clone(), &dir);
 
     assert!(store.list().unwrap().is_empty());
@@ -97,13 +60,15 @@ fn read_modify_write_persists_records() {
 
     let mut store = other;
     assert!(store.remove("https://a.example/").unwrap());
+    assert!(!store.remove("https://a.example/").unwrap());
     assert_eq!(store.list().unwrap().len(), 1);
+    assert_eq!(store.list().unwrap()[0].key, "https://b.example/");
 }
 
 #[test]
 fn removing_last_record_deletes_the_entry() {
     let dir = tempdir().unwrap();
-    let backend = MemoryBackend::default();
+    let backend = InMemoryBlobBackend::default();
     let mut store = store_at(backend.clone(), &dir);
 
     store.upsert(record("https://a.example/", "tok")).unwrap();
@@ -119,7 +84,7 @@ fn removing_last_record_deletes_the_entry() {
 #[test]
 fn corrupt_blob_fails_closed_and_is_not_clobbered() {
     let dir = tempdir().unwrap();
-    let backend = MemoryBackend::with_contents("not json at all");
+    let backend = InMemoryBlobBackend::with_contents("not json at all");
     let mut store = store_at(backend.clone(), &dir);
 
     assert!(matches!(
@@ -147,7 +112,7 @@ fn corrupt_blob_fails_closed_and_is_not_clobbered() {
 fn lock_wait_is_bounded() {
     let dir = tempdir().unwrap();
     let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
-    let mut store = LockedBlobStore::new(MemoryBackend::default(), lock_path.clone())
+    let mut store = LockedBlobStore::new(InMemoryBlobBackend::default(), lock_path.clone())
         .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
 
     // Hold the advisory lock on a separate file descriptor; flock and
@@ -202,7 +167,7 @@ fn lock_path_prefers_state_then_data_local_then_home() {
 fn shared_lock_lets_reads_through_but_blocks_writes() {
     let dir = tempdir().unwrap();
     let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
-    let mut store = LockedBlobStore::new(MemoryBackend::default(), lock_path.clone())
+    let mut store = LockedBlobStore::new(InMemoryBlobBackend::default(), lock_path.clone())
         .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
     store.upsert(record("https://a.example/", "tok")).unwrap();
 
@@ -231,7 +196,7 @@ fn shared_lock_lets_reads_through_but_blocks_writes() {
 fn exclusive_lock_blocks_reads() {
     let dir = tempdir().unwrap();
     let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
-    let store = LockedBlobStore::new(MemoryBackend::default(), lock_path.clone())
+    let store = LockedBlobStore::new(InMemoryBlobBackend::default(), lock_path.clone())
         .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
 
     let file = std::fs::OpenOptions::new()
@@ -291,7 +256,7 @@ fn map_keyring_error_covers_the_taxonomy() {
 #[test]
 fn concurrent_writers_do_not_lose_records() {
     let dir = tempdir().unwrap();
-    let backend = MemoryBackend::default();
+    let backend = InMemoryBlobBackend::default();
     let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
 
     // 4 writers x 2 records: enough to lose an update without the lock,
@@ -346,7 +311,7 @@ fn upsert_enforces_the_size_limit_and_does_not_write_when_exceeded() {
     // that the `check_blob_size` helper works, and that an over-limit write
     // is refused before it reaches the backend.
     let dir = tempdir().unwrap();
-    let backend = MemoryBackend::default();
+    let backend = InMemoryBlobBackend::default();
     let mut store = store_at(backend.clone(), &dir).with_size_limit(Some(16));
 
     let err = store

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -9,8 +9,11 @@ use std::time::Duration;
 
 use camino_tempfile::tempdir;
 
+use std::path::PathBuf;
+
 use super::{
-    BlobBackend, LockedBlobStore, WINDOWS_MAX_BLOB_BYTES, check_blob_size, utf16_byte_len,
+    BlobBackend, LockedBlobStore, WINDOWS_MAX_BLOB_BYTES, check_blob_size, lock_path_from_dirs,
+    utf16_byte_len,
 };
 use crate::credential_store::{
     CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
@@ -166,6 +169,123 @@ fn lock_wait_is_bounded() {
 
     // Once released, the operation succeeds.
     store.upsert(record("https://a.example/", "tok")).unwrap();
+}
+
+#[test]
+fn lock_path_prefers_state_then_data_local_then_home() {
+    // Pure precedence check: no process-env mutation. The session-scoped
+    // XDG_RUNTIME_DIR is deliberately not a candidate (two same-user
+    // processes with different environments must lock the same file).
+    let state = Some(PathBuf::from("/xdg/state"));
+    let data_local = Some(PathBuf::from("/xdg/data-local"));
+    let home = Some(PathBuf::from("/home/user"));
+
+    assert_eq!(
+        lock_path_from_dirs(state.clone(), data_local.clone(), home.clone()).unwrap(),
+        PathBuf::from("/xdg/state/sysand/credentials.lock")
+    );
+    assert_eq!(
+        lock_path_from_dirs(None, data_local, home.clone()).unwrap(),
+        PathBuf::from("/xdg/data-local/sysand/credentials.lock")
+    );
+    assert_eq!(
+        lock_path_from_dirs(None, None, home).unwrap(),
+        PathBuf::from("/home/user/.sysand/credentials.lock")
+    );
+    assert!(matches!(
+        lock_path_from_dirs(None, None, None).unwrap_err(),
+        CredentialStoreError::Lock(_)
+    ));
+}
+
+#[test]
+fn shared_lock_lets_reads_through_but_blocks_writes() {
+    let dir = tempdir().unwrap();
+    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+    let mut store = LockedBlobStore::new(MemoryBackend::default(), lock_path.clone())
+        .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
+    store.upsert(record("https://a.example/", "tok")).unwrap();
+
+    // Hold a shared lock on a separate file descriptor, like a concurrent
+    // `list` would.
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    file.try_lock_shared().unwrap();
+
+    // Reads take the shared lock and proceed alongside another reader...
+    assert_eq!(store.list().unwrap().len(), 1);
+    // ...while read-modify-write needs the exclusive lock and times out.
+    let err = store
+        .upsert(record("https://b.example/", "tok"))
+        .unwrap_err();
+    assert!(matches!(err, CredentialStoreError::LockTimeout { .. }));
+    file.unlock().unwrap();
+}
+
+#[test]
+fn exclusive_lock_blocks_reads() {
+    let dir = tempdir().unwrap();
+    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+    let store = LockedBlobStore::new(MemoryBackend::default(), lock_path.clone())
+        .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    file.try_lock().unwrap();
+
+    // A writer holds the exclusive lock: the shared read must wait it out
+    // (bounded), never read a half-written store.
+    let err = store.list().unwrap_err();
+    assert!(matches!(err, CredentialStoreError::LockTimeout { .. }));
+    file.unlock().unwrap();
+    assert!(store.list().unwrap().is_empty());
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+#[test]
+fn map_keyring_error_covers_the_taxonomy() {
+    use super::map_keyring_error;
+
+    // `PlatformFailure` (for example no Secret Service daemon) means "no
+    // usable backend": callers may fall back to `SYSAND_CRED_*`.
+    assert!(matches!(
+        map_keyring_error(keyring::Error::PlatformFailure("no daemon".into())),
+        CredentialStoreError::BackendAbsent { .. }
+    ));
+    // A present-but-locked/denied backend must be surfaced.
+    assert!(matches!(
+        map_keyring_error(keyring::Error::NoStorageAccess("locked".into())),
+        CredentialStoreError::BackendDenied { .. }
+    ));
+    // The platform size backstop maps to the same error as the size gate.
+    assert!(matches!(
+        map_keyring_error(keyring::Error::TooLong("secret".to_string(), 2560)),
+        CredentialStoreError::BlobTooLarge
+    ));
+    // Corrupt or ambiguous entries read as an unreadable store.
+    assert!(matches!(
+        map_keyring_error(keyring::Error::BadEncoding(vec![0xff])),
+        CredentialStoreError::Unreadable
+    ));
+    assert!(matches!(
+        map_keyring_error(keyring::Error::Ambiguous(Vec::new())),
+        CredentialStoreError::Unreadable
+    ));
+    // Anything else is surfaced as a denied backend, never a fallback.
+    assert!(matches!(
+        map_keyring_error(keyring::Error::NoDefaultStore),
+        CredentialStoreError::BackendDenied { .. }
+    ));
 }
 
 #[test]

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -61,6 +61,7 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
         subject: None,
         token_name: None,
         token_prefix: None,
+        validated: Vec::new(),
         extra: serde_json::Map::new(),
     }
 }

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! Tests of the locked blob store logic against an in-memory backend, so
+//! they run headlessly without a real OS keyring.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use camino_tempfile::tempdir;
+
+use super::{
+    BlobBackend, LockedBlobStore, WINDOWS_MAX_BLOB_BYTES, check_blob_size, utf16_byte_len,
+};
+use crate::credential_store::{
+    CredentialRecord, CredentialScheme, CredentialStore, CredentialStoreError,
+};
+
+/// In-memory [`BlobBackend`] sharing its contents across clones, standing
+/// in for the single OS keyring entry.
+#[derive(Debug, Clone, Default)]
+struct MemoryBackend {
+    blob: Arc<Mutex<Option<String>>>,
+}
+
+impl MemoryBackend {
+    fn with_contents(raw: &str) -> Self {
+        MemoryBackend {
+            blob: Arc::new(Mutex::new(Some(raw.to_string()))),
+        }
+    }
+
+    fn contents(&self) -> Option<String> {
+        self.blob.lock().unwrap().clone()
+    }
+}
+
+impl BlobBackend for MemoryBackend {
+    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
+        Ok(self.blob.lock().unwrap().clone())
+    }
+
+    fn write(&self, raw: &str) -> Result<(), CredentialStoreError> {
+        *self.blob.lock().unwrap() = Some(raw.to_string());
+        Ok(())
+    }
+
+    fn delete(&self) -> Result<(), CredentialStoreError> {
+        *self.blob.lock().unwrap() = None;
+        Ok(())
+    }
+}
+
+fn record(key: &str, secret: &str) -> CredentialRecord {
+    CredentialRecord {
+        key: key.to_string(),
+        globs: vec![format!("{key}**")],
+        scheme: CredentialScheme::Bearer,
+        secret: secret.to_string(),
+        expires_at: None,
+        extra: serde_json::Map::new(),
+    }
+}
+
+fn store_at(
+    backend: MemoryBackend,
+    dir: &camino_tempfile::Utf8TempDir,
+) -> LockedBlobStore<MemoryBackend> {
+    LockedBlobStore::new(backend, dir.path().join("credentials.lock").into())
+}
+
+#[test]
+fn read_modify_write_persists_records() {
+    let dir = tempdir().unwrap();
+    let backend = MemoryBackend::default();
+    let mut store = store_at(backend.clone(), &dir);
+
+    assert!(store.list().unwrap().is_empty());
+    store.upsert(record("https://a.example/", "tok-a")).unwrap();
+    store.upsert(record("https://b.example/", "tok-b")).unwrap();
+    store
+        .upsert(record("https://a.example/", "tok-a2"))
+        .unwrap();
+
+    // A second store over the same backend sees the same records.
+    let other = store_at(backend, &dir);
+    let records = other.list().unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].secret, "tok-a2");
+
+    let mut store = other;
+    assert!(store.remove("https://a.example/").unwrap());
+    assert_eq!(store.list().unwrap().len(), 1);
+}
+
+#[test]
+fn removing_last_record_deletes_the_entry() {
+    let dir = tempdir().unwrap();
+    let backend = MemoryBackend::default();
+    let mut store = store_at(backend.clone(), &dir);
+
+    store.upsert(record("https://a.example/", "tok")).unwrap();
+    assert!(backend.contents().is_some());
+    assert!(store.remove("https://a.example/").unwrap());
+    assert_eq!(
+        backend.contents(),
+        None,
+        "empty store must delete the entry"
+    );
+}
+
+#[test]
+fn corrupt_blob_fails_closed_and_is_not_clobbered() {
+    let dir = tempdir().unwrap();
+    let backend = MemoryBackend::with_contents("not json at all");
+    let mut store = store_at(backend.clone(), &dir);
+
+    assert!(matches!(
+        store.list().unwrap_err(),
+        CredentialStoreError::Unreadable
+    ));
+    assert!(matches!(
+        store
+            .upsert(record("https://a.example/", "tok"))
+            .unwrap_err(),
+        CredentialStoreError::Unreadable
+    ));
+    assert!(matches!(
+        store.remove("https://a.example/").unwrap_err(),
+        CredentialStoreError::Unreadable
+    ));
+    assert_eq!(
+        backend.contents().as_deref(),
+        Some("not json at all"),
+        "a failed operation must never overwrite the stored blob"
+    );
+}
+
+#[test]
+fn lock_wait_is_bounded() {
+    let dir = tempdir().unwrap();
+    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+    let mut store = LockedBlobStore::new(MemoryBackend::default(), lock_path.clone())
+        .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
+
+    // Hold the advisory lock on a separate file descriptor; flock and
+    // LockFileEx contend per open file description, also in-process.
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    let mut held = fd_lock::RwLock::new(file);
+    let guard = held.try_write().unwrap();
+
+    let err = store
+        .upsert(record("https://a.example/", "tok"))
+        .unwrap_err();
+    assert!(matches!(err, CredentialStoreError::LockTimeout { .. }));
+    drop(guard);
+
+    // Once released, the operation succeeds.
+    store.upsert(record("https://a.example/", "tok")).unwrap();
+}
+
+#[test]
+fn concurrent_writers_do_not_lose_records() {
+    let dir = tempdir().unwrap();
+    let backend = MemoryBackend::default();
+    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+
+    // 4 writers x 2 records: enough to lose an update without the lock,
+    // while the final blob stays under the Windows UTF-16 size cap, which
+    // is enforced on every write there (8 short records is ~900 of the
+    // 1280 allowed UTF-16 units).
+    let handles: Vec<_> = (0..4)
+        .map(|writer| {
+            let backend = backend.clone();
+            let lock_path = lock_path.clone();
+            std::thread::spawn(move || {
+                let mut store = LockedBlobStore::new(backend, lock_path);
+                for i in 0..2 {
+                    store
+                        .upsert(record(&format!("https://w{writer}.example/{i}/"), "tok"))
+                        .unwrap();
+                }
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let store = store_at(backend, &dir);
+    assert_eq!(store.list().unwrap().len(), 8);
+}
+
+#[test]
+fn blob_size_check_uses_utf16_length() {
+    // 1300 ASCII chars fit in UTF-8 under 2560 bytes but exceed the
+    // Windows UTF-16 limit.
+    let blob = "a".repeat(1300);
+    assert_eq!(utf16_byte_len(&blob), 2600);
+    let err = check_blob_size(utf16_byte_len(&blob), WINDOWS_MAX_BLOB_BYTES).unwrap_err();
+    assert!(matches!(err, CredentialStoreError::BlobTooLarge));
+    assert_eq!(
+        err.to_string(),
+        "credential store full on this platform (Windows ~2.5 KB limit); \
+         remove an unused login or use a smaller token"
+    );
+
+    let small = "a".repeat(1280);
+    check_blob_size(utf16_byte_len(&small), WINDOWS_MAX_BLOB_BYTES).unwrap();
+}

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -10,7 +10,7 @@ use camino_tempfile::tempdir;
 
 use std::path::PathBuf;
 
-use super::{BlobBackend, LockedBlobStore, lock_path_from_dirs};
+use super::{LockedBlobStore, lock_path_from_dirs};
 use crate::credential_store::test_support::InMemoryBlobBackend;
 use crate::credential_store::{CredentialRecord, CredentialScheme, CredentialStoreError};
 

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use camino_tempfile::tempdir;
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use super::{LockedBlobStore, lock_path_from_dirs};
 use crate::credential_store::test_support::InMemoryBlobBackend;
@@ -33,7 +33,7 @@ fn store_at(
     backend: InMemoryBlobBackend,
     dir: &camino_tempfile::Utf8TempDir,
 ) -> LockedBlobStore<InMemoryBlobBackend> {
-    LockedBlobStore::new(backend, dir.path().join("credentials.lock").into())
+    LockedBlobStore::new(backend, dir.path().join("credentials.lock"))
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn corrupt_blob_fails_closed_and_is_not_clobbered() {
 #[test]
 fn lock_wait_is_bounded() {
     let dir = tempdir().unwrap();
-    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+    let lock_path: Utf8PathBuf = dir.path().join("credentials.lock");
     let mut store = LockedBlobStore::new(InMemoryBlobBackend::default(), lock_path.clone())
         .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
 
@@ -130,21 +130,21 @@ fn lock_path_prefers_state_then_data_local_then_home() {
     // Pure precedence check: no process-env mutation. The session-scoped
     // XDG_RUNTIME_DIR is deliberately not a candidate (two same-user
     // processes with different environments must lock the same file).
-    let state = Some(PathBuf::from("/xdg/state"));
-    let data_local = Some(PathBuf::from("/xdg/data-local"));
-    let home = Some(PathBuf::from("/home/user"));
+    let state = Some(std::path::PathBuf::from("/xdg/state"));
+    let data_local = Some(std::path::PathBuf::from("/xdg/data-local"));
+    let home = Some(std::path::PathBuf::from("/home/user"));
 
     assert_eq!(
         lock_path_from_dirs(state.clone(), data_local.clone(), home.clone()).unwrap(),
-        PathBuf::from("/xdg/state/sysand/credentials.lock")
+        Utf8PathBuf::from("/xdg/state/sysand/credentials.lock")
     );
     assert_eq!(
         lock_path_from_dirs(None, data_local, home.clone()).unwrap(),
-        PathBuf::from("/xdg/data-local/sysand/credentials.lock")
+        Utf8PathBuf::from("/xdg/data-local/sysand/credentials.lock")
     );
     assert_eq!(
         lock_path_from_dirs(None, None, home).unwrap(),
-        PathBuf::from("/home/user/.sysand/credentials.lock")
+        Utf8PathBuf::from("/home/user/.sysand/credentials.lock")
     );
     assert!(matches!(
         lock_path_from_dirs(None, None, None).unwrap_err(),
@@ -155,7 +155,7 @@ fn lock_path_prefers_state_then_data_local_then_home() {
 #[test]
 fn shared_lock_lets_reads_through_but_blocks_writes() {
     let dir = tempdir().unwrap();
-    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+    let lock_path: Utf8PathBuf = dir.path().join("credentials.lock");
     let mut store = LockedBlobStore::new(InMemoryBlobBackend::default(), lock_path.clone())
         .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
     store.upsert(record("https://a.example/", "tok")).unwrap();
@@ -184,7 +184,7 @@ fn shared_lock_lets_reads_through_but_blocks_writes() {
 #[test]
 fn exclusive_lock_blocks_reads() {
     let dir = tempdir().unwrap();
-    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+    let lock_path: Utf8PathBuf = dir.path().join("credentials.lock");
     let store = LockedBlobStore::new(InMemoryBlobBackend::default(), lock_path.clone())
         .with_lock_timing(Duration::from_millis(100), Duration::from_millis(10));
 
@@ -246,7 +246,7 @@ fn map_keyring_error_covers_the_taxonomy() {
 fn concurrent_writers_do_not_lose_records() {
     let dir = tempdir().unwrap();
     let backend = InMemoryBlobBackend::default();
-    let lock_path: std::path::PathBuf = dir.path().join("credentials.lock").into();
+    let lock_path: Utf8PathBuf = dir.path().join("credentials.lock");
 
     // 4 writers x 2 records: enough to lose an update without the lock,
     // while the final blob stays under the Windows UTF-16 size cap, which

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -10,10 +10,7 @@ use camino_tempfile::tempdir;
 
 use std::path::PathBuf;
 
-use super::{
-    BlobBackend, LockedBlobStore, WINDOWS_MAX_BLOB_BYTES, check_blob_size, lock_path_from_dirs,
-    utf16_byte_len,
-};
+use super::{BlobBackend, LockedBlobStore, lock_path_from_dirs};
 use crate::credential_store::test_support::InMemoryBlobBackend;
 use crate::credential_store::{CredentialRecord, CredentialScheme, CredentialStoreError};
 
@@ -275,51 +272,4 @@ fn concurrent_writers_do_not_lose_records() {
 
     let store = store_at(backend, &dir);
     assert_eq!(store.list().unwrap().len(), 8);
-}
-
-#[test]
-fn blob_size_check_uses_utf16_length() {
-    // 1300 ASCII chars fit in UTF-8 under 2560 bytes but exceed the
-    // Windows UTF-16 limit.
-    let blob = "a".repeat(1300);
-    assert_eq!(utf16_byte_len(&blob), 2600);
-    let err = check_blob_size(utf16_byte_len(&blob), WINDOWS_MAX_BLOB_BYTES).unwrap_err();
-    assert!(matches!(err, CredentialStoreError::BlobTooLarge));
-    assert!(
-        err.to_string().contains("Windows"),
-        "message must name the platform limit: {err}"
-    );
-
-    let small = "a".repeat(1280);
-    check_blob_size(utf16_byte_len(&small), WINDOWS_MAX_BLOB_BYTES).unwrap();
-}
-
-#[test]
-fn upsert_enforces_the_size_limit_and_does_not_write_when_exceeded() {
-    // The platform-cap enforcement (store_blob -> upsert) is Windows-only
-    // in production, so CI never runs it. Inject a tiny limit to drive the
-    // same wiring on any platform: prove the gate is connected, not just
-    // that the `check_blob_size` helper works, and that an over-limit write
-    // is refused before it reaches the backend.
-    let dir = tempdir().unwrap();
-    let backend = InMemoryBlobBackend::default();
-    let mut store = store_at(backend.clone(), &dir).with_size_limit(Some(16));
-
-    let err = store
-        .upsert(record(
-            "https://a.example/",
-            "a-token-well-over-sixteen-bytes",
-        ))
-        .unwrap_err();
-    assert!(matches!(err, CredentialStoreError::BlobTooLarge));
-    // The oversized blob never reached the backend.
-    assert!(backend.read().unwrap().is_none());
-
-    // A generous limit lets the same write through, so the gate is the
-    // size check, not an unconditional refusal.
-    let mut ok_store = store_at(backend.clone(), &dir).with_size_limit(Some(100_000));
-    ok_store
-        .upsert(record("https://a.example/", "tok"))
-        .unwrap();
-    assert!(backend.read().unwrap().is_some());
 }

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -186,19 +186,22 @@ pub fn serialize_blob(blob: &CredentialBlob) -> Result<String, CredentialStoreEr
 /// trailing slash, and the fragment dropped. URLs carrying a query string
 /// or userinfo are rejected: they do not describe an index root.
 pub fn normalize_index_key(raw: &str) -> Result<String, CredentialStoreError> {
-    let mut url = Url::parse(raw)
-        .map_err(|err| CredentialStoreError::InvalidIndexUrl(format!("`{raw}`: {err}")))?;
+    let mut url = Url::parse(raw).map_err(|err| {
+        CredentialStoreError::InvalidIndexUrl(format!("`{}`: {err}", redact_userinfo(raw)))
+    })?;
     match url.scheme() {
         "http" | "https" => {}
         other => {
             return Err(CredentialStoreError::InvalidIndexUrl(format!(
-                "`{raw}`: unsupported scheme `{other}`; only http(s) indexes store credentials"
+                "`{}`: unsupported scheme `{other}`; only http(s) indexes store credentials",
+                redact_userinfo(raw)
             )));
         }
     }
     if !url.username().is_empty() || url.password().is_some() {
         return Err(CredentialStoreError::InvalidIndexUrl(format!(
-            "`{raw}`: must not embed userinfo credentials"
+            "`{}`: must not embed userinfo credentials",
+            redact_userinfo(raw)
         )));
     }
     if url.query().is_some() {
@@ -212,6 +215,27 @@ pub fn normalize_index_key(raw: &str) -> Result<String, CredentialStoreError> {
         url.set_path(&path);
     }
     Ok(url.into())
+}
+
+/// Render a possibly malformed URL for an error message with any userinfo
+/// replaced by `<redacted>`, so an embedded password never reaches stderr
+/// or CI logs. String-based on purpose: it must work for inputs
+/// `Url::parse` rejected.
+fn redact_userinfo(raw: &str) -> std::borrow::Cow<'_, str> {
+    // The authority runs from after any scheme separator to the first
+    // `/`, `?`, or `#`; userinfo is everything up to the last `@` in it.
+    let authority_start = raw.find("://").map_or(0, |idx| idx + 3);
+    let authority_end = raw[authority_start..]
+        .find(['/', '?', '#'])
+        .map_or(raw.len(), |idx| authority_start + idx);
+    match raw[authority_start..authority_end].rfind('@') {
+        Some(at) => std::borrow::Cow::Owned(format!(
+            "{}<redacted>@{}",
+            &raw[..authority_start],
+            &raw[authority_start + at + 1..]
+        )),
+        None => std::borrow::Cow::Borrowed(raw),
+    }
 }
 
 /// A persistent store of credential records.

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -208,9 +208,10 @@ pub fn normalize_index_key(raw: &str) -> Result<String, CredentialStoreError> {
         )));
     }
     url.set_fragment(None);
-    // This will not panic for http(s)
-    let path = url.path_segments_mut().unwrap();
-    path.pop_if_empty().push("");
+    url.path_segments_mut()
+        .expect("http(s) URLs always have path segments")
+        .pop_if_empty()
+        .push("");
     Ok(url.into())
 }
 

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -58,7 +58,7 @@ pub enum CredentialStoreError {
     Lock(#[from] std::io::Error),
     /// The serialized blob exceeds the platform credential size limit.
     #[error(
-        "credential store full on this platform (Windows ~2.5 KB limit); remove an unused login or use a smaller token"
+        "credential store full on this platform (Windows ~2.5 KB limit); remove an unused credential or use a smaller token"
     )]
     BlobTooLarge,
     /// Serializing the blob failed.
@@ -251,18 +251,23 @@ fn remove_record(records: &mut Vec<CredentialRecord>, key: &str) -> bool {
 }
 
 /// An in-memory [`CredentialStore`], for tests of code that consumes the
-/// trait.
+/// trait. Test-only (`#[cfg(test)]`) so this double never reaches the
+/// library's public API; several core test modules share it, which is why
+/// it lives here rather than in one test file.
+#[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InMemoryCredentialStore {
     records: Vec<CredentialRecord>,
 }
 
+#[cfg(test)]
 impl InMemoryCredentialStore {
     pub fn new() -> Self {
         InMemoryCredentialStore::default()
     }
 }
 
+#[cfg(test)]
 impl CredentialStore for InMemoryCredentialStore {
     fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
         Ok(self.records.clone())

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -208,10 +208,9 @@ pub fn normalize_index_key(raw: &str) -> Result<String, CredentialStoreError> {
         )));
     }
     url.set_fragment(None);
-    if !url.path().ends_with('/') {
-        let path = format!("{}/", url.path());
-        url.set_path(&path);
-    }
+    // This will not panic for http(s)
+    let path = url.path_segments_mut().unwrap();
+    path.pop_if_empty().push("");
     Ok(url.into())
 }
 

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -356,7 +356,6 @@ fn redact_userinfo(raw: &str) -> std::borrow::Cow<'_, str> {
 /// file. Test-only so they never reach the library's public API.
 #[cfg(test)]
 pub(crate) mod test_support {
-    use std::path::PathBuf;
     use std::sync::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
@@ -402,13 +401,15 @@ pub(crate) mod test_support {
 
     /// A lock-file path no other store in this test process shares, so
     /// parallel tests never contend on the cross-process lock.
-    pub(crate) fn unique_lock_path() -> PathBuf {
+    pub(crate) fn unique_lock_path() -> camino::Utf8PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
-        std::env::temp_dir().join(format!(
-            "sysand-core-test-{}-{}.lock",
-            std::process::id(),
-            COUNTER.fetch_add(1, Ordering::Relaxed)
-        ))
+        camino::Utf8PathBuf::from_path_buf(std::env::temp_dir())
+            .unwrap_or_else(|p| camino::Utf8PathBuf::from(p.display().to_string()))
+            .join(format!(
+                "sysand-core-test-{}-{}.lock",
+                std::process::id(),
+                COUNTER.fetch_add(1, Ordering::Relaxed)
+            ))
     }
 
     /// An empty in-memory store, the test stand-in for the keyring store.

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -117,7 +117,7 @@ pub struct CredentialRecord {
     pub token_prefix: Option<String>,
     /// The index surfaces that exercised and accepted the credential at
     /// login, in probe order (`"read"`, `"api"`). Empty means "not
-    /// validated": either `--no-validation` or nothing exercised the
+    /// validated": nothing exercised the
     /// credential. Plain strings, not an enum, so a surface name written
     /// by a newer sysand parses instead of failing the whole blob closed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -4,17 +4,16 @@
 //! Persistent credential storage (design/credential-storage.md §9, §14).
 //!
 //! This module holds the unconditional pieces: the record types, the
-//! versioned JSON blob codec, the index-URL key normalization helper, and
-//! the [`CredentialStore`] trait, plus an in-memory implementation for
-//! tests. The OS-keyring-backed implementation lives in [`keyring_store`]
-//! behind the `keyring` cargo feature.
+//! versioned JSON blob codec, and the index-URL key normalization helper.
+//! The store itself is [`keyring_store::LockedBlobStore`], generic over
+//! the [`keyring_store::BlobBackend`] storage seam; the OS-keyring backend
+//! lives behind the `keyring` cargo feature.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
-#[cfg(feature = "keyring")]
 pub mod keyring_store;
 
 /// Current credential blob format version.
@@ -238,75 +237,72 @@ fn redact_userinfo(raw: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
-/// A persistent store of credential records.
-///
-/// Each method is atomic with respect to other processes: implementations
-/// guard read-modify-write internally (the keyring implementation with a
-/// cross-process advisory file lock).
-pub trait CredentialStore {
-    /// All stored records.
-    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError>;
-
-    /// Insert a record, replacing any existing record with the same `key`.
-    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError>;
-
-    /// Remove the record with the given `key`. Returns whether a record
-    /// was removed.
-    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError>;
-}
-
-/// Replace-by-key upsert shared by store implementations (the keyring
-/// store and the test-only in-memory store).
-#[cfg(any(feature = "keyring", test))]
-fn upsert_record(records: &mut Vec<CredentialRecord>, record: CredentialRecord) {
-    match records
-        .iter_mut()
-        .find(|existing| existing.key == record.key)
-    {
-        Some(existing) => *existing = record,
-        None => records.push(record),
-    }
-}
-
-/// Remove-by-key shared by store implementations (the keyring store and
-/// the test-only in-memory store). Returns whether a record was removed.
-#[cfg(any(feature = "keyring", test))]
-fn remove_record(records: &mut Vec<CredentialRecord>, key: &str) -> bool {
-    let before = records.len();
-    records.retain(|record| record.key != key);
-    records.len() != before
-}
-
-/// An in-memory [`CredentialStore`], for tests of code that consumes the
-/// trait. Test-only (`#[cfg(test)]`) so this double never reaches the
-/// library's public API; several core test modules share it, which is why
-/// it lives here rather than in one test file.
+/// Test doubles shared by the core test modules (auth, commands::auth,
+/// keyring_store): an in-memory [`keyring_store::BlobBackend`] standing in
+/// for the single OS keyring entry, and a [`keyring_store::LockedBlobStore`]
+/// constructor over it. Test-only (`#[cfg(test)]`) so the doubles never
+/// reach the library's public API; several test modules share them, which
+/// is why they live here rather than in one test file.
 #[cfg(test)]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct InMemoryCredentialStore {
-    records: Vec<CredentialRecord>,
-}
+pub(crate) mod test_support {
+    use std::path::PathBuf;
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    };
 
-#[cfg(test)]
-impl InMemoryCredentialStore {
-    pub fn new() -> Self {
-        InMemoryCredentialStore::default()
-    }
-}
+    use super::CredentialStoreError;
+    use super::keyring_store::{BlobBackend, LockedBlobStore};
 
-#[cfg(test)]
-impl CredentialStore for InMemoryCredentialStore {
-    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
-        Ok(self.records.clone())
-    }
-
-    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
-        upsert_record(&mut self.records, record);
-        Ok(())
+    /// In-memory [`BlobBackend`] sharing its contents across clones,
+    /// standing in for the single OS keyring entry.
+    #[derive(Debug, Clone, Default)]
+    pub(crate) struct InMemoryBlobBackend {
+        blob: Arc<Mutex<Option<String>>>,
     }
 
-    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
-        Ok(remove_record(&mut self.records, key))
+    impl InMemoryBlobBackend {
+        pub(crate) fn with_contents(raw: &str) -> Self {
+            InMemoryBlobBackend {
+                blob: Arc::new(Mutex::new(Some(raw.to_string()))),
+            }
+        }
+
+        pub(crate) fn contents(&self) -> Option<String> {
+            self.blob.lock().unwrap().clone()
+        }
+    }
+
+    impl BlobBackend for InMemoryBlobBackend {
+        fn read(&self) -> Result<Option<String>, CredentialStoreError> {
+            Ok(self.blob.lock().unwrap().clone())
+        }
+
+        fn write(&self, raw: &str) -> Result<(), CredentialStoreError> {
+            *self.blob.lock().unwrap() = Some(raw.to_string());
+            Ok(())
+        }
+
+        fn delete(&self) -> Result<(), CredentialStoreError> {
+            *self.blob.lock().unwrap() = None;
+            Ok(())
+        }
+    }
+
+    /// A lock-file path no other store in this test process shares, so
+    /// parallel tests never contend on the cross-process lock.
+    pub(crate) fn unique_lock_path() -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "sysand-core-test-{}-{}.lock",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    /// An empty in-memory store, the test stand-in for the keyring store.
+    pub(crate) fn in_memory_store() -> LockedBlobStore<InMemoryBlobBackend> {
+        LockedBlobStore::new(InMemoryBlobBackend::default(), unique_lock_path())
     }
 }
 

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -231,7 +231,9 @@ pub trait CredentialStore {
     fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError>;
 }
 
-/// Replace-by-key upsert shared by store implementations.
+/// Replace-by-key upsert shared by store implementations (the keyring
+/// store and the test-only in-memory store).
+#[cfg(any(feature = "keyring", test))]
 fn upsert_record(records: &mut Vec<CredentialRecord>, record: CredentialRecord) {
     match records
         .iter_mut()
@@ -242,8 +244,9 @@ fn upsert_record(records: &mut Vec<CredentialRecord>, record: CredentialRecord) 
     }
 }
 
-/// Remove-by-key shared by store implementations. Returns whether a record
-/// was removed.
+/// Remove-by-key shared by store implementations (the keyring store and
+/// the test-only in-memory store). Returns whether a record was removed.
+#[cfg(any(feature = "keyring", test))]
 fn remove_record(records: &mut Vec<CredentialRecord>, key: &str) -> bool {
     let before = records.len();
     records.retain(|record| record.key != key);

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -28,11 +28,18 @@ pub const BLOB_VERSION: u32 = 1;
 /// never silently degrade).
 #[derive(Debug, Error)]
 pub enum CredentialStoreError {
-    /// The stored blob failed to parse or has an unknown version. This
-    /// fails closed: a corrupt blob is never treated as empty, which would
-    /// clobber all stored credentials on the next write.
+    /// The stored blob failed to parse. This fails closed: a corrupt
+    /// blob is never treated as empty, which would clobber all stored
+    /// credentials on the next write.
     #[error("credential store unreadable; remove the `sysand` keyring entry to reset")]
     Unreadable,
+    /// The stored blob parsed but declares a format version this build
+    /// does not know (likely written by a newer sysand). Also fails
+    /// closed, but the blob is not corrupt, so no reset is suggested.
+    #[error(
+        "unsupported credential store blob version {found} (this build supports version {expected})"
+    )]
+    UnsupportedBlobVersion { found: u32, expected: u32 },
     /// The given index URL cannot be used as a credential store key.
     #[error("invalid index URL for credential storage: {0}")]
     InvalidIndexUrl(String),
@@ -62,9 +69,6 @@ pub enum CredentialStoreError {
         remove an unused credential or use a smaller token"
     )]
     BlobTooLarge,
-    /// Serializing the blob failed.
-    #[error("failed to serialize credential store: {0}")]
-    Serialize(String),
 }
 
 /// Authentication scheme of a stored credential. v1 stores bearer tokens
@@ -75,14 +79,116 @@ pub enum CredentialScheme {
     Bearer,
 }
 
+/// The principal type of a [`CredentialSubject`]. A value this build does
+/// not know parses as [`SubjectKind::Other`] and round-trips verbatim, so
+/// a read-modify-write by an older binary preserves a newer server's type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+pub enum SubjectKind {
+    User,
+    Project,
+    Oidc,
+    /// An unrecognized principal type, preserved verbatim.
+    Other(String),
+}
+
+impl SubjectKind {
+    /// The canonical string form: the wire form and the display form.
+    pub fn as_str(&self) -> &str {
+        match self {
+            SubjectKind::User => "user",
+            SubjectKind::Project => "project",
+            SubjectKind::Oidc => "oidc",
+            SubjectKind::Other(value) => value,
+        }
+    }
+}
+
+impl From<String> for SubjectKind {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "user" => SubjectKind::User,
+            "project" => SubjectKind::Project,
+            "oidc" => SubjectKind::Oidc,
+            _ => SubjectKind::Other(value),
+        }
+    }
+}
+
+impl From<SubjectKind> for String {
+    fn from(kind: SubjectKind) -> Self {
+        match kind {
+            // Moves the unknown value out instead of cloning via `as_str`.
+            SubjectKind::Other(value) => value,
+            known => known.as_str().to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for SubjectKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// An index surface that exercised and accepted a credential at login. A
+/// value this build does not know parses as [`ValidatedSurface::Other`]
+/// and round-trips verbatim, so a surface name written by a newer sysand
+/// neither fails the whole blob closed nor gets dropped on rewrite.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
+pub enum ValidatedSurface {
+    Read,
+    Api,
+    /// An unrecognized surface name, preserved verbatim.
+    Other(String),
+}
+
+impl ValidatedSurface {
+    /// The canonical string form: the wire form and the display form.
+    pub fn as_str(&self) -> &str {
+        match self {
+            ValidatedSurface::Read => "read",
+            ValidatedSurface::Api => "api",
+            ValidatedSurface::Other(value) => value,
+        }
+    }
+}
+
+impl From<String> for ValidatedSurface {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "read" => ValidatedSurface::Read,
+            "api" => ValidatedSurface::Api,
+            _ => ValidatedSurface::Other(value),
+        }
+    }
+}
+
+impl From<ValidatedSurface> for String {
+    fn from(surface: ValidatedSurface) -> Self {
+        match surface {
+            // Moves the unknown value out instead of cloning via `as_str`.
+            ValidatedSurface::Other(value) => value,
+            known => known.as_str().to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for ValidatedSurface {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Identity of the principal a credential authenticates as, learned from
 /// `v1/whoami` by a validating login.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CredentialSubject {
-    /// The principal type: `user`, `project`, or `oidc`. Kept as a plain
-    /// string so a future server-side type survives a round-trip.
+    /// The principal type; unknown types survive a round-trip
+    /// ([`SubjectKind::Other`]).
     #[serde(rename = "type")]
-    pub kind: String,
+    pub kind: SubjectKind,
     /// The principal name: the username for a user token, the project id
     /// for a project token, the publisher identity for an OIDC token.
     pub name: String,
@@ -114,12 +220,11 @@ pub struct CredentialRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_prefix: Option<String>,
     /// The index surfaces that exercised and accepted the credential at
-    /// login, in probe order (`"read"`, `"api"`). Empty means "not
-    /// validated": nothing exercised the
-    /// credential. Plain strings, not an enum, so a surface name written
-    /// by a newer sysand parses instead of failing the whole blob closed.
+    /// login, in probe order (`"read"`, `"api"` on the wire). Empty means
+    /// "not validated": nothing exercised the credential. Unknown surface
+    /// names survive a round-trip ([`ValidatedSurface::Other`]).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub validated: Vec<String>,
+    pub validated: Vec<ValidatedSurface>,
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
@@ -154,21 +259,27 @@ impl Default for CredentialBlob {
     }
 }
 
-/// Parse a credential blob. Any parse failure, or an unknown `version`,
-/// fails closed with [`CredentialStoreError::Unreadable`]: a corrupt blob
-/// is never silently treated as empty.
+/// Parse a credential blob. Both failure modes fail closed (the blob is
+/// never silently treated as empty): a parse failure as
+/// [`CredentialStoreError::Unreadable`], an unknown `version` as
+/// [`CredentialStoreError::UnsupportedBlobVersion`].
 pub fn parse_blob(raw: &str) -> Result<CredentialBlob, CredentialStoreError> {
+    // Parse error is ignored here, because it may include secrets
     let blob: CredentialBlob =
         serde_json::from_str(raw).map_err(|_| CredentialStoreError::Unreadable)?;
     if blob.version != BLOB_VERSION {
-        return Err(CredentialStoreError::Unreadable);
+        return Err(CredentialStoreError::UnsupportedBlobVersion {
+            found: blob.version,
+            expected: BLOB_VERSION,
+        });
     }
     Ok(blob)
 }
 
 /// Serialize a credential blob to its JSON wire form.
-pub fn serialize_blob(blob: &CredentialBlob) -> Result<String, CredentialStoreError> {
-    serde_json::to_string(blob).map_err(|err| CredentialStoreError::Serialize(err.to_string()))
+pub fn serialize_blob(blob: &CredentialBlob) -> String {
+    // Serialization failure is a bug
+    serde_json::to_string(blob).unwrap()
 }
 
 /// Normalize an index URL for use as a credential record key, so different

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -60,9 +60,13 @@ pub enum CredentialStoreError {
         "timed out waiting for the credential store lock at `{path}`; retry once other sysand processes finish"
     )]
     LockTimeout { path: String },
-    /// I/O failure around the credential store lock file.
+    /// I/O failure around the credential store lock file; the inner
+    /// error names the operation and path.
     #[error("credential store lock error")]
-    Lock(#[from] std::io::Error),
+    Lock(#[from] crate::project::utils::FsIoError),
+    /// No per-user directory could be determined for the lock file.
+    #[error("could not determine a per-user directory for the credential store lock file")]
+    NoLockDir,
     /// The serialized blob exceeds the platform credential size limit.
     #[error(
         "credential store full on this platform (Windows ~2.5 KB limit);\n\

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! Persistent credential storage (design/credential-storage.md §9, §14).
+//!
+//! This module holds the unconditional pieces: the record types, the
+//! versioned JSON blob codec, the index-URL key normalization helper, and
+//! the [`CredentialStore`] trait, plus an in-memory implementation for
+//! tests. The OS-keyring-backed implementation lives in [`keyring_store`]
+//! behind the `keyring` cargo feature.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+#[cfg(feature = "keyring")]
+pub mod keyring_store;
+
+/// Current credential blob format version.
+pub const BLOB_VERSION: u32 = 1;
+
+/// Errors from the credential store.
+///
+/// The taxonomy distinguishes an *absent* keyring backend (callers may fall
+/// back to `SYSAND_CRED_*` environment variables) from a
+/// *present-but-locked/denied* backend (callers must surface the error and
+/// never silently degrade).
+#[derive(Debug, Error)]
+pub enum CredentialStoreError {
+    /// The stored blob failed to parse or has an unknown version. This
+    /// fails closed: a corrupt blob is never treated as empty, which would
+    /// clobber all stored logins on the next write.
+    #[error("credential store unreadable; remove the `sysand` keyring entry to reset")]
+    Unreadable,
+    /// The given index URL cannot be used as a credential store key.
+    #[error("invalid index URL for credential storage: {0}")]
+    InvalidIndexUrl(String),
+    /// No usable OS keyring backend. Callers can fall back to
+    /// `SYSAND_CRED_*` environment variables.
+    #[error("no OS keyring backend is available: {source}")]
+    BackendAbsent {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// The OS keyring exists but refused access (locked or denied).
+    /// Callers must surface this, never silently degrade.
+    #[error("the OS keyring denied access (it may be locked): {source}")]
+    BackendDenied {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// Timed out waiting for the cross-process credential store lock.
+    #[error(
+        "timed out waiting for the credential store lock at `{path}`; retry once other sysand processes finish"
+    )]
+    LockTimeout { path: String },
+    /// I/O failure around the credential store lock file.
+    #[error("credential store lock error: {0}")]
+    Lock(#[from] std::io::Error),
+    /// The serialized blob exceeds the platform credential size limit.
+    #[error(
+        "credential store full on this platform (Windows ~2.5 KB limit); remove an unused login or use a smaller token"
+    )]
+    BlobTooLarge,
+    /// Serializing the blob failed.
+    #[error("failed to serialize credential store: {0}")]
+    Serialize(String),
+}
+
+/// Authentication scheme of a stored credential. v1 stores bearer tokens
+/// only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CredentialScheme {
+    Bearer,
+}
+
+/// One stored login: a normalized index-URL key, the URL glob patterns the
+/// credential applies to, the scheme, the secret, and the expiry when a
+/// validating login learned it.
+///
+/// Unknown fields written by a newer sysand are preserved in `extra` so a
+/// read-modify-write by an older binary does not drop them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialRecord {
+    pub key: String,
+    pub globs: Vec<String>,
+    pub scheme: CredentialScheme,
+    pub secret: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// The versioned credential blob: what the single keyring entry holds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialBlob {
+    pub version: u32,
+    #[serde(default)]
+    pub credentials: Vec<CredentialRecord>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl CredentialBlob {
+    pub fn new(credentials: Vec<CredentialRecord>) -> Self {
+        CredentialBlob {
+            version: BLOB_VERSION,
+            credentials,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    pub fn empty() -> Self {
+        CredentialBlob::new(Vec::new())
+    }
+}
+
+impl Default for CredentialBlob {
+    fn default() -> Self {
+        CredentialBlob::empty()
+    }
+}
+
+/// Parse a credential blob. Any parse failure, or an unknown `version`,
+/// fails closed with [`CredentialStoreError::Unreadable`]: a corrupt blob
+/// is never silently treated as empty.
+pub fn parse_blob(raw: &str) -> Result<CredentialBlob, CredentialStoreError> {
+    let blob: CredentialBlob =
+        serde_json::from_str(raw).map_err(|_| CredentialStoreError::Unreadable)?;
+    if blob.version != BLOB_VERSION {
+        return Err(CredentialStoreError::Unreadable);
+    }
+    Ok(blob)
+}
+
+/// Serialize a credential blob to its JSON wire form.
+pub fn serialize_blob(blob: &CredentialBlob) -> Result<String, CredentialStoreError> {
+    serde_json::to_string(blob).map_err(|err| CredentialStoreError::Serialize(err.to_string()))
+}
+
+/// Normalize an index URL for use as a credential record key, so different
+/// spellings of the same index do not create duplicate entries
+/// (design/credential-storage.md §4).
+///
+/// Uses the `url` crate deliberately (not `iri_normalize`): §8 requires
+/// glob derivation and runtime matching to share `url::Url::as_str()` as
+/// their serialization, and the key must agree with the derived globs.
+///
+/// Normalization: `Url` parsing (lowercased host, punycoded IDN, default
+/// port stripped), the scheme restricted to http(s), the path given a
+/// trailing slash, and the fragment dropped. URLs carrying a query string
+/// or userinfo are rejected: they do not describe an index root.
+pub fn normalize_index_key(raw: &str) -> Result<String, CredentialStoreError> {
+    let mut url = Url::parse(raw)
+        .map_err(|err| CredentialStoreError::InvalidIndexUrl(format!("`{raw}`: {err}")))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(CredentialStoreError::InvalidIndexUrl(format!(
+                "`{raw}`: unsupported scheme `{other}`; only http(s) indexes store credentials"
+            )));
+        }
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(CredentialStoreError::InvalidIndexUrl(format!(
+            "`{raw}`: must not embed userinfo credentials"
+        )));
+    }
+    if url.query().is_some() {
+        return Err(CredentialStoreError::InvalidIndexUrl(format!(
+            "`{raw}`: must not contain a query string"
+        )));
+    }
+    url.set_fragment(None);
+    if !url.path().ends_with('/') {
+        let path = format!("{}/", url.path());
+        url.set_path(&path);
+    }
+    Ok(url.into())
+}
+
+/// A persistent store of credential records.
+///
+/// Each method is atomic with respect to other processes: implementations
+/// guard read-modify-write internally (the keyring implementation with a
+/// cross-process advisory file lock).
+pub trait CredentialStore {
+    /// All stored records.
+    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError>;
+
+    /// Insert a record, replacing any existing record with the same `key`.
+    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError>;
+
+    /// Remove the record with the given `key`. Returns whether a record
+    /// was removed.
+    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError>;
+}
+
+/// Replace-by-key upsert shared by store implementations.
+fn upsert_record(records: &mut Vec<CredentialRecord>, record: CredentialRecord) {
+    match records
+        .iter_mut()
+        .find(|existing| existing.key == record.key)
+    {
+        Some(existing) => *existing = record,
+        None => records.push(record),
+    }
+}
+
+/// Remove-by-key shared by store implementations. Returns whether a record
+/// was removed.
+fn remove_record(records: &mut Vec<CredentialRecord>, key: &str) -> bool {
+    let before = records.len();
+    records.retain(|record| record.key != key);
+    records.len() != before
+}
+
+/// An in-memory [`CredentialStore`], for tests of code that consumes the
+/// trait.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InMemoryCredentialStore {
+    records: Vec<CredentialRecord>,
+}
+
+impl InMemoryCredentialStore {
+    pub fn new() -> Self {
+        InMemoryCredentialStore::default()
+    }
+}
+
+impl CredentialStore for InMemoryCredentialStore {
+    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+        Ok(self.records.clone())
+    }
+
+    fn upsert(&mut self, record: CredentialRecord) -> Result<(), CredentialStoreError> {
+        upsert_record(&mut self.records, record);
+        Ok(())
+    }
+
+    fn remove(&mut self, key: &str) -> Result<bool, CredentialStoreError> {
+        Ok(remove_record(&mut self.records, key))
+    }
+}
+
+// Private tests
+
+#[cfg(test)]
+#[path = "./mod_tests.rs"]
+mod tests;

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -74,9 +74,25 @@ pub enum CredentialScheme {
     Bearer,
 }
 
+/// Identity of the principal a credential authenticates as, learned from
+/// `v1/whoami` by a validating login (design/credential-storage.md
+/// sections 5, 6).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialSubject {
+    /// The principal type: `user`, `project`, or `oidc`. Kept as a plain
+    /// string so a future server-side type survives a round-trip.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// The principal name: the username for a user token, the project id
+    /// for a project token, the publisher identity for an OIDC token.
+    pub name: String,
+}
+
 /// One stored login: a normalized index-URL key, the URL glob patterns the
-/// credential applies to, the scheme, the secret, and the expiry when a
-/// validating login learned it.
+/// credential applies to, the scheme, the secret, plus the identity and
+/// expiry fields a validating login learned from `v1/whoami` (absent for
+/// non-validated logins and read-only indexes; blob version stays 1, older
+/// blobs without them still parse).
 ///
 /// Unknown fields written by a newer sysand are preserved in `extra` so a
 /// read-modify-write by an older binary does not drop them.
@@ -88,6 +104,16 @@ pub struct CredentialRecord {
     pub secret: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<DateTime<Utc>>,
+    /// Who the credential authenticates as, from `v1/whoami`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<CredentialSubject>,
+    /// The user-given token label, from `v1/whoami`. May be absent even
+    /// after validation (trusted-publishing tokens have no label).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_name: Option<String>,
+    /// The token's non-secret display prefix, from `v1/whoami`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_prefix: Option<String>,
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -92,7 +92,8 @@ pub struct CredentialSubject {
 /// credential applies to, the scheme, the secret, plus the identity and
 /// expiry fields a validating login learned from `v1/whoami` (absent for
 /// non-validated logins and read-only indexes; blob version stays 1, older
-/// blobs without them still parse).
+/// blobs without them still parse). A validating login also records which
+/// surfaces accepted the credential (`validated`), shown by `auth status`.
 ///
 /// Unknown fields written by a newer sysand are preserved in `extra` so a
 /// read-modify-write by an older binary does not drop them.
@@ -114,6 +115,13 @@ pub struct CredentialRecord {
     /// The token's non-secret display prefix, from `v1/whoami`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_prefix: Option<String>,
+    /// The index surfaces that exercised and accepted the credential at
+    /// login, in probe order (`"read"`, `"api"`). Empty means "not
+    /// validated": either `--no-validation` or nothing exercised the
+    /// credential. Plain strings, not an enum, so a surface name written
+    /// by a newer sysand parses instead of failing the whole blob closed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validated: Vec<String>,
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -44,7 +44,7 @@ pub enum CredentialStoreError {
     },
     /// The OS keyring exists but refused access (locked or denied).
     /// Callers must surface this, never silently degrade.
-    #[error("the OS keyring denied access (it may be locked): {source}")]
+    #[error("the OS keyring denied access (it may be locked)")]
     BackendDenied {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -54,11 +54,12 @@ pub enum CredentialStoreError {
     )]
     LockTimeout { path: String },
     /// I/O failure around the credential store lock file.
-    #[error("credential store lock error: {0}")]
+    #[error("credential store lock error")]
     Lock(#[from] std::io::Error),
     /// The serialized blob exceeds the platform credential size limit.
     #[error(
-        "credential store full on this platform (Windows ~2.5 KB limit); remove an unused credential or use a smaller token"
+        "credential store full on this platform (Windows ~2.5 KB limit);\n\
+        remove an unused credential or use a smaller token"
     )]
     BlobTooLarge,
     /// Serializing the blob failed.
@@ -89,10 +90,8 @@ pub struct CredentialSubject {
 
 /// One stored credential: a normalized index-URL key, the URL glob patterns the
 /// credential applies to, the scheme, the secret, plus the identity and
-/// expiry fields a validating login learned from `v1/whoami` (absent for
-/// non-validated logins and read-only indexes; blob version stays 1, older
-/// blobs without them still parse). A validating login also records which
-/// surfaces accepted the credential (`validated`), shown by `auth status`.
+/// expiry fields a validating login learned from `v1/whoami`. A validating login also
+/// records which surfaces accepted the credential (`validated`), shown by `auth status`.
 ///
 /// Unknown fields written by a newer sysand are preserved in `extra` so a
 /// read-modify-write by an older binary does not drop them.

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -319,7 +319,8 @@ pub fn normalize_index_key(raw: &str) -> Result<String, CredentialStoreError> {
     }
     url.set_fragment(None);
     url.path_segments_mut()
-        .expect("http(s) URLs always have path segments")
+        // http(s) URLs always have path segments
+        .unwrap()
         .pop_if_empty()
         .push("");
     Ok(url.into())

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -30,7 +30,7 @@ pub const BLOB_VERSION: u32 = 1;
 pub enum CredentialStoreError {
     /// The stored blob failed to parse or has an unknown version. This
     /// fails closed: a corrupt blob is never treated as empty, which would
-    /// clobber all stored logins on the next write.
+    /// clobber all stored credentials on the next write.
     #[error("credential store unreadable; remove the `sysand` keyring entry to reset")]
     Unreadable,
     /// The given index URL cannot be used as a credential store key.
@@ -88,7 +88,7 @@ pub struct CredentialSubject {
     pub name: String,
 }
 
-/// One stored login: a normalized index-URL key, the URL glob patterns the
+/// One stored credential: a normalized index-URL key, the URL glob patterns the
 /// credential applies to, the scheme, the secret, plus the identity and
 /// expiry fields a validating login learned from `v1/whoami` (absent for
 /// non-validated logins and read-only indexes; blob version stays 1, older

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-//! Persistent credential storage (design/credential-storage.md §9, §14).
+//! Persistent credential storage; the full design is in
+//! design/credential-storage.md.
 //!
 //! This module holds the unconditional pieces: the record types, the
 //! versioned JSON blob codec, and the index-URL key normalization helper.
@@ -74,8 +75,7 @@ pub enum CredentialScheme {
 }
 
 /// Identity of the principal a credential authenticates as, learned from
-/// `v1/whoami` by a validating login (design/credential-storage.md
-/// sections 5, 6).
+/// `v1/whoami` by a validating login.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CredentialSubject {
     /// The principal type: `user`, `project`, or `oidc`. Kept as a plain
@@ -173,12 +173,11 @@ pub fn serialize_blob(blob: &CredentialBlob) -> Result<String, CredentialStoreEr
 }
 
 /// Normalize an index URL for use as a credential record key, so different
-/// spellings of the same index do not create duplicate entries
-/// (design/credential-storage.md §4).
+/// spellings of the same index do not create duplicate entries.
 ///
-/// Uses the `url` crate deliberately (not `iri_normalize`): §8 requires
-/// glob derivation and runtime matching to share `url::Url::as_str()` as
-/// their serialization, and the key must agree with the derived globs.
+/// Uses the `url` crate deliberately (not `iri_normalize`): glob
+/// derivation and runtime matching share `url::Url::as_str()` as their
+/// serialization, and the key must agree with the derived globs.
 ///
 /// Normalization: `Url` parsing (lowercased host, punycoded IDN, default
 /// port stripped), the scheme restricted to http(s), the path given a

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -13,7 +13,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use url::Url;
 
 pub mod keyring_store;
 
@@ -40,9 +39,6 @@ pub enum CredentialStoreError {
         "unsupported credential store blob version {found} (this build supports version {expected})"
     )]
     UnsupportedBlobVersion { found: u32, expected: u32 },
-    /// The given index URL cannot be used as a credential store key.
-    #[error("invalid index URL for credential storage: {0}")]
-    InvalidIndexUrl(String),
     /// No usable OS keyring backend. Callers can fall back to
     /// `SYSAND_CRED_*` environment variables.
     #[error("no OS keyring backend is available: {source}")]
@@ -284,71 +280,6 @@ pub fn parse_blob(raw: &str) -> Result<CredentialBlob, CredentialStoreError> {
 pub fn serialize_blob(blob: &CredentialBlob) -> String {
     // Serialization failure is a bug
     serde_json::to_string(blob).unwrap()
-}
-
-/// Normalize an index URL for use as a credential record key, so different
-/// spellings of the same index do not create duplicate entries.
-///
-/// Uses the `url` crate deliberately (not `iri_normalize`): glob
-/// derivation and runtime matching share `url::Url::as_str()` as their
-/// serialization, and the key must agree with the derived globs.
-///
-/// Normalization: `Url` parsing (lowercased host, punycoded IDN, default
-/// port stripped), the scheme restricted to http(s), the path given a
-/// trailing slash, and the fragment dropped. URLs carrying a query string
-/// or userinfo are rejected: they do not describe an index root.
-pub fn normalize_index_key(raw: &str) -> Result<String, CredentialStoreError> {
-    let mut url = Url::parse(raw).map_err(|err| {
-        CredentialStoreError::InvalidIndexUrl(format!("`{}`: {err}", redact_userinfo(raw)))
-    })?;
-    match url.scheme() {
-        "http" | "https" => {}
-        other => {
-            return Err(CredentialStoreError::InvalidIndexUrl(format!(
-                "`{}`: unsupported scheme `{other}`; only http(s) indexes store credentials",
-                redact_userinfo(raw)
-            )));
-        }
-    }
-    if !url.username().is_empty() || url.password().is_some() {
-        return Err(CredentialStoreError::InvalidIndexUrl(format!(
-            "`{}`: must not embed userinfo credentials",
-            redact_userinfo(raw)
-        )));
-    }
-    if url.query().is_some() {
-        return Err(CredentialStoreError::InvalidIndexUrl(format!(
-            "`{raw}`: must not contain a query string"
-        )));
-    }
-    url.set_fragment(None);
-    url.path_segments_mut()
-        // http(s) URLs always have path segments
-        .unwrap()
-        .pop_if_empty()
-        .push("");
-    Ok(url.into())
-}
-
-/// Render a possibly malformed URL for an error message with any userinfo
-/// replaced by `<redacted>`, so an embedded password never reaches stderr
-/// or CI logs. String-based on purpose: it must work for inputs
-/// `Url::parse` rejected.
-fn redact_userinfo(raw: &str) -> std::borrow::Cow<'_, str> {
-    // The authority runs from after any scheme separator to the first
-    // `/`, `?`, or `#`; userinfo is everything up to the last `@` in it.
-    let authority_start = raw.find("://").map_or(0, |idx| idx + 3);
-    let authority_end = raw[authority_start..]
-        .find(['/', '?', '#'])
-        .map_or(raw.len(), |idx| authority_start + idx);
-    match raw[authority_start..authority_end].rfind('@') {
-        Some(at) => std::borrow::Cow::Owned(format!(
-            "{}<redacted>@{}",
-            &raw[..authority_start],
-            &raw[authority_start + at + 1..]
-        )),
-        None => std::borrow::Cow::Borrowed(raw),
-    }
 }
 
 /// Test doubles shared by several core test modules (auth, commands::auth,

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -237,12 +237,9 @@ fn redact_userinfo(raw: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
-/// Test doubles shared by the core test modules (auth, commands::auth,
-/// keyring_store): an in-memory [`keyring_store::BlobBackend`] standing in
-/// for the single OS keyring entry, and a [`keyring_store::LockedBlobStore`]
-/// constructor over it. Test-only (`#[cfg(test)]`) so the doubles never
-/// reach the library's public API; several test modules share them, which
-/// is why they live here rather than in one test file.
+/// Test doubles shared by several core test modules (auth, commands::auth,
+/// keyring_store), which is why they live here rather than in one test
+/// file. Test-only so they never reach the library's public API.
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::path::PathBuf;

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -242,6 +242,30 @@ fn normalize_rejects_query_and_userinfo() {
 }
 
 #[test]
+fn normalize_errors_never_echo_an_embedded_password() {
+    // One URL per error branch that can carry userinfo: the userinfo
+    // rejection, the scheme rejection, and the parse failure (a space in
+    // the host). These messages reach stderr and CI logs, so the password
+    // must never appear in them.
+    for url in [
+        "https://user:hunter2@example.com/idx",
+        "ftp://user:hunter2@example.com/idx",
+        "https://user:hunter2@exa mple.com/idx",
+    ] {
+        let err = normalize_index_key(url).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            !message.contains("hunter2") && !message.contains("user:"),
+            "url {url:?} leaked userinfo: {message}"
+        );
+        assert!(
+            message.contains("<redacted>@"),
+            "url {url:?} must show the redaction marker: {message}"
+        );
+    }
+}
+
+#[test]
 fn in_memory_store_upsert_list_remove() {
     let mut store = InMemoryCredentialStore::new();
     assert!(store.list().unwrap().is_empty());

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -19,6 +19,7 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
         subject: None,
         token_name: None,
         token_prefix: None,
+        validated: Vec::new(),
         extra: serde_json::Map::new(),
     }
 }
@@ -106,11 +107,42 @@ fn identity_fields_round_trip() {
     });
     with_identity.token_name = Some("laptop".to_string());
     with_identity.token_prefix = Some("sysand_u_1a2b3c4d".to_string());
+    with_identity.validated = vec!["read".to_string(), "api".to_string()];
     let blob = CredentialBlob::new(vec![with_identity]);
     let raw = serialize_blob(&blob).unwrap();
     // `kind` serializes under the protocol's `type` key.
     assert!(raw.contains(r#""subject":{"type":"user","name":"alice"}"#));
+    // The validation claim serializes compactly.
+    assert!(raw.contains(r#""validated":["read","api"]"#));
     assert_eq!(parse_blob(&raw).unwrap(), blob);
+}
+
+#[test]
+fn blob_omits_an_empty_validated_list() {
+    let blob = CredentialBlob::new(vec![record("https://example.com/", "tok")]);
+    let raw = serialize_blob(&blob).unwrap();
+    assert!(!raw.contains("validated"));
+}
+
+#[test]
+fn parse_accepts_a_blob_written_before_the_validated_field() {
+    // A blob written before `validated` existed (still version 1) must
+    // parse, and the absent claim reads as "not validated".
+    let raw = r#"{
+        "version": 1,
+        "credentials": [{
+            "key": "https://example.com/",
+            "globs": ["https://example.com/**"],
+            "scheme": "bearer",
+            "secret": "tok",
+            "subject": {"type": "user", "name": "alice"},
+            "token_prefix": "sysand_u_1a2b3c4d"
+        }]
+    }"#;
+    let blob = parse_blob(raw).unwrap();
+    let record = &blob.credentials[0];
+    assert!(record.validated.is_empty());
+    assert!(record.extra.is_empty());
 }
 
 #[test]

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use chrono::{TimeZone, Utc};
+
+use super::{
+    BLOB_VERSION, CredentialBlob, CredentialRecord, CredentialScheme, CredentialStore,
+    CredentialStoreError, InMemoryCredentialStore, normalize_index_key, parse_blob, serialize_blob,
+};
+
+fn record(key: &str, secret: &str) -> CredentialRecord {
+    CredentialRecord {
+        key: key.to_string(),
+        globs: vec![format!("{key}**")],
+        scheme: CredentialScheme::Bearer,
+        secret: secret.to_string(),
+        expires_at: None,
+        extra: serde_json::Map::new(),
+    }
+}
+
+#[test]
+fn blob_round_trip() {
+    let mut with_expiry = record("https://example.com/idx/", "tok-1");
+    with_expiry.expires_at = Some(Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap());
+    let blob = CredentialBlob::new(vec![with_expiry, record("https://other.example/", "tok-2")]);
+    let raw = serialize_blob(&blob).unwrap();
+    let parsed = parse_blob(&raw).unwrap();
+    assert_eq!(parsed, blob);
+}
+
+#[test]
+fn blob_serializes_version_field() {
+    let raw = serialize_blob(&CredentialBlob::empty()).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(value["version"], serde_json::json!(BLOB_VERSION));
+}
+
+#[test]
+fn blob_omits_absent_expiry() {
+    let blob = CredentialBlob::new(vec![record("https://example.com/", "tok")]);
+    let raw = serialize_blob(&blob).unwrap();
+    assert!(!raw.contains("expires_at"));
+}
+
+#[test]
+fn parse_tolerates_unknown_fields_and_round_trips_them() {
+    let raw = r#"{
+        "version": 1,
+        "future_top_level": true,
+        "credentials": [{
+            "key": "https://example.com/",
+            "globs": ["https://example.com/**"],
+            "scheme": "bearer",
+            "secret": "tok",
+            "future_record_field": {"nested": 1}
+        }]
+    }"#;
+    let blob = parse_blob(raw).unwrap();
+    assert_eq!(blob.credentials.len(), 1);
+    assert_eq!(
+        blob.credentials[0].extra["future_record_field"],
+        serde_json::json!({"nested": 1})
+    );
+    assert_eq!(blob.extra["future_top_level"], serde_json::json!(true));
+    // A read-modify-write must not drop fields a newer sysand wrote.
+    let rewritten = serialize_blob(&blob).unwrap();
+    assert!(rewritten.contains("future_top_level"));
+    assert!(rewritten.contains("future_record_field"));
+}
+
+#[test]
+fn parse_fails_closed_on_unknown_version() {
+    let raw = r#"{"version": 2, "credentials": []}"#;
+    let err = parse_blob(raw).unwrap_err();
+    assert!(matches!(err, CredentialStoreError::Unreadable));
+}
+
+#[test]
+fn parse_fails_closed_on_garbage() {
+    for garbage in ["", "not json", "{\"version\": \"one\"}", "[]", "{}"] {
+        let err = parse_blob(garbage).unwrap_err();
+        assert!(
+            matches!(err, CredentialStoreError::Unreadable),
+            "input {garbage:?} must fail closed"
+        );
+        assert_eq!(
+            err.to_string(),
+            "credential store unreadable; remove the `sysand` keyring entry to reset"
+        );
+    }
+}
+
+#[test]
+fn normalize_adds_trailing_slash() {
+    assert_eq!(
+        normalize_index_key("https://example.com/idx").unwrap(),
+        "https://example.com/idx/"
+    );
+    assert_eq!(
+        normalize_index_key("https://example.com").unwrap(),
+        "https://example.com/"
+    );
+}
+
+#[test]
+fn normalize_keeps_existing_trailing_slash() {
+    assert_eq!(
+        normalize_index_key("https://example.com/idx/").unwrap(),
+        "https://example.com/idx/"
+    );
+}
+
+#[test]
+fn normalize_lowercases_host_and_strips_default_port() {
+    assert_eq!(
+        normalize_index_key("HTTPS://EXAMPLE.com:443/Idx").unwrap(),
+        "https://example.com/Idx/"
+    );
+}
+
+#[test]
+fn normalize_keeps_explicit_port_and_ipv6_literal() {
+    assert_eq!(
+        normalize_index_key("https://[::1]:8000/idx").unwrap(),
+        "https://[::1]:8000/idx/"
+    );
+}
+
+#[test]
+fn normalize_drops_fragment() {
+    assert_eq!(
+        normalize_index_key("https://example.com/idx#frag").unwrap(),
+        "https://example.com/idx/"
+    );
+}
+
+#[test]
+fn normalize_rejects_non_http_schemes() {
+    for url in ["file:///tmp/idx", "ftp://example.com/idx", "not a url"] {
+        assert!(
+            matches!(
+                normalize_index_key(url),
+                Err(CredentialStoreError::InvalidIndexUrl(_))
+            ),
+            "url {url:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn normalize_rejects_query_and_userinfo() {
+    for url in [
+        "https://example.com/idx?token=x",
+        "https://user:pass@example.com/idx",
+        "https://user@example.com/idx",
+    ] {
+        assert!(
+            matches!(
+                normalize_index_key(url),
+                Err(CredentialStoreError::InvalidIndexUrl(_))
+            ),
+            "url {url:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn in_memory_store_upsert_list_remove() {
+    let mut store = InMemoryCredentialStore::new();
+    assert!(store.list().unwrap().is_empty());
+
+    store.upsert(record("https://a.example/", "tok-a")).unwrap();
+    store.upsert(record("https://b.example/", "tok-b")).unwrap();
+    assert_eq!(store.list().unwrap().len(), 2);
+
+    // Upsert replaces by key without duplicating.
+    store
+        .upsert(record("https://a.example/", "tok-a2"))
+        .unwrap();
+    let records = store.list().unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].secret, "tok-a2");
+
+    assert!(store.remove("https://a.example/").unwrap());
+    assert!(!store.remove("https://a.example/").unwrap());
+    assert_eq!(store.list().unwrap().len(), 1);
+    assert_eq!(store.list().unwrap()[0].key, "https://b.example/");
+}

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -5,7 +5,8 @@ use chrono::{TimeZone, Utc};
 
 use super::{
     BLOB_VERSION, CredentialBlob, CredentialRecord, CredentialScheme, CredentialStore,
-    CredentialStoreError, InMemoryCredentialStore, normalize_index_key, parse_blob, serialize_blob,
+    CredentialStoreError, CredentialSubject, InMemoryCredentialStore, normalize_index_key,
+    parse_blob, serialize_blob,
 };
 
 fn record(key: &str, secret: &str) -> CredentialRecord {
@@ -15,6 +16,9 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
         scheme: CredentialScheme::Bearer,
         secret: secret.to_string(),
         expires_at: None,
+        subject: None,
+        token_name: None,
+        token_prefix: None,
         extra: serde_json::Map::new(),
     }
 }
@@ -67,6 +71,46 @@ fn parse_tolerates_unknown_fields_and_round_trips_them() {
     let rewritten = serialize_blob(&blob).unwrap();
     assert!(rewritten.contains("future_top_level"));
     assert!(rewritten.contains("future_record_field"));
+}
+
+#[test]
+fn parse_accepts_a_blob_written_before_the_identity_fields() {
+    // A blob written before `subject` / `token_name` / `token_prefix`
+    // existed (still version 1) must parse, with the new fields absent.
+    let raw = r#"{
+        "version": 1,
+        "credentials": [{
+            "key": "https://example.com/",
+            "globs": ["https://example.com/**"],
+            "scheme": "bearer",
+            "secret": "tok",
+            "expires_at": "2026-09-01T00:00:00Z"
+        }]
+    }"#;
+    let blob = parse_blob(raw).unwrap();
+    let record = &blob.credentials[0];
+    assert_eq!(record.secret, "tok");
+    assert_eq!(record.subject, None);
+    assert_eq!(record.token_name, None);
+    assert_eq!(record.token_prefix, None);
+    assert!(record.expires_at.is_some());
+    assert!(record.extra.is_empty());
+}
+
+#[test]
+fn identity_fields_round_trip() {
+    let mut with_identity = record("https://example.com/idx/", "tok");
+    with_identity.subject = Some(CredentialSubject {
+        kind: "user".to_string(),
+        name: "alice".to_string(),
+    });
+    with_identity.token_name = Some("laptop".to_string());
+    with_identity.token_prefix = Some("sysand_u_1a2b3c4d".to_string());
+    let blob = CredentialBlob::new(vec![with_identity]);
+    let raw = serialize_blob(&blob).unwrap();
+    // `kind` serializes under the protocol's `type` key.
+    assert!(raw.contains(r#""subject":{"type":"user","name":"alice"}"#));
+    assert_eq!(parse_blob(&raw).unwrap(), blob);
 }
 
 #[test]

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -5,8 +5,7 @@ use chrono::{TimeZone, Utc};
 
 use super::{
     BLOB_VERSION, CredentialBlob, CredentialRecord, CredentialScheme, CredentialStoreError,
-    CredentialSubject, SubjectKind, ValidatedSurface, normalize_index_key, parse_blob,
-    serialize_blob,
+    CredentialSubject, SubjectKind, ValidatedSurface, parse_blob, serialize_blob,
 };
 
 fn record(key: &str, secret: &str) -> CredentialRecord {
@@ -183,70 +182,6 @@ fn parse_fails_closed_on_garbage() {
             err.to_string()
                 .contains("remove the `sysand` keyring entry"),
             "message must point at the reset: {err}"
-        );
-    }
-}
-
-#[test]
-fn normalize_canonicalizes_accepted_urls() {
-    // Trailing slash added/kept, host lowercased, default port stripped,
-    // explicit port and IPv6 literal kept, fragment dropped.
-    for (url, expected) in [
-        ("https://example.com/idx", "https://example.com/idx/"),
-        ("https://example.com", "https://example.com/"),
-        ("https://example.com/idx/", "https://example.com/idx/"),
-        ("HTTPS://EXAMPLE.com:443/Idx", "https://example.com/Idx/"),
-        ("https://[::1]:8000/idx", "https://[::1]:8000/idx/"),
-        ("https://example.com/idx#frag", "https://example.com/idx/"),
-    ] {
-        assert_eq!(
-            normalize_index_key(url).unwrap(),
-            expected,
-            "url {url:?} must normalize to {expected:?}"
-        );
-    }
-}
-
-#[test]
-fn normalize_rejects_non_http_query_and_userinfo() {
-    for url in [
-        "file:///tmp/idx",
-        "ftp://example.com/idx",
-        "not a url",
-        "https://example.com/idx?token=x",
-        "https://user:pass@example.com/idx",
-        "https://user@example.com/idx",
-    ] {
-        assert!(
-            matches!(
-                normalize_index_key(url),
-                Err(CredentialStoreError::InvalidIndexUrl(_))
-            ),
-            "url {url:?} must be rejected"
-        );
-    }
-}
-
-#[test]
-fn normalize_errors_never_echo_an_embedded_password() {
-    // One URL per error branch that can carry userinfo: the userinfo
-    // rejection, the scheme rejection, and the parse failure (a space in
-    // the host). These messages reach stderr and CI logs, so the password
-    // must never appear in them.
-    for url in [
-        "https://user:hunter2@example.com/idx",
-        "ftp://user:hunter2@example.com/idx",
-        "https://user:hunter2@exa mple.com/idx",
-    ] {
-        let err = normalize_index_key(url).unwrap_err();
-        let message = err.to_string();
-        assert!(
-            !message.contains("hunter2") && !message.contains("user:"),
-            "url {url:?} leaked userinfo: {message}"
-        );
-        assert!(
-            message.contains("<redacted>@"),
-            "url {url:?} must show the redaction marker: {message}"
         );
     }
 }

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -24,27 +24,15 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
 }
 
 #[test]
-fn blob_round_trip() {
+fn blob_round_trip_and_version_field() {
     let mut with_expiry = record("https://example.com/idx/", "tok-1");
     with_expiry.expires_at = Some(Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap());
     let blob = CredentialBlob::new(vec![with_expiry, record("https://other.example/", "tok-2")]);
     let raw = serialize_blob(&blob).unwrap();
-    let parsed = parse_blob(&raw).unwrap();
-    assert_eq!(parsed, blob);
-}
-
-#[test]
-fn blob_serializes_version_field() {
-    let raw = serialize_blob(&CredentialBlob::empty()).unwrap();
     let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
     assert_eq!(value["version"], serde_json::json!(BLOB_VERSION));
-}
-
-#[test]
-fn blob_omits_absent_expiry() {
-    let blob = CredentialBlob::new(vec![record("https://example.com/", "tok")]);
-    let raw = serialize_blob(&blob).unwrap();
-    assert!(!raw.contains("expires_at"));
+    let parsed = parse_blob(&raw).unwrap();
+    assert_eq!(parsed, blob);
 }
 
 #[test]
@@ -74,9 +62,10 @@ fn parse_tolerates_unknown_fields_and_round_trips_them() {
 }
 
 #[test]
-fn parse_accepts_a_blob_written_before_the_identity_fields() {
-    // A blob written before `subject` / `token_name` / `token_prefix`
-    // existed (still version 1) must parse, with the new fields absent.
+fn parse_accepts_a_blob_written_before_the_newer_fields() {
+    // A blob written before `subject` / `token_name` / `token_prefix` /
+    // `validated` existed (still version 1) must parse, with the newer
+    // fields absent and the absent claim reading as "not validated".
     let raw = r#"{
         "version": 1,
         "credentials": [{
@@ -93,6 +82,7 @@ fn parse_accepts_a_blob_written_before_the_identity_fields() {
     assert_eq!(record.subject, None);
     assert_eq!(record.token_name, None);
     assert_eq!(record.token_prefix, None);
+    assert!(record.validated.is_empty());
     assert!(record.expires_at.is_some());
     assert!(record.extra.is_empty());
 }
@@ -117,34 +107,6 @@ fn identity_fields_round_trip() {
 }
 
 #[test]
-fn blob_omits_an_empty_validated_list() {
-    let blob = CredentialBlob::new(vec![record("https://example.com/", "tok")]);
-    let raw = serialize_blob(&blob).unwrap();
-    assert!(!raw.contains("validated"));
-}
-
-#[test]
-fn parse_accepts_a_blob_written_before_the_validated_field() {
-    // A blob written before `validated` existed (still version 1) must
-    // parse, and the absent claim reads as "not validated".
-    let raw = r#"{
-        "version": 1,
-        "credentials": [{
-            "key": "https://example.com/",
-            "globs": ["https://example.com/**"],
-            "scheme": "bearer",
-            "secret": "tok",
-            "subject": {"type": "user", "name": "alice"},
-            "token_prefix": "sysand_u_1a2b3c4d"
-        }]
-    }"#;
-    let blob = parse_blob(raw).unwrap();
-    let record = &blob.credentials[0];
-    assert!(record.validated.is_empty());
-    assert!(record.extra.is_empty());
-}
-
-#[test]
 fn parse_fails_closed_on_unknown_version() {
     let raw = r#"{"version": 2, "credentials": []}"#;
     let err = parse_blob(raw).unwrap_err();
@@ -159,73 +121,40 @@ fn parse_fails_closed_on_garbage() {
             matches!(err, CredentialStoreError::Unreadable),
             "input {garbage:?} must fail closed"
         );
-        assert_eq!(
-            err.to_string(),
-            "credential store unreadable; remove the `sysand` keyring entry to reset"
-        );
-    }
-}
-
-#[test]
-fn normalize_adds_trailing_slash() {
-    assert_eq!(
-        normalize_index_key("https://example.com/idx").unwrap(),
-        "https://example.com/idx/"
-    );
-    assert_eq!(
-        normalize_index_key("https://example.com").unwrap(),
-        "https://example.com/"
-    );
-}
-
-#[test]
-fn normalize_keeps_existing_trailing_slash() {
-    assert_eq!(
-        normalize_index_key("https://example.com/idx/").unwrap(),
-        "https://example.com/idx/"
-    );
-}
-
-#[test]
-fn normalize_lowercases_host_and_strips_default_port() {
-    assert_eq!(
-        normalize_index_key("HTTPS://EXAMPLE.com:443/Idx").unwrap(),
-        "https://example.com/Idx/"
-    );
-}
-
-#[test]
-fn normalize_keeps_explicit_port_and_ipv6_literal() {
-    assert_eq!(
-        normalize_index_key("https://[::1]:8000/idx").unwrap(),
-        "https://[::1]:8000/idx/"
-    );
-}
-
-#[test]
-fn normalize_drops_fragment() {
-    assert_eq!(
-        normalize_index_key("https://example.com/idx#frag").unwrap(),
-        "https://example.com/idx/"
-    );
-}
-
-#[test]
-fn normalize_rejects_non_http_schemes() {
-    for url in ["file:///tmp/idx", "ftp://example.com/idx", "not a url"] {
         assert!(
-            matches!(
-                normalize_index_key(url),
-                Err(CredentialStoreError::InvalidIndexUrl(_))
-            ),
-            "url {url:?} must be rejected"
+            err.to_string()
+                .contains("remove the `sysand` keyring entry"),
+            "message must point at the reset: {err}"
         );
     }
 }
 
 #[test]
-fn normalize_rejects_query_and_userinfo() {
+fn normalize_canonicalizes_accepted_urls() {
+    // Trailing slash added/kept, host lowercased, default port stripped,
+    // explicit port and IPv6 literal kept, fragment dropped.
+    for (url, expected) in [
+        ("https://example.com/idx", "https://example.com/idx/"),
+        ("https://example.com", "https://example.com/"),
+        ("https://example.com/idx/", "https://example.com/idx/"),
+        ("HTTPS://EXAMPLE.com:443/Idx", "https://example.com/Idx/"),
+        ("https://[::1]:8000/idx", "https://[::1]:8000/idx/"),
+        ("https://example.com/idx#frag", "https://example.com/idx/"),
+    ] {
+        assert_eq!(
+            normalize_index_key(url).unwrap(),
+            expected,
+            "url {url:?} must normalize to {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn normalize_rejects_non_http_query_and_userinfo() {
     for url in [
+        "file:///tmp/idx",
+        "ftp://example.com/idx",
+        "not a url",
         "https://example.com/idx?token=x",
         "https://user:pass@example.com/idx",
         "https://user@example.com/idx",

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -5,7 +5,8 @@ use chrono::{TimeZone, Utc};
 
 use super::{
     BLOB_VERSION, CredentialBlob, CredentialRecord, CredentialScheme, CredentialStoreError,
-    CredentialSubject, normalize_index_key, parse_blob, serialize_blob,
+    CredentialSubject, SubjectKind, ValidatedSurface, normalize_index_key, parse_blob,
+    serialize_blob,
 };
 
 fn record(key: &str, secret: &str) -> CredentialRecord {
@@ -28,7 +29,7 @@ fn blob_round_trip_and_version_field() {
     let mut with_expiry = record("https://example.com/idx/", "tok-1");
     with_expiry.expires_at = Some(Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap());
     let blob = CredentialBlob::new(vec![with_expiry, record("https://other.example/", "tok-2")]);
-    let raw = serialize_blob(&blob).unwrap();
+    let raw = serialize_blob(&blob);
     let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
     assert_eq!(value["version"], serde_json::json!(BLOB_VERSION));
     let parsed = parse_blob(&raw).unwrap();
@@ -56,7 +57,7 @@ fn parse_tolerates_unknown_fields_and_round_trips_them() {
     );
     assert_eq!(blob.extra["future_top_level"], serde_json::json!(true));
     // A read-modify-write must not drop fields a newer sysand wrote.
-    let rewritten = serialize_blob(&blob).unwrap();
+    let rewritten = serialize_blob(&blob);
     assert!(rewritten.contains("future_top_level"));
     assert!(rewritten.contains("future_record_field"));
 }
@@ -91,14 +92,14 @@ fn parse_accepts_a_blob_written_before_the_newer_fields() {
 fn identity_fields_round_trip() {
     let mut with_identity = record("https://example.com/idx/", "tok");
     with_identity.subject = Some(CredentialSubject {
-        kind: "user".to_string(),
+        kind: SubjectKind::User,
         name: "alice".to_string(),
     });
     with_identity.token_name = Some("laptop".to_string());
     with_identity.token_prefix = Some("sysand_u_1a2b3c4d".to_string());
-    with_identity.validated = vec!["read".to_string(), "api".to_string()];
+    with_identity.validated = vec![ValidatedSurface::Read, ValidatedSurface::Api];
     let blob = CredentialBlob::new(vec![with_identity]);
-    let raw = serialize_blob(&blob).unwrap();
+    let raw = serialize_blob(&blob);
     // `kind` serializes under the protocol's `type` key.
     assert!(raw.contains(r#""subject":{"type":"user","name":"alice"}"#));
     // The validation claim serializes compactly.
@@ -107,10 +108,67 @@ fn identity_fields_round_trip() {
 }
 
 #[test]
-fn parse_fails_closed_on_unknown_version() {
+fn parse_fails_closed_on_unknown_version_with_a_dedicated_error() {
+    // An unknown version is not corruption: the dedicated error names
+    // both versions and never suggests resetting the store.
     let raw = r#"{"version": 2, "credentials": []}"#;
     let err = parse_blob(raw).unwrap_err();
-    assert!(matches!(err, CredentialStoreError::Unreadable));
+    assert!(matches!(
+        err,
+        CredentialStoreError::UnsupportedBlobVersion {
+            found: 2,
+            expected: BLOB_VERSION,
+        }
+    ));
+    let message = err.to_string();
+    assert!(
+        message.contains("version 2") && message.contains("supports version 1"),
+        "message must name both versions: {message}"
+    );
+    assert!(
+        !message.contains("remove"),
+        "must not suggest a reset: {message}"
+    );
+}
+
+#[test]
+fn unknown_subject_kind_and_surface_round_trip_unchanged() {
+    // Values a newer server or sysand wrote must parse as `Other` and
+    // survive an older binary's read-modify-write byte-for-byte.
+    let raw = r#"{
+        "version": 1,
+        "credentials": [{
+            "key": "https://example.com/",
+            "globs": ["https://example.com/**"],
+            "scheme": "bearer",
+            "secret": "tok",
+            "subject": {"type": "robot", "name": "bot-7"},
+            "validated": ["read", "novel-surface"]
+        }]
+    }"#;
+    let blob = parse_blob(raw).unwrap();
+    let record = &blob.credentials[0];
+    assert_eq!(
+        record.subject,
+        Some(CredentialSubject {
+            kind: SubjectKind::Other("robot".to_string()),
+            name: "bot-7".to_string(),
+        })
+    );
+    assert_eq!(
+        record.validated,
+        vec![
+            ValidatedSurface::Read,
+            ValidatedSurface::Other("novel-surface".to_string()),
+        ]
+    );
+    // The canonical string form renders unknown values verbatim.
+    assert_eq!(record.subject.as_ref().unwrap().kind.to_string(), "robot");
+    assert_eq!(record.validated[1].to_string(), "novel-surface");
+    let rewritten = serialize_blob(&blob);
+    assert!(rewritten.contains(r#""subject":{"type":"robot","name":"bot-7"}"#));
+    assert!(rewritten.contains(r#""validated":["read","novel-surface"]"#));
+    assert_eq!(parse_blob(&rewritten).unwrap(), blob);
 }
 
 #[test]

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -4,9 +4,8 @@
 use chrono::{TimeZone, Utc};
 
 use super::{
-    BLOB_VERSION, CredentialBlob, CredentialRecord, CredentialScheme, CredentialStore,
-    CredentialStoreError, CredentialSubject, InMemoryCredentialStore, normalize_index_key,
-    parse_blob, serialize_blob,
+    BLOB_VERSION, CredentialBlob, CredentialRecord, CredentialScheme, CredentialStoreError,
+    CredentialSubject, normalize_index_key, parse_blob, serialize_blob,
 };
 
 fn record(key: &str, secret: &str) -> CredentialRecord {
@@ -263,27 +262,4 @@ fn normalize_errors_never_echo_an_embedded_password() {
             "url {url:?} must show the redaction marker: {message}"
         );
     }
-}
-
-#[test]
-fn in_memory_store_upsert_list_remove() {
-    let mut store = InMemoryCredentialStore::new();
-    assert!(store.list().unwrap().is_empty());
-
-    store.upsert(record("https://a.example/", "tok-a")).unwrap();
-    store.upsert(record("https://b.example/", "tok-b")).unwrap();
-    assert_eq!(store.list().unwrap().len(), 2);
-
-    // Upsert replaces by key without duplicating.
-    store
-        .upsert(record("https://a.example/", "tok-a2"))
-        .unwrap();
-    let records = store.list().unwrap();
-    assert_eq!(records.len(), 2);
-    assert_eq!(records[0].secret, "tok-a2");
-
-    assert!(store.remove("https://a.example/").unwrap());
-    assert!(!store.remove("https://a.example/").unwrap());
-    assert_eq!(store.list().unwrap().len(), 1);
-    assert_eq!(store.list().unwrap()[0].key, "https://b.example/");
 }

--- a/core/src/env/discovery.rs
+++ b/core/src/env/discovery.rs
@@ -234,11 +234,7 @@ pub async fn fetch_index_config<P: HTTPAuthentication>(
 
 /// [`fetch_index_config`], except an absent document (HTTP 404) surfaces
 /// as [`HttpFetchError::BadHttpStatus`] instead of folding into the flat
-/// topology. "Strict" is about observability, not requirement: login's
-/// discovery fetch must see the unauthenticated 404 to decide on its
-/// authenticated retry (a private GitLab answers 404, not 401, when auth
-/// is missing), and then reconstructs the flat topology itself when the
-/// retry confirms the document is genuinely absent.
+/// topology
 pub(crate) async fn fetch_index_config_strict<P: HTTPAuthentication>(
     client: &reqwest_middleware::ClientWithMiddleware,
     auth: &P,

--- a/core/src/env/discovery.rs
+++ b/core/src/env/discovery.rs
@@ -20,6 +20,12 @@ use crate::{
     index_location::{IndexLocation, IndexLocationError, with_trailing_slash},
 };
 
+/// Path of the discovery document under the discovery root. Shared with
+/// login's authenticated discovery retry
+/// (`crate::commands::auth`), which fetches the same URL with a forced
+/// bearer.
+pub(crate) const INDEX_CONFIG_PATH: &str = "sysand-index-config.json";
+
 const INDEX_PATH: &str = "index.json";
 const VERSIONS_PATH: &str = "versions.json";
 const KPAR_FILE: &str = "project.kpar";
@@ -129,8 +135,11 @@ impl ResolvedEndpoints {
     }
 }
 
+/// Wire shape of the discovery document. `pub(crate)` so login's
+/// authenticated discovery retry can parse the forced response body and
+/// interpret it through [`resolve_index_config`].
 #[derive(Debug, Deserialize)]
-struct IndexConfigRaw {
+pub(crate) struct IndexConfigRaw {
     #[serde(default)]
     index_root: Option<String>,
     #[serde(default)]
@@ -234,16 +243,39 @@ pub async fn fetch_index_config<P: HTTPAuthentication>(
     auth: &P,
     discovery_root: &IndexLocation,
 ) -> Result<ResolvedEndpoints, DiscoveryError> {
+    fetch_index_config_with(client, auth, discovery_root, MissingPolicy::AllowNotFound).await
+}
+
+/// [`fetch_index_config`], except an absent document (HTTP 404) surfaces
+/// as [`HttpFetchError::BadHttpStatus`] instead of folding into the flat
+/// topology. "Strict" is about observability, not requirement: login's
+/// discovery fetch must see the unauthenticated 404 to decide on its
+/// authenticated retry (a private GitLab answers 404, not 401, when auth
+/// is missing), and then reconstructs the flat topology itself when the
+/// retry confirms the document is genuinely absent.
+pub(crate) async fn fetch_index_config_strict<P: HTTPAuthentication>(
+    client: &reqwest_middleware::ClientWithMiddleware,
+    auth: &P,
+    discovery_root: &IndexLocation,
+) -> Result<ResolvedEndpoints, DiscoveryError> {
+    fetch_index_config_with(client, auth, discovery_root, MissingPolicy::RequirePresent).await
+}
+
+async fn fetch_index_config_with<P: HTTPAuthentication>(
+    client: &reqwest_middleware::ClientWithMiddleware,
+    auth: &P,
+    discovery_root: &IndexLocation,
+    missing: MissingPolicy,
+) -> Result<ResolvedEndpoints, DiscoveryError> {
     // `IndexLocation` enforces its own invariants at construction — a
     // plain root is already an absolute HTTP(S) URL, without userinfo, and
     // with a trailing slash so relative-path resolution treats it as a
     // directory — so no normalization is needed here.
     let discovery_location = discovery_root.clone();
 
-    let config_url = discovery_location.resolve(["sysand-index-config.json"]);
+    let config_url = discovery_location.resolve([INDEX_CONFIG_PATH]);
 
-    let parsed: Option<IndexConfigRaw> =
-        fetch_json(client, auth, &config_url, MissingPolicy::AllowNotFound).await?;
+    let parsed: Option<IndexConfigRaw> = fetch_json(client, auth, &config_url, missing).await?;
 
     let Some(raw) = parsed else {
         let endpoints = ResolvedEndpoints::flat(discovery_location);
@@ -251,6 +283,18 @@ pub async fn fetch_index_config<P: HTTPAuthentication>(
         return Ok(endpoints);
     };
 
+    resolve_index_config(raw, &config_url, discovery_location)
+}
+
+/// Interpret a parsed discovery document fetched from `config_url` into
+/// the resolved endpoints, validating the URL shapes it supplies.
+/// `pub(crate)` so login's authenticated discovery retry can interpret a
+/// forced-fetch response through exactly the same rules.
+pub(crate) fn resolve_index_config(
+    raw: IndexConfigRaw,
+    config_url: &url::Url,
+    discovery_location: IndexLocation,
+) -> Result<ResolvedEndpoints, DiscoveryError> {
     // Parse a supplied field value as a plain base URL.
     // `url::Url::parse` on a relative input (e.g. `"/index/"`) returns
     // `Err(RelativeUrlWithoutBase)` — map that specifically to
@@ -275,7 +319,7 @@ pub async fn fetch_index_config<P: HTTPAuthentication>(
             }
         };
         validate_http_base_url_shape(&parsed)
-            .map_err(|error| discovery_shape_error(&config_url, field, &parsed, error))?;
+            .map_err(|error| discovery_shape_error(config_url, field, &parsed, error))?;
         Ok(with_trailing_slash(parsed))
     };
 

--- a/core/src/env/discovery.rs
+++ b/core/src/env/discovery.rs
@@ -20,10 +20,7 @@ use crate::{
     index_location::{IndexLocation, IndexLocationError, with_trailing_slash},
 };
 
-/// Path of the discovery document under the discovery root. Shared with
-/// login's authenticated discovery retry
-/// (`crate::commands::auth`), which fetches the same URL with a forced
-/// bearer.
+/// Path of the discovery document under the discovery root
 pub(crate) const INDEX_CONFIG_PATH: &str = "sysand-index-config.json";
 
 const INDEX_PATH: &str = "index.json";

--- a/core/src/env/discovery.rs
+++ b/core/src/env/discovery.rs
@@ -39,6 +39,14 @@ pub struct ResolvedEndpoints {
     /// does not advertise `api_root` is read-only from this client's
     /// point of view.
     pub api_root: Option<url::Url>,
+    /// Whether the discovery document explicitly supplied `api_root`, as
+    /// opposed to the runtime default (a plain discovery root doubling as
+    /// `api_root`, including the absent-document [`ResolvedEndpoints::flat`]
+    /// case). When true, `api_root` is always `Some`. Consumed by
+    /// credential validation (design/credential-storage.md section 5): only
+    /// an advertised API surface is probed, so a static plain-URL index is
+    /// never phantom-probed for an API it does not have.
+    pub api_root_advertised: bool,
 }
 
 impl ResolvedEndpoints {
@@ -50,6 +58,7 @@ impl ResolvedEndpoints {
         Self {
             index_root: discovery_root,
             api_root: None,
+            api_root_advertised: false,
         }
     }
 
@@ -287,6 +296,7 @@ pub async fn fetch_index_config<P: HTTPAuthentication>(
     // The API surface exists only when the discovery document advertises
     // `api_root`; a plain discovery root is not an implicit API (see the
     // `ResolvedEndpoints::api_root` field doc).
+    let api_root_advertised = raw.api_root.is_some();
     let api_root = match raw.api_root {
         Some(s) => Some(parse_base_url("api_root", s)?),
         None => None,
@@ -295,6 +305,7 @@ pub async fn fetch_index_config<P: HTTPAuthentication>(
     let endpoints = ResolvedEndpoints {
         index_root,
         api_root,
+        api_root_advertised,
     };
     log_resolved(&endpoints);
     Ok(endpoints)

--- a/core/src/env/discovery.rs
+++ b/core/src/env/discovery.rs
@@ -45,14 +45,6 @@ pub struct ResolvedEndpoints {
     /// does not advertise `api_root` is read-only from this client's
     /// point of view.
     pub api_root: Option<url::Url>,
-    /// Whether the discovery document explicitly supplied `api_root`, as
-    /// opposed to the runtime default (a plain discovery root doubling as
-    /// `api_root`, including the absent-document [`ResolvedEndpoints::flat`]
-    /// case). When true, `api_root` is always `Some`. Consumed by
-    /// credential validation (design/credential-storage.md section 5): only
-    /// an advertised API surface is probed, so a static plain-URL index is
-    /// never phantom-probed for an API it does not have.
-    pub api_root_advertised: bool,
 }
 
 impl ResolvedEndpoints {
@@ -64,7 +56,6 @@ impl ResolvedEndpoints {
         Self {
             index_root: discovery_root,
             api_root: None,
-            api_root_advertised: false,
         }
     }
 
@@ -340,7 +331,6 @@ pub(crate) fn resolve_index_config(
     // The API surface exists only when the discovery document advertises
     // `api_root`; a plain discovery root is not an implicit API (see the
     // `ResolvedEndpoints::api_root` field doc).
-    let api_root_advertised = raw.api_root.is_some();
     let api_root = match raw.api_root {
         Some(s) => Some(parse_base_url("api_root", s)?),
         None => None,
@@ -349,7 +339,6 @@ pub(crate) fn resolve_index_config(
     let endpoints = ResolvedEndpoints {
         index_root,
         api_root,
-        api_root_advertised,
     };
     log_resolved(&endpoints);
     Ok(endpoints)

--- a/core/src/env/discovery.rs
+++ b/core/src/env/discovery.rs
@@ -123,9 +123,7 @@ impl ResolvedEndpoints {
     }
 }
 
-/// Wire shape of the discovery document. `pub(crate)` so login's
-/// authenticated discovery retry can parse the forced response body and
-/// interpret it through [`resolve_index_config`].
+/// Wire shape of the discovery document.
 #[derive(Debug, Deserialize)]
 pub(crate) struct IndexConfigRaw {
     #[serde(default)]

--- a/core/src/index_location.rs
+++ b/core/src/index_location.rs
@@ -217,10 +217,13 @@ impl IndexUrlTemplate {
         // Rewrite the prefix into the text `url::Url` serializes it as
         // (lowercase scheme and host, punycode, default port dropped,
         // explicit root `/`), so `Display` output is canonical. The probe
-        // goes on the prefix alone: with the suffix included, literal
-        // probe-like suffix text or a `..` suffix segment could move the
-        // cut. URL serialization keeps the probe's unreserved characters
-        // and `%20` escape verbatim, so the parsed text ends with it.
+        // keeps the prefix's end mid-segment, where it sits in every
+        // expansion: parsed bare, a prefix ending in `.`, `..`, or a
+        // space hits end-of-URL rules (dot-segment resolution, trailing
+        // whitespace trimming) that never apply to the template. The
+        // probe goes on the prefix alone so suffix text cannot move the
+        // cut, and URL serialization keeps the probe's unreserved
+        // characters and `%20` escape verbatim.
         let probe = utf8_percent_encode("pr obe", PATH_ENCODE_SET).to_string();
         let normalized = url::Url::parse(&format!("{}{probe}", template.prefix))
             .expect("BUG: the prefix of a validated template followed by the probe parses");

--- a/core/src/index_location.rs
+++ b/core/src/index_location.rs
@@ -226,6 +226,15 @@ impl IndexUrlTemplate {
         out
     }
 
+    /// The literal template text before the placeholder. Support for
+    /// credential glob derivation (`commands::auth`), not general API: the
+    /// prefix is raw text, not a valid URL on its own. Gated like its only
+    /// consumer so feature subsets stay dead-code-free.
+    #[cfg(all(feature = "filesystem", feature = "networking"))]
+    pub(crate) fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
     /// Substitute the relative index path `segments` (each percent-encoded
     /// according to the placeholder spelling) into the template. Infallible:
     /// the template was validated at construction and the segments encode to
@@ -430,7 +439,7 @@ fn validate_url_shape(reported: &str, url: &url::Url) -> Result<(), IndexLocatio
 }
 
 /// Whether `s` uses index URL template syntax (contains a brace).
-fn is_template_syntax(s: &str) -> bool {
+pub(crate) fn is_template_syntax(s: &str) -> bool {
     s.contains(['{', '}'])
 }
 

--- a/core/src/index_location.rs
+++ b/core/src/index_location.rs
@@ -156,7 +156,11 @@ impl PathEncoding {
 /// A URL template with exactly one `{path}` or `{path_raw}` placeholder,
 /// validated at construction. Stored as the text on either side of the
 /// placeholder rather than as a `url::Url` because `url::Url` percent-encodes
-/// `{` or `}` on parse, which would corrupt the placeholder.
+/// `{` or `}` on parse, which would corrupt the placeholder. The prefix is
+/// normalized at parse to the text `url::Url` serializes it as (lowercase
+/// scheme and host, punycode, default port dropped, explicit root `/`), so
+/// different spellings of one template `Display` identically; the suffix
+/// stays as written.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexUrlTemplate {
     prefix: String,
@@ -169,7 +173,8 @@ impl IndexUrlTemplate {
     /// one `{path}` or `{path_raw}` placeholder, no other `{...}` tokens
     /// or stray braces, no fragment, and must expand to an absolute
     /// HTTP(S) URL without userinfo, with the placeholder in the path or
-    /// query.
+    /// query. The literal prefix is normalized to canonical URL text, so
+    /// `Display` renders one canonical spelling per template.
     fn parse(raw: &str) -> Result<Self, IndexLocationError> {
         let boxed_url = || -> Box<str> { raw.into() };
 
@@ -186,7 +191,7 @@ impl IndexUrlTemplate {
         let split = raw
             .find(placeholder)
             .expect("BUG: validate_placeholders guarantees exactly one placeholder");
-        let template = Self {
+        let mut template = Self {
             prefix: raw[..split].to_owned(),
             suffix: raw[split + placeholder.len()..].to_owned(),
             encoding,
@@ -209,6 +214,22 @@ impl IndexUrlTemplate {
         };
         validate_url_shape(raw, &expanded)?;
 
+        // Rewrite the prefix into the text `url::Url` serializes it as
+        // (lowercase scheme and host, punycode, default port dropped,
+        // explicit root `/`), so `Display` output is canonical. The probe
+        // goes on the prefix alone: with the suffix included, literal
+        // probe-like suffix text or a `..` suffix segment could move the
+        // cut. URL serialization keeps the probe's unreserved characters
+        // and `%20` escape verbatim, so the parsed text ends with it.
+        let probe = utf8_percent_encode("pr obe", PATH_ENCODE_SET).to_string();
+        let normalized = url::Url::parse(&format!("{}{probe}", template.prefix))
+            .expect("BUG: the prefix of a validated template followed by the probe parses");
+        template.prefix = normalized
+            .as_str()
+            .strip_suffix(&probe)
+            .expect("BUG: URL serialization preserves the probe text")
+            .to_owned();
+
         Ok(template)
     }
 
@@ -226,10 +247,11 @@ impl IndexUrlTemplate {
         out
     }
 
-    /// The literal template text before the placeholder. Support for
-    /// credential glob derivation (`commands::auth`), not general API: the
-    /// prefix is raw text, not a valid URL on its own. Gated like its only
-    /// consumer so feature subsets stay dead-code-free.
+    /// The literal template text before the placeholder, in normalized
+    /// form. Support for credential glob derivation (`commands::auth`),
+    /// not general API: the prefix is normalized URL text but not a
+    /// complete URL on its own (it can end mid-segment or mid-query).
+    /// Gated like its only consumer so feature subsets stay dead-code-free.
     #[cfg(all(feature = "filesystem", feature = "networking"))]
     pub(crate) fn prefix(&self) -> &str {
         &self.prefix

--- a/core/src/index_location.rs
+++ b/core/src/index_location.rs
@@ -224,14 +224,17 @@ impl IndexUrlTemplate {
         // probe goes on the prefix alone so suffix text cannot move the
         // cut, and URL serialization keeps the probe's unreserved
         // characters and `%20` escape verbatim.
-        let probe = utf8_percent_encode("pr obe", PATH_ENCODE_SET).to_string();
+        let probe = "pr%20obe";
         let normalized = url::Url::parse(&format!("{}{probe}", template.prefix))
             .expect("BUG: the prefix of a validated template followed by the probe parses");
-        template.prefix = normalized
-            .as_str()
-            .strip_suffix(&probe)
-            .expect("BUG: URL serialization preserves the probe text")
-            .to_owned();
+        template.prefix = normalized.into();
+        debug_assert!(
+            template.prefix.ends_with(probe),
+            "BUG: URL serialization preserves the probe text"
+        );
+        template
+            .prefix
+            .truncate(template.prefix.len() - probe.len());
 
         Ok(template)
     }

--- a/core/src/index_location.rs
+++ b/core/src/index_location.rs
@@ -480,7 +480,7 @@ fn validate_url_shape(reported: &str, url: &url::Url) -> Result<(), IndexLocatio
 }
 
 /// Whether `s` uses index URL template syntax (contains a brace).
-pub(crate) fn is_template_syntax(s: &str) -> bool {
+fn is_template_syntax(s: &str) -> bool {
     s.contains(['{', '}'])
 }
 

--- a/core/src/index_location.rs
+++ b/core/src/index_location.rs
@@ -118,8 +118,8 @@ pub enum IndexLocationError {
     )]
     Userinfo { url: Box<str> },
     #[error(
-        "index URL template `{url}` includes a `#` fragment;\n\
-         fragments are never sent to the server and are not allowed in templates"
+        "index URL `{url}` includes a `#` fragment;\n\
+         fragments are never sent to the server and are not allowed in index locations"
     )]
     Fragment { url: Box<str> },
 }
@@ -176,7 +176,7 @@ impl IndexUrlTemplate {
     /// query. The literal prefix is normalized to canonical URL text, so
     /// `Display` renders one canonical spelling per template.
     fn parse(raw: &str) -> Result<Self, IndexLocationError> {
-        let boxed_url = || -> Box<str> { raw.into() };
+        let boxed_url = || redact_userinfo(raw);
 
         let encoding = validate_placeholders(raw)?;
 
@@ -306,8 +306,8 @@ impl IndexLocation {
     /// URLs are now template-syntax errors.)
     ///
     /// Both variants enforce the same validity invariants at construction:
-    /// an absolute HTTP(S) URL without userinfo. Later resolution is thus
-    /// infallible.
+    /// an absolute HTTP(S) URL without userinfo or fragment. Later
+    /// resolution is thus infallible.
     ///
     /// [RFC 3986 §2]: https://www.rfc-editor.org/rfc/rfc3986#section-2
     pub fn parse(s: &str) -> Result<Self, IndexLocationError> {
@@ -323,17 +323,21 @@ impl IndexLocation {
         if s.contains('%') {
             let lower = s.to_ascii_lowercase();
             if lower.contains("%7bpath%7d") || lower.contains("%7bpath_raw%7d") {
-                return Err(IndexLocationError::PreEncodedPlaceholder { url: s.into() });
+                return Err(IndexLocationError::PreEncodedPlaceholder {
+                    url: redact_userinfo(s),
+                });
             }
         }
         let url = match url::Url::parse(s) {
             Ok(url) => url,
             Err(url::ParseError::RelativeUrlWithoutBase) => {
-                return Err(IndexLocationError::RelativeUrl { url: s.into() });
+                return Err(IndexLocationError::RelativeUrl {
+                    url: redact_userinfo(s),
+                });
             }
             Err(source) => {
                 return Err(IndexLocationError::InvalidUrl {
-                    url: s.into(),
+                    url: redact_userinfo(s),
                     source,
                 });
             }
@@ -401,7 +405,7 @@ impl FromStr for IndexLocation {
 /// that braces are balanced and non-nested, and that exactly one
 /// placeholder occurs. Returns the encoding the placeholder selects.
 fn validate_placeholders(raw: &str) -> Result<PathEncoding, IndexLocationError> {
-    let boxed_url = || -> Box<str> { raw.into() };
+    let boxed_url = || redact_userinfo(raw);
     let mut found: Vec<PathEncoding> = Vec::new();
     let mut rest = raw;
     while let Some(open) = rest.find(['{', '}']) {
@@ -446,18 +450,27 @@ fn validate_placeholders(raw: &str) -> Result<PathEncoding, IndexLocationError> 
 }
 
 /// Enforce the shared index-location invariant on `url`: an absolute
-/// HTTP(S) URL without userinfo. `reported` is the string named in any
-/// error (the template text for a template, the URL itself for a root).
+/// HTTP(S) URL without userinfo or fragment. `reported` is the string
+/// named in any error (the template text for a template, the URL itself
+/// for a root).
 fn validate_url_shape(reported: &str, url: &url::Url) -> Result<(), IndexLocationError> {
     if !matches!(url.scheme(), "http" | "https") {
         return Err(IndexLocationError::UnsupportedScheme {
-            url: reported.into(),
+            url: redact_userinfo(reported),
             scheme: url.scheme().into(),
         });
     }
     if !url.username().is_empty() || url.password().is_some() {
         return Err(IndexLocationError::Userinfo {
-            url: reported.into(),
+            url: redact_userinfo(reported),
+        });
+    }
+    // Fragments are never sent to the server; on an index location one
+    // is always a mistake. Templates reject `#` before parsing (it would
+    // swallow the placeholder), so this arm fires for roots.
+    if url.fragment().is_some() {
+        return Err(IndexLocationError::Fragment {
+            url: redact_userinfo(reported),
         });
     }
     Ok(())
@@ -466,6 +479,28 @@ fn validate_url_shape(reported: &str, url: &url::Url) -> Result<(), IndexLocatio
 /// Whether `s` uses index URL template syntax (contains a brace).
 pub(crate) fn is_template_syntax(s: &str) -> bool {
     s.contains(['{', '}'])
+}
+
+/// Render a possibly malformed URL for an error message with any userinfo
+/// replaced by `<redacted>`, so an embedded password never reaches stderr
+/// or CI logs. String-based on purpose: it must work for inputs
+/// `url::Url::parse` rejected.
+fn redact_userinfo(raw: &str) -> Box<str> {
+    // The authority runs from after any scheme separator to the first
+    // `/`, `?`, or `#`; userinfo is everything up to the last `@` in it.
+    let authority_start = raw.find("://").map_or(0, |idx| idx + 3);
+    let authority_end = raw[authority_start..]
+        .find(['/', '?', '#'])
+        .map_or(raw.len(), |idx| authority_start + idx);
+    match raw[authority_start..authority_end].rfind('@') {
+        Some(at) => format!(
+            "{}<redacted>@{}",
+            &raw[..authority_start],
+            &raw[authority_start + at + 1..]
+        )
+        .into(),
+        None => raw.into(),
+    }
 }
 
 /// Return `url` with a guaranteed trailing slash on its path so that

--- a/core/src/index_location_tests.rs
+++ b/core/src/index_location_tests.rs
@@ -203,6 +203,48 @@ fn template_fragment_is_rejected() {
 }
 
 #[test]
+fn root_fragment_is_rejected() {
+    // Same invariant as templates: a fragment is never sent to the
+    // server, so on an index location it is always a mistake.
+    assert!(matches!(
+        IndexLocation::parse("https://example.org/idx#frag"),
+        Err(IndexLocationError::Fragment { .. })
+    ));
+}
+
+#[test]
+fn root_userinfo_is_rejected() {
+    assert!(matches!(
+        IndexLocation::parse("https://user:pass@example.org/idx"),
+        Err(IndexLocationError::Userinfo { .. })
+    ));
+}
+
+#[test]
+fn parse_errors_never_echo_an_embedded_password() {
+    // One URL per error branch that can carry userinfo: the userinfo
+    // rejection, the scheme rejection, the parse failure (a space in
+    // the host), and the template expansion failure. These messages
+    // reach stderr and CI logs, so the password must never appear.
+    for url in [
+        "https://user:hunter2@example.com/idx",
+        "ftp://user:hunter2@example.com/idx",
+        "https://user:hunter2@exa mple.com/idx",
+        "https://user:hunter2@example.com/files/{path}",
+    ] {
+        let message = IndexLocation::parse(url).unwrap_err().to_string();
+        assert!(
+            !message.contains("hunter2") && !message.contains("user:"),
+            "url {url:?} leaked userinfo: {message}"
+        );
+        assert!(
+            message.contains("<redacted>@"),
+            "url {url:?} must show the redaction marker: {message}"
+        );
+    }
+}
+
+#[test]
 fn template_in_host_is_rejected() {
     assert!(matches!(
         IndexLocation::parse("https://{path}.example.org/files"),
@@ -329,5 +371,13 @@ fn display_round_trips_templates_and_normalizes_roots() {
             .unwrap()
             .to_string(),
         "https://example.org/index/"
+    );
+    // A root query is kept; the trailing slash lands on the path, so
+    // resolved index paths append before the query.
+    assert_eq!(
+        IndexLocation::parse("HTTPS://Example.ORG:443/index?ref=main")
+            .unwrap()
+            .to_string(),
+        "https://example.org/index/?ref=main"
     );
 }

--- a/core/src/index_location_tests.rs
+++ b/core/src/index_location_tests.rs
@@ -272,6 +272,24 @@ fn template_prefix_normalizes_at_parse() {
             "http://EXAMPLE.com:80/a/{path}/../x?Y=Z",
             "http://example.com/a/{path}/../x?Y=Z",
         ),
+        // A prefix ending in `..` or `.` is mid-segment text in every
+        // expansion (`..{path}` names a `..foo` segment), so it must
+        // survive normalization instead of resolving as a dot segment.
+        (
+            "https://example.com/a/..{path}",
+            "https://example.com/a/..{path}",
+        ),
+        (
+            "https://example.com/a/.{path}.json",
+            "https://example.com/a/.{path}.json",
+        ),
+        // A space before the placeholder is likewise mid-segment: it
+        // normalizes to `%20` rather than being trimmed as trailing
+        // whitespace.
+        (
+            "https://example.com/a {path}",
+            "https://example.com/a%20{path}",
+        ),
     ] {
         let location = IndexLocation::parse(spelled).unwrap();
         assert_eq!(location.to_string(), canonical, "for `{spelled}`");

--- a/core/src/index_location_tests.rs
+++ b/core/src/index_location_tests.rs
@@ -235,6 +235,72 @@ fn schemeless_template_is_rejected_as_relative() {
 }
 
 #[test]
+fn template_prefix_normalizes_at_parse() {
+    // The literal prefix is rewritten to the text `url::Url` serializes,
+    // so `Display` renders one canonical spelling per template; the
+    // placeholder and suffix stay verbatim.
+    for (spelled, canonical) in [
+        // Host case and the default port.
+        (
+            "HTTPS://GitLab.COM:443/files/{path}/raw?ref=main",
+            "https://gitlab.com/files/{path}/raw?ref=main",
+        ),
+        // A path-less prefix gains the explicit root `/`.
+        (
+            "https://example.com?x={path}",
+            "https://example.com/?x={path}",
+        ),
+        // Mid-segment placeholder: the cut lands exactly where the
+        // substituted text will begin.
+        (
+            "https://Example.com/files/v{path}.json",
+            "https://example.com/files/v{path}.json",
+        ),
+        // IDN host to punycode.
+        (
+            "https://bücher.example/{path_raw}",
+            "https://xn--bcher-kva.example/{path_raw}",
+        ),
+        // Literal text aliasing the internal probe's encoding does not
+        // confuse the cut.
+        (
+            "https://example.com/pr%20obe/{path}?x=pr%20obe",
+            "https://example.com/pr%20obe/{path}?x=pr%20obe",
+        ),
+        // The suffix stays as written, whatever it contains.
+        (
+            "http://EXAMPLE.com:80/a/{path}/../x?Y=Z",
+            "http://example.com/a/{path}/../x?Y=Z",
+        ),
+    ] {
+        let location = IndexLocation::parse(spelled).unwrap();
+        assert_eq!(location.to_string(), canonical, "for `{spelled}`");
+        // Idempotent: parsing the canonical text reproduces it.
+        assert_eq!(
+            IndexLocation::parse(canonical).unwrap().to_string(),
+            canonical,
+            "reparsing the canonical form of `{spelled}`"
+        );
+    }
+}
+
+#[test]
+fn normalized_template_expands_like_the_spelled_one() {
+    // Prefix normalization must not change where requests go: the
+    // spelled and canonical forms expand to the same URL.
+    let spelled = parse_template("HTTPS://Example.COM:443/files/{path}?ref=main");
+    let canonical = parse_template("https://example.com/files/{path}?ref=main");
+    assert_eq!(
+        spelled.expand(["a b", "c.json"]),
+        canonical.expand(["a b", "c.json"])
+    );
+    assert_eq!(
+        spelled.expand(["a b", "c.json"]).as_str(),
+        "https://example.com/files/a%20b%2Fc.json?ref=main"
+    );
+}
+
+#[test]
 fn display_round_trips_templates_and_normalizes_roots() {
     assert_eq!(
         IndexLocation::parse(GITLAB_TEMPLATE).unwrap().to_string(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod model;
 pub mod auth;
 pub mod config;
 pub mod context;
+pub mod credential_store;
 pub mod env;
 #[cfg(feature = "filesystem")]
 pub mod index;

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -131,6 +131,8 @@ pub enum FsIoError {
     CopyFile(Utf8PathBuf, Utf8PathBuf, io::Error),
     #[error("failed to remove file\n  `{0}`:\n  {1}")]
     RmFile(Utf8PathBuf, io::Error),
+    #[error("failed to lock file\n  `{0}`:\n  {1}")]
+    LockFile(Utf8PathBuf, io::Error),
     #[error("failed to remove directory\n  `{0}`:\n  {1}")]
     RmDir(Utf8PathBuf, io::Error),
     #[error("failed to get path to current directory:\n  {0}")]

--- a/core/src/resolve/net_utils.rs
+++ b/core/src/resolve/net_utils.rs
@@ -77,6 +77,9 @@ impl Display for ReqwestClientBuildError {
 }
 impl Error for ReqwestClientBuildError {}
 
+/// sysand HTTP user agent
+pub(crate) const USER_AGENT: &str = concat!("sysand/", env!("CARGO_PKG_VERSION"));
+
 /// Create a reqwest client. This must be used where possible.
 /// Note that gix manages its own HTTP client, so logs may indicate
 /// duplicate initialization.
@@ -84,11 +87,6 @@ impl Error for ReqwestClientBuildError {}
 /// Relies on `reqwest`'s default redirect behaviour (up to 10
 /// automatic redirects); index clients MUST follow HTTP redirects
 /// on the index URL discovery fetch and on every index resource.
-/// The sysand HTTP user agent (sysand-core's version, pre-existing
-/// behavior; shared with the validation probe client in
-/// `crate::commands::auth`).
-pub(crate) const USER_AGENT: &str = concat!("sysand/", env!("CARGO_PKG_VERSION"));
-
 pub fn create_reqwest_client()
 -> Result<reqwest_middleware::ClientWithMiddleware, ReqwestClientBuildError> {
     let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;

--- a/core/src/resolve/net_utils.rs
+++ b/core/src/resolve/net_utils.rs
@@ -84,11 +84,14 @@ impl Error for ReqwestClientBuildError {}
 /// Relies on `reqwest`'s default redirect behaviour (up to 10
 /// automatic redirects); index clients MUST follow HTTP redirects
 /// on the index URL discovery fetch and on every index resource.
+/// The sysand HTTP user agent (sysand-core's version, pre-existing
+/// behavior; shared with the validation probe client in
+/// `crate::commands::auth`).
+pub(crate) const USER_AGENT: &str = concat!("sysand/", env!("CARGO_PKG_VERSION"));
+
 pub fn create_reqwest_client()
 -> Result<reqwest_middleware::ClientWithMiddleware, ReqwestClientBuildError> {
-    const UA: &str = concat!("sysand/", env!("CARGO_PKG_VERSION"));
-
-    let client = reqwest::Client::builder().user_agent(UA).build()?;
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
 
     Ok(reqwest_middleware::ClientBuilder::new(client).build())
 }

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -16,6 +16,9 @@ pub struct Config {
     pub good: Style,
     pub valid: Style,
     pub invalid: Style,
+    /// De-emphasis for secondary text (for example the sublabels of an
+    /// `auth status` entry).
+    pub dim: Style,
 }
 
 impl Default for Config {
@@ -31,6 +34,7 @@ impl Default for Config {
             good: Style::new(),
             valid: Style::new(),
             invalid: Style::new(),
+            dim: Style::new(),
         }
     }
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -254,3 +254,9 @@ pub fn to_pretty_json_string<T: Serialize>(value: &T) -> String {
 }
 
 pub const SP: char = ' ';
+
+/// Render an expiry timestamp for display, without chrono's sub-second
+/// noise (`11:39:28.149443` reads as `11:39:28`).
+pub fn format_expiry_utc(expires_at: &chrono::DateTime<chrono::Utc>) -> String {
+    expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+}

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -186,7 +186,8 @@ actually tested_, warning about any surface that rejected or was
 unreachable. Refuse only when at least one exercised surface rejected the
 credential and none accepted it. A surface counts as "tested" only if the
 credential was exercised: a _public_ read surface returns 200 without
-sending the credential, so it proves nothing. If nothing exercised the
+sending the credential, so it proves nothing. A 429 response is never a
+verdict; a rate-limited probe counts the surface as not tested. If nothing exercised the
 credential (fully public read with no API, or every probe unreachable),
 store as "stored, not validated".
 

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -356,9 +356,12 @@ logout` removes) may fall back to the default index.
   (their `api_root` is a disjoint plain URL).
 - Each login is one record (`{key, globs, scheme, secret,
 expires_at-if-known}`, plus optional whoami-derived identity fields
-  `subject`, `token_name`, `token_prefix` persisted by a validating login)
-  inside the single keyring blob (§9), so `logout` removes it and `status`
-  shows one login covering N patterns.
+  `subject`, `token_name`, `token_prefix` persisted by a validating login,
+  plus `validated`: the surfaces that exercised and accepted the credential
+  at login, serialized compactly as `["read","api"]` strings and absent for
+  `--no-validation` or nothing-exercised logins) inside the single keyring
+  blob (§9), so `logout` removes it and `status` shows one login covering
+  N patterns.
 - **Discovery changes over time (globs are a login-time boundary).** Reads
   and publish re-fetch discovery live each run, but the stored globs are the
   login-time snapshot and are **not** auto-updated from discovery. This is
@@ -409,8 +412,8 @@ supported; the full transport-security guidance lives in the docs (§13).
   keyring entry (for example `service = "sysand"`, `account =
 "credentials"`) holding a JSON blob: a list of records `{key, globs,
 scheme, secret, expires_at-if-known}` plus optional whoami-derived
-  identity fields (`subject`, `token_name`, `token_prefix`) written by a
-  validating login. Deliberate over a manifest file:
+  identity fields (`subject`, `token_name`, `token_prefix`) and the
+  `validated` surface list (§8), written by a validating login. Deliberate over a manifest file:
   the `keyring` crate cannot portably enumerate entries, and one blob is
   **atomic** (no metadata/secret drift), needs **no file**, and prompts the
   keychain at most once. `login` / `logout` read-modify-write the blob;
@@ -525,11 +528,23 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   authenticate with**, both sources, each entry tagged `Stored` or `Env`
   (right-aligned in the CLI's 12-column status gutter).
   Per stored entry: the key printed in the exact form
-  `sysand auth logout <key>` accepts, covered globs, `subject` and token
+  `sysand auth logout <key>` accepts, the login-time validation claim on
+  the key line (`validated (read)` / `validated (read, api)` from the
+  record's `validated` list, or a warn-styled `not validated` when it is
+  absent, the security-relevant case), covered globs, `subject` and token
   `prefix` (from whoami, if a validating login ran), `expires_at` if
   stored, and whether a `SYSAND_CRED_*` var shadows it, never the secret.
-  Env entries list the variable label and pattern. No `scheme` column in v1
-  (always bearer for stored; env entries may be basic).
+  Multiple stored entries are separated by one blank line. The sublabels
+  (`patterns:`, `subject:`, `token prefix:`, `expires:`) render dim so the
+  values carry the visual weight; `shadowed by:` stays warn-styled. Env
+  entries list the variable label and pattern. A source with nothing to
+  show is omitted rather than announced with a negative; only when neither
+  stored logins nor `SYSAND_CRED_*` variables exist does status print the
+  single line "No credentials configured (no stored logins, no
+  `SYSAND_CRED_*` variables)." The no-usable-keyring note still prints
+  whenever the backend is unusable (it is information, not a negative). No
+  `scheme` column in v1 (always bearer for stored; env entries may be
+  basic).
 - **Re-login:** `auth login` over an existing entry for the same key
   overwrites it, printing "Replacing existing credential for `<index>`"
   before the write; the previous stored token is discarded locally (not

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -269,7 +269,8 @@ Publish's bearer selection uses **source precedence**: env bearer matches
 first, then keyring, never one flat "exactly one match or error" over a
 merged set. Within a source the exactly-one rule stands
 (`AmbiguousPublishBearer` is per-source), with candidates carrying the
-identical token collapsing to one match, like the reads rule in section 9. Env and keyring stay **two maps** (source-tagged, with the selected
+identical token collapsing to one match, like the reads rule in section 9.
+Env and keyring stay **two maps** (source-tagged, with the selected
 bearer's provenance threaded to the failure messages) with a two-stage
 lookup, making the precedence real: a CI `SYSAND_CRED_*` overrides an
 interactive login. The two-leg flow and trusted publishing are otherwise

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -471,9 +471,9 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   treats the blob as empty, which would clobber all stored credentials on the
   next `login`.
 - **Concurrency.** Read-modify-write is guarded by a **cross-process
-  advisory OS file lock** (`flock`/`LockFileEx`, via a crate like
-  `fd-lock`), never an existence-based lock file (those go stale after a
-  crash). The lock file lives in a **per-user** location
+  advisory OS file lock** (`flock`/`LockFileEx`, via the stable
+  `std::fs::File` locking API), never an existence-based lock file (those
+  go stale after a crash). The lock file lives in a **per-user** location
   (`XDG_RUNTIME_DIR`/`XDG_STATE_HOME` on Linux, `%LOCALAPPDATA%` on
   Windows, falling back to the home directory), mode `0600`, never a
   world-writable shared path (lock squatting / symlink games), with a
@@ -727,17 +727,16 @@ capabilities behind cargo features (`filesystem`, `networking`).
   build for wasm. A browser-side store could later implement the same trait
   (bindings/js already has local-storage machinery), but that is not v1 and
   localStorage is not secure storage.
-  - **Vendored dbus.** The Linux Secret Service backend pulls libdbus;
-    build it `vendored` so CI's `clippy --all-features` and contributor
-    machines need no system libdbus headers. Vendoring statically embeds
-    libdbus (dual AFL-2.1 OR GPL-2.0) in shipped binaries; verify with
-    cargo-deny.
-  - **musl exclusion.** The vendored dbus C build does not link on
-    aarch64-musl (missing outline-atomics helpers), and musl targets are
-    containers/CI where a Secret Service never runs. Target-gate the
-    keyring dependency off musl entirely and give `OsKeyringBackend` a
-    musl stub returning the backend-absent error, so the documented
-    `SYSAND_CRED_*` fallback is the behavior there.
+  - **Pure-Rust Secret Service.** keyring 4.x's `v1` feature uses the
+    zbus Secret Service backend on glibc Linux, with no system libdbus
+    (nothing to vendor) and a `crypto-rust` session that keeps openssl out
+    of the tree, so CI's `clippy --all-features` and contributor machines
+    need no system libraries.
+  - **musl exclusion.** musl targets are containers/CI where a Secret
+    Service never runs, so target-gate the keyring dependency off musl
+    entirely and give `OsKeyringBackend` a musl stub returning the
+    backend-absent error; the documented `SYSAND_CRED_*` fallback is the
+    behavior there.
   - **Test seam.** CLI integration tests must never touch the real OS
     keyring (macOS prompts on differently-signed test binaries; CI has no
     Secret Service). Provide a deliberate seam, a debug-build-only env var

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -75,11 +75,12 @@ The collapsed situation space:
 
 Under a `sysand auth` namespace:
 
-| Command                          | Role                                                                            |
-| -------------------------------- | ------------------------------------------------------------------------------- |
-| `sysand auth login [index-url]`  | validated, index-keyed bearer credential (see §5); no URL = the default index   |
-| `sysand auth logout [index-url]` | remove an index login; no URL = the default index (symmetric with `login`)      |
-| `sysand auth status`             | list stored credentials (never secrets), backend, and `SYSAND_CRED_*` shadowing |
+| Command                          | Role                                                                                                                                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sysand auth login [index-url]`  | validated, index-keyed bearer credential (see §5); no URL = the default index                                                                                                         |
+| `sysand auth logout [index-url]` | remove an index login; no URL = the default index (symmetric with `login`)                                                                                                            |
+| `sysand auth status`             | list stored credentials (never secrets), backend, and `SYSAND_CRED_*` shadowing                                                                                                       |
+| `sysand auth whoami [index-url]` | query-only live identity via `v1/whoami` (advertised `api_root` required), with runtime credential selection (env over stored, §7); names the source used; no URL = the default index |
 
 - **Bearer only in v1.** The token is entered via a hidden prompt
   ("Enter token for `<index>`:", neutral wording since the credential may be
@@ -308,6 +309,11 @@ two-leg flow and trusted publishing are otherwise unchanged.
   client clock could false-trip), publish stops before uploading the archive
   and points at `sysand auth login`. The server's `401` remains the real
   authority; the escape hatches are re-login or an env var.
+
+Target-defaulting principle: irreversible remote effects require an
+explicit target (`sysand publish --index` stays required), while
+reversible local effects (an `auth login` writing a record that `auth
+logout` removes) may fall back to the default index.
 
 ## 8. Glob scoping and conflict resolution
 

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -140,29 +140,28 @@ duplicate entries.
 
 ## 5. Validation
 
-Validation is on by default; the CLI flag to disable it is
-`--no-validation`, a presence flag following the repo's `--no-<thing>`
-convention (`--no-lock`, `--no-deps`, ...). The flag spelling and the
-library parameter are independent: core's `do_auth_login` takes
-`validation: Option<bool>` (`None` = the default, validate), the CLI maps
-`--no-validation` to `Some(false)`, and the language bindings expose the
-parameter as a clean optional keyword (`validation: Optional[bool] =
-None`). Both the house-style flag and the bindings ergonomics are kept.
+Login has exactly one behavior, with no opt-out flag or parameter:
+discovery is fetched for glob scoping (with the authenticated retry
+described below), every surface the index supports is probed, and the
+refusal rule decides. A static index has only the read surface; a
+dynamic index adds the API.
 
-- Default (validate): probe every surface the index supports and store
-  unless the credential is rejected everywhere it was actually tested (see
-  the refusal rule below). A static index has only the read surface; a
-  dynamic index adds the API.
-- `--no-validation`: store without any credential probe. Discovery is
-  still fetched best-effort for glob scoping (§8); if unreachable, fall back
-  to the URL-derived glob with a warning. Use it offline, or when a probe
-  would false-refuse.
+There is deliberately no `--no-validation` escape (and core's
+`do_auth_login` takes no validation parameter, so the bindings expose no
+knob either). Offline or unreachable-index logins already degrade
+gracefully through the refusal rule: nothing exercises the credential,
+so the login stores as "stored, not validated" with warnings, and no
+secret is transmitted (an unreachable discovery baseline gets no forced
+retry, and unreachable probes produce no verdict). False refusals are
+engineered out rather than opted out of: 429 and redirects are never
+verdicts, and acceptance by any exercised surface wins. For the residual
+case where an index genuinely misbehaves, `SYSAND_CRED_*` environment
+credentials remain the escape hatch.
 
-Validation is a boolean, not per-surface levels: since `v1/whoami` checks
-only that a token is _accepted_ by the API (identity, not capability, §6),
-validating everything almost never wrongly refuses a valid token, so a
-"read-only" level would add a choice without payoff. The flag could later
-give way to a levelled one without disrupting this default.
+Validation is not levelled per surface either: since `v1/whoami` checks
+only that a token is _accepted_ by the API (identity, not capability,
+§6), validating everything almost never wrongly refuses a valid token,
+so a "read-only" level would add a choice without payoff.
 
 **Probe mechanism.** Validation cannot reuse the runtime unauth-first
 policy, which returns only the final response and cannot report whether a
@@ -180,10 +179,31 @@ advertised an `api_root`** (not the runtime plain-URL default, §3), probe
 for an API it does not have. Advertised-vs-defaulted needs a flag on the
 resolved endpoints (for example `api_root_advertised: bool`), true only in
 the explicit-field arm of discovery parsing, false in both defaulting arms
-and the no-document path. If the discovery fetch itself fails or is
-rejected, the read probe falls back to the URL-derived `index.json`
-location, so a private index whose discovery 401s still gets its read leg
-exercised. **Probes do not follow redirects**: a redirect
+and the no-document path.
+
+**Login's discovery fetch is itself unauth-baseline-then-forced** (only
+the backend-absent path of §9 stays strictly unauthenticated, since its
+secret is discarded). The
+baseline is unauthenticated; any 4xx answer triggers one forced-bearer
+retry with the in-hand secret. The retry must fire on 404 too: a private
+GitLab answers 404, not 401, when auth is missing, and the credentialed
+answer is what distinguishes a hidden discovery document from an absent
+one. This means an index with no discovery document sees one extra
+credentialed request at login; it goes to the same user-supplied trust
+anchor (§8) the probes already hit. Forced-retry outcomes: a 200 with a
+valid document is used exactly like a public discovery success (globs,
+`api_root_advertised`, the whoami gate); a 404 is the authoritative "no
+document" answer and reconstructs the flat topology with no warning; and
+everything else (other 4xx, 429, a redirect, since the retry goes through
+the no-redirect probe client unlike the redirect-following baseline, 5xx,
+or a network failure) is not a verdict and falls back to the URL-derived
+glob with a warning. In every fallback case the read probe falls back to
+the URL-derived `index.json` location, so a fully private index still
+gets its read leg exercised. The forced discovery fetch never counts
+toward the validated claim: the `index.json` probe is the sole read
+verdict (one verdict per surface), and claim strings stay `read`/`api`.
+
+**Probes do not follow redirects**: a redirect
 would mean the verdict comes from a different URL than the surface nominally
 probed (and a cross-host redirect strips the header, misreading "rejected"),
 so a redirected probe counts as "not tested" with a warning naming the
@@ -363,8 +383,8 @@ logout` removes) may fall back to the default index.
 expires_at-if-known}`, plus optional whoami-derived identity fields
   `subject`, `token_name`, `token_prefix` persisted by a validating login,
   plus `validated`: the surfaces that exercised and accepted the credential
-  at login, serialized compactly as `["read","api"]` strings and absent for
-  `--no-validation` or nothing-exercised logins) inside the single keyring
+  at login, serialized compactly as `["read","api"]` strings and absent
+  for nothing-exercised logins) inside the single keyring
   blob (§9), so `logout` removes it and `status` shows one login covering
   N patterns.
 - **Discovery changes over time (globs are a login-time boundary).** Reads
@@ -611,7 +631,7 @@ Each phase is independently shippable.
    default-index resolution + echo; non-interactive fail-fast; discovery
    fetch; escaped glob derivation (discovery/index root + divergent
    `api_root`; templated targets anchored at their literal prefix);
-   validation with `--no-validation` opt-out, unauth-baseline-then-forced
+   always-on validation, unauth-baseline-then-forced discovery and
    probes (no-redirect), the refusal rule, and the basic-auth routing
    message; `expires_at` persistence; source-named auth-failure messages
    (§7); the query-only `whoami` command; gutter-aligned styled output
@@ -650,7 +670,7 @@ not here. Follow that repo's `docs/README.md` (sentence case, no em-dash,
 trailing-slash links). Pages to touch:
 
 - **Reference, rewrite** `docs/source/client/reference/authentication.md`:
-  the `sysand auth` model, single-keyring storage, `--no-validation`,
+  the `sysand auth` model, single-keyring storage, always-on validation,
   precedence (`SYSAND_CRED_*` > keyring), read/API surfaces, the trust
   model. Keep the `SYSAND_CRED_*` reference, it remains the CI / no-keyring
   path (and the only basic-auth path in v1).
@@ -721,9 +741,8 @@ capabilities behind cargo features (`filesystem`, `networking`).
   same gate as publish): `do_auth_login` / `do_auth_logout` /
   `do_auth_status` orchestration (discovery fetch, glob derivation,
   validation probes, refusal rule), generic over the store trait.
-  **A library call must never prompt**: the secret arrives as a parameter,
-  and `validation: Option<bool>` is a plain argument, which is exactly what
-  gives the bindings their clean optional keyword (§5).
+  **A library call must never prompt**: the secret arrives as a
+  parameter, and there is no validation knob to plumb (§5).
 - **sysand CLI:** the clap surface, hidden prompt, TTY detection,
   `--token-stdin`, default-index resolution, and user-facing messages; it
   constructs the keyring store and the composed policy and passes them into

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -331,8 +331,10 @@ two-leg flow and trusted publishing are otherwise unchanged.
   additionally points at `sysand auth status`, which shows the stored
   `subject`, catching "this is a project token for a different project".
 - **Fail fast on expiry:** if the selected bearer carries a known
-  `expires_at` (§9) already past (with a small skew margin, since a fast
-  client clock could false-trip), publish stops before uploading the archive
+  `expires_at` (§9) already past by more than a **generous clock-skew
+  margin** (an hour; real client-clock skew is often minutes, and the stop
+  is only an optimization, so it errs toward attempting rather than refuse a
+  token the server would accept), publish stops before uploading the archive
   and points at `sysand auth login`. The server's `401` remains the real
   authority; the escape hatches are re-login or an env var.
 
@@ -454,10 +456,16 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
     "credential store full on this platform (Windows ~2.5 KB limit);
     remove an unused login or use a smaller token", and `status`/the error
     flag stale or expired entries so the user knows what to drop.
-- **Blob format robustness.** The blob carries a `version` field; readers
-  do not merely tolerate unknown record fields but **round-trip** them
-  (serde-flatten passthrough maps), so an older binary's read-modify-write
-  preserves a newer binary's fields instead of dropping them. On a parse failure
+- **Blob format robustness.** The blob carries a `version` field that
+  **gates the format**: a reader that does not recognize the version fails
+  closed rather than guessing, reserving a clean migration point if the
+  schema ever changes. Readers do not merely tolerate unknown record fields
+  but **round-trip** them (serde-flatten passthrough maps), so an older
+  binary's read-modify-write preserves a newer binary's fields instead of
+  dropping them. There is no record-level merge: concurrent writers are
+  serialized by the file lock (below) so the last writer wins, and that
+  field round-tripping is what keeps a concurrent newer binary's additions
+  from being lost. On a parse failure
   (interrupted write, older/newer sysand, another same-user process's
   scribble) read-modify-write **fails closed**, "credential store
   unreadable; remove the `sysand` keyring entry to reset", never silently
@@ -472,7 +480,9 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   world-writable shared path (lock squatting / symlink games), with a
   bounded wait and a clear error. A lock file is not a credentials file, so
   the no-plaintext rule is untouched. Parallel `sysand` invocations are
-  real; an in-process mutex alone would lose one writer's record.
+  real; an in-process mutex alone would lose one writer's record. The lock
+  coordinates `sysand` processes with each other only, not `sysand` against
+  another application that writes the same keyring entry.
 - **Consumption and keyring access.** The blob is read only when a
   credential might actually be needed, to avoid unnecessary keychain prompts.
   This requires a credential source the auth policy consults on demand. The

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -1,0 +1,690 @@
+# Credential storage and authentication commands (plan)
+
+> **Status: plan / draft.** Not yet a stable contract. This document
+> captures the agreed design for persisting index credentials and the
+> `sysand auth` command family, so implementation can proceed in phases.
+
+## 1. Goal
+
+Let users store an index credential once and have `sysand` reuse it across
+runs, on Windows, macOS, and Linux, without `sysand` owning any secret
+storage or cryptography. Acquisition of the token (GitLab/GitHub PAT,
+Sysand Index API token) is out of scope: `sysand` stores what the user
+provides.
+
+v1 is deliberately narrow: bearer tokens, `login` / `logout` / `status` /
+`whoami`, with plain and URL-template index locations both supported as
+targets. Basic auth, raw-pattern commands, and the P2 protocol change are
+deferred (§10).
+
+## 2. Current state
+
+- **Request-time application of credentials already exists** in
+  `core/src/auth.rs`: a per-URL glob map of auth policies (bearer, basic),
+  combinators that try unauthenticated first and send the secret only on a
+  4xx, and same-host redirect handling. The policy is built **eagerly and
+  immutably** at startup in `sysand/src/lib.rs` from `SYSAND_CRED_*`.
+- **Publish OIDC (trusted publishing)** exists in
+  `core/src/commands/publish.rs` for CI.
+- **Token sourcing is a stopgap:** `sysand/src/lib.rs` scans
+  `SYSAND_CRED_*` environment variables on every run. There is no
+  persistence: a user re-supplies env vars each invocation.
+
+The gap this plan fills is the missing middle: persist a credential once,
+retrieve it on later runs, feed it into the glob-based auth layer.
+
+## 3. Model and constraints
+
+Three surfaces, and one access rule:
+
+| Surface    | Probe path                 | Creds required? |
+| ---------- | -------------------------- | --------------- |
+| Discovery  | `sysand-index-config.json` | sometimes       |
+| Index root | `index.json`               | sometimes       |
+| API root   | `v1/whoami`, `v1/upload`   | always          |
+
+Constraints:
+
+- **C1 - unified read access.** Discovery and index root share one auth
+  status (public or private together). This removes pathological split
+  permutations and collapses the space to a 2x2.
+- **C2 - one credential per index.** `auth login` stores one credential per
+  index, used for both the read leg and the API leg. Separate read/write
+  tokens are not a v1 concept (a later `auth set` could cover them, §10).
+- **P2 - API presence is read from discovery (consumed, not enforced
+  here).** This plan treats an index as having an API iff its discovery
+  document advertises `api_root`, and derives globs accordingly. It does
+  **not** change the runtime default (today a plain-URL index still defaults
+  `api_root` to its root). Enforcing "`api_root` required" at the protocol
+  level, and dropping that default, is a **separate, decoupled change**
+  (§12), out of this plan's phases.
+- **P1 - public discovery: not required.** Under C2 the single credential
+  reads discovery on a private index, so there is no bootstrap paradox.
+  Current behavior (discovery may be private) stands.
+
+The collapsed situation space:
+
+| #   | Read surface | API     | Example                     | Creds used for  |
+| --- | ------------ | ------- | --------------------------- | --------------- |
+| S1  | public       | none    | public static index         | nothing         |
+| S2  | private      | none    | private static index        | read            |
+| S3  | public       | present | official sysand.com         | write (publish) |
+| S4  | private      | present | fully private dynamic index | read + write    |
+
+## 4. Command surface (v1)
+
+Under a `sysand auth` namespace:
+
+| Command                          | Role                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `sysand auth login [index-url]`  | validated, index-keyed bearer credential (see §5); no URL = the default index   |
+| `sysand auth logout [index-url]` | remove an index login; no URL = the default index (symmetric with `login`)      |
+| `sysand auth status`             | list stored credentials (never secrets), backend, and `SYSAND_CRED_*` shadowing |
+
+- **Bearer only in v1.** The token is entered via a hidden prompt
+  ("Enter token for `<index>`:", neutral wording since the credential may be
+  a forge PAT rather than a Sysand API token) or `--token-stdin`, never an
+  inline value flag (shell-history / `ps` leakage). Basic auth
+  (`--username`) and raw-pattern `auth set` / `unset` are deferred (§10);
+  request-time basic auth via `SYSAND_CRED_*` still works.
+- **`auth whoami` semantics.** Query-only: it never writes the credential
+  store (no refresh of cached identity fields). Its discovery fetch uses
+  the regular runtime read policy (env credentials and stored logins
+  apply), so it works against private indexes. Exit code 0 only when the
+  API accepted the credential; rejected, unreachable, redirected, and
+  rate-limited responses are distinct nonzero errors. An index whose
+  discovery did not advertise an `api_root` gets a clear "no API" error.
+- **Output style.** All auth command output follows the CLI's existing
+  conventions: the styled leading word right-aligned in the 12-column
+  gutter (as in `Publishing ...` / `Published ...`), anstyle tokens for
+  emphasis, and byte-identical plain text when piped or under `NO_COLOR`.
+  Timestamps are shown without sub-second precision.
+- **Non-interactive safety.** If stdin is not a TTY and `--token-stdin` was
+  not given, `login` fails fast ("no terminal for prompt; pass the token
+  with `--token-stdin`") instead of hanging or reading a pipe as a secret.
+- **Default index.** `sysand auth login` with no URL resolves the target
+  from the default-index chain: `--default-index` / `SYSAND_DEFAULT_INDEX`,
+  then a `default = true` index in configuration, else the built-in
+  `DEFAULT_INDEX_URL` (`https://sysand.com`). Note `sysand publish` has no
+  such default (its `--index` is required), so this chain is defined here,
+  not borrowed. If the chain yields **more than one** default index, bare
+  `login` errors and asks for an explicit URL. `login` always **echoes the
+  resolved index** before prompting (and on the `--token-stdin` path), so a
+  project-configured default cannot be targeted silently.
+- **HTTP(S) only.** `auth login` against a non-HTTP(S) location (for
+  example a local file path, which index resolution accepts elsewhere)
+  errors with "not an HTTP(S) index; nothing to authenticate to".
+- **Glob derivation** (§8): automatic from the URL; no manual `--pattern` in
+  v1. If derivation is ever wrong for an unusual layout, the `SYSAND_CRED_*`
+  env var is the escape hatch until `--pattern` / `auth set` land (§10).
+  v1 implementation note: a **templated URL as the login target itself**
+  (the user typing a `{path}` template into `auth login`/`logout`) is
+  rejected with a pointer to `SYSAND_CRED_*`; a templated `index_root`
+  advertised **by discovery** is anchored per §8 as planned. Revisit if
+  template-target logins turn out to matter.
+
+The index URL is normalized (trailing slash, scheme) before use as the
+storage key and for glob derivation, so different spellings do not create
+duplicate entries.
+
+## 5. Validation
+
+`auth login` takes `--validation true|false` (default `true`). It maps to
+an `Option<bool>` argument (absent = `None` = the default), so the language
+bindings expose a clean optional keyword: `validation: Optional[bool] =
+None`. This intentionally diverges from the repo's `--no-<flag>` boolean
+convention (for example `--no-lock`), which binds as a required,
+negative-sense `no_lock: bool`; a positive `Option<bool>` reads better as an
+optional keyword across the py/js/java bindings.
+
+- `--validation true` (default): probe every surface the index supports and
+  store unless the credential is rejected everywhere it was actually tested
+  (see the refusal rule below). A static index has only the read surface; a
+  dynamic index adds the API.
+- `--validation false`: store without any credential probe. Discovery is
+  still fetched best-effort for glob scoping (§8); if unreachable, fall back
+  to the URL-derived glob with a warning. Use it offline, or when a probe
+  would false-refuse.
+
+Validation is a boolean, not per-surface levels: since `v1/whoami` checks
+only that a token is _accepted_ by the API (identity, not capability, §6),
+validating everything almost never wrongly refuses a valid token, so a
+"read-only" level would add a choice without payoff. `--validation` could
+later give way to a levelled flag without disrupting this default.
+
+**Probe mechanism.** Validation cannot reuse the runtime unauth-first
+policy, which returns only the final response and cannot report whether a
+surface actually _accepted_ the credential. Each surface is probed as an
+**unauth baseline then a forced-auth retry**: a surface counts as
+accepted/tested only when the unauth baseline was a 4xx and the forced retry
+then succeeded, so a public surface (200 unauth, credential never sent) is
+correctly "not tested", not "accepted". The API surface (`v1/whoami`) is
+always authenticated, so its baseline is a known 401 and only the forced
+request is needed. Validation is discovery-first (`api_root` is known only
+after reading discovery): fetch discovery, resolve `index_root` and
+`api_root`, probe `index_root/index.json`, and, **only if discovery
+advertised an `api_root`** (not the runtime plain-URL default, §3), probe
+`api_root/v1/whoami`, so a static plain-URL index is never phantom-probed
+for an API it does not have. Advertised-vs-defaulted needs a flag on the
+resolved endpoints (for example `api_root_advertised: bool`), true only in
+the explicit-field arm of discovery parsing, false in both defaulting arms
+and the no-document path. If the discovery fetch itself fails or is
+rejected, the read probe falls back to the URL-derived `index.json`
+location, so a private index whose discovery 401s still gets its read leg
+exercised. **Probes do not follow redirects**: a redirect
+would mean the verdict comes from a different URL than the surface nominally
+probed (and a cross-host redirect strips the header, misreading "rejected"),
+so a redirected probe counts as "not tested" with a warning naming the
+redirect target.
+
+User-visible wording uses one stem, **validated**: "validated (read)",
+"stored, not validated", matching the `--validation` flag, rather than
+mixing "verified"/"unvalidated" families.
+
+**Refusal rule.** Store if the credential is _accepted by any surface it
+actually tested_, warning about any surface that rejected or was
+unreachable. Refuse only when at least one exercised surface rejected the
+credential and none accepted it. A surface counts as "tested" only if the
+credential was exercised: a _public_ read surface returns 200 without
+sending the credential, so it proves nothing. If nothing exercised the
+credential (fully public read with no API, or every probe unreachable),
+store as "stored, not validated".
+
+This self-adjusts across the situation space:
+
+- Private index, read works, API rejects: store with an "API access failed"
+  warning (the token is still useful for reading).
+- Public-read index (for example sysand.com): the read probe never tests
+  the token, so `v1/whoami` is the only real test, and a rejected token is
+  refused, keeping the publish flow protected.
+- Every exercised surface rejects: refuse.
+
+**Basic-auth indexes must not dead-end.** In bearer-only v1, a user of a
+private basic-auth index will naturally try `auth login` and be refused. The
+read probe sees the server's `WWW-Authenticate: Basic` challenge, so the
+refusal message must say so and route the user to the working path: "this
+index uses username/password (HTTP basic) authentication; configure
+`SYSAND_CRED_<X>_BASIC_USER` / `_BASIC_PASS` instead (see docs)".
+
+Never print a bare "validated"; always scope the claim to the surfaces that
+actually accepted the credential.
+
+## 6. The `v1/whoami` endpoint
+
+New endpoint on the index API (server side, the `sysand-index` Django app),
+under `api_root`. Its purpose is credential validation and identity for
+`auth status`.
+
+- `GET api_root/v1/whoami`, bearer credential. The server routes it under
+  `api/` (`api/v1/whoami`); `api_root` carries the `/api/` segment, so the
+  client's `api_root/v1/whoami` join is consistent with `v1/upload`.
+- `200` on a valid, unexpired token; `401` otherwise. Under
+  `--validation true` a `200` passes the API leg (§5). The `401` body is
+  unspecified (the client only reads the status).
+- Body on `200`:
+
+```json
+{
+  "subject": { "type": "user", "name": "alice" },
+  "token": {
+    "name": "laptop",
+    "prefix": "sysand_u_1a2b3c4d",
+    "expires_at": "2026-09-01T00:00:00Z"
+  }
+}
+```
+
+- `subject.type` is `user`, `project`, or `oidc`, so the endpoint is
+  principal-agnostic (hence `whoami`, not `user`). `subject.name` is the
+  **username** for a user token, the **project id** (`publisher/name`) for a
+  project token, and the **publisher identity** for an OIDC token; it is
+  distinct from `token.name` (the user-given token label).
+- `token.expires_at` is always **returned** by whoami (the model's
+  `expires_at` is non-nullable); the stored record persists it only when a
+  validating login actually ran, hence "expires_at-if-known" in §8/§9.
+  `token.prefix` is the non-secret display prefix (type prefix + first 8
+  hex).
+- No `can_publish` flag and no scope list: at login there is no target
+  project and every valid token can publish somewhere, so a capability
+  boolean is vacuous; per-project authorization stays enforced at the upload
+  (its existing `403`). An optional `?project=<id>` pre-flight may be added
+  later.
+
+## 7. Publish interaction
+
+Publish is two legs with **different** credential handling:
+
+- **Leg 1, discovery read** (`sysand-index-config.json`, to resolve
+  `api_root`): uses the general read auth policy, unauth-first, authenticated
+  only if the index is private. `login` scopes the credential to cover the
+  discovery/index root (§8), so a private index's discovery fetch gets it.
+- **Leg 2, upload** (`POST api_root/v1/upload`): **bearer only**, sent
+  proactively (an upload cannot be tried unauthenticated then retried).
+  Publish checks env bearers first; only when **no env bearer matches** does
+  it read the keyring blob (one keychain access), consistent with "never
+  read the keyring when env already works". It then selects the bearer whose
+  glob matches the upload URL.
+
+The one change to publish's bearer selection is **source precedence**: try
+env bearer matches first (single match within env), then keyring (single
+match within keyring), instead of one flat "exactly one match or error" over
+the merged set. Within a source the existing exactly-one rule stands (its
+`AmbiguousPublishBearer` error becomes per-source). Concretely:
+`publish_bearer_auth_map` (the by-ref bearer extraction in
+`core/src/auth.rs`) and `resolve_publish_bearer_from_config` (in
+`core/src/commands/publish.rs`) keep env and keyring as **two maps**
+(source-tagged, with the selected bearer's provenance threaded to the
+failure messages) with a two-stage lookup, never collapsing to one flat
+`GlobMap`. This makes the stated
+precedence real, a CI `SYSAND_CRED_*` overrides an interactive login. The
+two-leg flow and trusted publishing are otherwise unchanged.
+
+- **Trusted-publishing precedence:** in `auto` mode publish uses OIDC
+  trusted publishing when a supported CI environment is detected, and
+  otherwise falls back to the bearer map (env > keyring). CI has no keyring,
+  so the two rarely coexist.
+- **Basic auth cannot publish** (leg 2 is bearer-only); a basic
+  `SYSAND_CRED_*` entry is ignored for the upload.
+- **No matching bearer** fails up front (before the upload) with a hint to
+  run `sysand auth login <index>` to store a publish token.
+- **Auth failures name the credential's source.** Because env shadows
+  keyring, "re-run `sysand auth login`" is the wrong fix when the rejected
+  bearer came from a stale `SYSAND_CRED_*` var (a fresh login would stay
+  shadowed and the user would loop). So an upload auth failure states where
+  the selected bearer came from ("from `SYSAND_CRED_TEAMIDX`" vs "from your
+  stored login for `<index>`") and tailors the remediation (unset/rotate the
+  env var vs re-login). A `403` (authorization, not authentication)
+  additionally points at `sysand auth status`, which shows the stored
+  `subject`, catching "this is a project token for a different project".
+- **Fail fast on expiry:** if the selected bearer carries a known
+  `expires_at` (§9) already past (with a small skew margin, since a fast
+  client clock could false-trip), publish stops before uploading the archive
+  and points at `sysand auth login`. The server's `401` remains the real
+  authority; the escape hatches are re-login or an env var.
+
+## 8. Glob scoping and conflict resolution
+
+- **Source precedence, single match within a source.** For a given URL, all
+  `SYSAND_CRED_*` (env) matches take precedence over all keyring matches
+  (so CI can override an interactive login). Within one source, the existing
+  single-match rule applies (publish errors on a within-source ambiguity;
+  reads try-all). v1 deliberately does **not** add longest-prefix
+  tie-breaking, that is only needed once raw-pattern `auth set` or
+  same-host nested logins create within-source overlaps (§10).
+- **Glob coverage.** `login` anchors the primary glob on the **discovery URL
+  the user supplied** (so the discovery fetch itself is authenticated), and
+  additionally covers the resolved `index_root` and `api_root` when they
+  diverge from it, minimal and non-overlapping. Templated URLs are anchored
+  before `{path}` / `{path_raw}`.
+- **Glob derivation is escaped and pinned.** URLs can legally contain glob
+  metacharacters (an IPv6 literal `https://[::1]:8000/` reads as a globset
+  character class; `{path}` templates read as alternation), and
+  `GlobMapBuilder` uses `literal_separator(true)` (`*` does not cross `/`).
+  So the derived glob is `globset::escape(<normalized root>)` + `**`, with
+  the root normalized to end in `/` (for example
+  `https://example.com/idx/**`), and both derivation and runtime matching
+  use the same serialization (`url::Url::as_str()`) so IDN/percent-encoding
+  agree on both sides. Two refinements: a templated root's literal-prefix
+  anchor must be **clamped to at least `scheme://authority/`** (a
+  query-position placeholder would otherwise degenerate the anchor to
+  `https://**`), skipping the root with a notice when even that is not
+  meaningful; and when a newly derived root **subsumes** an already-derived
+  one (string-prefix coverage with both sides slash-terminated), it
+  replaces it, keeping the set minimal and non-overlapping. Normative test
+  requirements: the discovery-document URL, the `index.json` URL, and the
+  upload URL each match the compiled derived set, and an IPv6-literal login
+  (`https://[::1]:8000/`) works.
+- **Divergent `api_root` (Case B).** If `api_root` nests under the derived
+  root (Case A), one glob suffices. If it is a disjoint host/path, store the
+  same credential under both globs (minimal, non-overlapping), so the upload
+  URL matches exactly the api glob. Templated indexes are inherently Case B
+  (their `api_root` is a disjoint plain URL).
+- Each login is one record (`{key, globs, scheme, secret,
+expires_at-if-known}`, plus optional whoami-derived identity fields
+  `subject`, `token_name`, `token_prefix` persisted by a validating login)
+  inside the single keyring blob (§9), so `logout` removes it and `status`
+  shows one login covering N patterns.
+- **Discovery changes over time (globs are a login-time boundary).** Reads
+  and publish re-fetch discovery live each run, but the stored globs are the
+  login-time snapshot and are **not** auto-updated from discovery. This is
+  deliberate: auto-following a changed `api_root`/`index_root` would let a
+  changed (see the trust model below) discovery silently redirect the stored
+  token to a new host. So when a discovery change moves a root **outside**
+  the login's globs, the credential stops matching and the request fails
+  cleanly rather than following, either way safe. **Best-effort diagnostic
+  (may land later):** where sysand can correlate the failing request with a
+  login whose snapshot globs no longer cover the resolved root, it prints
+  "the index configuration has changed since you logged in; re-run
+  `sysand auth login <index>` to update". This correlation is non-trivial on
+  the read path (the auth layer sees per-request URLs, not the resolved
+  index identity), so if it does not ship in the first cut the generic "no
+  bearer / re-run login" hint applies. Re-login re-derives the globs and
+  re-validates.
+  **Caveats, two ways the boundary is narrower than it sounds:**
+  (a) it covers the login's own globs only, a broad `SYSAND_CRED_*` env
+  pattern that also matches the moved root can still shadow it (env is
+  user-controlled and takes precedence); and (b) **same-host redirects
+  bypass the glob**: the glob is evaluated against the initial URL only, and
+  the credential is then forwarded to a same-host redirect target (existing
+  `RestrictAuthentication`/reqwest behavior), so a server that answers a
+  matched URL with `302` to another path on the same host receives the
+  credential there without any glob re-check. Cross-host redirects strip the
+  header. The precise guarantee is therefore: "sysand does not itself
+  auto-follow discovery to a **different host**"; within a host the server
+  can move the credential via redirects.
+
+**Trust model.** The discovery document at the URL you supply is the trust
+anchor: `sysand` sends the credential to the `index_root`/`api_root` it
+advertises (including a different host) and to `v1/whoami`, with no
+same-origin or HTTPS restriction. Trusting the discovery URL means trusting
+what it points at. Note the amplification honestly: over plain `http`, a
+_one-time_ MITM at login can rewrite discovery to a hostile `api_root`,
+which both leaks the freshly entered token and gets **persisted** as a glob,
+so it keeps being sent there until re-login, not merely a single
+eavesdropped request. `http` (localhost or a trusted LAN) is still
+supported; the full transport-security guidance lives in the docs (§13).
+
+## 9. Storage, consumption, precedence
+
+- **Backends:** OS keyring by default (macOS Keychain, Windows Credential
+  Manager, Linux Secret Service via the `keyring` crate), with environment
+  variables as the automatic fallback where no keyring exists. **No
+  plaintext credentials file, ever.**
+- **Single keyring entry.** All persisted credentials live in **one**
+  keyring entry (for example `service = "sysand"`, `account =
+"credentials"`) holding a JSON blob: a list of records `{key, globs,
+scheme, secret, expires_at-if-known}` plus optional whoami-derived
+  identity fields (`subject`, `token_name`, `token_prefix`) written by a
+  validating login. Deliberate over a manifest file:
+  the `keyring` crate cannot portably enumerate entries, and one blob is
+  **atomic** (no metadata/secret drift), needs **no file**, and prompts the
+  keychain at most once. `login` / `logout` read-modify-write the blob;
+  `status` reads it. Removing the last record **deletes the keyring
+  entry**, preserving the cheap no-entry path for users who logged out of
+  everything.
+  - **Windows size limit.** Windows caps a blob at ~2.5 KB
+    (`CRED_MAX_CREDENTIAL_BLOB_SIZE` = 2560), measured in **UTF-16 code
+    units**, so ~1280 ASCII characters of serialized JSON. With small
+    tokens that is roughly ten entries; large JWTs, fewer, and a single
+    token can exceed it on the first login. One message covers both:
+    "credential store full on this platform (Windows ~2.5 KB limit);
+    remove an unused login or use a smaller token", and `status`/the error
+    flag stale or expired entries so the user knows what to drop.
+- **Blob format robustness.** The blob carries a `version` field; readers
+  do not merely tolerate unknown record fields but **round-trip** them
+  (serde-flatten passthrough maps), so an older binary's read-modify-write
+  preserves a newer binary's fields instead of dropping them. On a parse failure
+  (interrupted write, older/newer sysand, another same-user process's
+  scribble) read-modify-write **fails closed**, "credential store
+  unreadable; remove the `sysand` keyring entry to reset", never silently
+  treats the blob as empty, which would clobber all stored logins on the
+  next `login`.
+- **Concurrency.** Read-modify-write is guarded by a **cross-process
+  advisory OS file lock** (`flock`/`LockFileEx`, via a crate like
+  `fd-lock`), never an existence-based lock file (those go stale after a
+  crash). The lock file lives in a **per-user** location
+  (`XDG_RUNTIME_DIR`/`XDG_STATE_HOME` on Linux, `%LOCALAPPDATA%` on
+  Windows, falling back to the home directory), mode `0600`, never a
+  world-writable shared path (lock squatting / symlink games), with a
+  bounded wait and a clear error. A lock file is not a credentials file, so
+  the no-plaintext rule is untouched. Parallel `sysand` invocations are
+  real; an in-process mutex alone would lose one writer's record.
+- **Consumption and keyring access.** The blob is read only when a
+  credential might actually be needed, to avoid unnecessary keychain prompts.
+  This requires a credential source the auth policy consults on demand. The
+  natural shape (implementable from the existing combinators) is
+  `SequenceAuthentication<EnvLayer, LazyKeyringLayer>`: the env layer is the
+  existing eager `RestrictAuthentication` from `SYSAND_CRED_*` (no keychain),
+  and the lazy keyring layer is consulted only in `SequenceAuthentication`'s
+  4xx-escalation branch, so the blob read happens exactly when needed and
+  env-before-keyring falls out for free. Note it can **not** be a
+  `RestrictAuthentication` with a lazy inner map (that classifies the URL up
+  front and would force the read). The composed policy is a dedicated
+  `CredentialStoreAuthentication` combinator with a concrete CLI alias
+  (`CliAuthPolicy`) used by `command_publish`; it takes the place of an
+  eager, immutable policy built once in `sysand/src/lib.rs`. Because the
+  lazy layer holds a cache (`OnceCell`) it is not `Clone`, so publish's
+  bearer extraction (`publish_bearer_auth_map`) is **by-ref** and clones
+  the secrets it extracts, accepted as the cost of the lazy layer. It defers the blob read to
+  the first auth-relevant 4xx (or publish / `auth` command), reads the whole
+  blob once, and caches it for the process. Escalation semantics: a
+  **failed** env credential (env 4xx) escalates into the keyring layer; a
+  matching keyring record sends **forced** auth (not another unauth-first
+  inner sequence, which would triple requests). **No-match must not
+  re-request:** 404 is a routine outcome on the resolve path
+  (`MissingPolicy::AllowNotFound`, version probing), so stock
+  `SequenceAuthentication`, whose lower arm cannot see the higher arm's
+  response, would re-issue an identical unauthenticated request on every
+  ordinary 404, permanently doubling round-trips for logged-in users. The
+  keyring layer therefore needs a **variant combinator that passes the
+  initial response down**, returning it untouched when no record matches.
+  Two further semantics to pin: the blob cache needs **dual accessors**,
+  an async one (`OnceCell` + `spawn_blocking`, since the keyring crate is
+  synchronous and a locked store can block for seconds) for the request
+  path, and a plain sync one for publish, which runs outside the async
+  runtime and must not nest `block_on`. When several records' globs match
+  one URL: matches carrying the **identical token collapse to one retry**;
+  genuinely distinct tokens warn and are tried in order (the reads
+  try-all rule, section 8).
+  - **Never read** for local/offline commands, for reads that succeed
+    unauthenticated (public indexes return 200 and never touch the keyring),
+    or for users who never ran `auth login` (no entry: a cheap "not found",
+    no unlock).
+  - **Read once, then cache** on the first auth-relevant 4xx, on publish's
+    upload leg, and on the `auth` commands. At most one keychain touch per
+    command.
+  - Reads escalate on **any** 4xx (not just 401/403), because some hosts
+    (GitLab) answer `404` on missing/under-scoped auth. Cost: a logged-in
+    user on a _locked_ Linux keyring may see one unlock prompt on a non-auth
+    404, rare, once per session, preferred over breaking the zero-config
+    GitLab flow. (Future refinement, gated on `keyring` support for
+    non-forcing reads: force-unlock only on `401`/`403`.)
+  - In steady state keychain reads are silent (Windows no prompt, macOS
+    one-time "always allow", unlocked Linux no re-prompt).
+- **Keyring error taxonomy:** _absent_ backend falls back to env;
+  _present-but-locked/denied_ surfaces the error, suggests unlocking, and
+  also names the `SYSAND_CRED_*` fallback, since on a headless box over SSH
+  there is often no practical way to unlock the keyring.
+- **No-keyring host:** `auth login` refuses to persist and prints the
+  `SYSAND_CRED_*` lines to set, with the pattern value exact but the secret
+  as a **`<token>` placeholder, never the entered value**: no-keyring hosts
+  are typically CI/headless where stdout lands in captured job logs, and
+  echoing the secret would defeat the hidden prompt. Honest posture note:
+  on such hosts the env fallback means the secret lives in same-user
+  process environments and typically ends up at rest in CI secret config or
+  shell rc files; that is the accepted floor there, stated in the docs.
+- **Precedence:** `SYSAND_CRED_*` > keyring > unauthenticated (source
+  precedence, §8), so CI can override an interactive login. There is no
+  separate runtime shadow warning: `auth status` shows per-entry shadowing,
+  and the source-named auth-failure messages (§7) identify a stale env var
+  exactly when it bites.
+- **Expiry:** reactive first, when a request that exercised a stored
+  credential ends in **any 4xx** and the record's `expires_at` is past,
+  print "credential for `<index>` may be expired or revoked; re-run
+  `sysand auth login <index>`", any 4xx, not just 401, because
+  GitLab-style hosts answer 404 on bad auth and the blob is already loaded
+  on that path. Proactive when known, `expires_at` (stored from `v1/whoami`
+  at login, absent for static/read-only or non-validated logins) lets
+  `auth status` show "expires in N days / expired".
+- **`auth status` output:** one unified view of **everything sysand will
+  authenticate with**, both sources, each entry tagged `stored` or `env`.
+  Per stored entry: the key printed in the exact form
+  `sysand auth logout <key>` accepts, covered globs, `subject` and token
+  `prefix` (from whoami, if a validating login ran), `expires_at` if
+  stored, and whether a `SYSAND_CRED_*` var shadows it, never the secret.
+  Env entries list the variable label and pattern. No `scheme` column in v1
+  (always bearer for stored; env entries may be basic).
+- **Re-login:** `auth login` over an existing entry for the same key
+  overwrites it, printing "replacing existing credential for `<index>`"
+  before the write; the previous stored token is discarded locally (not
+  revoked server-side).
+
+## 10. Scope boundaries
+
+**Deferred to later phases (intended, not v1):**
+
+- `auth set` / `auth unset` (raw-pattern credentials) and the `--pattern`
+  override on `login`.
+- Basic auth via `--username` (request-time basic via `SYSAND_CRED_*` still
+  works).
+- Longest-prefix most-specific-glob-wins (needed only once `set` / nested
+  logins create within-source overlaps).
+- **P2 enforcement** (dropping the plain-URL `api_root` default), a
+  separate protocol change on its own timeline (§12); this plan only
+  consumes `api_root` when advertised.
+
+**Out of scope entirely:** acquisition beyond store-what-you-paste (OAuth
+apps, device flows, refresh-token lifecycle); a self-written encrypted vault
+or plaintext credentials file; a user-facing credential "label" concept;
+multi-account-per-host switching; git credentials (git keeps its own).
+
+## 11. Build phases
+
+Each phase is independently shippable.
+
+1. **Credential store.** Single-keyring-blob store (versioned format,
+   fail-closed on parse errors) with cross-process advisory file locking +
+   env fallback, keyring error taxonomy, index-URL normalization,
+   source-precedence lookup, Windows size-limit handling. Introduce the
+   **deferred/cached auth policy** that reads the blob on demand and caches
+   it, replacing the eager `SYSAND_CRED_*`-only build in
+   `sysand/src/lib.rs`. This phase's value is landing and soaking the risky
+   refactor with no behavior change; user-visible persistence arrives with
+   phase 3's `login` (until then only tests populate the store). Crate
+   placement per §14.
+2. **`v1/whoami`** (server side, `sysand-index` repo, **already
+   implemented and merged there**): identity + token metadata, acceptance
+   via HTTP status, routed at `api/v1/whoami`. **This ordering is
+   load-bearing:** if `login` shipped first, a validating login against
+   the official index (public read + advertised `api_root`) would probe
+   whoami, get a 404, count the API surface as rejected with the read
+   surface "not tested", and refuse a valid token. The cross-repo
+   dependency (and the §13 docs work) is tracked in `sysand-index`'s
+   `.agents/plans/`.
+3. **`auth login` / `logout` / `status` / `whoami`.** Bearer-only;
+   default-index resolution + echo; non-interactive fail-fast; discovery
+   fetch; escaped glob derivation (discovery/index root + divergent
+   `api_root`; templated targets anchored at their literal prefix);
+   validation with `--no-validation` opt-out, unauth-baseline-then-forced
+   probes (no-redirect), the refusal rule, and the basic-auth routing
+   message; `expires_at` persistence; source-named auth-failure messages
+   (§7); the query-only `whoami` command; gutter-aligned styled output
+   (§4). The tailored discovery-drift message (§8) is **best-effort**
+   here, not
+   required for the phase to ship.
+4. **Docs and specs** (§12, §13). Protocol specs in this repo; user docs in
+   the `sysand-index` repo (docs.sysand.com).
+
+Separate, not part of these phases: **P2 enforcement** (§10, §12) and the
+deferred `auth set` / basic-auth work.
+
+CI notes for these phases: the test lanes do not enable `-F keyring`, so
+keyring-gated tests only compile via `clippy --all-features` until a
+keyring lane is added; and the prek job needs its rust hooks pinned via
+`language_version` (handled separately from this plan), since prek does
+not read `rust-toolchain.toml`.
+
+## 12. Protocol/spec changes (this repo, `design/`)
+
+- `design/index-api-protocol.md`: specify `v1/whoami` (§6), routed under
+  `api/`.
+- `design/index-protocol.md` (**decoupled change**, not this plan's
+  phases): enforce "an index has an API iff discovery advertises `api_root`"
+  and drop the plain-URL default. This is a **breaking change**, a
+  third-party plain-URL _dynamic_ index that relies on the defaulted
+  `api_root` (no discovery document, or one without the field) becomes
+  read-only and must serve `sysand-index-config.json` with an explicit
+  `api_root` (the official index already does). Both the field-absent branch
+  and the 404 `flat()` path in `core/src/env/discovery.rs` must change.
+
+## 13. Documentation (docs.sysand.com, in the `sysand-index` repo)
+
+Cross-repo: the published docs live under `docs/source/` in `sysand-index`,
+not here. Follow that repo's `docs/README.md` (sentence case, no em-dash,
+trailing-slash links). Pages to touch:
+
+- **Reference, rewrite** `docs/source/client/reference/authentication.md`:
+  the `sysand auth` model, single-keyring storage, `--validation`,
+  precedence (`SYSAND_CRED_*` > keyring), read/API surfaces, the trust
+  model. Keep the `SYSAND_CRED_*` reference, it remains the CI / no-keyring
+  path (and the only basic-auth path in v1).
+- **Reference, new** `docs/source/client/reference/commands/auth/`
+  subdirectory (mirroring `commands/index/` and `commands/env/`): an
+  `auth-command.md` parent plus `login.md`, `logout.md`, `status.md`,
+  `whoami.md`; add
+  them to the command toctree.
+- **How-to, rewrite** `docs/source/client/how-to/authenticate-to-an-index.md`:
+  lead with `sysand auth login`; demote the env-var steps to a CI / fallback
+  section.
+- **Explanation, update**
+  `docs/source/client/explanation/authentication.md`: keyring persistence,
+  read vs API surfaces, validation, the publish two-leg flow, the
+  discovery-drift boundary and trust model (§8).
+- **Index side, light**: cross-link `v1/whoami` from the index API
+  reference if user-facing; the token pages
+  (`docs/source/index/reference/api-tokens.md`,
+  `how-to/create-an-api-token.md`) may gain a "use with `sysand auth login`"
+  pointer.
+- **CLI help**: `about`/`long_about` text for the `sysand auth` command and
+  subcommands (in this repo), which the reference pages mirror.
+
+## 14. Code placement (core vs CLI vs bindings)
+
+The workspace splits into `core` (`sysand-core`, consumed by the CLI **and**
+the py/js/java bindings; the js binding compiles to wasm) and `sysand` (the
+CLI). Placement follows the repo's existing pattern: `do_*` command logic in
+`core/src/commands/`, thin wrappers in `sysand/src/commands/`, optional
+capabilities behind cargo features (`filesystem`, `networking`).
+
+- **core, unconditional:** only the record types, blob JSON codec (pure
+  serde), and the `CredentialStore` trait.
+- **core, behind the existing `networking` feature:** the `LazyKeyringLayer`
+  policy layer and its composition with the env layer, since `auth.rs` (and
+  the `HTTPAuthentication` trait, defined over reqwest types) is already
+  gated on `networking` (`core/src/lib.rs`). Note the wasm build is green
+  today because the js binding enables neither `networking` nor
+  `filesystem`, not because of keyring gating; keeping the new policy layer
+  under `networking` preserves that. `SequenceAuthentication`'s fields are
+  currently private, so the composition needs a public constructor (or a
+  new combinator, see §9's pass-the-response-down variant).
+- **core, behind a new `keyring` cargo feature** (not in `default`): the
+  OS-keyring-backed `CredentialStore` impl and the cross-process file lock
+  (uses `dirs`, mirroring `filesystem`). Enabled by the CLI and the py/java
+  bindings; **off for the js/wasm binding**, the `keyring` crate does not
+  build for wasm. A browser-side store could later implement the same trait
+  (bindings/js already has local-storage machinery), but that is not v1 and
+  localStorage is not secure storage.
+  - **Vendored dbus.** The Linux Secret Service backend pulls libdbus;
+    build it `vendored` so CI's `clippy --all-features` and contributor
+    machines need no system libdbus headers. Vendoring statically embeds
+    libdbus (dual AFL-2.1 OR GPL-2.0) in shipped binaries; verify with
+    cargo-deny.
+  - **musl exclusion.** The vendored dbus C build does not link on
+    aarch64-musl (missing outline-atomics helpers), and musl targets are
+    containers/CI where a Secret Service never runs. Target-gate the
+    keyring dependency off musl entirely and give `OsKeyringBackend` a
+    musl stub returning the backend-absent error, so the documented
+    `SYSAND_CRED_*` fallback is the behavior there.
+  - **Test seam.** CLI integration tests must never touch the real OS
+    keyring (macOS prompts on differently-signed test binaries; CI has no
+    Secret Service). Provide a deliberate seam, a debug-build-only env var
+    (`SYSAND_TEST_CREDENTIAL_STORE`) selecting a file-backed or absent
+    blob backend, refused loudly in release builds, and route every auth
+    command and the lazy policy through it.
+- **core `commands/auth.rs`, gated `all(filesystem, networking)`** (the
+  same gate as publish): `do_auth_login` / `do_auth_logout` /
+  `do_auth_status` orchestration (discovery fetch, glob derivation,
+  validation probes, refusal rule), generic over the store trait.
+  **A library call must never prompt**: the secret arrives as a parameter,
+  and `validation: Option<bool>` is a plain argument, which is exactly what
+  gives the bindings their clean optional keyword (§5).
+- **sysand CLI:** the clap surface, hidden prompt, TTY detection,
+  `--token-stdin`, default-index resolution, and user-facing messages; it
+  constructs the keyring store and the composed policy and passes them into
+  core, exactly like today's `auth_policy` handoff in `sysand/src/lib.rs`.
+
+**Index reading and the keyring.** Reads in core stay generic over
+`HTTPAuthentication` (`IndexEnvironmentAsync<Policy>`), so core's
+index-reading code gains no keyring knowledge at compile time. At runtime
+the keyring is touched only inside the policy instance the host constructed
+and handed in; on wasm no such instance exists and reads behave as today.

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -522,7 +522,8 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   at login, absent for static/read-only or non-validated logins) lets
   `auth status` show "expires in N days / expired".
 - **`auth status` output:** one unified view of **everything sysand will
-  authenticate with**, both sources, each entry tagged `stored` or `env`.
+  authenticate with**, both sources, each entry tagged `Stored` or `Env`
+  (right-aligned in the CLI's 12-column status gutter).
   Per stored entry: the key printed in the exact form
   `sysand auth logout <key>` accepts, covered globs, `subject` and token
   `prefix` (from whoami, if a validating login ran), `expires_at` if
@@ -530,7 +531,7 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   Env entries list the variable label and pattern. No `scheme` column in v1
   (always bearer for stored; env entries may be basic).
 - **Re-login:** `auth login` over an existing entry for the same key
-  overwrites it, printing "replacing existing credential for `<index>`"
+  overwrites it, printing "Replacing existing credential for `<index>`"
   before the write; the previous stored token is discarded locally (not
   revoked server-side).
 

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -333,11 +333,9 @@ logout` removes) may fall back to the default index.
   with a notice when even that is not meaningful; and a newly derived
   root that **subsumes** an already-derived one replaces it, keeping the
   set minimal and non-overlapping. Normative test requirements: the
-  discovery-document URL, the `index.json` URL, and the upload URL each
-  match the compiled derived set (for a template-target login without an
-  advertised `api_root`, an encoded-`{path}` project-file URL stands in
-  for the upload URL), and an IPv6-literal login (`https://[::1]:8000/`)
-  works.
+  discovery-document URL, the `index.json` URL, and the upload URL
+  (if present) each match the compiled derived set, and an IPv6-literal
+  login (`https://[::1]:8000/`) works.
 - **Divergent `api_root` (Case B).** If `api_root` nests under the derived
   root (Case A), one glob suffices. If it is a disjoint host/path, store the
   same credential under both globs (minimal, non-overlapping), so the upload

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -402,10 +402,12 @@ transport-security guidance lives in the docs (§13).
   - **Windows size limit.** Windows caps a blob at ~2.5 KB
     (`CRED_MAX_CREDENTIAL_BLOB_SIZE` = 2560), measured in **UTF-16 code
     units**, so ~1280 ASCII characters of serialized JSON; a single large
-    JWT can exceed it on the first login. One message covers both cases
-    ("credential store full on this platform (Windows ~2.5 KB limit);
-    remove an unused login or use a smaller token"), and `status`/the
-    error flag stale or expired entries so the user knows what to drop.
+    JWT can exceed it on the first login. Size enforcement is the
+    platform's: an oversized write surfaces as the backend's own error,
+    mapped to one user-friendly message ("credential store full on this
+    platform (Windows ~2.5 KB limit); remove an unused credential or use
+    a smaller token"), and the CLI lists expired logins so the user knows
+    what to drop.
 - **Blob format robustness.** The blob carries a `version` field that
   **gates the format**: a reader that does not recognize the version fails
   closed rather than guessing, reserving a clean migration point. Readers

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -611,7 +611,7 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   basic).
 - **Re-login:** `auth login` over an existing entry for the same key
   overwrites it, printing "Replacing existing credential for `<index>`"
-  before the write; the previous stored token is discarded locally (not
+  (informational output, suppressed under `--quiet`) before the write; the previous stored token is discarded locally (not
   revoked server-side).
 
 ## 10. Scope boundaries

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -120,9 +120,13 @@ Under a `sysand auth` namespace:
 - **HTTP(S) only.** `auth login` against a non-HTTP(S) location (for
   example a local file path, which index resolution accepts elsewhere)
   errors with "not an HTTP(S) index; nothing to authenticate to".
-- **Glob derivation** (§8): automatic from the URL; no manual `--pattern` in
-  v1. If derivation is ever wrong for an unusual layout, the `SYSAND_CRED_*`
-  env var is the escape hatch until `--pattern` / `auth set` land (§10).
+- **Glob derivation** (§8): automatic from the login-target index URL (the
+  URL the user passes to `auth login`, or the resolved default index when
+  none is given), not from the discovery document; discovery-advertised
+  `index_root` / `api_root` add further globs per §8. No manual `--pattern`
+  in v1. If derivation is ever wrong for an unusual layout, the
+  `SYSAND_CRED_*` env var is the escape hatch until `--pattern` / `auth set`
+  land (§10).
   A **templated URL as the login target itself** (the user typing a
   `{path}` / `{path_raw}` template into `auth login`/`logout`, for example
   a GitLab repository-files URL) is supported: the storage key is the

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -117,11 +117,16 @@ Under a `sysand auth` namespace:
 - **Glob derivation** (§8): automatic from the URL; no manual `--pattern` in
   v1. If derivation is ever wrong for an unusual layout, the `SYSAND_CRED_*`
   env var is the escape hatch until `--pattern` / `auth set` land (§10).
-  v1 implementation note: a **templated URL as the login target itself**
-  (the user typing a `{path}` template into `auth login`/`logout`) is
-  rejected with a pointer to `SYSAND_CRED_*`; a templated `index_root`
-  advertised **by discovery** is anchored per §8 as planned. Revisit if
-  template-target logins turn out to matter.
+  A **templated URL as the login target itself** (the user typing a
+  `{path}` / `{path_raw}` template into `auth login`/`logout`, for example
+  a GitLab repository-files URL) is supported: the storage key is the
+  template text with its literal-prefix anchor normalized through
+  `url::Url` serialization (lowercased scheme and host, default port
+  stripped, IDN punycoded; the rest of the template stays verbatim, since
+  it is raw text rather than a parsed URL), and the primary glob anchors
+  on that literal prefix per §8, exactly like a templated `index_root`
+  advertised by discovery. A template with no safe anchor (at least
+  `scheme://authority/`) is rejected with a pointer to `SYSAND_CRED_*`.
 
 The index URL is normalized (trailing slash, scheme) before use as the
 storage key and for glob derivation, so different spellings do not create
@@ -334,8 +339,10 @@ two-leg flow and trusted publishing are otherwise unchanged.
   one (string-prefix coverage with both sides slash-terminated), it
   replaces it, keeping the set minimal and non-overlapping. Normative test
   requirements: the discovery-document URL, the `index.json` URL, and the
-  upload URL each match the compiled derived set, and an IPv6-literal login
-  (`https://[::1]:8000/`) works.
+  upload URL each match the compiled derived set (for a template-target
+  login without an advertised `api_root` there is no upload URL, and an
+  encoded-`{path}` project-file URL stands in for it), and an IPv6-literal
+  login (`https://[::1]:8000/`) works.
 - **Divergent `api_root` (Case B).** If `api_root` nests under the derived
   root (Case A), one glob suffices. If it is a disjoint host/path, store the
   same credential under both globs (minimal, non-overlapping), so the upload

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -155,8 +155,8 @@ There is deliberately no way to disable credential validation against the index
 that has an API. Offline or unreachable-index logins already degrade
 gracefully through the refusal rule: nothing exercises the credential,
 so the login stores as "stored, not validated" with warnings, and no
-secret is transmitted (an unreachable discovery baseline gets no forced
-retry, and unreachable probes produce no verdict). False refusals are
+secret is transmitted (an unreachable or rate-limited discovery baseline
+gets no forced retry, and unreachable probes produce no verdict). False refusals are
 engineered out rather than opted out of: 429 and redirects are never
 verdicts, and acceptance by any exercised surface wins. For the residual
 case where an index genuinely misbehaves, `SYSAND_CRED_*` environment
@@ -184,8 +184,11 @@ plain-URL index is never phantom-probed for an API it does not have.
 **Login's discovery fetch is itself unauth-baseline-then-forced** (only
 the backend-absent path of §9 stays strictly unauthenticated, since its
 secret is discarded). The
-baseline is unauthenticated; any 4xx answer triggers one forced-bearer
-retry with the in-hand secret. The retry must fire on 404 too: a private
+baseline is unauthenticated; any 4xx answer except 429 triggers one
+forced-bearer retry with the in-hand secret. A rate-limited baseline
+mirrors the probes' 429 carve-out: a throttling host gets no extra
+request and never sees the secret, and discovery falls back to the
+URL-derived glob with a notice. The retry must fire on 404 too: a private
 GitLab answers 404, not 401, when auth is missing, and the credentialed
 answer is what distinguishes a hidden discovery document from an absent
 one. This means an index with no discovery document sees one extra
@@ -194,10 +197,10 @@ anchor (§8) the probes already hit. Forced-retry outcomes: a 200 with a
 valid document is used exactly like a public discovery success (globs,
 an advertised `api_root`, the whoami gate); a 404 is the authoritative "no
 document" answer and reconstructs the flat topology with no warning; and
-everything else (other 4xx, 429, a redirect, since the retry goes through
-the no-redirect probe client unlike the redirect-following baseline, 5xx,
-or a network failure) is not a verdict and falls back to the URL-derived
-glob with a warning. In every fallback case the read probe falls back to
+everything else (other 4xx, a 429 answer to the retry itself, a redirect,
+since the retry goes through the no-redirect probe client unlike the
+redirect-following baseline, 5xx, or a network failure) is not a verdict
+and falls back to the URL-derived glob with a warning. In every fallback case the read probe falls back to
 the URL-derived `index.json` location, so a fully private index still
 gets its read leg exercised. The forced discovery fetch never counts
 toward the validated claim: the `index.json` probe is the sole read
@@ -216,7 +219,14 @@ mixing "verified"/"unvalidated" families.
 **Refusal rule.** Store if the credential is _accepted by any surface it
 actually tested_, warning about any surface that rejected or was
 unreachable. Refuse only when at least one exercised surface rejected the
-credential and none accepted it. A surface counts as "tested" only if the
+credential and none accepted it. A single-surface refusal reads plainly,
+naming the endpoint and its answer ("the index rejected the token for
+`<index>` (`v1/whoami` answered HTTP 401); nothing was stored"); the
+surface-enumeration wording is kept for the two-surface case. When the
+read surface alone rejected with a 404, the message hedges with "or no
+index exists at this URL": a valid token against a URL without an
+`index.json` answers the same way, so the credential must not be blamed
+outright. A surface counts as "tested" only if the
 credential was exercised: a _public_ read surface returns 200 without
 sending the credential, so it proves nothing. A 429 response is never a
 verdict; a rate-limited probe counts the surface as not tested. If nothing exercised the
@@ -302,7 +312,10 @@ The one change to publish's bearer selection is **source precedence**: try
 env bearer matches first (single match within env), then keyring (single
 match within keyring), instead of one flat "exactly one match or error" over
 the merged set. Within a source the existing exactly-one rule stands (its
-`AmbiguousPublishBearer` error becomes per-source). Concretely:
+`AmbiguousPublishBearer` error becomes per-source), with candidates
+carrying the identical token collapsing to one match, like the reads rule
+in section 9 (two stored globs of one login both matching the upload URL
+are one credential in effect). Concretely:
 `publish_bearer_auth_map` (the by-ref bearer extraction in
 `core/src/auth.rs`) and `resolve_publish_bearer_from_config` (in
 `core/src/commands/publish.rs`) keep env and keyring as **two maps**
@@ -347,8 +360,8 @@ logout` removes) may fall back to the default index.
 - **Source precedence, single match within a source.** For a given URL, all
   `SYSAND_CRED_*` (env) matches take precedence over all keyring matches
   (so CI can override an interactive login). Within one source, the existing
-  single-match rule applies (publish errors on a within-source ambiguity;
-  reads try-all). v1 deliberately does **not** add longest-prefix
+  single-match rule applies (publish errors on a within-source ambiguity,
+  identical-token matches collapsing first; reads try-all). v1 deliberately does **not** add longest-prefix
   tie-breaking, that is only needed once raw-pattern `auth set` or
   same-host nested logins create within-source overlaps (§10).
 - **Glob coverage.** `login` anchors the primary glob on the **discovery URL
@@ -470,14 +483,19 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   unreadable; remove the `sysand` keyring entry to reset", never silently
   treats the blob as empty, which would clobber all stored credentials on the
   next `login`.
-- **Concurrency.** Read-modify-write is guarded by a **cross-process
-  advisory OS file lock** (`flock`/`LockFileEx`, via the stable
-  `std::fs::File` locking API), never an existence-based lock file (those
-  go stale after a crash). The lock file lives in a **per-user** location
-  (`XDG_RUNTIME_DIR`/`XDG_STATE_HOME` on Linux, `%LOCALAPPDATA%` on
-  Windows, falling back to the home directory), mode `0600`, never a
-  world-writable shared path (lock squatting / symlink games), with a
-  bounded wait and a clear error. A lock file is not a credentials file, so
+- **Concurrency.** Read-modify-write is guarded by an **exclusive
+  cross-process advisory OS file lock** (`flock`/`LockFileEx`, via the
+  stable `std::fs::File` locking API), never an existence-based lock file
+  (those go stale after a crash); read-only operations take its shared
+  counterpart so concurrent readers do not serialize, both with a bounded
+  wait and a clear error. The lock file lives in a **per-user** location
+  with a stable order: the state dir (`XDG_STATE_HOME` on Linux), then the
+  local data dir (`%LOCALAPPDATA%` on Windows), falling back to a dotdir
+  in the home directory; deliberately never the session-scoped
+  `XDG_RUNTIME_DIR`, which is often unset for cron, systemd, and container
+  processes, so two same-user processes could lock different files while
+  writing the same keyring entry. It is mode `0600`, never a
+  world-writable shared path (lock squatting / symlink games). A lock file is not a credentials file, so
   the no-plaintext rule is untouched. Parallel `sysand` invocations are
   real; an in-process mutex alone would lose one writer's record. The lock
   coordinates `sysand` processes with each other only, not `sysand` against
@@ -581,7 +599,7 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   never breaks status. Default-index resolution for the marker never
   errors (section 4).
   Multiple stored entries are separated by one blank line. The sublabels
-  (`patterns:`, `subject:`, `token prefix:`, `expires:`) render dim so the
+  (`covers:`, `subject:`, `token prefix:`, `expires:`) render dim so the
   values carry the visual weight; `shadowed by:` stays warn-styled. Env
   entries list the variable label and pattern. A source with nothing to
   show is omitted rather than announced with a negative; only when neither
@@ -651,9 +669,11 @@ Each phase is independently shippable.
 Separate, not part of these phases: the deferred `auth set` / basic-auth
 work.
 
-CI notes for these phases: the test lanes do not enable `-F keyring`, so
-keyring-gated tests only compile via `clippy --all-features` until a
-keyring lane is added; and the prek job needs its rust hooks pinned via
+CI notes for these phases: the workspace test lane runs `sysand-core` and
+`sysand` together, and the CLI crate enables `sysand-core/keyring`, so
+with resolver 3 feature unification the keyring-gated tests build and run
+in the ordinary test lane (no separate keyring lane is needed); and the
+prek job needs its rust hooks pinned via
 `language_version` (handled separately from this plan), since prek does
 not read `rust-toolchain.toml`.
 
@@ -742,7 +762,9 @@ capabilities behind cargo features (`filesystem`, `networking`).
     Secret Service). Provide a deliberate seam, a debug-build-only env var
     (`SYSAND_TEST_CREDENTIAL_STORE`) selecting a file-backed or absent
     blob backend, refused loudly in release builds, and route every auth
-    command and the lazy policy through it.
+    command and the lazy policy through it. The shared CLI test harness
+    defaults the seam to the absent backend, so a test reaches a real
+    keyring only by opting out explicitly.
 - **core `commands/auth.rs`, gated `all(filesystem, networking)`** (the
   same gate as publish): `do_auth_login` / `do_auth_logout` /
   `do_auth_status` orchestration (discovery fetch, glob derivation,

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -329,9 +329,11 @@ logout` removes) may fall back to the default index.
   (`url::Url::as_str()`) so IDN/percent-encoding agree on both sides. Two
   refinements: a templated root's anchor is the literal prefix cut back
   to its **last `/`**, and the root is skipped with a notice unless that
-  anchor still parses as `scheme://authority/` or deeper (a placeholder
-  in the host position, or a template with no `/` after the authority,
-  would otherwise degenerate the anchor toward `https://**`); and within
+  anchor still parses as `scheme://authority/` or deeper (template
+  parsing already rejects placeholders outside the path or query, so the
+  reachable degenerate case is a template with no `/` after the
+  authority, where the cut would land inside `https://`; the parse check
+  is defense-in-depth for the rest); and within
   one login's derived set (the login URL plus its resolved `index_root`
   and `api_root`, never other stored records), a newly derived root that
   **subsumes** an already-derived one replaces it, keeping the set

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -147,9 +147,8 @@ described below), every surface the index supports is probed, and the
 refusal rule decides. A static index has only the read surface; a
 dynamic index adds the API.
 
-There is deliberately no `--no-validation` escape (and core's
-`do_auth_login` takes no validation parameter, so the bindings expose no
-knob either). Offline or unreachable-index logins already degrade
+There is deliberately no way to disable credential validation against the index
+that has an API. Offline or unreachable-index logins already degrade
 gracefully through the refusal rule: nothing exercises the credential,
 so the login stores as "stored, not validated" with warnings, and no
 secret is transmitted (an unreachable discovery baseline gets no forced
@@ -177,10 +176,7 @@ after reading discovery): fetch discovery, resolve `index_root` and
 `api_root`, probe `index_root/index.json`, and, **only if discovery
 advertised an `api_root`** (not the runtime plain-URL default, §3), probe
 `api_root/v1/whoami`, so a static plain-URL index is never phantom-probed
-for an API it does not have. Advertised-vs-defaulted needs a flag on the
-resolved endpoints (for example `api_root_advertised: bool`), true only in
-the explicit-field arm of discovery parsing, false in both defaulting arms
-and the no-document path.
+for an API it does not have.
 
 **Login's discovery fetch is itself unauth-baseline-then-forced** (only
 the backend-absent path of §9 stays strictly unauthenticated, since its

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -729,8 +729,9 @@ CLI). Placement follows the repo's existing pattern: `do_*` command logic in
 `core/src/commands/`, thin wrappers in `sysand/src/commands/`, optional
 capabilities behind cargo features (`filesystem`, `networking`).
 
-- **core, unconditional:** only the record types, blob JSON codec (pure
-  serde), and the `CredentialStore` trait.
+- **core, unconditional:** the record types, blob JSON codec (pure
+  serde), and the store type itself (`LockedBlobStore`, including the
+  cross-process file lock), generic over the `BlobBackend` storage seam.
 - **core, behind the existing `networking` feature:** the `LazyKeyringLayer`
   policy layer and its composition with the env layer, since `auth.rs` (and
   the `HTTPAuthentication` trait, defined over reqwest types) is already
@@ -741,12 +742,12 @@ capabilities behind cargo features (`filesystem`, `networking`).
   currently private, so the composition needs a public constructor (or a
   new combinator, see §9's pass-the-response-down variant).
 - **core, behind a new `keyring` cargo feature** (not in `default`): the
-  OS-keyring-backed `CredentialStore` impl and the cross-process file lock
-  (uses `dirs`, mirroring `filesystem`). Enabled by the CLI and the py/java
+  OS-keyring `BlobBackend` and the default lock-file path (uses `dirs`,
+  mirroring `filesystem`). Enabled by the CLI and the py/java
   bindings; **off for the js/wasm binding**, the `keyring` crate does not
-  build for wasm. A browser-side store could later implement the same trait
-  (bindings/js already has local-storage machinery), but that is not v1 and
-  localStorage is not secure storage.
+  build for wasm. A browser-side store could later implement the same
+  backend trait (bindings/js already has local-storage machinery), but
+  that is not v1 and localStorage is not secure storage.
   - **Pure-Rust Secret Service.** keyring 4.x's `v1` feature uses the
     zbus Secret Service backend on glibc Linux, with no system libdbus
     (nothing to vendor) and a `crypto-rust` session that keeps openssl out
@@ -768,7 +769,8 @@ capabilities behind cargo features (`filesystem`, `networking`).
 - **core `commands/auth.rs`, gated `all(filesystem, networking)`** (the
   same gate as publish): `do_auth_login` / `do_auth_logout` /
   `do_auth_status` orchestration (discovery fetch, glob derivation,
-  validation probes, refusal rule), generic over the store trait.
+  validation probes, refusal rule), generic over the store's blob
+  backend.
   **A library call must never prompt**: the secret arrives as a
   parameter, and there is no validation knob to plumb (§5).
 - **sysand CLI:** the clap surface, hidden prompt, TTY detection,

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -534,10 +534,14 @@ transport-security guidance lives in the docs (§13).
   works).
 - Longest-prefix most-specific-glob-wins (needed only once `set` / nested
   logins create within-source overlaps).
-  **Out of scope entirely:** acquisition beyond store-what-you-paste (OAuth
-  apps, device flows, refresh-token lifecycle); a self-written encrypted vault
-  or plaintext credentials file; a user-facing credential "label" concept;
-  multi-account-per-host switching; git credentials (git keeps its own).
+
+**Out of scope entirely:**
+
+- Acquisition beyond store-what-you-paste (OAuth apps, device flows, refresh-token lifecycle).
+- Self-written encrypted vault or plaintext credentials file.
+- User-facing credential "label" concept.
+- Multi-account-per-host switching.
+- git credentials (git keeps its own).
 
 ## 11. Phases (landed)
 
@@ -552,18 +556,12 @@ valid token.
 CI notes that remain true: the workspace test lane runs `sysand-core` and
 `sysand` together, and the CLI crate enables `sysand-core/keyring`, so
 with resolver 3 feature unification the keyring-gated tests run in the
-ordinary test lane (no separate keyring lane); prek's rust hooks are
-pinned via `language_version`, since prek does not read
-`rust-toolchain.toml`.
+ordinary test lane (no separate keyring lane).
 
 ## 12. Protocol/spec changes (this repo, `design/`)
 
 `design/index-api-protocol.md` specifies `v1/whoami` (§6), routed under
-`api/`. The `design/index-protocol.md` require-`api_root` change landed
-separately (an index has an API iff discovery advertises `api_root`; the
-plain-URL default was dropped, a breaking change for third-party plain-URL
-dynamic indexes, which must now serve `sysand-index-config.json` with an
-explicit `api_root`).
+`api/`.
 
 ## 13. Documentation (docs.sysand.com, in the `sysand-index` repo)
 

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -78,7 +78,7 @@ Under a `sysand auth` namespace:
 | Command                          | Role                                                                                                                                                                                  |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sysand auth login [index-url]`  | validated, index-keyed bearer credential (see §5); no URL = the default index                                                                                                         |
-| `sysand auth logout [index-url]` | remove an index login; no URL = the default index (symmetric with `login`)                                                                                                            |
+| `sysand auth logout [index-url]` | remove a stored credential; no URL = the default index (symmetric with `login`)                                                                                                       |
 | `sysand auth status`             | list stored credentials (never secrets), backend, and `SYSAND_CRED_*` shadowing; marks the entries that apply to the default index                                                    |
 | `sysand auth whoami [index-url]` | query-only live identity via `v1/whoami` (advertised `api_root` required), with runtime credential selection (env over stored, §7); names the source used; no URL = the default index |
 
@@ -90,7 +90,7 @@ Under a `sysand auth` namespace:
   request-time basic auth via `SYSAND_CRED_*` still works.
 - **`auth whoami` semantics.** Query-only: it never writes the credential
   store (no refresh of cached identity fields). Its discovery fetch uses
-  the regular runtime read policy (env credentials and stored logins
+  the regular runtime read policy (env credentials and stored credentials
   apply), so it works against private indexes. Exit code 0 only when the
   API accepted the credential; rejected, unreachable, redirected, and
   rate-limited responses are distinct nonzero errors. An index whose
@@ -326,7 +326,7 @@ two-leg flow and trusted publishing are otherwise unchanged.
   bearer came from a stale `SYSAND_CRED_*` var (a fresh login would stay
   shadowed and the user would loop). So an upload auth failure states where
   the selected bearer came from ("from `SYSAND_CRED_TEAMIDX`" vs "from your
-  stored login for `<index>`") and tailors the remediation (unset/rotate the
+  stored credential for `<index>`") and tailors the remediation (unset/rotate the
   env var vs re-login). A `403` (authorization, not authentication)
   additionally points at `sysand auth status`, which shows the stored
   `subject`, catching "this is a project token for a different project".
@@ -469,7 +469,7 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   (interrupted write, older/newer sysand, another same-user process's
   scribble) read-modify-write **fails closed**, "credential store
   unreadable; remove the `sysand` keyring entry to reset", never silently
-  treats the blob as empty, which would clobber all stored logins on the
+  treats the blob as empty, which would clobber all stored credentials on the
   next `login`.
 - **Concurrency.** Read-modify-write is guarded by a **cross-process
   advisory OS file lock** (`flock`/`LockFileEx`, via a crate like
@@ -586,8 +586,8 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   values carry the visual weight; `shadowed by:` stays warn-styled. Env
   entries list the variable label and pattern. A source with nothing to
   show is omitted rather than announced with a negative; only when neither
-  stored logins nor `SYSAND_CRED_*` variables exist does status print the
-  single line "No credentials configured (no stored logins, no
+  stored credentials nor `SYSAND_CRED_*` variables exist does status print the
+  single line "No credentials configured (no stored credentials, no
   `SYSAND_CRED_*` variables)." The no-usable-keyring note still prints
   whenever the backend is unusable (it is information, not a negative). No
   `scheme` column in v1 (always bearer for stored; env entries may be

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -104,7 +104,8 @@ Under a `sysand auth` namespace:
   not given, `login` fails fast ("no terminal for prompt; pass the token
   with `--token-stdin`") instead of hanging or reading a pipe as a secret.
 - **Default index.** `sysand auth login` with no URL resolves the target
-  from the default-index chain: `--default-index` / `SYSAND_DEFAULT_INDEX`,
+  from the default-index chain: the `SYSAND_DEFAULT_INDEX` environment
+  variable (comma-delimited),
   then a `default = true` index in configuration, else the built-in
   `DEFAULT_INDEX_URL` (`https://sysand.com`). Note `sysand publish` has no
   such default (its `--index` is required), so this chain is defined here,
@@ -112,7 +113,7 @@ Under a `sysand auth` namespace:
   `login` errors and asks for an explicit URL. `login` always **echoes the
   resolved index** before prompting (and on the `--token-stdin` path), so a
   project-configured default cannot be targeted silently. `auth status`
-  reuses the same chain (including a `--default-index` override), but only
+  reuses the same chain, but only
   to mark the entries that apply to the default index, and **never
   hard-errors over it**: an ambiguous chain prints a note and marks
   nothing, and a default that is not a valid HTTP(S) index key (for

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -554,10 +554,11 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   exactly when it bites.
 - **Expiry:** reactive first, when a request that exercised a stored
   credential ends in **any 4xx** and the record's `expires_at` is past,
-  print "credential for `<index>` may be expired or revoked; re-run
-  `sysand auth login <index>`", any 4xx, not just 401, because
-  GitLab-style hosts answer 404 on bad auth and the blob is already loaded
-  on that path. Proactive when known, `expires_at` (stored from `v1/whoami`
+  print "credential for `<index>` may be expired or revoked; re-authenticate
+  to store a fresh credential", any 4xx, not just 401, because GitLab-style
+  hosts answer 404 on bad auth and the blob is already loaded on that path.
+  This warning is emitted in the library (on the read path, where the CLI
+  cannot re-wrap it), so it names no CLI command. Proactive when known, `expires_at` (stored from `v1/whoami`
   at login, absent for static/read-only or non-validated logins) lets
   `auth status` show "expires in N days / expired".
 - **`auth status` output:** one unified view of **everything sysand will

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -529,11 +529,11 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   ordinary 404, permanently doubling round-trips for logged-in users. The
   keyring layer therefore needs a **variant combinator that passes the
   initial response down**, returning it untouched when no record matches.
-  Two further semantics to pin: the blob cache needs **dual accessors**,
-  an async one (`OnceCell` + `spawn_blocking`, since the keyring crate is
-  synchronous and a locked store can block for seconds) for the request
-  path, and a plain sync one for publish, which runs outside the async
-  runtime and must not nest `block_on`. When several records' globs match
+  Two further semantics to pin: the blob cache serves the **request path
+  only**, through one async accessor (`OnceCell` + `spawn_blocking`, since
+  the keyring crate is synchronous and a locked store can block for
+  seconds); publish runs outside the async runtime and performs its own
+  single direct store read, outside the cache. When several records' globs match
   one URL: matches carrying the **identical token collapse to one retry**;
   genuinely distinct tokens warn and are tried in order (the reads
   try-all rule, section 8).

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -79,7 +79,7 @@ Under a `sysand auth` namespace:
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sysand auth login [index-url]`  | validated, index-keyed bearer credential (see §5); no URL = the default index                                                                                                         |
 | `sysand auth logout [index-url]` | remove an index login; no URL = the default index (symmetric with `login`)                                                                                                            |
-| `sysand auth status`             | list stored credentials (never secrets), backend, and `SYSAND_CRED_*` shadowing                                                                                                       |
+| `sysand auth status`             | list stored credentials (never secrets), backend, and `SYSAND_CRED_*` shadowing; marks the entries that apply to the default index                                                    |
 | `sysand auth whoami [index-url]` | query-only live identity via `v1/whoami` (advertised `api_root` required), with runtime credential selection (env over stored, §7); names the source used; no URL = the default index |
 
 - **Bearer only in v1.** The token is entered via a hidden prompt
@@ -111,7 +111,12 @@ Under a `sysand auth` namespace:
   not borrowed. If the chain yields **more than one** default index, bare
   `login` errors and asks for an explicit URL. `login` always **echoes the
   resolved index** before prompting (and on the `--token-stdin` path), so a
-  project-configured default cannot be targeted silently.
+  project-configured default cannot be targeted silently. `auth status`
+  reuses the same chain (including a `--default-index` override), but only
+  to mark the entries that apply to the default index, and **never
+  hard-errors over it**: an ambiguous chain prints a note and marks
+  nothing, and a default that is not a valid HTTP(S) index key (for
+  example `file://`) silently marks nothing.
 - **HTTP(S) only.** `auth login` against a non-HTTP(S) location (for
   example a local file path, which index resolution accepts elsewhere)
   errors with "not an HTTP(S) index; nothing to authenticate to".
@@ -534,6 +539,16 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   absent, the security-relevant case), covered globs, `subject` and token
   `prefix` (from whoami, if a validating login ran), `expires_at` if
   stored, and whether a `SYSAND_CRED_*` var shadows it, never the secret.
+  Entries of both sources that **apply to the default index** (which is
+  what bare commands actually use) carry a dim `(default index)`
+  annotation at the end of their header line: a stored entry on
+  normalized-key equality with the default's key or when one of its globs
+  matches the default index root URL (for a template default, its
+  literal-prefix anchor; the match shares `shadowed by`'s root-URL
+  approximation), an env entry when its pattern matches that root.
+  Patterns compile leniently here, like shadow detection: one bad pattern
+  never breaks status. Default-index resolution for the marker never
+  errors (section 4).
   Multiple stored entries are separated by one blank line. The sublabels
   (`patterns:`, `subject:`, `token prefix:`, `expires:`) render dim so the
   values carry the visual weight; `shadowed by:` stays warn-styled. Env

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -119,9 +119,13 @@ Under a `sysand auth` namespace:
   always carries an explicit path `/`, so every template anchors at least
   at `scheme://authority/`.
 
-The index URL is normalized (trailing slash, scheme) before use as the
-storage key and for glob derivation, so different spellings do not create
-duplicate entries.
+The index URL is validated and normalized by the shared index-location
+parser (absolute HTTP(S), no userinfo, no fragment; lowercased host,
+default port dropped, trailing path slash) before use as the storage key,
+so different spellings do not create duplicate entries. A query string is
+allowed on plain roots just as in templates and stays part of the key;
+glob derivation anchors on the query-stripped root (§8), because resolved
+request URLs continue the path before the query.
 
 ## 5. Validation
 
@@ -328,7 +332,10 @@ logout` removes) may fall back to the default index.
   to end in `/` (for example `https://example.com/idx/**`), and both
   derivation and runtime matching use the same serialization
   (`url::Url::as_str()`) so IDN/percent-encoding agree on both sides. Two
-  refinements: a templated root's anchor is the normalized literal
+  refinements: a plain root's anchor is the **query-stripped** URL
+  (resolved request URLs continue the path before any query, so a query
+  in the anchor would match nothing); a templated root's anchor is the
+  normalized literal
   prefix cut back to its **last `/`** (prefix normalization gives every
   template an explicit path `/`, so the anchor always parses as
   `scheme://authority/` or deeper; a placeholder directly after the

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -1,8 +1,9 @@
-# Credential storage and authentication commands (plan)
+# Credential storage and authentication commands
 
-> **Status: plan / draft.** Not yet a stable contract. This document
-> captures the agreed design for persisting index credentials and the
-> `sysand auth` command family, so implementation can proceed in phases.
+> **Status: shipped.** This document records the design behind the
+> implemented credential persistence and the `sysand auth` command
+> family. Sections 3-10 and 14 are the normative reference; section 11
+> summarizes how the work landed.
 
 ## 1. Goal
 
@@ -17,21 +18,14 @@ v1 is deliberately narrow: bearer tokens, `login` / `logout` / `status` /
 targets. Basic auth, raw-pattern commands, and the P2 protocol change are
 deferred (§10).
 
-## 2. Current state
+## 2. Architecture context
 
-- **Request-time application of credentials already exists** in
-  `core/src/auth.rs`: a per-URL glob map of auth policies (bearer, basic),
-  combinators that try unauthenticated first and send the secret only on a
-  4xx, and same-host redirect handling. The policy is built **eagerly and
-  immutably** at startup in `sysand/src/lib.rs` from `SYSAND_CRED_*`.
-- **Publish OIDC (trusted publishing)** exists in
-  `core/src/commands/publish.rs` for CI.
-- **Token sourcing is a stopgap:** `sysand/src/lib.rs` scans
-  `SYSAND_CRED_*` environment variables on every run. There is no
-  persistence: a user re-supplies env vars each invocation.
-
-The gap this plan fills is the missing middle: persist a credential once,
-retrieve it on later runs, feed it into the glob-based auth layer.
+Request-time application of credentials lives in `core/src/auth.rs` (a
+per-URL glob map of policies, unauth-first with 4xx escalation); publish
+OIDC in `core/src/commands/publish.rs`. `SYSAND_CRED_*` env variables
+remain the per-run path. The credential store supplies the missing
+middle: persist once, retrieve on later runs, feed the glob-based auth
+layer.
 
 ## 3. Model and constraints
 
@@ -46,20 +40,17 @@ Three surfaces, and one access rule:
 Constraints:
 
 - **C1 - unified read access.** Discovery and index root share one auth
-  status (public or private together). This removes pathological split
-  permutations and collapses the space to a 2x2.
-- **C2 - one credential per index.** `auth login` stores one credential per
-  index, used for both the read leg and the API leg. Separate read/write
-  tokens are not a v1 concept (a later `auth set` could cover them, §10).
-- **P2 - API presence is read from discovery.** This plan treats an index
-  as having an API iff its discovery document advertises `api_root`, and
-  derives globs accordingly. Enforcing "`api_root` required" at the protocol
-  level (dropping the old plain-URL default) landed separately (§12); this
-  plan relies on it, so `api_root` is `Some` exactly when an API is
-  advertised.
+  status (public or private together), collapsing the space to a 2x2.
+- **C2 - one credential per index.** `auth login` stores one credential
+  per index, used for both the read leg and the API leg. Separate
+  read/write tokens are not a v1 concept (a later `auth set`, §10).
+- **P2 - API presence is read from discovery.** An index has an API iff
+  its discovery document advertises `api_root` (the protocol-level
+  requirement landed separately, §12), so `api_root` is `Some` exactly
+  when an API is advertised.
 - **P1 - public discovery: not required.** Under C2 the single credential
   reads discovery on a private index, so there is no bootstrap paradox.
-  Current behavior (discovery may be private) stands.
+  Discovery may be private.
 
 The collapsed situation space:
 
@@ -82,61 +73,49 @@ Under a `sysand auth` namespace:
 | `sysand auth whoami [index-url]` | query-only live identity via `v1/whoami` (advertised `api_root` required), with runtime credential selection (env over stored, §7); names the source used; no URL = the default index |
 
 - **Bearer only in v1.** The token is entered via a hidden prompt
-  ("Enter token for `<index>`:", neutral wording since the credential may be
-  a forge PAT rather than a Sysand API token) or `--token-stdin`, never an
-  inline value flag (shell-history / `ps` leakage). Basic auth
-  (`--username`) and raw-pattern `auth set` / `unset` are deferred (§10);
-  request-time basic auth via `SYSAND_CRED_*` still works.
+  ("Enter token for `<index>`:", neutral wording since the credential may
+  be a forge PAT) or `--token-stdin`, never an inline value flag
+  (shell-history / `ps` leakage). Basic auth (`--username`) and
+  raw-pattern `auth set` / `unset` are deferred (§10); request-time basic
+  auth via `SYSAND_CRED_*` still works.
 - **`auth whoami` semantics.** Query-only: it never writes the credential
   store (no refresh of cached identity fields). Its discovery fetch uses
-  the regular runtime read policy (env credentials and stored credentials
-  apply), so it works against private indexes. Exit code 0 only when the
-  API accepted the credential; rejected, unreachable, redirected, and
-  rate-limited responses are distinct nonzero errors. An index whose
-  discovery did not advertise an `api_root` gets a clear "no API" error.
-- **Output style.** All auth command output follows the CLI's existing
-  conventions: the styled leading word right-aligned in the 12-column
-  gutter (as in `Publishing ...` / `Published ...`), anstyle tokens for
-  emphasis, and byte-identical plain text when piped or under `NO_COLOR`.
-  Timestamps are shown without sub-second precision.
+  the regular runtime read policy, so it works against private indexes.
+  Exit code 0 only when the API accepted the credential; rejected,
+  unreachable, redirected, and rate-limited responses are distinct
+  nonzero errors. No advertised `api_root` gets a clear "no API" error.
+- **Output style.** The CLI's existing conventions: styled leading word
+  right-aligned in the 12-column gutter, anstyle tokens, byte-identical
+  plain text when piped or under `NO_COLOR`, timestamps without
+  sub-second precision.
 - **Non-interactive safety.** If stdin is not a TTY and `--token-stdin` was
   not given, `login` fails fast ("no terminal for prompt; pass the token
   with `--token-stdin`") instead of hanging or reading a pipe as a secret.
-- **Default index.** `sysand auth login` with no URL resolves the target
-  from the default-index chain: the `SYSAND_DEFAULT_INDEX` environment
-  variable (comma-delimited),
-  then a `default = true` index in configuration, else the built-in
-  `DEFAULT_INDEX_URL` (`https://sysand.com`). Note `sysand publish` has no
-  such default (its `--index` is required), so this chain is defined here,
-  not borrowed. If the chain yields **more than one** default index, bare
-  `login` errors and asks for an explicit URL. `login` always **echoes the
-  resolved index** before prompting (and on the `--token-stdin` path), so a
-  project-configured default cannot be targeted silently. `auth status`
-  reuses the same chain, but only
-  to mark the entries that apply to the default index, and **never
-  hard-errors over it**: an ambiguous chain prints a note and marks
-  nothing, and a default that is not a valid HTTP(S) index key (for
-  example `file://`) silently marks nothing.
-- **HTTP(S) only.** `auth login` against a non-HTTP(S) location (for
-  example a local file path or `file://` URL, which sysand accepts
-  elsewhere as a project source but never as an index) errors with "not an
-  HTTP(S) index; nothing to authenticate to".
-- **Glob derivation** (§8): automatic from the login-target index URL (the
-  URL the user passes to `auth login`, or the resolved default index when
-  none is given), not from the discovery document; discovery-advertised
-  `index_root` / `api_root` add further globs per §8. No manual `--pattern`
-  in v1. If derivation is ever wrong for an unusual layout, the
-  `SYSAND_CRED_*` env var is the escape hatch until `--pattern` / `auth set`
-  land (§10).
-  A **templated URL as the login target itself** (the user typing a
-  `{path}` / `{path_raw}` template into `auth login`/`logout`, for example
-  a GitLab repository-files URL) is supported: the storage key is the
-  template text with its literal-prefix anchor normalized through
-  `url::Url` serialization (lowercased scheme and host, default port
-  stripped, IDN punycoded; the rest of the template stays verbatim, since
-  it is raw text rather than a parsed URL), and the primary glob anchors
-  on that literal prefix per §8, exactly like a templated `index_root`
-  advertised by discovery. A template with no safe anchor (at least
+- **Default index.** A bare `auth` command resolves its target from the
+  default-index chain: `SYSAND_DEFAULT_INDEX` (comma-delimited), then a
+  `default = true` index in configuration, else the built-in
+  `DEFAULT_INDEX_URL` (`https://sysand.com`). `sysand publish` has no
+  such default (its `--index` is required). If the chain yields **more
+  than one** default index, bare `login` errors and asks for an explicit
+  URL. `login` always **echoes the resolved index** before prompting (and
+  on the `--token-stdin` path), so a project-configured default cannot be
+  targeted silently. `auth status` reuses the chain only to mark the
+  entries that apply to the default index and **never hard-errors over
+  it**: an ambiguous chain prints a note and marks nothing; an invalid
+  default silently marks nothing.
+- **HTTP(S) only.** `auth login` against a non-HTTP(S) location (a local
+  path or `file://` URL) errors with "not an HTTP(S) index; nothing to
+  authenticate to".
+- **Glob derivation** (§8): automatic from the login-target index URL,
+  with discovery-advertised `index_root` / `api_root` adding further
+  globs. No manual `--pattern` in v1; the `SYSAND_CRED_*` env var is the
+  escape hatch for unusual layouts until `--pattern` / `auth set` land
+  (§10). A **templated URL as the login target itself** (a `{path}` /
+  `{path_raw}` template, for example a GitLab repository-files URL) is
+  supported: the storage key is the template text with its literal-prefix
+  anchor normalized through `url::Url` serialization (the rest stays
+  verbatim: raw text, not a parsed URL), and the primary glob anchors on
+  that prefix per §8. A template with no safe anchor (at least
   `scheme://authority/`) is rejected with a pointer to `SYSAND_CRED_*`.
 
 The index URL is normalized (trailing slash, scheme) before use as the
@@ -145,116 +124,96 @@ duplicate entries.
 
 ## 5. Validation
 
-Login has exactly one behavior, with no opt-out flag or parameter:
-discovery is fetched for glob scoping (with the authenticated retry
-described below), every surface the index supports is probed, and the
-refusal rule decides. A static index has only the read surface; a
-dynamic index adds the API.
+Login has exactly one behavior, with no opt-out flag: discovery is
+fetched for glob scoping (with the authenticated retry described below),
+every surface the index supports is probed, and the refusal rule decides.
+A static index has only the read surface; a dynamic index adds the API.
 
-There is deliberately no way to disable credential validation against the index
-that has an API. Offline or unreachable-index logins already degrade
-gracefully through the refusal rule: nothing exercises the credential,
-so the login stores as "stored, not validated" with warnings, and no
-secret is transmitted (an unreachable or rate-limited discovery baseline
-gets no forced retry, and unreachable probes produce no verdict). False refusals are
-engineered out rather than opted out of: 429 and redirects are never
-verdicts, and acceptance by any exercised surface wins. For the residual
-case where an index genuinely misbehaves, `SYSAND_CRED_*` environment
-credentials remain the escape hatch.
-
-Validation is not levelled per surface either: since `v1/whoami` checks
-only that a token is _accepted_ by the API (identity, not capability,
-§6), validating everything almost never wrongly refuses a valid token,
-so a "read-only" level would add a choice without payoff.
+There is deliberately no way to disable credential validation. Offline or
+unreachable-index logins degrade gracefully through the refusal rule:
+nothing exercises the credential, so the login stores as "stored, not
+validated" with warnings, and no secret is transmitted. False refusals
+are engineered out rather than opted out of: 429 and redirects are never
+verdicts, and acceptance by any exercised surface wins. For an index that
+genuinely misbehaves, `SYSAND_CRED_*` environment credentials remain the
+escape hatch. Validation is not levelled per surface either: `v1/whoami`
+checks only that a token is _accepted_ (identity, not capability, §6), so
+a "read-only" level would add a choice without payoff.
 
 **Probe mechanism.** Validation cannot reuse the runtime unauth-first
 policy, which returns only the final response and cannot report whether a
 surface actually _accepted_ the credential. Each surface is probed as an
 **unauth baseline then a forced-auth retry**: a surface counts as
-accepted/tested only when the unauth baseline was a 4xx and the forced retry
-then succeeded, so a public surface (200 unauth, credential never sent) is
-correctly "not tested", not "accepted". The API surface (`v1/whoami`) is
-always authenticated, so its baseline is a known 401 and only the forced
-request is needed. Validation is discovery-first (`api_root` is known only
-after reading discovery): fetch discovery, resolve `index_root` and
-`api_root`, probe `index_root/index.json`, and, **only if discovery
-advertised an `api_root`**, probe `api_root/v1/whoami`, so a static
-plain-URL index is never phantom-probed for an API it does not have.
+accepted/tested only when the baseline was a 4xx and the forced retry
+succeeded, so a public surface (200 unauth, credential never sent) is
+"not tested", not "accepted". The API surface (`v1/whoami`) is always
+authenticated, so only the forced request is sent. Validation is
+discovery-first: fetch discovery, probe `index_root/index.json`, and,
+**only if discovery advertised an `api_root`**, probe
+`api_root/v1/whoami`, so a static plain-URL index is never phantom-probed
+for an API it does not have.
 
 **Login's discovery fetch is itself unauth-baseline-then-forced** (only
 the backend-absent path of §9 stays strictly unauthenticated, since its
-secret is discarded). The
-baseline is unauthenticated; any 4xx answer except 429 triggers one
-forced-bearer retry with the in-hand secret. A rate-limited baseline
-mirrors the probes' 429 carve-out: a throttling host gets no extra
-request and never sees the secret, and discovery falls back to the
-URL-derived glob with a notice. The retry must fire on 404 too: a private
-GitLab answers 404, not 401, when auth is missing, and the credentialed
-answer is what distinguishes a hidden discovery document from an absent
-one. This means an index with no discovery document sees one extra
-credentialed request at login; it goes to the same user-supplied trust
-anchor (§8) the probes already hit. Forced-retry outcomes: a 200 with a
-valid document is used exactly like a public discovery success (globs,
-an advertised `api_root`, the whoami gate); a 404 is the authoritative "no
-document" answer and reconstructs the flat topology with no warning; and
-everything else (other 4xx, a 429 answer to the retry itself, a redirect,
-since the retry goes through the no-redirect probe client unlike the
-redirect-following baseline, 5xx, or a network failure) is not a verdict
-and falls back to the URL-derived glob with a warning. In every fallback case the read probe falls back to
-the URL-derived `index.json` location, so a fully private index still
-gets its read leg exercised. The forced discovery fetch never counts
-toward the validated claim: the `index.json` probe is the sole read
-verdict (one verdict per surface), and claim strings stay `read`/`api`.
+secret is discarded). Any 4xx baseline answer except 429 triggers one
+forced-bearer retry with the in-hand secret; a rate-limited baseline gets
+no extra request and never sees the secret. The retry must fire on 404
+too: a private GitLab answers 404, not 401, when auth is missing, and the
+credentialed answer is what distinguishes a hidden discovery document
+from an absent one. Forced-retry outcomes: a 200 with a valid document is
+used exactly like a public discovery success; a 404 is the authoritative
+"no document" answer and reconstructs the flat topology with no warning;
+everything else (other 4xx, 429, a redirect, 5xx, or a network failure)
+is not a verdict and falls back to the URL-derived glob with a warning,
+where the read probe uses the URL-derived `index.json` location so a
+fully private index still gets its read leg exercised. The forced
+discovery fetch never counts toward the validated claim: the `index.json`
+probe is the sole read verdict, and claim strings stay `read`/`api`.
 
-**Probes do not follow redirects**: a redirect
-would mean the verdict comes from a different URL than the surface nominally
-probed (and a cross-host redirect strips the header, misreading "rejected"),
-so a redirected probe counts as "not tested" with a warning naming the
+**Probes do not follow redirects**: a redirect would mean the verdict
+comes from a different URL than the surface nominally probed (and a
+cross-host redirect strips the header, misreading "rejected"), so a
+redirected probe counts as "not tested" with a warning naming the
 redirect target.
 
 User-visible wording uses one stem, **validated**: "validated (read)",
-"stored, not validated", rather than
-mixing "verified"/"unvalidated" families.
+"stored, not validated", rather than mixing "verified"/"unvalidated"
+families.
 
 **Refusal rule.** Store if the credential is _accepted by any surface it
 actually tested_, warning about any surface that rejected or was
 unreachable. Refuse only when at least one exercised surface rejected the
-credential and none accepted it. A single-surface refusal reads plainly,
-naming the endpoint and its answer ("the index rejected the token for
-`<index>` (`v1/whoami` answered HTTP 401); nothing was stored"); the
+credential and none accepted it. A single-surface refusal names the
+endpoint and its answer ("the index rejected the token for `<index>`
+(`v1/whoami` answered HTTP 401); nothing was stored"); the
 surface-enumeration wording is kept for the two-surface case. When the
 read surface alone rejected with a 404, the message hedges with "or no
 index exists at this URL": a valid token against a URL without an
 `index.json` answers the same way, so the credential must not be blamed
-outright. A surface counts as "tested" only if the
-credential was exercised: a _public_ read surface returns 200 without
-sending the credential, so it proves nothing. A 429 response is never a
-verdict; a rate-limited probe counts the surface as not tested. If nothing exercised the
-credential (fully public read with no API, or every probe unreachable),
-store as "stored, not validated".
+outright. A surface counts as "tested" only if the credential was
+exercised (a public read surface proves nothing; a 429 is never a
+verdict). If nothing exercised the credential, store as "stored, not
+validated".
 
-This self-adjusts across the situation space:
+This self-adjusts across the situation space: on a private index where
+read works but the API rejects, store with a warning (the token still
+reads); on a public-read index (sysand.com), `v1/whoami` is the only real
+test and a rejected token is refused, keeping the publish flow protected;
+when every exercised surface rejects, refuse.
 
-- Private index, read works, API rejects: store with an "API access failed"
-  warning (the token is still useful for reading).
-- Public-read index (for example sysand.com): the read probe never tests
-  the token, so `v1/whoami` is the only real test, and a rejected token is
-  refused, keeping the publish flow protected.
-- Every exercised surface rejects: refuse.
-
-**Basic-auth indexes must not dead-end.** In bearer-only v1, a user of a
-private basic-auth index will naturally try `auth login` and be refused. The
-read probe sees the server's `WWW-Authenticate: Basic` challenge, so the
-refusal message must say so and route the user to the working path: "this
-index uses username/password (HTTP basic) authentication; configure
+**Basic-auth indexes must not dead-end.** A user of a private basic-auth
+index will naturally try `auth login` and be refused. The read probe sees
+the server's `WWW-Authenticate: Basic` challenge, so the refusal message
+must say so and route the user to the working path: "this index uses
+username/password (HTTP basic) authentication; configure
 `SYSAND_CRED_<X>_BASIC_USER` / `_BASIC_PASS` instead (see docs)".
 
-Never print a bare "validated"; always scope the claim to the surfaces that
-actually accepted the credential.
+Never print a bare "validated"; always scope the claim to the surfaces
+that actually accepted the credential.
 
 ## 6. The `v1/whoami` endpoint
 
-New endpoint on the index API (server side, the `sysand-index` Django app),
+Endpoint on the index API (server side, the `sysand-index` Django app),
 under `api_root`. Its purpose is credential validation and identity for
 `auth status`.
 
@@ -279,51 +238,42 @@ under `api_root`. Its purpose is credential validation and identity for
 
 - `subject.type` is `user`, `project`, or `oidc`, so the endpoint is
   principal-agnostic (hence `whoami`, not `user`). `subject.name` is the
-  **username** for a user token, the **project id** (`publisher/name`) for a
-  project token, and the **publisher identity** for an OIDC token; it is
+  **username** for a user token, the **project id** (`publisher/name`)
+  for a project token, and the **publisher identity** for an OIDC token;
   distinct from `token.name` (the user-given token label).
-- `token.expires_at` is always **returned** by whoami (the model's
-  `expires_at` is non-nullable); the stored record persists it only when a
-  validating login actually ran, hence "expires_at-if-known" in §8/§9.
-  `token.prefix` is the non-secret display prefix (type prefix + first 8
-  hex).
+- `token.expires_at` is always **returned** by whoami; the stored record
+  persists it only when a validating login ran, hence
+  "expires_at-if-known" in §8/§9. `token.prefix` is the non-secret
+  display prefix (type prefix + first 8 hex).
 - No `can_publish` flag and no scope list: at login there is no target
   project and every valid token can publish somewhere, so a capability
-  boolean is vacuous; per-project authorization stays enforced at the upload
-  (its existing `403`). An optional `?project=<id>` pre-flight may be added
-  later.
+  boolean is vacuous; per-project authorization stays enforced at the
+  upload (its existing `403`). An optional `?project=<id>` pre-flight may
+  be added later.
 
 ## 7. Publish interaction
 
 Publish is two legs with **different** credential handling:
 
 - **Leg 1, discovery read** (`sysand-index-config.json`, to resolve
-  `api_root`): uses the general read auth policy, unauth-first, authenticated
-  only if the index is private. `login` scopes the credential to cover the
-  discovery/index root (§8), so a private index's discovery fetch gets it.
+  `api_root`): the general read auth policy, unauth-first. `login` scopes
+  the credential to cover the discovery/index root (§8), so a private
+  index's discovery fetch gets it.
 - **Leg 2, upload** (`POST api_root/v1/upload`): **bearer only**, sent
   proactively (an upload cannot be tried unauthenticated then retried).
-  Publish checks env bearers first; only when **no env bearer matches** does
-  it read the keyring blob (one keychain access), consistent with "never
-  read the keyring when env already works". It then selects the bearer whose
-  glob matches the upload URL.
+  Publish checks env bearers first; only when **no env bearer matches**
+  does it read the keyring blob (one keychain access). It selects the
+  bearer whose glob matches the upload URL.
 
-The one change to publish's bearer selection is **source precedence**: try
-env bearer matches first (single match within env), then keyring (single
-match within keyring), instead of one flat "exactly one match or error" over
-the merged set. Within a source the existing exactly-one rule stands (its
-`AmbiguousPublishBearer` error becomes per-source), with candidates
-carrying the identical token collapsing to one match, like the reads rule
-in section 9 (two stored globs of one login both matching the upload URL
-are one credential in effect). Concretely:
-`publish_bearer_auth_map` (the by-ref bearer extraction in
-`core/src/auth.rs`) and `resolve_publish_bearer_from_config` (in
-`core/src/commands/publish.rs`) keep env and keyring as **two maps**
-(source-tagged, with the selected bearer's provenance threaded to the
-failure messages) with a two-stage lookup, never collapsing to one flat
-`GlobMap`. This makes the stated
-precedence real, a CI `SYSAND_CRED_*` overrides an interactive login. The
-two-leg flow and trusted publishing are otherwise unchanged.
+Publish's bearer selection uses **source precedence**: env bearer matches
+first, then keyring, never one flat "exactly one match or error" over a
+merged set. Within a source the exactly-one rule stands
+(`AmbiguousPublishBearer` is per-source), with candidates carrying the
+identical token collapsing to one match, like the reads rule in section 9. Env and keyring stay **two maps** (source-tagged, with the selected
+bearer's provenance threaded to the failure messages) with a two-stage
+lookup, making the precedence real: a CI `SYSAND_CRED_*` overrides an
+interactive login. The two-leg flow and trusted publishing are otherwise
+unchanged.
 
 - **Trusted-publishing precedence:** in `auto` mode publish uses OIDC
   trusted publishing when a supported CI environment is detected, and
@@ -334,21 +284,20 @@ two-leg flow and trusted publishing are otherwise unchanged.
 - **No matching bearer** fails up front (before the upload) with a hint to
   run `sysand auth login <index>` to store a publish token.
 - **Auth failures name the credential's source.** Because env shadows
-  keyring, "re-run `sysand auth login`" is the wrong fix when the rejected
-  bearer came from a stale `SYSAND_CRED_*` var (a fresh login would stay
-  shadowed and the user would loop). So an upload auth failure states where
-  the selected bearer came from ("from `SYSAND_CRED_TEAMIDX`" vs "from your
-  stored credential for `<index>`") and tailors the remediation (unset/rotate the
-  env var vs re-login). A `403` (authorization, not authentication)
-  additionally points at `sysand auth status`, which shows the stored
-  `subject`, catching "this is a project token for a different project".
+  keyring, "re-run `sysand auth login`" is the wrong fix when the
+  rejected bearer came from a stale `SYSAND_CRED_*` var (a fresh login
+  would stay shadowed and the user would loop). So an upload auth failure
+  states where the selected bearer came from and tailors the remediation
+  (unset/rotate the env var vs re-login). A `403` (authorization, not
+  authentication) additionally points at `sysand auth status`, which
+  shows the stored `subject`, catching "this is a project token for a
+  different project".
 - **Fail fast on expiry:** if the selected bearer carries a known
   `expires_at` (§9) already past by more than a **generous clock-skew
-  margin** (an hour; real client-clock skew is often minutes, and the stop
-  is only an optimization, so it errs toward attempting rather than refuse a
-  token the server would accept), publish stops before uploading the archive
-  and points at `sysand auth login`. The server's `401` remains the real
-  authority; the escape hatches are re-login or an env var.
+  margin** (an hour; the stop is only an optimization, so it errs toward
+  attempting rather than refuse a token the server would accept), publish
+  stops before uploading and points at `sysand auth login`. The server's
+  `401` remains the real authority.
 
 Target-defaulting principle: irreversible remote effects require an
 explicit target (`sysand publish --index` stays required), while
@@ -357,90 +306,80 @@ logout` removes) may fall back to the default index.
 
 ## 8. Glob scoping and conflict resolution
 
-- **Source precedence, single match within a source.** For a given URL, all
-  `SYSAND_CRED_*` (env) matches take precedence over all keyring matches
-  (so CI can override an interactive login). Within one source, the existing
-  single-match rule applies (publish errors on a within-source ambiguity,
-  identical-token matches collapsing first; reads try-all). v1 deliberately does **not** add longest-prefix
-  tie-breaking, that is only needed once raw-pattern `auth set` or
+- **Source precedence, single match within a source.** For a given URL,
+  all `SYSAND_CRED_*` (env) matches take precedence over all keyring
+  matches. Within one source, the single-match rule applies (publish
+  errors on a within-source ambiguity, identical-token matches collapsing
+  first; reads try-all). v1 deliberately does **not** add longest-prefix
+  tie-breaking; that is only needed once raw-pattern `auth set` or
   same-host nested logins create within-source overlaps (§10).
 - **Glob coverage.** `login` anchors the primary glob on the **discovery URL
   the user supplied** (so the discovery fetch itself is authenticated), and
   additionally covers the resolved `index_root` and `api_root` when they
   diverge from it, minimal and non-overlapping. Templated URLs are anchored
   before `{path}` / `{path_raw}`.
-- **Glob derivation is escaped and pinned.** URLs can legally contain glob
-  metacharacters (an IPv6 literal `https://[::1]:8000/` reads as a globset
-  character class; `{path}` templates read as alternation), and
-  `GlobMapBuilder` uses `literal_separator(true)` (`*` does not cross `/`).
-  So the derived glob is `globset::escape(<normalized root>)` + `**`, with
-  the root normalized to end in `/` (for example
-  `https://example.com/idx/**`), and both derivation and runtime matching
-  use the same serialization (`url::Url::as_str()`) so IDN/percent-encoding
-  agree on both sides. Two refinements: a templated root's literal-prefix
-  anchor must be **clamped to at least `scheme://authority/`** (a
-  query-position placeholder would otherwise degenerate the anchor to
-  `https://**`), skipping the root with a notice when even that is not
-  meaningful; and when a newly derived root **subsumes** an already-derived
-  one (string-prefix coverage with both sides slash-terminated), it
-  replaces it, keeping the set minimal and non-overlapping. Normative test
-  requirements: the discovery-document URL, the `index.json` URL, and the
-  upload URL each match the compiled derived set (for a template-target
-  login without an advertised `api_root` there is no upload URL, and an
-  encoded-`{path}` project-file URL stands in for it), and an IPv6-literal
-  login (`https://[::1]:8000/`) works.
+- **Glob derivation is escaped and pinned.** URLs can legally contain
+  glob metacharacters (an IPv6 literal reads as a globset character
+  class; `{path}` templates as alternation), and `GlobMapBuilder` uses
+  `literal_separator(true)`. So the derived glob is
+  `globset::escape(<normalized root>)` + `**`, with the root normalized
+  to end in `/` (for example `https://example.com/idx/**`), and both
+  derivation and runtime matching use the same serialization
+  (`url::Url::as_str()`) so IDN/percent-encoding agree on both sides. Two
+  refinements: a templated root's literal-prefix anchor is **clamped to
+  at least `scheme://authority/`** (a query-position placeholder would
+  otherwise degenerate the anchor to `https://**`), skipping the root
+  with a notice when even that is not meaningful; and a newly derived
+  root that **subsumes** an already-derived one replaces it, keeping the
+  set minimal and non-overlapping. Normative test requirements: the
+  discovery-document URL, the `index.json` URL, and the upload URL each
+  match the compiled derived set (for a template-target login without an
+  advertised `api_root`, an encoded-`{path}` project-file URL stands in
+  for the upload URL), and an IPv6-literal login (`https://[::1]:8000/`)
+  works.
 - **Divergent `api_root` (Case B).** If `api_root` nests under the derived
   root (Case A), one glob suffices. If it is a disjoint host/path, store the
   same credential under both globs (minimal, non-overlapping), so the upload
   URL matches exactly the api glob. Templated indexes are inherently Case B
   (their `api_root` is a disjoint plain URL).
-- Each login is one record (`{key, globs, scheme, secret,
-expires_at-if-known}`, plus optional whoami-derived identity fields
-  `subject`, `token_name`, `token_prefix` persisted by a validating login,
-  plus `validated`: the surfaces that exercised and accepted the credential
-  at login, serialized compactly as `["read","api"]` strings and absent
-  for nothing-exercised logins) inside the single keyring
-  blob (§9), so `logout` removes it and `status` shows one login covering
-  N patterns.
+- Each login is one record inside the single keyring blob (§9):
+  `{key, globs, scheme, secret, expires_at-if-known}`, plus optional
+  whoami-derived identity fields (`subject`, `token_name`,
+  `token_prefix`) persisted by a validating login, plus `validated`: the
+  surfaces that exercised and accepted the credential, serialized as
+  `["read","api"]` strings and absent for nothing-exercised logins. So
+  `logout` removes one record and `status` shows one login covering N
+  patterns.
 - **Discovery changes over time (globs are a login-time boundary).** Reads
-  and publish re-fetch discovery live each run, but the stored globs are the
-  login-time snapshot and are **not** auto-updated from discovery. This is
-  deliberate: auto-following a changed `api_root`/`index_root` would let a
-  changed (see the trust model below) discovery silently redirect the stored
-  token to a new host. So when a discovery change moves a root **outside**
-  the login's globs, the credential stops matching and the request fails
-  cleanly rather than following, either way safe. **Best-effort diagnostic
-  (may land later):** where sysand can correlate the failing request with a
-  login whose snapshot globs no longer cover the resolved root, it prints
-  "the index configuration has changed since you logged in; re-run
-  `sysand auth login <index>` to update". This correlation is non-trivial on
-  the read path (the auth layer sees per-request URLs, not the resolved
-  index identity), so if it does not ship in the first cut the generic "no
-  bearer / re-run login" hint applies. Re-login re-derives the globs and
-  re-validates.
+  and publish re-fetch discovery live each run, but the stored globs are
+  the login-time snapshot and are **not** auto-updated from discovery:
+  auto-following a changed `api_root`/`index_root` would let a changed
+  discovery silently redirect the stored token to a new host. When a
+  discovery change moves a root **outside** the login's globs, the
+  credential stops matching and the request fails cleanly; the generic
+  "no bearer / re-run login" hint applies, and re-login re-derives the
+  globs and re-validates.
   **Caveats, two ways the boundary is narrower than it sounds:**
-  (a) it covers the login's own globs only, a broad `SYSAND_CRED_*` env
-  pattern that also matches the moved root can still shadow it (env is
-  user-controlled and takes precedence); and (b) **same-host redirects
-  bypass the glob**: the glob is evaluated against the initial URL only, and
-  the credential is then forwarded to a same-host redirect target (existing
-  `RestrictAuthentication`/reqwest behavior), so a server that answers a
-  matched URL with `302` to another path on the same host receives the
-  credential there without any glob re-check. Cross-host redirects strip the
-  header. The precise guarantee is therefore: "sysand does not itself
-  auto-follow discovery to a **different host**"; within a host the server
-  can move the credential via redirects.
+  (a) it covers the login's own globs only; a broad `SYSAND_CRED_*` env
+  pattern that also matches the moved root can still shadow it. And (b)
+  **same-host redirects bypass the glob**: it is evaluated against the
+  initial URL only, and the credential is forwarded to a same-host
+  redirect target (existing `RestrictAuthentication`/reqwest behavior);
+  cross-host redirects strip the header. The precise guarantee is
+  therefore: "sysand does not itself auto-follow discovery to a
+  **different host**"; within a host the server can move the credential
+  via redirects.
 
 **Trust model.** The discovery document at the URL you supply is the trust
 anchor: `sysand` sends the credential to the `index_root`/`api_root` it
 advertises (including a different host) and to `v1/whoami`, with no
-same-origin or HTTPS restriction. Trusting the discovery URL means trusting
-what it points at. Note the amplification honestly: over plain `http`, a
-_one-time_ MITM at login can rewrite discovery to a hostile `api_root`,
-which both leaks the freshly entered token and gets **persisted** as a glob,
-so it keeps being sent there until re-login, not merely a single
-eavesdropped request. `http` (localhost or a trusted LAN) is still
-supported; the full transport-security guidance lives in the docs (§13).
+same-origin or HTTPS restriction. Trusting the discovery URL means
+trusting what it points at. Note the amplification honestly: over plain
+`http`, a _one-time_ MITM at login can rewrite discovery to a hostile
+`api_root`, which both leaks the freshly entered token and gets
+**persisted** as a glob, so it keeps being sent there until re-login.
+`http` (localhost or a trusted LAN) is still supported; the full
+transport-security guidance lives in the docs (§13).
 
 ## 9. Storage, consumption, precedence
 
@@ -449,107 +388,86 @@ supported; the full transport-security guidance lives in the docs (§13).
   variables as the automatic fallback where no keyring exists. **No
   plaintext credentials file, ever.**
 - **Single keyring entry.** All persisted credentials live in **one**
-  keyring entry (for example `service = "sysand"`, `account =
-"credentials"`) holding a JSON blob: a list of records `{key, globs,
-scheme, secret, expires_at-if-known}` plus optional whoami-derived
-  identity fields (`subject`, `token_name`, `token_prefix`) and the
-  `validated` surface list (§8), written by a validating login. Deliberate over a manifest file:
-  the `keyring` crate cannot portably enumerate entries, and one blob is
-  **atomic** (no metadata/secret drift), needs **no file**, and prompts the
-  keychain at most once. `login` / `logout` read-modify-write the blob;
-  `status` reads it. Removing the last record **deletes the keyring
-  entry**, preserving the cheap no-entry path for users who logged out of
-  everything.
+  keyring entry (`service = "sysand"`, `account = "credentials"`) holding
+  a JSON blob of records (§8). Deliberate over a manifest file: the
+  `keyring` crate cannot portably enumerate entries, and one blob is
+  **atomic** (no metadata/secret drift), needs **no file**, and prompts
+  the keychain at most once. `login` / `logout` read-modify-write the
+  blob; `status` reads it. Removing the last record **deletes the keyring
+  entry**, preserving the cheap no-entry path.
   - **Windows size limit.** Windows caps a blob at ~2.5 KB
     (`CRED_MAX_CREDENTIAL_BLOB_SIZE` = 2560), measured in **UTF-16 code
-    units**, so ~1280 ASCII characters of serialized JSON. With small
-    tokens that is roughly ten entries; large JWTs, fewer, and a single
-    token can exceed it on the first login. One message covers both:
-    "credential store full on this platform (Windows ~2.5 KB limit);
-    remove an unused login or use a smaller token", and `status`/the error
-    flag stale or expired entries so the user knows what to drop.
+    units**, so ~1280 ASCII characters of serialized JSON; a single large
+    JWT can exceed it on the first login. One message covers both cases
+    ("credential store full on this platform (Windows ~2.5 KB limit);
+    remove an unused login or use a smaller token"), and `status`/the
+    error flag stale or expired entries so the user knows what to drop.
 - **Blob format robustness.** The blob carries a `version` field that
   **gates the format**: a reader that does not recognize the version fails
-  closed rather than guessing, reserving a clean migration point if the
-  schema ever changes. Readers do not merely tolerate unknown record fields
-  but **round-trip** them (serde-flatten passthrough maps), so an older
-  binary's read-modify-write preserves a newer binary's fields instead of
-  dropping them. There is no record-level merge: concurrent writers are
-  serialized by the file lock (below) so the last writer wins, and that
-  field round-tripping is what keeps a concurrent newer binary's additions
-  from being lost. On a parse failure
-  (interrupted write, older/newer sysand, another same-user process's
-  scribble) read-modify-write **fails closed**, "credential store
-  unreadable; remove the `sysand` keyring entry to reset", never silently
-  treats the blob as empty, which would clobber all stored credentials on the
-  next `login`.
+  closed rather than guessing, reserving a clean migration point. Readers
+  **round-trip** unknown record fields (serde-flatten passthrough maps),
+  so an older binary's read-modify-write preserves a newer binary's
+  fields. There is no record-level merge: concurrent writers are
+  serialized by the file lock (below), last writer wins, and the field
+  round-tripping is what keeps a concurrent newer binary's additions from
+  being lost. On a parse failure, read-modify-write **fails closed**
+  ("credential store unreadable; remove the `sysand` keyring entry to
+  reset"), never silently treats the blob as empty, which would clobber
+  all stored credentials on the next `login`.
 - **Concurrency.** Read-modify-write is guarded by an **exclusive
   cross-process advisory OS file lock** (`flock`/`LockFileEx`, via the
   stable `std::fs::File` locking API), never an existence-based lock file
   (those go stale after a crash); read-only operations take its shared
-  counterpart so concurrent readers do not serialize, both with a bounded
-  wait and a clear error. The lock file lives in a **per-user** location
-  with a stable order: the state dir (`XDG_STATE_HOME` on Linux), then the
-  local data dir (`%LOCALAPPDATA%` on Windows), falling back to a dotdir
-  in the home directory; deliberately never the session-scoped
-  `XDG_RUNTIME_DIR`, which is often unset for cron, systemd, and container
-  processes, so two same-user processes could lock different files while
-  writing the same keyring entry. It is mode `0600`, never a
-  world-writable shared path (lock squatting / symlink games). A lock file is not a credentials file, so
-  the no-plaintext rule is untouched. Parallel `sysand` invocations are
-  real; an in-process mutex alone would lose one writer's record. The lock
-  coordinates `sysand` processes with each other only, not `sysand` against
-  another application that writes the same keyring entry.
+  counterpart, both with a bounded wait and a clear error. The lock file
+  lives in a **per-user** location with a stable order: the state dir
+  (`XDG_STATE_HOME` on Linux), then the local data dir (`%LOCALAPPDATA%`
+  on Windows), falling back to a dotdir in the home directory;
+  deliberately never the session-scoped `XDG_RUNTIME_DIR`, which is often
+  unset for cron, systemd, and container processes, so two same-user
+  processes could lock different files while writing the same keyring
+  entry. It is mode `0600`, never a world-writable shared path (lock
+  squatting / symlink games); a lock file is not a credentials file, so
+  the no-plaintext rule is untouched. The lock coordinates `sysand`
+  processes with each other only, not against another application writing
+  the same keyring entry.
 - **Consumption and keyring access.** The blob is read only when a
-  credential might actually be needed, to avoid unnecessary keychain prompts.
-  This requires a credential source the auth policy consults on demand. The
-  natural shape (implementable from the existing combinators) is
-  `SequenceAuthentication<EnvLayer, LazyKeyringLayer>`: the env layer is the
-  existing eager `RestrictAuthentication` from `SYSAND_CRED_*` (no keychain),
-  and the lazy keyring layer is consulted only in `SequenceAuthentication`'s
-  4xx-escalation branch, so the blob read happens exactly when needed and
-  env-before-keyring falls out for free. Note it can **not** be a
-  `RestrictAuthentication` with a lazy inner map (that classifies the URL up
-  front and would force the read). The composed policy is a dedicated
-  `CredentialStoreAuthentication` combinator with a concrete CLI alias
-  (`CliAuthPolicy`) used by `command_publish`; it takes the place of an
-  eager, immutable policy built once in `sysand/src/lib.rs`. Because the
-  lazy layer holds a cache (`OnceCell`) it is not `Clone`, so publish's
-  bearer extraction (`publish_bearer_auth_map`) is **by-ref** and clones
-  the secrets it extracts, accepted as the cost of the lazy layer. It defers the blob read to
-  the first auth-relevant 4xx (or publish / `auth` command), reads the whole
-  blob once, and caches it for the process. Escalation semantics: a
-  **failed** env credential (env 4xx) escalates into the keyring layer; a
-  matching keyring record sends **forced** auth (not another unauth-first
-  inner sequence, which would triple requests). **No-match must not
-  re-request:** 404 is a routine outcome on the resolve path
-  (`MissingPolicy::AllowNotFound`, version probing), so stock
+  credential might actually be needed: the eager env layer
+  (`RestrictAuthentication` from `SYSAND_CRED_*`, no keychain) runs
+  first, and a lazy keyring layer is consulted only in the 4xx-escalation
+  branch, so the blob read happens exactly when needed and
+  env-before-keyring falls out for free. It can **not** be a
+  `RestrictAuthentication` with a lazy inner map (that classifies the URL
+  up front and would force the read). The composed policy is the
+  dedicated `CredentialStoreAuthentication` combinator (CLI alias
+  `CliAuthPolicy`); the lazy layer holds a cache and is not `Clone`, so
+  publish's bearer extraction (`publish_bearer_auth_map`) is **by-ref**
+  and clones the secrets it extracts, accepted as the cost. Escalation
+  semantics: an env 4xx escalates into the keyring layer; a matching
+  keyring record sends **forced** auth (not another unauth-first inner
+  sequence, which would triple requests). **No-match must not
+  re-request:** 404 is routine on the resolve path, and stock
   `SequenceAuthentication`, whose lower arm cannot see the higher arm's
-  response, would re-issue an identical unauthenticated request on every
-  ordinary 404, permanently doubling round-trips for logged-in users. The
-  keyring layer therefore needs a **variant combinator that passes the
-  initial response down**, returning it untouched when no record matches.
-  Two further semantics to pin: the blob cache serves the **request path
-  only**, through one async accessor (`OnceCell` + `spawn_blocking`, since
-  the keyring crate is synchronous and a locked store can block for
-  seconds); publish runs outside the async runtime and performs its own
-  single direct store read, outside the cache. When several records' globs match
-  one URL: matches carrying the **identical token collapse to one retry**;
-  genuinely distinct tokens warn and are tried in order (the reads
-  try-all rule, section 8).
+  response, would re-issue an identical request on every ordinary 404,
+  permanently doubling round-trips for logged-in users; the keyring layer
+  therefore **passes the initial response down**, returning it untouched
+  when no record matches. The blob cache serves the **request path
+  only**, through one async accessor (`OnceCell` + `spawn_blocking`; the
+  keyring crate is synchronous and a locked store can block for seconds);
+  publish runs outside the async runtime and performs its own single
+  direct store read, outside the cache. Several matching records:
+  identical tokens **collapse to one retry**; genuinely distinct tokens
+  warn and are tried in order (the reads try-all rule, section 8).
   - **Never read** for local/offline commands, for reads that succeed
-    unauthenticated (public indexes return 200 and never touch the keyring),
-    or for users who never ran `auth login` (no entry: a cheap "not found",
-    no unlock).
-  - **Read once, then cache** on the first auth-relevant 4xx, on publish's
-    upload leg, and on the `auth` commands. At most one keychain touch per
-    command.
+    unauthenticated, or for users who never ran `auth login` (no entry: a
+    cheap "not found", no unlock).
+  - **Read once, then cache** on the first auth-relevant 4xx, on
+    publish's upload leg, and on the `auth` commands. At most one
+    keychain touch per command.
   - Reads escalate on **any** 4xx (not just 401/403), because some hosts
-    (GitLab) answer `404` on missing/under-scoped auth. Cost: a logged-in
-    user on a _locked_ Linux keyring may see one unlock prompt on a non-auth
-    404, rare, once per session, preferred over breaking the zero-config
-    GitLab flow. (Future refinement, gated on `keyring` support for
-    non-forcing reads: force-unlock only on `401`/`403`.)
+    (GitLab) answer `404` on missing/under-scoped auth. Cost: a
+    logged-in user on a _locked_ Linux keyring may see one unlock prompt
+    on a non-auth 404, rare, preferred over breaking the zero-config
+    GitLab flow.
   - In steady state keychain reads are silent (Windows no prompt, macOS
     one-time "always allow", unlocked Linux no re-prompt).
 - **Keyring error taxonomy:** _absent_ backend falls back to env;
@@ -557,62 +475,50 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   also names the `SYSAND_CRED_*` fallback, since on a headless box over SSH
   there is often no practical way to unlock the keyring.
 - **No-keyring host:** `auth login` refuses to persist and prints the
-  `SYSAND_CRED_*` lines to set, with the pattern value exact but the secret
-  as a **`<token>` placeholder, never the entered value**: no-keyring hosts
-  are typically CI/headless where stdout lands in captured job logs, and
-  echoing the secret would defeat the hidden prompt. Honest posture note:
-  on such hosts the env fallback means the secret lives in same-user
-  process environments and typically ends up at rest in CI secret config or
-  shell rc files; that is the accepted floor there, stated in the docs.
+  `SYSAND_CRED_*` lines to set, with the pattern value exact but the
+  secret as a **`<token>` placeholder, never the entered value**:
+  no-keyring hosts are typically CI/headless where stdout lands in
+  captured job logs. Honest posture note: on such hosts the env fallback
+  means the secret lives in same-user process environments and typically
+  at rest in CI secret config or shell rc files; that is the accepted
+  floor there, stated in the docs.
 - **Precedence:** `SYSAND_CRED_*` > keyring > unauthenticated (source
   precedence, §8), so CI can override an interactive login. There is no
   separate runtime shadow warning: `auth status` shows per-entry shadowing,
   and the source-named auth-failure messages (§7) identify a stale env var
   exactly when it bites.
-- **Expiry:** reactive first, when a request that exercised a stored
-  credential ends in **any 4xx** and the record's `expires_at` is past,
-  print "credential for `<index>` may be expired or revoked; re-authenticate
-  to store a fresh credential", any 4xx, not just 401, because GitLab-style
-  hosts answer 404 on bad auth and the blob is already loaded on that path.
-  This warning is emitted in the library (on the read path, where the CLI
-  cannot re-wrap it), so it names no CLI command. Proactive when known, `expires_at` (stored from `v1/whoami`
-  at login, absent for static/read-only or non-validated logins) lets
-  `auth status` show "expires in N days / expired".
+- **Expiry:** reactive first: when a request that exercised a stored
+  credential ends in **any 4xx** (not just 401, GitLab-style hosts answer
+  404 on bad auth) and the record's `expires_at` is past, print
+  "credential for `<index>` may be expired or revoked; re-authenticate to
+  store a fresh credential". Emitted in the library, so it names no CLI
+  command. Proactive when known: a stored `expires_at` lets `auth status`
+  show "expires in N days / expired".
 - **`auth status` output:** one unified view of **everything sysand will
-  authenticate with**, both sources, each entry tagged `Stored` or `Env`
-  (right-aligned in the CLI's 12-column status gutter).
-  Per stored entry: the key printed in the exact form
-  `sysand auth logout <key>` accepts, the login-time validation claim on
-  the key line (`validated (read)` / `validated (read, api)` from the
-  record's `validated` list, or a warn-styled `not validated` when it is
-  absent, the security-relevant case), covered globs, `subject` and token
-  `prefix` (from whoami, if a validating login ran), `expires_at` if
-  stored, and whether a `SYSAND_CRED_*` var shadows it, never the secret.
-  Entries of both sources that **apply to the default index** (which is
-  what bare commands actually use) carry a dim `(default index)`
-  annotation at the end of their header line: a stored entry on
-  normalized-key equality with the default's key or when one of its globs
-  matches the default index root URL (for a template default, its
-  literal-prefix anchor; the match shares `shadowed by`'s root-URL
-  approximation), an env entry when its pattern matches that root.
-  Patterns compile leniently here, like shadow detection: one bad pattern
-  never breaks status. Default-index resolution for the marker never
-  errors (section 4).
-  Multiple stored entries are separated by one blank line. The sublabels
-  (`covers:`, `subject:`, `token prefix:`, `expires:`) render dim so the
-  values carry the visual weight; `shadowed by:` stays warn-styled. Env
-  entries list the variable label and pattern. A source with nothing to
-  show is omitted rather than announced with a negative; only when neither
-  stored credentials nor `SYSAND_CRED_*` variables exist does status print the
-  single line "No credentials configured (no stored credentials, no
-  `SYSAND_CRED_*` variables)." The no-usable-keyring note still prints
-  whenever the backend is unusable (it is information, not a negative). No
-  `scheme` column in v1 (always bearer for stored; env entries may be
-  basic).
+  authenticate with**, both sources, each entry tagged `Stored` or `Env`.
+  Per stored entry: the key in the exact form `sysand auth logout <key>`
+  accepts, the login-time validation claim (`validated (read)` /
+  `validated (read, api)`, or a warn-styled `not validated`, the
+  security-relevant case), covered globs, `subject` and token `prefix`
+  (if a validating login ran), `expires_at` if stored, and whether a
+  `SYSAND_CRED_*` var shadows it, never the secret. Entries of both
+  sources that **apply to the default index** carry a dim
+  `(default index)` marker: a stored entry on normalized-key equality or
+  when one of its globs matches the default index root URL (sharing
+  `shadowed by`'s root-URL approximation), an env entry when its pattern
+  matches that root. Patterns compile leniently here, like shadow
+  detection: one bad pattern never breaks status, and default-index
+  resolution for the marker never errors (section 4). A source with
+  nothing to show is omitted rather than announced with a negative; only
+  when neither source has anything does status print "No credentials
+  configured (no stored credentials, no `SYSAND_CRED_*` variables)." The
+  no-usable-keyring note always prints when the backend is unusable (it
+  is information, not a negative). No `scheme` column in v1 (always
+  bearer for stored; env entries may be basic).
 - **Re-login:** `auth login` over an existing entry for the same key
   overwrites it, printing "Replacing existing credential for `<index>`"
-  (informational output, suppressed under `--quiet`) before the write; the previous stored token is discarded locally (not
-  revoked server-side).
+  (informational, suppressed under `--quiet`) before the write; the
+  previous token is discarded locally (not revoked server-side).
 
 ## 10. Scope boundaries
 
@@ -629,97 +535,40 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   or plaintext credentials file; a user-facing credential "label" concept;
   multi-account-per-host switching; git credentials (git keeps its own).
 
-## 11. Build phases
+## 11. Phases (landed)
 
-Each phase is independently shippable.
+The work shipped in phases: the credential store and lazy auth policy
+first (a behavior-neutral refactor to soak), then the server-side
+`v1/whoami`, then the `auth` commands, then docs. **The whoami-before-login
+ordering was load-bearing:** had `login` shipped first, a validating login
+against the official index would probe whoami, get a 404, count the API
+surface as rejected with the read surface "not tested", and refuse a
+valid token.
 
-1. **Credential store.** Single-keyring-blob store (versioned format,
-   fail-closed on parse errors) with cross-process advisory file locking +
-   env fallback, keyring error taxonomy, index-URL normalization,
-   source-precedence lookup, Windows size-limit handling. Introduce the
-   **deferred/cached auth policy** that reads the blob on demand and caches
-   it, replacing the eager `SYSAND_CRED_*`-only build in
-   `sysand/src/lib.rs`. This phase's value is landing and soaking the risky
-   refactor with no behavior change; user-visible persistence arrives with
-   phase 3's `login` (until then only tests populate the store). Crate
-   placement per §14.
-2. **`v1/whoami`** (server side, `sysand-index` repo, **already
-   implemented and merged there**): identity + token metadata, acceptance
-   via HTTP status, routed at `api/v1/whoami`. **This ordering is
-   load-bearing:** if `login` shipped first, a validating login against
-   the official index (public read + advertised `api_root`) would probe
-   whoami, get a 404, count the API surface as rejected with the read
-   surface "not tested", and refuse a valid token. The cross-repo
-   dependency (and the §13 docs work) is tracked in `sysand-index`'s
-   `.agents/plans/`.
-3. **`auth login` / `logout` / `status` / `whoami`.** Bearer-only;
-   default-index resolution + echo; non-interactive fail-fast; discovery
-   fetch; escaped glob derivation (discovery/index root + divergent
-   `api_root`; templated targets anchored at their literal prefix);
-   always-on validation, unauth-baseline-then-forced discovery and
-   probes (no-redirect), the refusal rule, and the basic-auth routing
-   message; `expires_at` persistence; source-named auth-failure messages
-   (§7); the query-only `whoami` command; gutter-aligned styled output
-   (§4). The tailored discovery-drift message (§8) is **best-effort**
-   here, not
-   required for the phase to ship.
-4. **Docs and specs** (§12, §13). Protocol specs in this repo; user docs in
-   the `sysand-index` repo (docs.sysand.com).
-
-Separate, not part of these phases: the deferred `auth set` / basic-auth
-work.
-
-CI notes for these phases: the workspace test lane runs `sysand-core` and
+CI notes that remain true: the workspace test lane runs `sysand-core` and
 `sysand` together, and the CLI crate enables `sysand-core/keyring`, so
-with resolver 3 feature unification the keyring-gated tests build and run
-in the ordinary test lane (no separate keyring lane is needed); and the
-prek job needs its rust hooks pinned via
-`language_version` (handled separately from this plan), since prek does
-not read `rust-toolchain.toml`.
+with resolver 3 feature unification the keyring-gated tests run in the
+ordinary test lane (no separate keyring lane); prek's rust hooks are
+pinned via `language_version`, since prek does not read
+`rust-toolchain.toml`.
 
 ## 12. Protocol/spec changes (this repo, `design/`)
 
-- `design/index-api-protocol.md`: specify `v1/whoami` (§6), routed under
-  `api/`.
-- `design/index-protocol.md` (**landed separately**, via the
-  require-`api_root` change now in `main`): an index has an API iff
-  discovery advertises `api_root`; the plain-URL default is dropped. This
-  was a **breaking change**, a third-party plain-URL _dynamic_ index that
-  relied on the defaulted `api_root` (no discovery document, or one without
-  the field) becomes read-only and must serve `sysand-index-config.json`
-  with an explicit `api_root` (the official index already does). This plan
-  relies on it: `api_root` is `Some` exactly when an API is advertised.
+`design/index-api-protocol.md` specifies `v1/whoami` (§6), routed under
+`api/`. The `design/index-protocol.md` require-`api_root` change landed
+separately (an index has an API iff discovery advertises `api_root`; the
+plain-URL default was dropped, a breaking change for third-party plain-URL
+dynamic indexes, which must now serve `sysand-index-config.json` with an
+explicit `api_root`).
 
 ## 13. Documentation (docs.sysand.com, in the `sysand-index` repo)
 
-Cross-repo: the published docs live under `docs/source/` in `sysand-index`,
-not here. Follow that repo's `docs/README.md` (sentence case, no em-dash,
-trailing-slash links). Pages to touch:
-
-- **Reference, rewrite** `docs/source/client/reference/authentication.md`:
-  the `sysand auth` model, single-keyring storage, always-on validation,
-  precedence (`SYSAND_CRED_*` > keyring), read/API surfaces, the trust
-  model. Keep the `SYSAND_CRED_*` reference, it remains the CI / no-keyring
-  path (and the only basic-auth path in v1).
-- **Reference, new** `docs/source/client/reference/commands/auth/`
-  subdirectory (mirroring `commands/index/` and `commands/env/`): an
-  `auth-command.md` parent plus `login.md`, `logout.md`, `status.md`,
-  `whoami.md`; add
-  them to the command toctree.
-- **How-to, rewrite** `docs/source/client/how-to/authenticate-to-an-index.md`:
-  lead with `sysand auth login`; demote the env-var steps to a CI / fallback
-  section.
-- **Explanation, update**
-  `docs/source/client/explanation/authentication.md`: keyring persistence,
-  read vs API surfaces, validation, the publish two-leg flow, the
-  discovery-drift boundary and trust model (§8).
-- **Index side, light**: cross-link `v1/whoami` from the index API
-  reference if user-facing; the token pages
-  (`docs/source/index/reference/api-tokens.md`,
-  `how-to/create-an-api-token.md`) may gain a "use with `sysand auth login`"
-  pointer.
-- **CLI help**: `about`/`long_about` text for the `sysand auth` command and
-  subcommands (in this repo), which the reference pages mirror.
+User docs live under `docs/source/` in the `sysand-index` repo and follow
+that repo's `docs/README.md` authoring guidance: the authentication
+reference and how-to, the `auth` command reference pages, and the
+explanation page cover the `sysand auth` model, precedence, surfaces, and
+trust model. CLI `about`/`long_about` text lives in this repo and the
+reference pages mirror it.
 
 ## 14. Code placement (core vs CLI vs bindings)
 
@@ -732,51 +581,45 @@ capabilities behind cargo features (`filesystem`, `networking`).
 - **core, unconditional:** the record types, blob JSON codec (pure
   serde), and the store type itself (`LockedBlobStore`, including the
   cross-process file lock), generic over the `BlobBackend` storage seam.
-- **core, behind the existing `networking` feature:** the `LazyKeyringLayer`
-  policy layer and its composition with the env layer, since `auth.rs` (and
-  the `HTTPAuthentication` trait, defined over reqwest types) is already
-  gated on `networking` (`core/src/lib.rs`). Note the wasm build is green
-  today because the js binding enables neither `networking` nor
-  `filesystem`, not because of keyring gating; keeping the new policy layer
-  under `networking` preserves that. `SequenceAuthentication`'s fields are
-  currently private, so the composition needs a public constructor (or a
-  new combinator, see §9's pass-the-response-down variant).
-- **core, behind a new `keyring` cargo feature** (not in `default`): the
+- **core, behind the existing `networking` feature:** the lazy
+  credential-store policy layer and its composition with the env layer,
+  since `auth.rs` (and the `HTTPAuthentication` trait, defined over
+  reqwest types) is already gated on `networking`. The wasm build is
+  green because the js binding enables neither `networking` nor
+  `filesystem`; keeping the policy layer under `networking` preserves
+  that.
+- **core, behind the `keyring` cargo feature** (not in `default`): the
   OS-keyring `BlobBackend` and the default lock-file path (uses `dirs`,
-  mirroring `filesystem`). Enabled by the CLI and the py/java
-  bindings; **off for the js/wasm binding**, the `keyring` crate does not
-  build for wasm. A browser-side store could later implement the same
-  backend trait (bindings/js already has local-storage machinery), but
-  that is not v1 and localStorage is not secure storage.
+  mirroring `filesystem`). Enabled by the CLI and the py/java bindings;
+  **off for the js/wasm binding**, the `keyring` crate does not build for
+  wasm. A browser-side store could later implement the same backend
+  trait, but that is not v1 and localStorage is not secure storage.
   - **Pure-Rust Secret Service.** keyring 4.x's `v1` feature uses the
     zbus Secret Service backend on glibc Linux, with no system libdbus
-    (nothing to vendor) and a `crypto-rust` session that keeps openssl out
-    of the tree, so CI's `clippy --all-features` and contributor machines
-    need no system libraries.
+    and a `crypto-rust` session that keeps openssl out of the tree, so CI
+    and contributor machines need no system libraries.
   - **musl exclusion.** musl targets are containers/CI where a Secret
-    Service never runs, so target-gate the keyring dependency off musl
-    entirely and give `OsKeyringBackend` a musl stub returning the
+    Service never runs, so the keyring dependency is target-gated off musl
+    entirely and `OsKeyringBackend` has a musl stub returning the
     backend-absent error; the documented `SYSAND_CRED_*` fallback is the
     behavior there.
   - **Test seam.** CLI integration tests must never touch the real OS
-    keyring (macOS prompts on differently-signed test binaries; CI has no
-    Secret Service). Provide a deliberate seam, a debug-build-only env var
-    (`SYSAND_TEST_CREDENTIAL_STORE`) selecting a file-backed or absent
-    blob backend, refused loudly in release builds, and route every auth
-    command and the lazy policy through it. The shared CLI test harness
-    defaults the seam to the absent backend, so a test reaches a real
-    keyring only by opting out explicitly.
+    keyring (macOS prompts on differently-signed test binaries; CI has
+    no Secret Service). The debug-build-only
+    `SYSAND_TEST_CREDENTIAL_STORE` env var selects a file-backed or
+    absent blob backend, refused loudly in release builds; every auth
+    command and the lazy policy route through it. The shared CLI test
+    harness defaults the seam to the absent backend, so a test reaches a
+    real keyring only by opting out explicitly.
 - **core `commands/auth.rs`, gated `all(filesystem, networking)`** (the
-  same gate as publish): `do_auth_login` / `do_auth_logout` /
-  `do_auth_status` orchestration (discovery fetch, glob derivation,
-  validation probes, refusal rule), generic over the store's blob
-  backend.
-  **A library call must never prompt**: the secret arrives as a
-  parameter, and there is no validation knob to plumb (§5).
+  same gate as publish): the `do_auth_*` orchestration (discovery fetch,
+  glob derivation, validation probes, refusal rule), generic over the
+  store's blob backend. **A library call must never prompt**: the secret
+  arrives as a parameter, and there is no validation knob to plumb (§5).
 - **sysand CLI:** the clap surface, hidden prompt, TTY detection,
   `--token-stdin`, default-index resolution, and user-facing messages; it
-  constructs the keyring store and the composed policy and passes them into
-  core, exactly like today's `auth_policy` handoff in `sysand/src/lib.rs`.
+  constructs the keyring store and the composed policy and passes them
+  into core.
 
 **Index reading and the keyring.** Reads in core stay generic over
 `HTTPAuthentication` (`IndexEnvironmentAsync<Policy>`), so core's

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -51,13 +51,12 @@ Constraints:
 - **C2 - one credential per index.** `auth login` stores one credential per
   index, used for both the read leg and the API leg. Separate read/write
   tokens are not a v1 concept (a later `auth set` could cover them, §10).
-- **P2 - API presence is read from discovery (consumed, not enforced
-  here).** This plan treats an index as having an API iff its discovery
-  document advertises `api_root`, and derives globs accordingly. It does
-  **not** change the runtime default (today a plain-URL index still defaults
-  `api_root` to its root). Enforcing "`api_root` required" at the protocol
-  level, and dropping that default, is a **separate, decoupled change**
-  (§12), out of this plan's phases.
+- **P2 - API presence is read from discovery.** This plan treats an index
+  as having an API iff its discovery document advertises `api_root`, and
+  derives globs accordingly. Enforcing "`api_root` required" at the protocol
+  level (dropping the old plain-URL default) landed separately (§12); this
+  plan relies on it, so `api_root` is `Some` exactly when an API is
+  advertised.
 - **P1 - public discovery: not required.** Under C2 the single credential
   reads discovery on a private index, so there is no bootstrap paradox.
   Current behavior (discovery may be private) stands.
@@ -174,9 +173,8 @@ always authenticated, so its baseline is a known 401 and only the forced
 request is needed. Validation is discovery-first (`api_root` is known only
 after reading discovery): fetch discovery, resolve `index_root` and
 `api_root`, probe `index_root/index.json`, and, **only if discovery
-advertised an `api_root`** (not the runtime plain-URL default, §3), probe
-`api_root/v1/whoami`, so a static plain-URL index is never phantom-probed
-for an API it does not have.
+advertised an `api_root`**, probe `api_root/v1/whoami`, so a static
+plain-URL index is never phantom-probed for an API it does not have.
 
 **Login's discovery fetch is itself unauth-baseline-then-forced** (only
 the backend-absent path of §9 stays strictly unauthenticated, since its
@@ -189,7 +187,7 @@ one. This means an index with no discovery document sees one extra
 credentialed request at login; it goes to the same user-supplied trust
 anchor (§8) the probes already hit. Forced-retry outcomes: a 200 with a
 valid document is used exactly like a public discovery success (globs,
-`api_root_advertised`, the whoami gate); a 404 is the authoritative "no
+an advertised `api_root`, the whoami gate); a 404 is the authoritative "no
 document" answer and reconstructs the flat topology with no warning; and
 everything else (other 4xx, 429, a redirect, since the retry goes through
 the no-redirect probe client unlike the redirect-following baseline, 5xx,
@@ -603,14 +601,10 @@ scheme, secret, expires_at-if-known}` plus optional whoami-derived
   works).
 - Longest-prefix most-specific-glob-wins (needed only once `set` / nested
   logins create within-source overlaps).
-- **P2 enforcement** (dropping the plain-URL `api_root` default), a
-  separate protocol change on its own timeline (§12); this plan only
-  consumes `api_root` when advertised.
-
-**Out of scope entirely:** acquisition beyond store-what-you-paste (OAuth
-apps, device flows, refresh-token lifecycle); a self-written encrypted vault
-or plaintext credentials file; a user-facing credential "label" concept;
-multi-account-per-host switching; git credentials (git keeps its own).
+  **Out of scope entirely:** acquisition beyond store-what-you-paste (OAuth
+  apps, device flows, refresh-token lifecycle); a self-written encrypted vault
+  or plaintext credentials file; a user-facing credential "label" concept;
+  multi-account-per-host switching; git credentials (git keeps its own).
 
 ## 11. Build phases
 
@@ -649,8 +643,8 @@ Each phase is independently shippable.
 4. **Docs and specs** (§12, §13). Protocol specs in this repo; user docs in
    the `sysand-index` repo (docs.sysand.com).
 
-Separate, not part of these phases: **P2 enforcement** (§10, §12) and the
-deferred `auth set` / basic-auth work.
+Separate, not part of these phases: the deferred `auth set` / basic-auth
+work.
 
 CI notes for these phases: the test lanes do not enable `-F keyring`, so
 keyring-gated tests only compile via `clippy --all-features` until a
@@ -662,14 +656,14 @@ not read `rust-toolchain.toml`.
 
 - `design/index-api-protocol.md`: specify `v1/whoami` (§6), routed under
   `api/`.
-- `design/index-protocol.md` (**decoupled change**, not this plan's
-  phases): enforce "an index has an API iff discovery advertises `api_root`"
-  and drop the plain-URL default. This is a **breaking change**, a
-  third-party plain-URL _dynamic_ index that relies on the defaulted
-  `api_root` (no discovery document, or one without the field) becomes
-  read-only and must serve `sysand-index-config.json` with an explicit
-  `api_root` (the official index already does). Both the field-absent branch
-  and the 404 `flat()` path in `core/src/env/discovery.rs` must change.
+- `design/index-protocol.md` (**landed separately**, via the
+  require-`api_root` change now in `main`): an index has an API iff
+  discovery advertises `api_root`; the plain-URL default is dropped. This
+  was a **breaking change**, a third-party plain-URL _dynamic_ index that
+  relied on the defaulted `api_root` (no discovery document, or one without
+  the field) becomes read-only and must serve `sysand-index-config.json`
+  with an explicit `api_root` (the official index already does). This plan
+  relies on it: `api_root` is `Some` exactly when an API is advertised.
 
 ## 13. Documentation (docs.sysand.com, in the `sysand-index` repo)
 

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -112,11 +112,12 @@ Under a `sysand auth` namespace:
   escape hatch for unusual layouts until `--pattern` / `auth set` land
   (§10). A **templated URL as the login target itself** (a `{path}` /
   `{path_raw}` template, for example a GitLab repository-files URL) is
-  supported: the storage key is the template text with its literal-prefix
-  anchor normalized through `url::Url` serialization (the rest stays
-  verbatim: raw text, not a parsed URL), and the primary glob anchors on
-  that prefix per §8. A template with no safe anchor (at least
-  `scheme://authority/`) is rejected with a pointer to `SYSAND_CRED_*`.
+  supported: template parsing normalizes the literal prefix through
+  `url::Url` serialization (the placeholder and suffix stay verbatim), so
+  the storage key is simply the template's canonical `Display` text, and
+  the primary glob anchors on that prefix per §8. The normalized prefix
+  always carries an explicit path `/`, so every template anchors at least
+  at `scheme://authority/`.
 
 The index URL is normalized (trailing slash, scheme) before use as the
 storage key and for glob derivation, so different spellings do not create
@@ -327,13 +328,11 @@ logout` removes) may fall back to the default index.
   to end in `/` (for example `https://example.com/idx/**`), and both
   derivation and runtime matching use the same serialization
   (`url::Url::as_str()`) so IDN/percent-encoding agree on both sides. Two
-  refinements: a templated root's anchor is the literal prefix cut back
-  to its **last `/`**, and the root is skipped with a notice unless that
-  anchor still parses as `scheme://authority/` or deeper (template
-  parsing already rejects placeholders outside the path or query, so the
-  reachable degenerate case is a template with no `/` after the
-  authority, where the cut would land inside `https://`; the parse check
-  is defense-in-depth for the rest); and within
+  refinements: a templated root's anchor is the normalized literal
+  prefix cut back to its **last `/`** (prefix normalization gives every
+  template an explicit path `/`, so the anchor always parses as
+  `scheme://authority/` or deeper; a placeholder directly after the
+  authority anchors at the host root); and within
   one login's derived set (the login URL plus its resolved `index_root`
   and `api_root`, never other stored records), a newly derived root that
   **subsumes** an already-derived one replaces it, keeping the set

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -129,19 +129,20 @@ duplicate entries.
 
 ## 5. Validation
 
-`auth login` takes `--validation true|false` (default `true`). It maps to
-an `Option<bool>` argument (absent = `None` = the default), so the language
-bindings expose a clean optional keyword: `validation: Optional[bool] =
-None`. This intentionally diverges from the repo's `--no-<flag>` boolean
-convention (for example `--no-lock`), which binds as a required,
-negative-sense `no_lock: bool`; a positive `Option<bool>` reads better as an
-optional keyword across the py/js/java bindings.
+Validation is on by default; the CLI flag to disable it is
+`--no-validation`, a presence flag following the repo's `--no-<thing>`
+convention (`--no-lock`, `--no-deps`, ...). The flag spelling and the
+library parameter are independent: core's `do_auth_login` takes
+`validation: Option<bool>` (`None` = the default, validate), the CLI maps
+`--no-validation` to `Some(false)`, and the language bindings expose the
+parameter as a clean optional keyword (`validation: Optional[bool] =
+None`). Both the house-style flag and the bindings ergonomics are kept.
 
-- `--validation true` (default): probe every surface the index supports and
-  store unless the credential is rejected everywhere it was actually tested
-  (see the refusal rule below). A static index has only the read surface; a
+- Default (validate): probe every surface the index supports and store
+  unless the credential is rejected everywhere it was actually tested (see
+  the refusal rule below). A static index has only the read surface; a
   dynamic index adds the API.
-- `--validation false`: store without any credential probe. Discovery is
+- `--no-validation`: store without any credential probe. Discovery is
   still fetched best-effort for glob scoping (§8); if unreachable, fall back
   to the URL-derived glob with a warning. Use it offline, or when a probe
   would false-refuse.
@@ -149,8 +150,8 @@ optional keyword across the py/js/java bindings.
 Validation is a boolean, not per-surface levels: since `v1/whoami` checks
 only that a token is _accepted_ by the API (identity, not capability, §6),
 validating everything almost never wrongly refuses a valid token, so a
-"read-only" level would add a choice without payoff. `--validation` could
-later give way to a levelled flag without disrupting this default.
+"read-only" level would add a choice without payoff. The flag could later
+give way to a levelled one without disrupting this default.
 
 **Probe mechanism.** Validation cannot reuse the runtime unauth-first
 policy, which returns only the final response and cannot report whether a
@@ -178,7 +179,7 @@ so a redirected probe counts as "not tested" with a warning naming the
 redirect target.
 
 User-visible wording uses one stem, **validated**: "validated (read)",
-"stored, not validated", matching the `--validation` flag, rather than
+"stored, not validated", rather than
 mixing "verified"/"unvalidated" families.
 
 **Refusal rule.** Store if the credential is _accepted by any surface it
@@ -220,7 +221,7 @@ under `api_root`. Its purpose is credential validation and identity for
   `api/` (`api/v1/whoami`); `api_root` carries the `/api/` segment, so the
   client's `api_root/v1/whoami` join is consistent with `v1/upload`.
 - `200` on a valid, unexpired token; `401` otherwise. Under
-  `--validation true` a `200` passes the API leg (§5). The `401` body is
+  validation (§5) a `200` passes the API leg. The `401` body is
   unspecified (the client only reads the status).
 - Body on `200`:
 
@@ -605,7 +606,7 @@ not here. Follow that repo's `docs/README.md` (sentence case, no em-dash,
 trailing-slash links). Pages to touch:
 
 - **Reference, rewrite** `docs/source/client/reference/authentication.md`:
-  the `sysand auth` model, single-keyring storage, `--validation`,
+  the `sysand auth` model, single-keyring storage, `--no-validation`,
   precedence (`SYSAND_CRED_*` > keyring), read/API surfaces, the trust
   model. Keep the `SYSAND_CRED_*` reference, it remains the CI / no-keyring
   path (and the only basic-auth path in v1).

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -327,12 +327,15 @@ logout` removes) may fall back to the default index.
   to end in `/` (for example `https://example.com/idx/**`), and both
   derivation and runtime matching use the same serialization
   (`url::Url::as_str()`) so IDN/percent-encoding agree on both sides. Two
-  refinements: a templated root's literal-prefix anchor is **clamped to
-  at least `scheme://authority/`** (a query-position placeholder would
-  otherwise degenerate the anchor to `https://**`), skipping the root
-  with a notice when even that is not meaningful; and a newly derived
-  root that **subsumes** an already-derived one replaces it, keeping the
-  set minimal and non-overlapping. Normative test requirements: the
+  refinements: a templated root's anchor is the literal prefix cut back
+  to its **last `/`**, and the root is skipped with a notice unless that
+  anchor still parses as `scheme://authority/` or deeper (a placeholder
+  in the host position, or a template with no `/` after the authority,
+  would otherwise degenerate the anchor toward `https://**`); and within
+  one login's derived set (the login URL plus its resolved `index_root`
+  and `api_root`, never other stored records), a newly derived root that
+  **subsumes** an already-derived one replaces it, keeping the set
+  minimal and non-overlapping. Normative test requirements: the
   discovery-document URL, the `index.json` URL, and the upload URL
   (if present) each match the compiled derived set, and an IPv6-literal
   login (`https://[::1]:8000/`) works.

--- a/design/credential-storage.md
+++ b/design/credential-storage.md
@@ -118,8 +118,9 @@ Under a `sysand auth` namespace:
   nothing, and a default that is not a valid HTTP(S) index key (for
   example `file://`) silently marks nothing.
 - **HTTP(S) only.** `auth login` against a non-HTTP(S) location (for
-  example a local file path, which index resolution accepts elsewhere)
-  errors with "not an HTTP(S) index; nothing to authenticate to".
+  example a local file path or `file://` URL, which sysand accepts
+  elsewhere as a project source but never as an index) errors with "not an
+  HTTP(S) index; nothing to authenticate to".
 - **Glob derivation** (§8): automatic from the login-target index URL (the
   URL the user passes to `auth login`, or the resolved default index when
   none is given), not from the discovery document; discovery-advertised

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -44,7 +44,7 @@ pubgrub = { version = "0.4.0", default-features = false }
 indexmap = "2.13.0"
 tokio = { version = "1.50.0", default-features = false }
 reqwest-middleware = { version = "0.5.1", features = ["multipart"] }
-rpassword = "7.4"
+rpassword = "7.5.4"
 reqwest = { version = "0.13.2", features = ["rustls", "blocking"] }
 
 [dev-dependencies]

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -27,6 +27,7 @@ camino.workspace = true
 camino-tempfile = "1.4"
 anstream = "1.0.0"
 anyhow = "1.0.102"
+chrono = { version = "0.4.44", default-features = false, features = ["now"] }
 clap = { version = "4.5.60", default-features = false, features = ["derive", "unicode", "help", "cargo", "color", "env", "suggestions", "usage"] }
 env_logger = "0.11.9"
 log.workspace = true

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -43,6 +43,7 @@ pubgrub = { version = "0.4.0", default-features = false }
 indexmap = "2.13.0"
 tokio = { version = "1.50.0", default-features = false }
 reqwest-middleware = { version = "0.5.1", features = ["multipart"] }
+rpassword = "7.4"
 reqwest = { version = "0.13.2", features = ["rustls", "blocking"] }
 
 [dev-dependencies]

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.102"
 clap = { version = "4.5.60", default-features = false, features = ["derive", "unicode", "help", "cargo", "color", "env", "suggestions", "usage"] }
 env_logger = "0.11.9"
 log.workspace = true
-sysand-core = { path = "../core", features = ["std", "filesystem", "networking"] }
+sysand-core = { path = "../core", features = ["std", "filesystem", "networking", "keyring"] }
 thiserror = "2.0.18"
 toml = { version = "1.0.6", features = ["fast_hash"] }
 semver = "1.0.27"

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -225,6 +225,11 @@ pub enum Command {
         )]
         trusted_publishing: TrustedPublishingMode,
     },
+    /// Manage stored credentials for package indexes
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
+    },
     /// Create or update lockfile
     Lock {
         #[command(flatten)]
@@ -1431,6 +1436,33 @@ impl InfoCommand {
             } => *numbered,
         }
     }
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum AuthCommand {
+    /// Show the credentials sysand will authenticate with: stored index
+    /// logins and `SYSAND_CRED_*` environment credentials. Never shows
+    /// secrets
+    #[clap(verbatim_doc_comment)]
+    Status,
+    /// Remove a stored index login
+    Logout {
+        /// Index URL to log out from (e.g. https://sysand.com).
+        /// Defaults to the default index
+        #[clap(verbatim_doc_comment)]
+        index_url: Option<String>,
+        /// Comma-delimited list of URLs to use as default index URLs.
+        /// This command targets a single index, so more than one
+        /// default index requires an explicit index URL instead
+        #[arg(
+            long,
+            num_args = 0..,
+            env = env_vars::SYSAND_DEFAULT_INDEX,
+            value_delimiter = ',',
+            verbatim_doc_comment
+        )]
+        default_index: Vec<String>,
+    },
 }
 
 #[derive(clap::Subcommand, Debug, Clone)]

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1444,19 +1444,7 @@ pub enum AuthCommand {
     /// logins and `SYSAND_CRED_*` environment credentials, marking the
     /// entries that apply to the default index. Never shows secrets
     #[clap(verbatim_doc_comment)]
-    Status {
-        /// Comma-delimited list of URLs to use as default index URLs.
-        /// Only used for the `(default index)` marker; more than one
-        /// distinct default index leaves all entries unmarked
-        #[arg(
-            long,
-            num_args = 0..,
-            env = env_vars::SYSAND_DEFAULT_INDEX,
-            value_delimiter = ',',
-            verbatim_doc_comment
-        )]
-        default_index: Vec<String>,
-    },
+    Status,
     /// Store a bearer token for an index. The token is read from a hidden
     /// prompt, or from standard input with `--token-stdin`, never from a
     /// command-line argument. The token is validated against the index
@@ -1474,17 +1462,6 @@ pub enum AuthCommand {
         /// newline) instead of prompting
         #[arg(long, verbatim_doc_comment)]
         token_stdin: bool,
-        /// Comma-delimited list of URLs to use as default index URLs.
-        /// This command targets a single index, so more than one
-        /// default index requires an explicit index URL instead
-        #[arg(
-            long,
-            num_args = 0..,
-            env = env_vars::SYSAND_DEFAULT_INDEX,
-            value_delimiter = ',',
-            verbatim_doc_comment
-        )]
-        default_index: Vec<String>,
     },
     /// Show who the index API identifies you as: sends one authenticated
     /// request to the index API (`v1/whoami`) with the credential sysand
@@ -1498,17 +1475,6 @@ pub enum AuthCommand {
         /// configuration. Defaults to the default index
         #[clap(verbatim_doc_comment)]
         index_url: Option<String>,
-        /// Comma-delimited list of URLs to use as default index URLs.
-        /// This command targets a single index, so more than one
-        /// default index requires an explicit index URL instead
-        #[arg(
-            long,
-            num_args = 0..,
-            env = env_vars::SYSAND_DEFAULT_INDEX,
-            value_delimiter = ',',
-            verbatim_doc_comment
-        )]
-        default_index: Vec<String>,
     },
     /// Remove a stored index login
     Logout {
@@ -1517,17 +1483,6 @@ pub enum AuthCommand {
         /// accepted. Defaults to the default index
         #[clap(verbatim_doc_comment)]
         index_url: Option<String>,
-        /// Comma-delimited list of URLs to use as default index URLs.
-        /// This command targets a single index, so more than one
-        /// default index requires an explicit index URL instead
-        #[arg(
-            long,
-            num_args = 0..,
-            env = env_vars::SYSAND_DEFAULT_INDEX,
-            value_delimiter = ',',
-            verbatim_doc_comment
-        )]
-        default_index: Vec<String>,
     },
 }
 

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1442,19 +1442,21 @@ impl InfoCommand {
 pub enum AuthCommand {
     /// Show the credentials sysand will authenticate with: stored index
     /// logins and `SYSAND_CRED_*` environment credentials, marking the
-    /// entries that apply to the default index. Never shows secrets
+    /// entries that apply to the default index. For stored logins,
+    /// `validated (read, api)` names the index endpoints that accepted
+    /// the token at login; `not validated` means no endpoint exercised
+    /// it. Never shows secrets
     #[clap(verbatim_doc_comment)]
     Status,
     /// Store a bearer token for an index. The token is read from a hidden
     /// prompt, or from standard input with `--token-stdin`, never from a
     /// command-line argument. The token is validated against the index
-    /// before it is stored: it is stored unless every surface that
-    /// exercised it rejected it
+    /// before it is stored; a token the index rejects is not stored
     #[clap(verbatim_doc_comment)]
     Login {
         /// Index URL to log in to (e.g. https://sysand.com).
-        /// URL templates (see --index under resolution options) are
-        /// accepted; the credential is scoped to the template's literal
+        /// URL templates are accepted (see `--index` in `sysand add
+        /// --help`); the credential is scoped to the template's literal
         /// prefix. Defaults to the default index
         #[clap(verbatim_doc_comment)]
         index_url: Option<String>,
@@ -1470,8 +1472,8 @@ pub enum AuthCommand {
     #[clap(verbatim_doc_comment)]
     Whoami {
         /// Index URL to query (e.g. https://sysand.com).
-        /// URL templates (see --index under resolution options) are
-        /// accepted; the index must advertise an API in its discovery
+        /// URL templates are accepted (see `--index` in `sysand add
+        /// --help`); the index must advertise an API in its discovery
         /// configuration. Defaults to the default index
         #[clap(verbatim_doc_comment)]
         index_url: Option<String>,
@@ -1479,8 +1481,8 @@ pub enum AuthCommand {
     /// Remove a stored index login
     Logout {
         /// Index URL to log out from (e.g. https://sysand.com).
-        /// URL templates (see --index under resolution options) are
-        /// accepted. Defaults to the default index
+        /// URL templates are accepted (see `--index` in `sysand add
+        /// --help`). Defaults to the default index
         #[clap(verbatim_doc_comment)]
         index_url: Option<String>,
     },

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1447,7 +1447,8 @@ pub enum AuthCommand {
     Status,
     /// Store a bearer token for an index. The token is read from a hidden
     /// prompt, or from standard input with `--token-stdin`, never from a
-    /// command-line argument. It is stored without validation
+    /// command-line argument. By default the token is validated against
+    /// the index before it is stored (see --validation)
     #[clap(verbatim_doc_comment)]
     Login {
         /// Index URL to log in to (e.g. https://sysand.com).
@@ -1458,6 +1459,13 @@ pub enum AuthCommand {
         /// newline) instead of prompting
         #[arg(long, verbatim_doc_comment)]
         token_stdin: bool,
+        /// Probe the index with the token before storing it (default
+        /// true): the token is stored unless every surface that
+        /// exercised it rejected it. `--validation false` stores
+        /// without probing (for offline use, or when a probe would
+        /// falsely refuse)
+        #[arg(long, value_name = "true|false", verbatim_doc_comment)]
+        validation: Option<bool>,
         /// Comma-delimited list of URLs to use as default index URLs.
         /// This command targets a single index, so more than one
         /// default index requires an explicit index URL instead

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1448,7 +1448,7 @@ pub enum AuthCommand {
     /// Store a bearer token for an index. The token is read from a hidden
     /// prompt, or from standard input with `--token-stdin`, never from a
     /// command-line argument. By default the token is validated against
-    /// the index before it is stored (see --validation)
+    /// the index before it is stored (see --no-validation)
     #[clap(verbatim_doc_comment)]
     Login {
         /// Index URL to log in to (e.g. https://sysand.com).
@@ -1459,13 +1459,12 @@ pub enum AuthCommand {
         /// newline) instead of prompting
         #[arg(long, verbatim_doc_comment)]
         token_stdin: bool,
-        /// Probe the index with the token before storing it (default
-        /// true): the token is stored unless every surface that
-        /// exercised it rejected it. `--validation false` stores
-        /// without probing (for offline use, or when a probe would
-        /// falsely refuse)
-        #[arg(long, value_name = "true|false", verbatim_doc_comment)]
-        validation: Option<bool>,
+        /// Store the token without probing the index (for offline use,
+        /// or when a probe would falsely refuse). By default the token
+        /// is validated: it is stored unless every surface that
+        /// exercised it rejected it
+        #[arg(long, verbatim_doc_comment)]
+        no_validation: bool,
         /// Comma-delimited list of URLs to use as default index URLs.
         /// This command targets a single index, so more than one
         /// default index requires an explicit index URL instead

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1466,7 +1466,7 @@ pub enum AuthCommand {
     /// Show who the index API identifies you as: sends one authenticated
     /// request to the index API (`v1/whoami`) with the credential sysand
     /// would use (`SYSAND_CRED_*` environment credentials take precedence
-    /// over stored logins). Query-only: nothing is stored or refreshed
+    /// over stored credentials). Query-only: nothing is stored or refreshed
     #[clap(verbatim_doc_comment)]
     Whoami {
         /// Index URL to query (e.g. https://sysand.com).

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1459,8 +1459,9 @@ pub enum AuthCommand {
     },
     /// Store a bearer token for an index. The token is read from a hidden
     /// prompt, or from standard input with `--token-stdin`, never from a
-    /// command-line argument. By default the token is validated against
-    /// the index before it is stored (see --no-validation)
+    /// command-line argument. The token is validated against the index
+    /// before it is stored: it is stored unless every surface that
+    /// exercised it rejected it
     #[clap(verbatim_doc_comment)]
     Login {
         /// Index URL to log in to (e.g. https://sysand.com).
@@ -1473,12 +1474,6 @@ pub enum AuthCommand {
         /// newline) instead of prompting
         #[arg(long, verbatim_doc_comment)]
         token_stdin: bool,
-        /// Store the token without probing the index (for offline use,
-        /// or when a probe would falsely refuse). By default the token
-        /// is validated: it is stored unless every surface that
-        /// exercised it rejected it
-        #[arg(long, verbatim_doc_comment)]
-        no_validation: bool,
         /// Comma-delimited list of URLs to use as default index URLs.
         /// This command targets a single index, so more than one
         /// default index requires an explicit index URL instead

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1452,7 +1452,9 @@ pub enum AuthCommand {
     #[clap(verbatim_doc_comment)]
     Login {
         /// Index URL to log in to (e.g. https://sysand.com).
-        /// Defaults to the default index
+        /// URL templates (see --index under resolution options) are
+        /// accepted; the credential is scoped to the template's literal
+        /// prefix. Defaults to the default index
         #[clap(verbatim_doc_comment)]
         index_url: Option<String>,
         /// Read the token from standard input (trimming one trailing
@@ -1480,7 +1482,8 @@ pub enum AuthCommand {
     /// Remove a stored index login
     Logout {
         /// Index URL to log out from (e.g. https://sysand.com).
-        /// Defaults to the default index
+        /// URL templates (see --index under resolution options) are
+        /// accepted. Defaults to the default index
         #[clap(verbatim_doc_comment)]
         index_url: Option<String>,
         /// Comma-delimited list of URLs to use as default index URLs.

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1445,6 +1445,31 @@ pub enum AuthCommand {
     /// secrets
     #[clap(verbatim_doc_comment)]
     Status,
+    /// Store a bearer token for an index. The token is read from a hidden
+    /// prompt, or from standard input with `--token-stdin`, never from a
+    /// command-line argument. It is stored without validation
+    #[clap(verbatim_doc_comment)]
+    Login {
+        /// Index URL to log in to (e.g. https://sysand.com).
+        /// Defaults to the default index
+        #[clap(verbatim_doc_comment)]
+        index_url: Option<String>,
+        /// Read the token from standard input (trimming one trailing
+        /// newline) instead of prompting
+        #[arg(long, verbatim_doc_comment)]
+        token_stdin: bool,
+        /// Comma-delimited list of URLs to use as default index URLs.
+        /// This command targets a single index, so more than one
+        /// default index requires an explicit index URL instead
+        #[arg(
+            long,
+            num_args = 0..,
+            env = env_vars::SYSAND_DEFAULT_INDEX,
+            value_delimiter = ',',
+            verbatim_doc_comment
+        )]
+        default_index: Vec<String>,
+    },
     /// Remove a stored index login
     Logout {
         /// Index URL to log out from (e.g. https://sysand.com).

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1479,6 +1479,30 @@ pub enum AuthCommand {
         )]
         default_index: Vec<String>,
     },
+    /// Show who the index API identifies you as: sends one authenticated
+    /// request to the index API (`v1/whoami`) with the credential sysand
+    /// would use (`SYSAND_CRED_*` environment credentials take precedence
+    /// over stored logins). Query-only: nothing is stored or refreshed
+    #[clap(verbatim_doc_comment)]
+    Whoami {
+        /// Index URL to query (e.g. https://sysand.com).
+        /// URL templates (see --index under resolution options) are
+        /// accepted; the index must advertise an API in its discovery
+        /// configuration. Defaults to the default index
+        #[clap(verbatim_doc_comment)]
+        index_url: Option<String>,
+        /// Comma-delimited list of URLs to use as default index URLs.
+        /// This command targets a single index, so more than one
+        /// default index requires an explicit index URL instead
+        #[arg(
+            long,
+            num_args = 0..,
+            env = env_vars::SYSAND_DEFAULT_INDEX,
+            value_delimiter = ',',
+            verbatim_doc_comment
+        )]
+        default_index: Vec<String>,
+    },
     /// Remove a stored index login
     Logout {
         /// Index URL to log out from (e.g. https://sysand.com).

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1441,10 +1441,22 @@ impl InfoCommand {
 #[derive(clap::Subcommand, Debug, Clone)]
 pub enum AuthCommand {
     /// Show the credentials sysand will authenticate with: stored index
-    /// logins and `SYSAND_CRED_*` environment credentials. Never shows
-    /// secrets
+    /// logins and `SYSAND_CRED_*` environment credentials, marking the
+    /// entries that apply to the default index. Never shows secrets
     #[clap(verbatim_doc_comment)]
-    Status,
+    Status {
+        /// Comma-delimited list of URLs to use as default index URLs.
+        /// Only used for the `(default index)` marker; more than one
+        /// distinct default index leaves all entries unmarked
+        #[arg(
+            long,
+            num_args = 0..,
+            env = env_vars::SYSAND_DEFAULT_INDEX,
+            value_delimiter = ',',
+            verbatim_doc_comment
+        )]
+        default_index: Vec<String>,
+    },
     /// Store a bearer token for an index. The token is read from a hidden
     /// prompt, or from standard input with `--token-stdin`, never from a
     /// command-line argument. By default the token is validated against

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -97,6 +97,17 @@ pub fn command_auth_login(
     let header = sysand_core::style::get_style_config().header;
     println!("{header}{:>12}{header:#} to index `{key}`", "Logging in");
 
+    // An `http` index sends the bearer token in cleartext, and a one-time
+    // MITM at login could rewrite discovery to a hostile `api_root` that
+    // then gets persisted (design/credential-storage.md section 8). Warn
+    // before the secret is entered so the user can abort.
+    if key.starts_with("http://") {
+        log::warn!(
+            "`{key}` uses an unencrypted (http) connection; the token will be \
+             sent in cleartext. Prefer an https:// index."
+        );
+    }
+
     let secret = read_token(&key, token_stdin)?;
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -120,6 +120,11 @@ pub fn command_auth_login(
                      validated against it",
                     surface_name(surface)
                 ),
+                AuthLoginNotice::ProbeRateLimited { surface } => log::warn!(
+                    "the {} probe was rate limited (HTTP 429); the credential was \
+                     not validated against it",
+                    surface_name(surface)
+                ),
                 AuthLoginNotice::SurfaceRejected {
                     surface,
                     basic_challenge,

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -11,10 +11,7 @@ use std::sync::Arc;
 use anstream::println;
 use anyhow::{Context, Result, bail};
 use sysand_core::{
-    auth::{
-        GlobMapBuilder, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder,
-        StandardLazyHTTPAuthentication,
-    },
+    auth::{GlobMapBuilder, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder},
     commands::auth::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
         ProbeSurface, StoredCredentialStatus, StoredCredentialsStatus, WhoamiCredentialSource,
@@ -22,12 +19,12 @@ use sysand_core::{
         do_auth_whoami, validated_index_key,
     },
     config::Config,
-    credential_store::{CredentialRecord, CredentialStore, CredentialStoreError},
+    credential_store::CredentialStoreError,
 };
 
 use chrono::{DateTime, Utc};
 
-use crate::{DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
+use crate::{CliAuthPolicy, DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
 
 const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide credentials via \
      `SYSAND_CRED_*` environment variables";
@@ -643,30 +640,6 @@ fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
         .context("could not compile `SYSAND_CRED_*` URL patterns")
 }
 
-/// An already-read snapshot of the credential store, backing `auth
-/// whoami`'s discovery policy so the command performs exactly one store
-/// backend read (the `list` in [`command_auth_whoami`]) instead of a
-/// second one inside the policy's lazy cache. Read-only by construction:
-/// whoami never writes the credential store, so the mutating methods are
-/// unreachable.
-struct PreloadedCredentials {
-    records: Vec<CredentialRecord>,
-}
-
-impl CredentialStore for PreloadedCredentials {
-    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
-        Ok(self.records.clone())
-    }
-
-    fn upsert(&mut self, _record: CredentialRecord) -> Result<(), CredentialStoreError> {
-        unreachable!("BUG: `auth whoami` never writes the credential store")
-    }
-
-    fn remove(&mut self, _key: &str) -> Result<bool, CredentialStoreError> {
-        unreachable!("BUG: `auth whoami` never writes the credential store")
-    }
-}
-
 pub fn command_auth_whoami(
     index_url: Option<String>,
     config: &Config,
@@ -711,12 +684,10 @@ pub fn command_auth_whoami(
         }
         Err(err) => return Err(err.into()),
     };
-    let discovery_policy = StandardLazyHTTPAuthentication::new(
-        env_policy,
-        PreloadedCredentials {
-            records: records.clone(),
-        },
-    );
+    // The policy is preloaded with the records read above, so whoami
+    // performs exactly one store backend read (on a locked keyring, the
+    // single unlock prompt) and its discovery policy never writes.
+    let discovery_policy = CliAuthPolicy::preloaded(env_policy, &records);
 
     let outcome = match do_auth_whoami(
         &records,

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -229,7 +229,7 @@ pub fn command_auth_login(
 /// (Windows ~2.5 KB). The core store reports only the condition; naming the
 /// `sysand auth` commands to fix it belongs here in the CLI. Points at
 /// `auth status`/`auth logout` and lists already-expired logins as the
-/// obvious drop candidates. With no stored logins (a single oversized token)
+/// obvious drop candidates. With no stored credentials (a single oversized token)
 /// there is nothing to remove, so it does not suggest removing one.
 fn blob_full_message(stored: &[(&str, Option<DateTime<Utc>>)], now: DateTime<Utc>) -> String {
     let expired: Vec<&str> = stored
@@ -523,11 +523,7 @@ fn render_auth_status(status: &AuthStatus) {
             validation_claim(&entry.validated),
             default_marker(entry.applies_to_default)
         );
-        println!(
-            "{:>12} {dim}patterns:{dim:#} {}",
-            ' ',
-            entry.globs.join(", ")
-        );
+        println!("{:>12} {dim}covers:{dim:#} {}", ' ', entry.globs.join(", "));
         if let Some(subject) = &entry.subject {
             println!(
                 "{:>12} {dim}subject:{dim:#} {} {}",
@@ -676,7 +672,7 @@ pub fn command_auth_whoami(
         Err(err) => return Err(err.into()),
     };
 
-    // Name the source: an env credential shadows a stored login, so the
+    // Name the source: an env credential shadows a stored credential, so the
     // right remediation for a bad credential depends on where it came
     // from (design/credential-storage.md section 7).
     match &outcome.source {

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -15,8 +15,8 @@ use sysand_core::{
     commands::auth::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
         ProbeSurface, StoredCredentialStatus, StoredCredentialsStatus, WhoamiCredentialSource,
-        WhoamiVerdict, do_auth_login, do_auth_logout, do_auth_status, do_auth_whoami,
-        validated_index_key,
+        WhoamiVerdict, assemble_auth_status, do_auth_login, do_auth_logout, do_auth_status,
+        do_auth_whoami, validated_index_key,
     },
     config::Config,
     credential_store::CredentialStoreError,
@@ -297,10 +297,28 @@ pub fn command_auth_logout(
     }
 }
 
-pub fn command_auth_status() -> Result<()> {
+pub fn command_auth_status(default_index: &[String], config: &Config) -> Result<()> {
+    // Resolve the default index only to mark the entries that apply to
+    // it. Status is a diagnostic view, so resolution is lenient: an
+    // ambiguous chain gets a note instead of the hard error bare
+    // `login`/`logout` raise, and a default that is not a valid HTTP(S)
+    // index key (for example `file://`) simply marks nothing.
+    let default_key = match resolve_default_index(default_index, config) {
+        Ok(url) => validated_index_key(&url).ok(),
+        // `resolve_default_index` errors only on an ambiguous chain
+        // (more than one distinct default index).
+        Err(_) => {
+            let note = sysand_core::style::get_style_config().note;
+            println!(
+                "{note}note:{note:#} more than one default index is configured; no entry \
+                 is marked as the default index"
+            );
+            None
+        }
+    };
     let env = collect_env_credential_entries();
     let status = match open_cli_credential_store() {
-        Ok(store) => match do_auth_status(&store, env) {
+        Ok(store) => match do_auth_status(&store, env, default_key.as_deref()) {
             Ok(status) => status,
             Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
                 return Err(err).context(KEYRING_LOCKED_HINT);
@@ -308,13 +326,16 @@ pub fn command_auth_status() -> Result<()> {
             Err(err) => return Err(err.into()),
         },
         // Could not even open the store (no per-user lock path): degrade
-        // to the env-only view like an absent backend.
-        Err(err) => AuthStatus {
-            stored: StoredCredentialsStatus::BackendUnavailable {
+        // to the env-only view like an absent backend. Assembly still
+        // runs so env entries keep their default-index marking.
+        Err(err) => {
+            let mut status =
+                assemble_auth_status(Vec::new(), env, chrono::Utc::now(), default_key.as_deref());
+            status.stored = StoredCredentialsStatus::BackendUnavailable {
                 reason: err.to_string(),
-            },
-            env: collect_env_credential_entries(),
-        },
+            };
+            status
+        }
     };
     render_auth_status(&status);
     Ok(())
@@ -339,6 +360,8 @@ fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
         .map(|(key, value)| EnvCredentialEntry {
             label: key,
             pattern: value,
+            // Set by status assembly when a default index is known.
+            applies_to_default: false,
         })
         .collect();
     entries.sort_by(|a, b| a.label.cmp(&b.label));
@@ -406,6 +429,11 @@ fn validation_claim(validated: &[String]) -> String {
 /// validation claim after the key, mirroring the `Env` lines' two-space
 /// label/pattern separation.
 ///
+/// Entries that apply to the default index (which is what bare commands
+/// use) carry a dim `(default index)` annotation at the end of their
+/// header line, two spaces after the validation claim (stored) or the
+/// pattern (env).
+///
 /// A source with nothing to show is simply omitted; only when neither
 /// source has anything does a single combined negative print. The
 /// backend-unavailable note is information, not a negative, and always
@@ -421,6 +449,13 @@ fn render_auth_status(status: &AuthStatus) {
     let name = style.literal;
     let warn = style.warn;
     let dim = style.dim;
+    let default_marker = |applies: bool| {
+        if applies {
+            format!("  {dim}(default index){dim:#}")
+        } else {
+            String::new()
+        }
+    };
     let none: Vec<StoredCredentialStatus> = Vec::new();
     let stored = match &status.stored {
         StoredCredentialsStatus::BackendUnavailable { reason } => {
@@ -438,10 +473,11 @@ fn render_auth_status(status: &AuthStatus) {
             println!();
         }
         println!(
-            "{tag}{:>12}{tag:#} {name}{}{name:#}  {}",
+            "{tag}{:>12}{tag:#} {name}{}{name:#}  {}{}",
             "Stored",
             entry.key,
-            validation_claim(&entry.validated)
+            validation_claim(&entry.validated),
+            default_marker(entry.applies_to_default)
         );
         println!(
             "{:>12} {dim}patterns:{dim:#} {}",
@@ -475,8 +511,11 @@ fn render_auth_status(status: &AuthStatus) {
     }
     for entry in &status.env {
         println!(
-            "{tag}{:>12}{tag:#} {name}{}{name:#}  {}",
-            "Env", entry.label, entry.pattern
+            "{tag}{:>12}{tag:#} {name}{}{name:#}  {}{}",
+            "Env",
+            entry.label,
+            entry.pattern,
+            default_marker(entry.applies_to_default)
         );
     }
     if stored.is_empty() && status.env.is_empty() {

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -16,7 +16,7 @@ use sysand_core::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
         IndexKey, ProbeSurface, StoredCredentialStatus, StoredCredentialsStatus,
         WhoamiCredentialSource, WhoamiVerdict, assemble_auth_status, do_auth_login, do_auth_logout,
-        do_auth_status, do_auth_whoami,
+        do_auth_status, do_auth_whoami, schemes_include_basic, unsupported_schemes_followup,
     },
     config::Config,
     credential_store::CredentialStoreError,
@@ -113,7 +113,7 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
         AuthLoginNotice::SurfaceRejected {
             surface,
             status,
-            basic_challenge,
+            challenge_schemes,
         } => {
             // Same read-404 hedge as the refusal message.
             let hedge = if surface == ProbeSurface::Read && status == 404 {
@@ -126,7 +126,7 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
                      it was stored anyway because another surface accepted it",
                 surface_name(surface)
             );
-            if basic_challenge {
+            if schemes_include_basic(&challenge_schemes) {
                 let stem = cred_env_var_stem(index_key);
                 // Keep this basic-auth routing hint consistent with the
                 // refusal-path variant in core/src/commands/auth.rs
@@ -136,6 +136,9 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
                          configure `SYSAND_CRED_{stem}_BASIC_USER` /\n\
                          `SYSAND_CRED_{stem}_BASIC_PASS` environment variables instead"
                 );
+            }
+            if let Some(followup) = unsupported_schemes_followup(&challenge_schemes) {
+                log::warn!("{followup}");
             }
         }
     }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -14,8 +14,9 @@ use sysand_core::{
     auth::{GlobMapBuilder, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder},
     commands::auth::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
-        ProbeSurface, StoredCredentialsStatus, WhoamiCredentialSource, WhoamiVerdict,
-        do_auth_login, do_auth_logout, do_auth_status, do_auth_whoami, validated_index_key,
+        ProbeSurface, StoredCredentialStatus, StoredCredentialsStatus, WhoamiCredentialSource,
+        WhoamiVerdict, do_auth_login, do_auth_logout, do_auth_status, do_auth_whoami,
+        validated_index_key,
     },
     config::Config,
     credential_store::CredentialStoreError,
@@ -376,6 +377,21 @@ fn expiry_qualifier(expired: bool, expires_in_days: Option<i64>) -> String {
     }
 }
 
+/// The per-entry validation claim: the same scoped wording `auth login`
+/// prints, from the surfaces a validating login recorded. Dim when
+/// validated (secondary detail); warn when not (the security-relevant
+/// case: nothing ever exercised this credential).
+fn validation_claim(validated: &[String]) -> String {
+    let style = sysand_core::style::get_style_config();
+    if validated.is_empty() {
+        let warn = style.warn;
+        format!("{warn}not validated{warn:#}")
+    } else {
+        let dim = style.dim;
+        format!("{dim}validated ({}){dim:#}", validated.join(", "))
+    }
+}
+
 /// Render the unified status view: stored entries tagged `Stored` (key in
 /// the exact form `sysand auth logout <key>` accepts), env entries tagged
 /// `Env`. Never any secret.
@@ -384,65 +400,87 @@ fn expiry_qualifier(expired: bool, expires_in_days: Option<i64>) -> String {
 /// of an entry keep their `label: value` form (unlike `auth whoami`, which
 /// puts each field's label in the gutter: here the fields are subordinate
 /// to a tagged entry, and the hierarchy would be lost) and are indented to
-/// the gutter like other multi-line log messages.
+/// the gutter like other multi-line log messages, with the sublabels
+/// dimmed so the values carry the visual weight. Multiple stored entries
+/// are separated by a blank line; each entry's header line carries its
+/// validation claim after the key, mirroring the `Env` lines' two-space
+/// label/pattern separation.
+///
+/// A source with nothing to show is simply omitted; only when neither
+/// source has anything does a single combined negative print. The
+/// backend-unavailable note is information, not a negative, and always
+/// prints when the keyring backend is unusable.
 ///
 /// Styling reuses the house tokens (`sysand_core::style`) and goes through
 /// `anstream::println`, which strips it on non-terminal stdout and under
 /// `NO_COLOR`, so piped output stays exactly the plain text the CLI tests
-/// assert on.
+/// assert on (the alignment spaces are content, the styling is not).
 fn render_auth_status(status: &AuthStatus) {
     let style = sysand_core::style::get_style_config();
     let tag = style.header;
     let name = style.literal;
     let warn = style.warn;
-    match &status.stored {
+    let dim = style.dim;
+    let none: Vec<StoredCredentialStatus> = Vec::new();
+    let stored = match &status.stored {
         StoredCredentialsStatus::BackendUnavailable { reason } => {
             let note = style.note;
             println!(
                 "{note}note:{note:#} no usable OS keyring backend ({reason}); showing \
                  `SYSAND_CRED_*` environment credentials only"
             );
+            &none
         }
-        StoredCredentialsStatus::Available(stored) if stored.is_empty() => {
-            println!("No stored index logins.");
+        StoredCredentialsStatus::Available(stored) => stored,
+    };
+    for (position, entry) in stored.iter().enumerate() {
+        if position > 0 {
+            println!();
         }
-        StoredCredentialsStatus::Available(stored) => {
-            for entry in stored {
-                println!("{tag}{:>12}{tag:#} {name}{}{name:#}", "Stored", entry.key);
-                println!("{:>12} patterns: {}", ' ', entry.globs.join(", "));
-                if let Some(subject) = &entry.subject {
-                    println!("{:>12} subject: {} {}", ' ', subject.kind, subject.name);
-                }
-                if let Some(prefix) = &entry.token_prefix {
-                    println!("{:>12} token prefix: {prefix}", ' ');
-                }
-                if let Some(expires_at) = &entry.expires_at {
-                    println!(
-                        "{:>12} expires: {}{}",
-                        ' ',
-                        format_expiry_timestamp(expires_at),
-                        expiry_qualifier(entry.expired, entry.expires_in_days)
-                    );
-                }
-                if !entry.shadowed_by.is_empty() {
-                    println!(
-                        "{:>12} {warn}shadowed by:{warn:#} {}",
-                        ' ',
-                        entry.shadowed_by.join(", ")
-                    );
-                }
-            }
-        }
-    }
-    if status.env.is_empty() {
-        println!("No `SYSAND_CRED_*` environment credentials.");
-    } else {
-        for entry in &status.env {
+        println!(
+            "{tag}{:>12}{tag:#} {name}{}{name:#}  {}",
+            "Stored",
+            entry.key,
+            validation_claim(&entry.validated)
+        );
+        println!(
+            "{:>12} {dim}patterns:{dim:#} {}",
+            ' ',
+            entry.globs.join(", ")
+        );
+        if let Some(subject) = &entry.subject {
             println!(
-                "{tag}{:>12}{tag:#} {name}{}{name:#}  {}",
-                "Env", entry.label, entry.pattern
+                "{:>12} {dim}subject:{dim:#} {} {}",
+                ' ', subject.kind, subject.name
             );
         }
+        if let Some(prefix) = &entry.token_prefix {
+            println!("{:>12} {dim}token prefix:{dim:#} {prefix}", ' ');
+        }
+        if let Some(expires_at) = &entry.expires_at {
+            println!(
+                "{:>12} {dim}expires:{dim:#} {}{}",
+                ' ',
+                format_expiry_timestamp(expires_at),
+                expiry_qualifier(entry.expired, entry.expires_in_days)
+            );
+        }
+        if !entry.shadowed_by.is_empty() {
+            println!(
+                "{:>12} {warn}shadowed by:{warn:#} {}",
+                ' ',
+                entry.shadowed_by.join(", ")
+            );
+        }
+    }
+    for entry in &status.env {
+        println!(
+            "{tag}{:>12}{tag:#} {name}{}{name:#}  {}",
+            "Env", entry.label, entry.pattern
+        );
+    }
+    if stored.is_empty() && status.env.is_empty() {
+        println!("No credentials configured (no stored logins, no `SYSAND_CRED_*` variables).");
     }
 }
 

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -305,8 +305,9 @@ fn read_token(key: &str, token_stdin: bool) -> Result<String> {
 /// Derive the `SYSAND_CRED_<NAME>` stem suggested on a no-keyring host
 /// from the index host plus any non-default port: two indexes on
 /// different ports of one host must not suggest the same variable names.
-/// Hostnames and ports cannot produce the reserved `_BASIC_USER` /
-/// `_BASIC_PASS` / `_BEARER_TOKEN` suffixes (a port is all digits).
+/// A stem whose `_`-mapped host text spells a reserved secret suffix or
+/// a bare role name (`_basic.pass`, `basic.user`) gets a `_0` tail so
+/// every suggested variable classifies back to the intended group.
 fn cred_env_var_stem(key: &str) -> String {
     let url = url::Url::parse(key).ok();
     let host = url
@@ -328,6 +329,11 @@ fn cred_env_var_stem(key: &str) -> String {
     if let Some(port) = url.as_ref().and_then(url::Url::port) {
         stem.push('_');
         stem.push_str(&port.to_string());
+    }
+    if !crate::cred_env::stem_is_unambiguous(&stem) {
+        // Appended digits can never re-create a reserved suffix or a
+        // bare role name.
+        stem.push_str("_0");
     }
     stem
 }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -91,10 +91,6 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
             "could not read the index configuration ({error});\n\
                  scoping the credential to the URL-derived pattern"
         ),
-        AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
-            "discovery advertises a templated index_root (`{template}`) that\n\
-                 cannot be covered safely; no pattern was derived for it"
-        ),
         AuthLoginNotice::ProbeRedirected { surface, target } => log::warn!(
             "the {} probe was redirected to `{target}`; probes do not follow\n\
                  redirects, so the credential was not validated against that surface",

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -85,7 +85,8 @@ pub fn command_auth_login(
     // prompt and the stdin path, so a project-configured default cannot
     // be targeted silently (design/credential-storage.md section 4).
     // Printed, not logged: `--quiet` must not hide it.
-    println!("Logging in to index `{key}`");
+    let header = sysand_core::style::get_style_config().header;
+    println!("{header}{:>12}{header:#} to index `{key}`", "Logging in");
 
     let secret = read_token(&key, token_stdin)?;
 
@@ -102,7 +103,11 @@ pub fn command_auth_login(
             match notice {
                 // Printed before the store write happens.
                 AuthLoginNotice::ReplacingExisting { key } => {
-                    println!("replacing existing credential for `{key}`");
+                    let header = sysand_core::style::get_style_config().header;
+                    println!(
+                        "{header}{:>12}{header:#} existing credential for `{key}`",
+                        "Replacing"
+                    );
                 }
                 AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
                     "could not read the index configuration ({error}); \
@@ -154,7 +159,6 @@ pub fn command_auth_login(
             globs,
             validated,
         }) => {
-            let header = sysand_core::style::get_style_config().header;
             // The claim is always scoped to the surfaces that accepted
             // the credential; never a bare "validated"
             // (design/credential-storage.md section 5).
@@ -171,7 +175,7 @@ pub fn command_auth_login(
                 "{header}{:>12}{header:#} credential for `{key}` ({claim})",
                 "Stored"
             );
-            println!("The credential covers: {}", globs.join(", "));
+            println!("{header}{:>12}{header:#} {}", "Covers", globs.join(", "));
             Ok(())
         }
         Ok(AuthLoginOutcome::BackendUnavailable { key, globs, reason }) => {
@@ -180,7 +184,7 @@ pub fn command_auth_login(
             // set instead. The secret is never echoed: stdout on such
             // hosts typically lands in captured CI job logs.
             println!(
-                "no OS keyring backend is available ({reason}), so the credential \
+                "No OS keyring backend is available ({reason}), so the credential \
                  was not stored."
             );
             println!(
@@ -265,12 +269,15 @@ pub fn command_auth_logout(
     // possible) so a configured default cannot be targeted silently.
     // Printed, not logged: `--quiet` must not hide it.
     let echo = validated_index_key(&target).unwrap_or_else(|_| target.clone());
-    println!("Logging out from index `{echo}`");
+    let header = sysand_core::style::get_style_config().header;
+    println!(
+        "{header}{:>12}{header:#} from index `{echo}`",
+        "Logging out"
+    );
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;
     match do_auth_logout(&mut store, &target) {
         Ok(key) => {
-            let header = sysand_core::style::get_style_config().header;
             log::info!(
                 "{header}{:>12}{header:#} stored credential for `{key}`",
                 "Removed"
@@ -341,6 +348,12 @@ fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
 /// highlighted as a warning.
 const EXPIRES_SOON_DAYS: i64 = 7;
 
+/// Render an expiry timestamp for display, without chrono's sub-second
+/// noise (`11:39:28.149443` reads as `11:39:28`).
+fn format_expiry_timestamp(expires_at: &chrono::DateTime<chrono::Utc>) -> String {
+    expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+}
+
 /// The ` (expired)` / ` (expires in N days)` qualifier for an expiry
 /// timestamp, styled through the house tokens (red for expired, yellow
 /// when expiry is close). Empty when nothing is known.
@@ -363,9 +376,15 @@ fn expiry_qualifier(expired: bool, expires_in_days: Option<i64>) -> String {
     }
 }
 
-/// Render the unified status view: stored entries tagged `stored` (key in
+/// Render the unified status view: stored entries tagged `Stored` (key in
 /// the exact form `sysand auth logout <key>` accepts), env entries tagged
-/// `env`. Never any secret.
+/// `Env`. Never any secret.
+///
+/// The tags sit right-aligned in the CLI's 12-column gutter; the sublines
+/// of an entry keep their `label: value` form (unlike `auth whoami`, which
+/// puts each field's label in the gutter: here the fields are subordinate
+/// to a tagged entry, and the hierarchy would be lost) and are indented to
+/// the gutter like other multi-line log messages.
 ///
 /// Styling reuses the house tokens (`sysand_core::style`) and goes through
 /// `anstream::println`, which strips it on non-terminal stdout and under
@@ -389,23 +408,26 @@ fn render_auth_status(status: &AuthStatus) {
         }
         StoredCredentialsStatus::Available(stored) => {
             for entry in stored {
-                println!("{tag}stored{tag:#}  {name}{}{name:#}", entry.key);
-                println!("        patterns: {}", entry.globs.join(", "));
+                println!("{tag}{:>12}{tag:#} {name}{}{name:#}", "Stored", entry.key);
+                println!("{:>12} patterns: {}", ' ', entry.globs.join(", "));
                 if let Some(subject) = &entry.subject {
-                    println!("        subject: {} {}", subject.kind, subject.name);
+                    println!("{:>12} subject: {} {}", ' ', subject.kind, subject.name);
                 }
                 if let Some(prefix) = &entry.token_prefix {
-                    println!("        token prefix: {prefix}");
+                    println!("{:>12} token prefix: {prefix}", ' ');
                 }
                 if let Some(expires_at) = &entry.expires_at {
                     println!(
-                        "        expires: {expires_at}{}",
+                        "{:>12} expires: {}{}",
+                        ' ',
+                        format_expiry_timestamp(expires_at),
                         expiry_qualifier(entry.expired, entry.expires_in_days)
                     );
                 }
                 if !entry.shadowed_by.is_empty() {
                     println!(
-                        "        {warn}shadowed by:{warn:#} {}",
+                        "{:>12} {warn}shadowed by:{warn:#} {}",
+                        ' ',
                         entry.shadowed_by.join(", ")
                     );
                 }
@@ -417,8 +439,8 @@ fn render_auth_status(status: &AuthStatus) {
     } else {
         for entry in &status.env {
             println!(
-                "{tag}env{tag:#}     {name}{}{name:#}  {}",
-                entry.label, entry.pattern
+                "{tag}{:>12}{tag:#} {name}{}{name:#}  {}",
+                "Env", entry.label, entry.pattern
             );
         }
     }
@@ -487,7 +509,11 @@ pub fn command_auth_whoami(
     // index so a configured default cannot be targeted silently. Printed,
     // not logged: `--quiet` must not hide it.
     let key = validated_index_key(&target)?;
-    println!("Checking identity on index `{key}`");
+    let header = sysand_core::style::get_style_config().header;
+    println!(
+        "{header}{:>12}{header:#} identity on index `{key}`",
+        "Checking"
+    );
 
     let env_policy = lenient_env_auth_policy()?;
     let env_bearers = env_policy
@@ -522,13 +548,19 @@ pub fn command_auth_whoami(
     // from (design/credential-storage.md section 7).
     match &outcome.source {
         WhoamiCredentialSource::Env { label: Some(label) } => {
-            println!("using credential from `SYSAND_CRED_{label}`");
+            println!(
+                "{header}{:>12}{header:#} credential from `SYSAND_CRED_{label}`",
+                "Using"
+            );
         }
         WhoamiCredentialSource::Env { label: None } => {
-            println!("using a `SYSAND_CRED_*` environment credential");
+            println!(
+                "{header}{:>12}{header:#} a `SYSAND_CRED_*` environment credential",
+                "Using"
+            );
         }
         WhoamiCredentialSource::Stored { key } => {
-            println!("using stored login for `{key}`");
+            println!("{header}{:>12}{header:#} stored login for `{key}`", "Using");
         }
     }
 
@@ -536,21 +568,22 @@ pub fn command_auth_whoami(
         WhoamiVerdict::Identified { identity } => {
             match identity {
                 Some(identity) => {
-                    let header = sysand_core::style::get_style_config().header;
                     println!(
-                        "{header}subject:{header:#} {} {}",
-                        identity.subject.kind, identity.subject.name
+                        "{header}{:>12}{header:#} {} {}",
+                        "Subject", identity.subject.kind, identity.subject.name
                     );
                     if let Some(token_name) = &identity.token_name {
-                        println!("{header}token name:{header:#} {token_name}");
+                        println!("{header}{:>12}{header:#} {token_name}", "Token name");
                     }
                     if let Some(prefix) = &identity.token_prefix {
-                        println!("{header}token prefix:{header:#} {prefix}");
+                        println!("{header}{:>12}{header:#} {prefix}", "Token prefix");
                     }
                     if let Some(expires_at) = identity.expires_at {
                         let now = chrono::Utc::now();
                         println!(
-                            "{header}expires:{header:#} {expires_at}{}",
+                            "{header}{:>12}{header:#} {}{}",
+                            "Expires",
+                            format_expiry_timestamp(&expires_at),
                             expiry_qualifier(expires_at < now, Some((expires_at - now).num_days()))
                         );
                     }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -425,6 +425,9 @@ fn expiry_qualifier(expired: bool, expires_in_days: Option<i64>) -> String {
         return format!(" {error}(expired){error:#}");
     }
     let text = match expires_in_days {
+        // `num_days` truncates, so a not-yet-expired token with under a day
+        // left reports 0; do not render "expires in 0 days".
+        Some(0) => "(expires in less than a day)".to_string(),
         Some(1) => "(expires in 1 day)".to_string(),
         Some(days) => format!("(expires in {days} days)"),
         None => return String::new(),
@@ -498,7 +501,7 @@ fn render_auth_status(status: &AuthStatus) {
         StoredCredentialsStatus::BackendUnavailable { reason } => {
             let note = style.note;
             println!(
-                "{note}note:{note:#} no usable OS keyring backend ({reason}); showing \
+                "{note}note:{note:#} no OS keyring backend is available ({reason}); showing \
                  `SYSAND_CRED_*` environment credentials only"
             );
             &none

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -76,6 +76,62 @@ fn surface_name(surface: ProbeSurface) -> &'static str {
     }
 }
 
+/// Render a login progress notice. `ReplacingExisting` is printed (it
+/// precedes the store write and must survive `--quiet`); the rest are
+/// warnings. `index_key` names the login for the basic-auth hint.
+fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
+    match notice {
+        AuthLoginNotice::ReplacingExisting { key } => {
+            let header = sysand_core::style::get_style_config().header;
+            println!(
+                "{header}{:>12}{header:#} existing credential for `{key}`",
+                "Replacing"
+            );
+        }
+        AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
+            "could not read the index configuration ({error}); \
+                 scoping the credential to the URL-derived pattern"
+        ),
+        AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
+            "discovery advertises a templated index_root (`{template}`) that \
+                 cannot be covered safely; no pattern was derived for it"
+        ),
+        AuthLoginNotice::ProbeRedirected { surface, target } => log::warn!(
+            "the {} probe was redirected to `{target}`; probes do not follow \
+                 redirects, so the credential was not validated against that surface",
+            surface_name(surface)
+        ),
+        AuthLoginNotice::ProbeUnreachable { surface, error } => log::warn!(
+            "could not probe the {} ({error}); the credential was not \
+                 validated against it",
+            surface_name(surface)
+        ),
+        AuthLoginNotice::ProbeRateLimited { surface } => log::warn!(
+            "the {} probe was rate limited (HTTP 429); the credential was \
+                 not validated against it",
+            surface_name(surface)
+        ),
+        AuthLoginNotice::SurfaceRejected {
+            surface,
+            basic_challenge,
+        } => {
+            log::warn!(
+                "the {} rejected the credential; it was stored anyway because \
+                     another surface accepted it",
+                surface_name(surface)
+            );
+            if basic_challenge {
+                let stem = cred_env_var_stem(index_key);
+                log::warn!(
+                    "this index uses username/password (HTTP basic) authentication; \
+                         configure `SYSAND_CRED_{stem}_BASIC_USER` / \
+                         `SYSAND_CRED_{stem}_BASIC_PASS` environment variables instead"
+                );
+            }
+        }
+    }
+}
+
 pub fn command_auth_login(
     index_url: Option<String>,
     token_stdin: bool,
@@ -113,57 +169,7 @@ pub fn command_auth_login(
     let mut store = open_cli_credential_store().context("could not open the credential store")?;
     let index_key = key.clone();
     let outcome = do_auth_login(&mut store, &key, secret, client, runtime, |notice| {
-        match notice {
-            // Printed before the store write happens.
-            AuthLoginNotice::ReplacingExisting { key } => {
-                let header = sysand_core::style::get_style_config().header;
-                println!(
-                    "{header}{:>12}{header:#} existing credential for `{key}`",
-                    "Replacing"
-                );
-            }
-            AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
-                "could not read the index configuration ({error}); \
-                     scoping the credential to the URL-derived pattern"
-            ),
-            AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
-                "discovery advertises a templated index_root (`{template}`) that \
-                     cannot be covered safely; no pattern was derived for it"
-            ),
-            AuthLoginNotice::ProbeRedirected { surface, target } => log::warn!(
-                "the {} probe was redirected to `{target}`; probes do not follow \
-                     redirects, so the credential was not validated against that surface",
-                surface_name(surface)
-            ),
-            AuthLoginNotice::ProbeUnreachable { surface, error } => log::warn!(
-                "could not probe the {} ({error}); the credential was not \
-                     validated against it",
-                surface_name(surface)
-            ),
-            AuthLoginNotice::ProbeRateLimited { surface } => log::warn!(
-                "the {} probe was rate limited (HTTP 429); the credential was \
-                     not validated against it",
-                surface_name(surface)
-            ),
-            AuthLoginNotice::SurfaceRejected {
-                surface,
-                basic_challenge,
-            } => {
-                log::warn!(
-                    "the {} rejected the credential; it was stored anyway because \
-                         another surface accepted it",
-                    surface_name(surface)
-                );
-                if basic_challenge {
-                    let stem = cred_env_var_stem(&index_key);
-                    log::warn!(
-                        "this index uses username/password (HTTP basic) authentication; \
-                             configure `SYSAND_CRED_{stem}_BASIC_USER` / \
-                             `SYSAND_CRED_{stem}_BASIC_PASS` environment variables instead"
-                    );
-                }
-            }
-        }
+        render_login_notice(notice, &index_key);
     });
     match outcome {
         Ok(AuthLoginOutcome::Stored {
@@ -471,33 +477,20 @@ fn validation_claim(validated: &[String]) -> String {
 }
 
 /// Render the unified status view: stored entries tagged `Stored` (key in
-/// the exact form `sysand auth logout <key>` accepts), env entries tagged
-/// `Env`. Never any secret.
+/// the exact form `sysand auth logout <key>` accepts) and env entries
+/// tagged `Env`. Never any secret.
 ///
-/// The tags sit right-aligned in the CLI's 12-column gutter; the sublines
-/// of an entry keep their `label: value` form (unlike `auth whoami`, which
-/// puts each field's label in the gutter: here the fields are subordinate
-/// to a tagged entry, and the hierarchy would be lost) and are indented to
-/// the gutter like other multi-line log messages, with the sublabels
-/// dimmed so the values carry the visual weight. Multiple stored entries
-/// are separated by a blank line; each entry's header line carries its
-/// validation claim after the key, mirroring the `Env` lines' two-space
-/// label/pattern separation.
+/// A few non-obvious rules the code below relies on: entry sublines keep a
+/// `label: value` form (unlike `auth whoami`, which puts each label in the
+/// gutter); stored entries are separated by a blank line and carry their
+/// validation claim, plus a dim `(default index)` marker when they apply to
+/// the default index, on the header line. A source with nothing to show is
+/// omitted, and a single combined negative prints only when neither source
+/// has anything; the backend-unavailable note always prints.
 ///
-/// Entries that apply to the default index (which is what bare commands
-/// use) carry a dim `(default index)` annotation at the end of their
-/// header line, two spaces after the validation claim (stored) or the
-/// pattern (env).
-///
-/// A source with nothing to show is simply omitted; only when neither
-/// source has anything does a single combined negative print. The
-/// backend-unavailable note is information, not a negative, and always
-/// prints when the keyring backend is unusable.
-///
-/// Styling reuses the house tokens (`sysand_core::style`) and goes through
-/// `anstream::println`, which strips it on non-terminal stdout and under
-/// `NO_COLOR`, so piped output stays exactly the plain text the CLI tests
-/// assert on (the alignment spaces are content, the styling is not).
+/// Styling goes through `anstream::println`, which strips it on
+/// non-terminal stdout and under `NO_COLOR`, so piped output is exactly the
+/// plain text the CLI tests assert on (the alignment spaces are content).
 fn render_auth_status(status: &AuthStatus) {
     let style = sysand_core::style::get_style_config();
     let tag = style.header;

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -5,19 +5,21 @@
 //! sections 4, 9): default-index resolution, the OS keyring store handoff
 //! to core, and user-facing rendering. Secrets never appear in any output.
 
+use std::io::{IsTerminal, Read};
+use std::sync::Arc;
+
 use anyhow::{Context, Result, bail};
 use sysand_core::{
     commands::auth::{
-        AuthCommandError, AuthStatus, EnvCredentialEntry, StoredCredentialsStatus, do_auth_logout,
-        do_auth_status,
+        AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
+        StoredCredentialsStatus, do_auth_login, do_auth_logout, do_auth_status,
+        validated_index_key,
     },
     config::Config,
-    credential_store::{
-        CredentialStoreError, keyring_store::KeyringCredentialStore, normalize_index_key,
-    },
+    credential_store::{CredentialStoreError, normalize_index_key},
 };
 
-use crate::DEFAULT_INDEX_URL;
+use crate::{DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
 
 const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide credentials via \
      `SYSAND_CRED_*` environment variables";
@@ -53,6 +55,134 @@ pub fn resolve_default_index(default_index_override: &[String], config: &Config)
     }
 }
 
+pub fn command_auth_login(
+    index_url: Option<String>,
+    token_stdin: bool,
+    default_index: &[String],
+    config: &Config,
+    client: &reqwest_middleware::ClientWithMiddleware,
+    runtime: Arc<tokio::runtime::Runtime>,
+) -> Result<()> {
+    let target = match index_url {
+        Some(url) => url,
+        None => resolve_default_index(default_index, config)?,
+    };
+    // Validate and normalize before any secret entry, so a `file://` or
+    // template target fails without prompting.
+    let key = validated_index_key(&target)?;
+    // Echo the resolved index before reading the secret, on both the
+    // prompt and the stdin path, so a project-configured default cannot
+    // be targeted silently (design/credential-storage.md section 4).
+    // Printed, not logged: `--quiet` must not hide it.
+    println!("Logging in to index `{key}`");
+
+    let secret = read_token(&key, token_stdin)?;
+
+    let mut store = open_cli_credential_store().context("could not open the credential store")?;
+    let outcome = do_auth_login(&mut store, &key, secret, client, runtime, |notice| {
+        match notice {
+            // Printed before the store write happens.
+            AuthLoginNotice::ReplacingExisting { key } => {
+                println!("replacing existing credential for `{key}`");
+            }
+            AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
+                "could not read the index configuration ({error}); \
+                 scoping the credential to the URL-derived pattern"
+            ),
+            AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
+                "discovery advertises a templated index_root (`{template}`) that \
+                 cannot be covered safely; no pattern was derived for it"
+            ),
+        }
+    });
+    match outcome {
+        Ok(AuthLoginOutcome::Stored { key, globs }) => {
+            let header = sysand_core::style::get_style_config().header;
+            log::info!(
+                "{header}{:>12}{header:#} credential for `{key}` (stored, not validated)",
+                "Stored"
+            );
+            println!("The credential covers: {}", globs.join(", "));
+            Ok(())
+        }
+        Ok(AuthLoginOutcome::BackendUnavailable { key, globs, reason }) => {
+            // No-keyring host (design/credential-storage.md section 9):
+            // refuse to persist, print the exact `SYSAND_CRED_*` lines to
+            // set instead. The secret is never echoed: stdout on such
+            // hosts typically lands in captured CI job logs.
+            println!(
+                "no OS keyring backend is available ({reason}), so the credential \
+                 was not stored."
+            );
+            println!(
+                "To authenticate on this host, set these environment variables \
+                 instead, replacing `<token>` with the token you entered:"
+            );
+            let stem = cred_env_var_stem(&key);
+            for (position, glob) in globs.iter().enumerate() {
+                let name = if position == 0 {
+                    stem.clone()
+                } else {
+                    format!("{}_{}", stem, position + 1)
+                };
+                println!("  SYSAND_CRED_{name}={glob}");
+                println!("  SYSAND_CRED_{name}_BEARER_TOKEN=<token>");
+            }
+            bail!("credential not stored: no OS keyring backend on this host");
+        }
+        Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
+            Err(err).context(KEYRING_LOCKED_HINT)
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Read the login secret: from stdin when `--token-stdin` was given
+/// (trimming exactly one trailing newline), else from a hidden terminal
+/// prompt. Fails fast when stdin is not a terminal and `--token-stdin`
+/// was not given, instead of hanging or reading a pipe as a secret.
+fn read_token(key: &str, token_stdin: bool) -> Result<String> {
+    let token = if token_stdin {
+        let mut raw = String::new();
+        std::io::stdin()
+            .read_to_string(&mut raw)
+            .context("could not read the token from stdin")?;
+        let trimmed = match raw.strip_suffix('\n') {
+            Some(rest) => rest.strip_suffix('\r').unwrap_or(rest),
+            None => raw.as_str(),
+        };
+        trimmed.to_string()
+    } else if std::io::stdin().is_terminal() {
+        rpassword::prompt_password(format!("Enter token for `{key}`:"))
+            .context("could not read the token from the terminal")?
+    } else {
+        bail!("no terminal for prompt; pass the token with `--token-stdin`");
+    };
+    if token.is_empty() {
+        bail!("empty token; nothing was stored");
+    }
+    Ok(token)
+}
+
+/// Derive the `SYSAND_CRED_<NAME>` stem suggested on a no-keyring host
+/// from the index host. Hostnames cannot produce the reserved
+/// `_BASIC_USER` / `_BASIC_PASS` / `_BEARER_TOKEN` suffixes.
+fn cred_env_var_stem(key: &str) -> String {
+    let host = url::Url::parse(key)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+        .unwrap_or_else(|| "INDEX".to_string());
+    host.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 pub fn command_auth_logout(
     index_url: Option<String>,
     default_index: &[String],
@@ -68,8 +198,7 @@ pub fn command_auth_logout(
     let echo = normalize_index_key(&target).unwrap_or_else(|_| target.clone());
     println!("Logging out from index `{echo}`");
 
-    let mut store =
-        KeyringCredentialStore::open_default().context("could not open the credential store")?;
+    let mut store = open_cli_credential_store().context("could not open the credential store")?;
     match do_auth_logout(&mut store, &target) {
         Ok(key) => {
             let header = sysand_core::style::get_style_config().header;
@@ -93,7 +222,7 @@ pub fn command_auth_logout(
 
 pub fn command_auth_status() -> Result<()> {
     let env = collect_env_credential_entries();
-    let status = match KeyringCredentialStore::open_default() {
+    let status = match open_cli_credential_store() {
         Ok(store) => match do_auth_status(&store, env) {
             Ok(status) => status,
             Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -172,11 +172,15 @@ pub fn command_auth_login(
                     .collect();
                 format!("validated ({})", surfaces.join(", "))
             };
+            // Both lines are the login result: keep them on one channel
+            // (the log) so `--quiet` suppresses the confirmation as a unit,
+            // the way `sysand publish` suppresses "Published", instead of
+            // leaving an orphan "Covers" line on stdout.
             log::info!(
                 "{header}{:>12}{header:#} credential for `{key}` ({claim})",
                 "Stored"
             );
-            println!("{header}{:>12}{header:#} {}", "Covers", globs.join(", "));
+            log::info!("{header}{:>12}{header:#} {}", "Covers", globs.join(", "));
             Ok(())
         }
         Ok(AuthLoginOutcome::BackendUnavailable { key, globs, reason }) => {
@@ -244,7 +248,7 @@ fn blob_full_message(stored: &[(&str, Option<DateTime<Utc>>)], now: DateTime<Utc
             .to_string()
     };
     if !expired.is_empty() {
-        message.push_str("\nthese stored logins have expired and are safe to remove:");
+        message.push_str("\nthese stored credentials have expired and are safe to remove:");
         for key in expired {
             message.push_str(&format!("\n  sysand auth logout {key}"));
         }
@@ -324,7 +328,7 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
         }
         Err(AuthCommandError::Store(CredentialStoreError::BackendAbsent { source })) => bail!(
             "no OS keyring backend is available ({source}), so this host has no \
-             stored logins; credentials here come from `SYSAND_CRED_*` \
+             stored credentials; credentials here come from `SYSAND_CRED_*` \
              environment variables"
         ),
         Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
@@ -559,7 +563,9 @@ fn render_auth_status(status: &AuthStatus) {
         );
     }
     if stored.is_empty() && status.env.is_empty() {
-        println!("No credentials configured (no stored logins, no `SYSAND_CRED_*` variables).");
+        println!(
+            "No credentials configured (no stored credentials, no `SYSAND_CRED_*` variables)."
+        );
     }
 }
 
@@ -687,7 +693,10 @@ pub fn command_auth_whoami(
             );
         }
         WhoamiCredentialSource::Stored { key } => {
-            println!("{header}{:>12}{header:#} stored login for `{key}`", "Using");
+            println!(
+                "{header}{:>12}{header:#} stored credential for `{key}`",
+                "Using"
+            );
         }
     }
 
@@ -739,8 +748,13 @@ pub fn command_auth_whoami(
                 outcome.whoami_url
             );
         }
+        // "Unreachable" here covers both genuine transport failures and a
+        // server that answered without a usable identity (a redirect, a
+        // 429, an unexpected status like 403). "could not get an identity"
+        // reads correctly for all of them, unlike "could not reach", which
+        // contradicts a 403 the API actually returned.
         WhoamiVerdict::Unreachable { detail } => bail!(
-            "could not reach the index API (`{}`): {detail}",
+            "could not get an identity from the index API (`{}`): {detail}",
             outcome.whoami_url
         ),
     }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -433,7 +433,10 @@ fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
         .filter(|(key, _)| {
             matches!(
                 crate::cred_env::classify(key),
-                Some((_, crate::cred_env::CredEnvRole::Pattern))
+                Some(crate::cred_env::CredEnvName::Grouped(
+                    _,
+                    crate::cred_env::CredEnvRole::Pattern
+                ))
             )
         })
         .map(|(key, value)| EnvCredentialEntry {
@@ -605,7 +608,7 @@ fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
             builder.add_basic_auth(pattern, user, password);
         }
         if let Some(token) = groups.bearer_tokens.get(stem) {
-            builder.add_bearer_auth_labeled(pattern, token, stem);
+            builder.add_bearer_auth(pattern, token, stem);
         }
     }
     builder
@@ -682,15 +685,9 @@ pub fn command_auth_whoami(
     // Name the source: env shadows stored, so the right remediation
     // depends on where the credential came from.
     match &outcome.source {
-        WhoamiCredentialSource::Env { label: Some(label) } => {
+        WhoamiCredentialSource::Env { label } => {
             println!(
                 "{header}{:>12}{header:#} credential from `SYSAND_CRED_{label}`",
-                "Using"
-            );
-        }
-        WhoamiCredentialSource::Env { label: None } => {
-            println!(
-                "{header}{:>12}{header:#} a `SYSAND_CRED_*` environment credential",
                 "Using"
             );
         }
@@ -735,11 +732,8 @@ pub fn command_auth_whoami(
         }
         WhoamiVerdict::Rejected => {
             let remediation = match &outcome.source {
-                WhoamiCredentialSource::Env { label: Some(label) } => {
+                WhoamiCredentialSource::Env { label } => {
                     format!("rotate or unset `SYSAND_CRED_{label}_BEARER_TOKEN`")
-                }
-                WhoamiCredentialSource::Env { label: None } => {
-                    "rotate or unset the matching `SYSAND_CRED_*` variables".to_string()
                 }
                 WhoamiCredentialSource::Stored { key } => {
                     format!("re-run `sysand auth login {key}`")

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -14,9 +14,9 @@ use sysand_core::{
     auth::{GlobMapBuilder, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder},
     commands::auth::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
-        ProbeSurface, StoredCredentialStatus, StoredCredentialsStatus, WhoamiCredentialSource,
-        WhoamiVerdict, assemble_auth_status, do_auth_login, do_auth_logout, do_auth_status,
-        do_auth_whoami, validated_index_key,
+        IndexKey, ProbeSurface, StoredCredentialStatus, StoredCredentialsStatus,
+        WhoamiCredentialSource, WhoamiVerdict, assemble_auth_status, do_auth_login, do_auth_logout,
+        do_auth_status, do_auth_whoami,
     },
     config::Config,
     credential_store::CredentialStoreError,
@@ -153,8 +153,9 @@ pub fn command_auth_login(
         None => resolve_default_index(config)?,
     };
     // Validate and normalize before any secret entry, so a `file://` or
-    // unanchorable-template target fails without prompting.
-    let key = validated_index_key(&target)?;
+    // unanchorable-template target fails without prompting. This is the
+    // one validation; core takes the resulting `IndexKey` as proof.
+    let key = IndexKey::validate(&target)?;
     // Echo the resolved index before reading the secret, on both the
     // prompt and the stdin path, so a project-configured default cannot
     // be targeted silently.
@@ -165,17 +166,17 @@ pub fn command_auth_login(
     // An `http` index sends the token in cleartext, and a MITM at login
     // could persist a hostile `api_root`. Warn before the secret is
     // entered so the user can abort.
-    if key.starts_with("http://") {
+    if key.as_str().starts_with("http://") {
         log::warn!(
             "`{key}` uses an unencrypted (http) connection; the token will be \
              sent in cleartext. Prefer an https:// index."
         );
     }
 
-    let secret = read_token(&key, token_stdin)?;
+    let secret = read_token(key.as_str(), token_stdin)?;
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;
-    let index_key = key.clone();
+    let index_key = key.to_string();
     let outcome = do_auth_login(&mut store, &key, secret, client, &runtime, |notice| {
         render_login_notice(notice, &index_key);
     });
@@ -340,7 +341,8 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
     // Echo the resolved index (normalized to the stored-key form when
     // possible) so a configured default cannot be targeted silently.
     // Printed, not logged: `--quiet` must not hide it.
-    let echo = validated_index_key(&target).unwrap_or_else(|_| target.clone());
+    let validated = IndexKey::validate(&target);
+    let echo = validated.as_ref().map_or(target.as_str(), IndexKey::as_str);
     let header = sysand_core::style::get_style_config().header;
     println!(
         "{header}{:>12}{header:#} from index `{echo}`",
@@ -348,7 +350,10 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
     );
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;
-    match do_auth_logout(&mut store, &target) {
+    // The one validation for this command; an invalid target surfaces
+    // here, after the echo, as it did when core validated it.
+    let key = validated?;
+    match do_auth_logout(&mut store, &key) {
         Ok(key) => {
             log::info!(
                 "{header}{:>12}{header:#} stored credential for `{key}`",
@@ -382,7 +387,7 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
     // ambiguous chain gets a note instead of the hard error bare
     // `login`/`logout` raise, and an invalid default simply marks nothing.
     let default_key = match resolve_default_index(config) {
-        Ok(url) => validated_index_key(&url).ok(),
+        Ok(url) => IndexKey::validate(&url).ok(),
         // `resolve_default_index` errors only on an ambiguous chain
         // (more than one distinct default index).
         Err(_) => {
@@ -394,9 +399,10 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
             None
         }
     };
+    let default_key = default_key.as_ref().map(IndexKey::as_str);
     let env = collect_env_credential_entries();
     let status = match open_cli_credential_store() {
-        Ok(store) => match do_auth_status(&store, env, default_key.as_deref()) {
+        Ok(store) => match do_auth_status(&store, env, default_key) {
             Ok(status) => status,
             Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
                 return Err(err).context(KEYRING_LOCKED_HINT);
@@ -406,8 +412,7 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
         // Could not open the store: degrade to the env-only view like an
         // absent backend, keeping the env entries' default-index marking.
         Err(err) => {
-            let mut status =
-                assemble_auth_status(Vec::new(), env, chrono::Utc::now(), default_key.as_deref());
+            let mut status = assemble_auth_status(Vec::new(), env, chrono::Utc::now(), default_key);
             status.stored = StoredCredentialsStatus::BackendUnavailable {
                 reason: err.to_string(),
             };
@@ -625,7 +630,7 @@ pub fn command_auth_whoami(
     // Validate before any store or network access, and echo the resolved
     // index so a configured default cannot be targeted silently. Printed,
     // not logged: `--quiet` must not hide it.
-    let key = validated_index_key(&target)?;
+    let key = IndexKey::validate(&target)?;
     let header = sysand_core::style::get_style_config().header;
     println!(
         "{header}{:>12}{header:#} identity on index `{key}`",
@@ -657,7 +662,7 @@ pub fn command_auth_whoami(
 
     let outcome = match do_auth_whoami(
         &records,
-        &target,
+        &key,
         &env_bearers,
         &discovery_policy,
         client,

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -8,18 +8,20 @@
 use std::io::{IsTerminal, Read};
 use std::sync::Arc;
 
+use anstream::println;
 use anyhow::{Context, Result, bail};
 use sysand_core::{
+    auth::{GlobMapBuilder, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder},
     commands::auth::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
-        ProbeSurface, StoredCredentialsStatus, do_auth_login, do_auth_logout, do_auth_status,
-        validated_index_key,
+        ProbeSurface, StoredCredentialsStatus, WhoamiCredentialSource, WhoamiVerdict,
+        do_auth_login, do_auth_logout, do_auth_status, do_auth_whoami, validated_index_key,
     },
     config::Config,
     credential_store::CredentialStoreError,
 };
 
-use crate::{DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
+use crate::{CliAuthPolicy, DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
 
 const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide credentials via \
      `SYSAND_CRED_*` environment variables";
@@ -335,14 +337,50 @@ fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
     entries
 }
 
+/// Days-to-expiry at or under which the `expires in N days` qualifier is
+/// highlighted as a warning.
+const EXPIRES_SOON_DAYS: i64 = 7;
+
+/// The ` (expired)` / ` (expires in N days)` qualifier for an expiry
+/// timestamp, styled through the house tokens (red for expired, yellow
+/// when expiry is close). Empty when nothing is known.
+fn expiry_qualifier(expired: bool, expires_in_days: Option<i64>) -> String {
+    let style = sysand_core::style::get_style_config();
+    if expired {
+        let error = style.error;
+        return format!(" {error}(expired){error:#}");
+    }
+    let text = match expires_in_days {
+        Some(1) => "(expires in 1 day)".to_string(),
+        Some(days) => format!("(expires in {days} days)"),
+        None => return String::new(),
+    };
+    if expires_in_days.is_some_and(|days| days <= EXPIRES_SOON_DAYS) {
+        let warn = style.warn;
+        format!(" {warn}{text}{warn:#}")
+    } else {
+        format!(" {text}")
+    }
+}
+
 /// Render the unified status view: stored entries tagged `stored` (key in
 /// the exact form `sysand auth logout <key>` accepts), env entries tagged
 /// `env`. Never any secret.
+///
+/// Styling reuses the house tokens (`sysand_core::style`) and goes through
+/// `anstream::println`, which strips it on non-terminal stdout and under
+/// `NO_COLOR`, so piped output stays exactly the plain text the CLI tests
+/// assert on.
 fn render_auth_status(status: &AuthStatus) {
+    let style = sysand_core::style::get_style_config();
+    let tag = style.header;
+    let name = style.literal;
+    let warn = style.warn;
     match &status.stored {
         StoredCredentialsStatus::BackendUnavailable { reason } => {
+            let note = style.note;
             println!(
-                "note: no usable OS keyring backend ({reason}); showing \
+                "{note}note:{note:#} no usable OS keyring backend ({reason}); showing \
                  `SYSAND_CRED_*` environment credentials only"
             );
         }
@@ -351,7 +389,7 @@ fn render_auth_status(status: &AuthStatus) {
         }
         StoredCredentialsStatus::Available(stored) => {
             for entry in stored {
-                println!("stored  {}", entry.key);
+                println!("{tag}stored{tag:#}  {name}{}{name:#}", entry.key);
                 println!("        patterns: {}", entry.globs.join(", "));
                 if let Some(subject) = &entry.subject {
                     println!("        subject: {} {}", subject.kind, subject.name);
@@ -360,19 +398,16 @@ fn render_auth_status(status: &AuthStatus) {
                     println!("        token prefix: {prefix}");
                 }
                 if let Some(expires_at) = &entry.expires_at {
-                    let qualifier = if entry.expired {
-                        " (expired)".to_string()
-                    } else {
-                        match entry.expires_in_days {
-                            Some(1) => " (expires in 1 day)".to_string(),
-                            Some(days) => format!(" (expires in {days} days)"),
-                            None => String::new(),
-                        }
-                    };
-                    println!("        expires: {expires_at}{qualifier}");
+                    println!(
+                        "        expires: {expires_at}{}",
+                        expiry_qualifier(entry.expired, entry.expires_in_days)
+                    );
                 }
                 if !entry.shadowed_by.is_empty() {
-                    println!("        shadowed by: {}", entry.shadowed_by.join(", "));
+                    println!(
+                        "        {warn}shadowed by:{warn:#} {}",
+                        entry.shadowed_by.join(", ")
+                    );
                 }
             }
         }
@@ -381,7 +416,172 @@ fn render_auth_status(status: &AuthStatus) {
         println!("No `SYSAND_CRED_*` environment credentials.");
     } else {
         for entry in &status.env {
-            println!("env     {}  {}", entry.label, entry.pattern);
+            println!(
+                "{tag}env{tag:#}     {name}{}{name:#}  {}",
+                entry.label, entry.pattern
+            );
         }
+    }
+}
+
+/// Build the read auth policy for `auth whoami`'s discovery fetch (and its
+/// env bearer map), tolerantly: unlike the eager policy build in
+/// `run_cli`, a malformed `SYSAND_CRED_*` group (an incomplete pair, an
+/// invalid glob pattern) is skipped with a debug log instead of failing
+/// the command, because the `auth` commands must stay usable to diagnose
+/// exactly those (same stance as `auth status`).
+fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
+    let mut patterns = std::collections::HashMap::new();
+    let mut users = std::collections::HashMap::new();
+    let mut passwords = std::collections::HashMap::new();
+    let mut tokens = std::collections::HashMap::new();
+    for (key, value) in std::env::vars() {
+        if let Some(rest) = key.strip_prefix("SYSAND_CRED_") {
+            if let Some(stem) = rest.strip_suffix("_BASIC_USER") {
+                users.insert(stem.to_owned(), value);
+            } else if let Some(stem) = rest.strip_suffix("_BASIC_PASS") {
+                passwords.insert(stem.to_owned(), value);
+            } else if let Some(stem) = rest.strip_suffix("_BEARER_TOKEN") {
+                tokens.insert(stem.to_owned(), value);
+            } else {
+                patterns.insert(rest.to_owned(), value);
+            }
+        }
+    }
+
+    let mut builder = StandardHTTPAuthenticationBuilder::new();
+    for (stem, pattern) in &patterns {
+        // Pre-compile each pattern individually: `build` below fails
+        // wholesale on one bad glob, and one bad group must not hide the
+        // other credentials.
+        let mut check: GlobMapBuilder<()> = GlobMapBuilder::new();
+        check.add(pattern, ());
+        if check.build().is_err() {
+            log::debug!("skipping SYSAND_CRED_{stem}: invalid URL glob pattern");
+            continue;
+        }
+        if let (Some(user), Some(password)) = (users.get(stem), passwords.get(stem)) {
+            builder.add_basic_auth(pattern, user, password);
+        }
+        if let Some(token) = tokens.get(stem) {
+            builder.add_bearer_auth_labeled(pattern, token, stem);
+        }
+    }
+    builder
+        .build()
+        .context("could not compile `SYSAND_CRED_*` URL patterns")
+}
+
+pub fn command_auth_whoami(
+    index_url: Option<String>,
+    default_index: &[String],
+    config: &Config,
+    client: &reqwest_middleware::ClientWithMiddleware,
+    runtime: &tokio::runtime::Runtime,
+) -> Result<()> {
+    let target = match index_url {
+        Some(url) => url,
+        None => resolve_default_index(default_index, config)?,
+    };
+    // Validate before any store or network access, and echo the resolved
+    // index so a configured default cannot be targeted silently. Printed,
+    // not logged: `--quiet` must not hide it.
+    let key = validated_index_key(&target)?;
+    println!("Checking identity on index `{key}`");
+
+    let env_policy = lenient_env_auth_policy()?;
+    let env_bearers = env_policy
+        .publish_bearer_auth_map()
+        .context("could not compile `SYSAND_CRED_*` URL patterns")?;
+    // Two store handles on the same underlying store: one feeds the
+    // discovery policy (a private index may gate its discovery document,
+    // so unlike login the fetch runs with the regular read policy), the
+    // other is read for credential selection.
+    let discovery_store =
+        open_cli_credential_store().context("could not open the credential store")?;
+    let store = open_cli_credential_store().context("could not open the credential store")?;
+    let discovery_policy = CliAuthPolicy::new(env_policy, discovery_store);
+
+    let outcome = match do_auth_whoami(
+        &store,
+        &target,
+        &env_bearers,
+        &discovery_policy,
+        client,
+        runtime,
+    ) {
+        Ok(outcome) => outcome,
+        Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
+            return Err(err).context(KEYRING_LOCKED_HINT);
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    // Name the source: an env credential shadows a stored login, so the
+    // right remediation for a bad credential depends on where it came
+    // from (design/credential-storage.md section 7).
+    match &outcome.source {
+        WhoamiCredentialSource::Env { label: Some(label) } => {
+            println!("using credential from `SYSAND_CRED_{label}`");
+        }
+        WhoamiCredentialSource::Env { label: None } => {
+            println!("using a `SYSAND_CRED_*` environment credential");
+        }
+        WhoamiCredentialSource::Stored { key } => {
+            println!("using stored login for `{key}`");
+        }
+    }
+
+    match outcome.verdict {
+        WhoamiVerdict::Identified { identity } => {
+            match identity {
+                Some(identity) => {
+                    let header = sysand_core::style::get_style_config().header;
+                    println!(
+                        "{header}subject:{header:#} {} {}",
+                        identity.subject.kind, identity.subject.name
+                    );
+                    if let Some(token_name) = &identity.token_name {
+                        println!("{header}token name:{header:#} {token_name}");
+                    }
+                    if let Some(prefix) = &identity.token_prefix {
+                        println!("{header}token prefix:{header:#} {prefix}");
+                    }
+                    if let Some(expires_at) = identity.expires_at {
+                        let now = chrono::Utc::now();
+                        println!(
+                            "{header}expires:{header:#} {expires_at}{}",
+                            expiry_qualifier(expires_at < now, Some((expires_at - now).num_days()))
+                        );
+                    }
+                }
+                None => println!(
+                    "The credential was accepted, but the identity response \
+                     could not be parsed."
+                ),
+            }
+            Ok(())
+        }
+        WhoamiVerdict::Rejected => {
+            let remediation = match &outcome.source {
+                WhoamiCredentialSource::Env { label: Some(label) } => {
+                    format!("rotate or unset `SYSAND_CRED_{label}_BEARER_TOKEN`")
+                }
+                WhoamiCredentialSource::Env { label: None } => {
+                    "rotate or unset the matching `SYSAND_CRED_*` variables".to_string()
+                }
+                WhoamiCredentialSource::Stored { key } => {
+                    format!("re-run `sysand auth login {key}`")
+                }
+            };
+            bail!(
+                "the index API (`{}`) rejected the credential (HTTP 401); {remediation}",
+                outcome.whoami_url
+            );
+        }
+        WhoamiVerdict::Unreachable { detail } => bail!(
+            "could not reach the index API (`{}`): {detail}",
+            outcome.whoami_url
+        ),
     }
 }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -112,18 +112,18 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
         ),
         AuthLoginNotice::SurfaceRejected {
             surface,
-            read_status,
+            status,
             basic_challenge,
         } => {
             // Same read-404 hedge as the refusal message.
-            let hedge = if read_status == Some(404) {
-                " (HTTP 404, which can also mean no index exists at this URL)"
+            let hedge = if surface == ProbeSurface::Read && status == 404 {
+                ", which can also mean no index exists at this URL"
             } else {
                 ""
             };
             log::warn!(
-                "the {} rejected the credential{hedge}; it was stored anyway\n\
-                     because another surface accepted it",
+                "the {} rejected the credential (HTTP {status}{hedge});\n\
+                     it was stored anyway because another surface accepted it",
                 surface_name(surface)
             );
             if basic_challenge {

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -479,15 +479,17 @@ fn expiry_qualifier(expired: bool, expires_in_days: Option<i64>) -> String {
 /// The per-entry validation claim: the same scoped wording `auth login`
 /// prints, from the surfaces a validating login recorded. Dim when
 /// validated (secondary detail); warn when not (the security-relevant
-/// case: nothing ever exercised this credential).
-fn validation_claim(validated: &[String]) -> String {
+/// case: nothing ever exercised this credential). Unknown surfaces
+/// render as their stored string.
+fn validation_claim(validated: &[sysand_core::credential_store::ValidatedSurface]) -> String {
     let style = sysand_core::style::get_style_config();
     if validated.is_empty() {
         let warn = style.warn;
         format!("{warn}not validated{warn:#}")
     } else {
+        let surfaces: Vec<&str> = validated.iter().map(|surface| surface.as_str()).collect();
         let dim = style.dim;
-        format!("{dim}validated ({}){dim:#}", validated.join(", "))
+        format!("{dim}validated ({}){dim:#}", surfaces.join(", "))
     }
 }
 

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, bail};
 use sysand_core::{
     commands::auth::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
-        StoredCredentialsStatus, do_auth_login, do_auth_logout, do_auth_status,
+        ProbeSurface, StoredCredentialsStatus, do_auth_login, do_auth_logout, do_auth_status,
         validated_index_key,
     },
     config::Config,
@@ -55,9 +55,18 @@ pub fn resolve_default_index(default_index_override: &[String], config: &Config)
     }
 }
 
+/// Human name of a probe surface for warnings.
+fn surface_name(surface: ProbeSurface) -> &'static str {
+    match surface {
+        ProbeSurface::Read => "index read surface (`index.json`)",
+        ProbeSurface::Api => "index API (`v1/whoami`)",
+    }
+}
+
 pub fn command_auth_login(
     index_url: Option<String>,
     token_stdin: bool,
+    validation: Option<bool>,
     default_index: &[String],
     config: &Config,
     client: &reqwest_middleware::ClientWithMiddleware,
@@ -79,27 +88,80 @@ pub fn command_auth_login(
     let secret = read_token(&key, token_stdin)?;
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;
-    let outcome = do_auth_login(&mut store, &key, secret, client, runtime, |notice| {
-        match notice {
-            // Printed before the store write happens.
-            AuthLoginNotice::ReplacingExisting { key } => {
-                println!("replacing existing credential for `{key}`");
+    let index_key = key.clone();
+    let outcome = do_auth_login(
+        &mut store,
+        &key,
+        secret,
+        validation,
+        client,
+        runtime,
+        |notice| {
+            match notice {
+                // Printed before the store write happens.
+                AuthLoginNotice::ReplacingExisting { key } => {
+                    println!("replacing existing credential for `{key}`");
+                }
+                AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
+                    "could not read the index configuration ({error}); \
+                     scoping the credential to the URL-derived pattern"
+                ),
+                AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
+                    "discovery advertises a templated index_root (`{template}`) that \
+                     cannot be covered safely; no pattern was derived for it"
+                ),
+                AuthLoginNotice::ProbeRedirected { surface, target } => log::warn!(
+                    "the {} probe was redirected to `{target}`; probes do not follow \
+                     redirects, so the credential was not validated against that surface",
+                    surface_name(surface)
+                ),
+                AuthLoginNotice::ProbeUnreachable { surface, error } => log::warn!(
+                    "could not probe the {} ({error}); the credential was not \
+                     validated against it",
+                    surface_name(surface)
+                ),
+                AuthLoginNotice::SurfaceRejected {
+                    surface,
+                    basic_challenge,
+                } => {
+                    log::warn!(
+                        "the {} rejected the credential; it was stored anyway because \
+                         another surface accepted it",
+                        surface_name(surface)
+                    );
+                    if basic_challenge {
+                        let stem = cred_env_var_stem(&index_key);
+                        log::warn!(
+                            "this index uses username/password (HTTP basic) authentication; \
+                             configure `SYSAND_CRED_{stem}_BASIC_USER` / \
+                             `SYSAND_CRED_{stem}_BASIC_PASS` environment variables instead"
+                        );
+                    }
+                }
             }
-            AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
-                "could not read the index configuration ({error}); \
-                 scoping the credential to the URL-derived pattern"
-            ),
-            AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
-                "discovery advertises a templated index_root (`{template}`) that \
-                 cannot be covered safely; no pattern was derived for it"
-            ),
-        }
-    });
+        },
+    );
     match outcome {
-        Ok(AuthLoginOutcome::Stored { key, globs }) => {
+        Ok(AuthLoginOutcome::Stored {
+            key,
+            globs,
+            validated,
+        }) => {
             let header = sysand_core::style::get_style_config().header;
+            // The claim is always scoped to the surfaces that accepted
+            // the credential; never a bare "validated"
+            // (design/credential-storage.md section 5).
+            let claim = if validated.is_empty() {
+                "stored, not validated".to_string()
+            } else {
+                let surfaces: Vec<String> = validated
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect();
+                format!("validated ({})", surfaces.join(", "))
+            };
             log::info!(
-                "{header}{:>12}{header:#} credential for `{key}` (stored, not validated)",
+                "{header}{:>12}{header:#} credential for `{key}` ({claim})",
                 "Stored"
             );
             println!("The credential covers: {}", globs.join(", "));
@@ -286,9 +348,23 @@ fn render_auth_status(status: &AuthStatus) {
             for entry in stored {
                 println!("stored  {}", entry.key);
                 println!("        patterns: {}", entry.globs.join(", "));
+                if let Some(subject) = &entry.subject {
+                    println!("        subject: {} {}", subject.kind, subject.name);
+                }
+                if let Some(prefix) = &entry.token_prefix {
+                    println!("        token prefix: {prefix}");
+                }
                 if let Some(expires_at) = &entry.expires_at {
-                    let expired = if entry.expired { " (expired)" } else { "" };
-                    println!("        expires: {expires_at}{expired}");
+                    let qualifier = if entry.expired {
+                        " (expired)".to_string()
+                    } else {
+                        match entry.expires_in_days {
+                            Some(1) => " (expires in 1 day)".to_string(),
+                            Some(days) => format!(" (expires in {days} days)"),
+                            None => String::new(),
+                        }
+                    };
+                    println!("        expires: {expires_at}{qualifier}");
                 }
                 if !entry.shadowed_by.is_empty() {
                     println!("        shadowed by: {}", entry.shadowed_by.join(", "));

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -29,12 +29,20 @@ const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide 
 
 /// Resolve the single index a bare `sysand auth login` / `auth logout`
 /// targets (design/credential-storage.md section 4): the
-/// `--default-index` / `SYSAND_DEFAULT_INDEX` override when given, else a
-/// `default = true` index from configuration, else the built-in
-/// [`DEFAULT_INDEX_URL`]. If the consulted stage yields more than one
-/// distinct URL, the target is ambiguous and an explicit URL is required.
-pub fn resolve_default_index(default_index_override: &[String], config: &Config) -> Result<String> {
-    let mut candidates: Vec<&str> = if default_index_override.is_empty() {
+/// `SYSAND_DEFAULT_INDEX` environment override (comma-delimited) when
+/// set, else a `default = true` index from configuration, else the
+/// built-in [`DEFAULT_INDEX_URL`]. If the consulted stage yields more
+/// than one distinct URL, the target is ambiguous and an explicit URL is
+/// required. Read from the environment here rather than a per-subcommand
+/// `--default-index` flag: a flag would only duplicate the positional
+/// index argument.
+pub fn resolve_default_index(config: &Config) -> Result<String> {
+    let env_override = std::env::var(crate::env_vars::SYSAND_DEFAULT_INDEX).ok();
+    let env_candidates: Vec<&str> = env_override
+        .as_deref()
+        .map(|raw| raw.split(',').filter(|url| !url.is_empty()).collect())
+        .unwrap_or_default();
+    let mut candidates: Vec<&str> = if env_candidates.is_empty() {
         config
             .indexes
             .iter()
@@ -42,7 +50,7 @@ pub fn resolve_default_index(default_index_override: &[String], config: &Config)
             .map(|index| index.url.as_str())
             .collect()
     } else {
-        default_index_override.iter().map(String::as_str).collect()
+        env_candidates
     };
     // Exact duplicates of one URL are still a single target.
     let mut seen = std::collections::HashSet::new();
@@ -69,14 +77,13 @@ fn surface_name(surface: ProbeSurface) -> &'static str {
 pub fn command_auth_login(
     index_url: Option<String>,
     token_stdin: bool,
-    default_index: &[String],
     config: &Config,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
 ) -> Result<()> {
     let target = match index_url {
         Some(url) => url,
-        None => resolve_default_index(default_index, config)?,
+        None => resolve_default_index(config)?,
     };
     // Validate and normalize before any secret entry, so a `file://` or
     // unanchorable-template target fails without prompting.
@@ -248,14 +255,10 @@ fn cred_env_var_stem(key: &str) -> String {
         .collect()
 }
 
-pub fn command_auth_logout(
-    index_url: Option<String>,
-    default_index: &[String],
-    config: &Config,
-) -> Result<()> {
+pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result<()> {
     let target = match index_url {
         Some(url) => url,
-        None => resolve_default_index(default_index, config)?,
+        None => resolve_default_index(config)?,
     };
     // Echo the resolved index (normalized to the stored-key form when
     // possible) so a configured default cannot be targeted silently.
@@ -288,13 +291,13 @@ pub fn command_auth_logout(
     }
 }
 
-pub fn command_auth_status(default_index: &[String], config: &Config) -> Result<()> {
+pub fn command_auth_status(config: &Config) -> Result<()> {
     // Resolve the default index only to mark the entries that apply to
     // it. Status is a diagnostic view, so resolution is lenient: an
     // ambiguous chain gets a note instead of the hard error bare
     // `login`/`logout` raise, and a default that is not a valid HTTP(S)
     // index key (for example `file://`) simply marks nothing.
-    let default_key = match resolve_default_index(default_index, config) {
+    let default_key = match resolve_default_index(config) {
         Ok(url) => validated_index_key(&url).ok(),
         // `resolve_default_index` errors only on an ambiguous chain
         // (more than one distinct default index).
@@ -564,14 +567,13 @@ fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
 
 pub fn command_auth_whoami(
     index_url: Option<String>,
-    default_index: &[String],
     config: &Config,
     client: &reqwest_middleware::ClientWithMiddleware,
     runtime: &tokio::runtime::Runtime,
 ) -> Result<()> {
     let target = match index_url {
         Some(url) => url,
-        None => resolve_default_index(default_index, config)?,
+        None => resolve_default_index(config)?,
     };
     // Validate before any store or network access, and echo the resolved
     // index so a configured default cannot be targeted silently. Printed,

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -16,7 +16,7 @@ use sysand_core::{
         validated_index_key,
     },
     config::Config,
-    credential_store::{CredentialStoreError, normalize_index_key},
+    credential_store::CredentialStoreError,
 };
 
 use crate::{DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
@@ -77,7 +77,7 @@ pub fn command_auth_login(
         None => resolve_default_index(default_index, config)?,
     };
     // Validate and normalize before any secret entry, so a `file://` or
-    // template target fails without prompting.
+    // unanchorable-template target fails without prompting.
     let key = validated_index_key(&target)?;
     // Echo the resolved index before reading the secret, on both the
     // prompt and the stdin path, so a project-configured default cannot
@@ -262,7 +262,7 @@ pub fn command_auth_logout(
     // Echo the resolved index (normalized to the stored-key form when
     // possible) so a configured default cannot be targeted silently.
     // Printed, not logged: `--quiet` must not hide it.
-    let echo = normalize_index_key(&target).unwrap_or_else(|_| target.clone());
+    let echo = validated_index_key(&target).unwrap_or_else(|_| target.clone());
     println!("Logging out from index `{echo}`");
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -79,14 +79,15 @@ fn surface_name(surface: ProbeSurface) -> &'static str {
     }
 }
 
-/// Render a login progress notice. `ReplacingExisting` is printed (it
-/// precedes the store write and must survive `--quiet`); the rest are
-/// warnings. `index_key` names the login for the basic-auth hint.
+/// Render a login progress notice. `ReplacingExisting` is informational
+/// (log output, suppressed under `--quiet`, like the `Stored`/`Covers`
+/// result lines); the rest are warnings. `index_key` names the login for
+/// the basic-auth hint.
 fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
     match notice {
         AuthLoginNotice::ReplacingExisting { key } => {
             let header = sysand_core::style::get_style_config().header;
-            println!(
+            log::info!(
                 "{header}{:>12}{header:#} existing credential for `{key}`",
                 "Replacing"
             );
@@ -378,12 +379,17 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
         Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
             Err(err).context(KEYRING_LOCKED_HINT)
         }
-        // The core error states the condition; the CLI points at `auth
-        // status`, which lists every stored login under its exact key (a
-        // logout target must match the key exactly, so a typo is best
-        // fixed by copying the key from that list).
+        // Logging out of an index with nothing stored is idempotent: a
+        // warning and exit 0, so cleanup scripts need not swallow a
+        // failure. The core error states the condition; the CLI points at
+        // `auth status`, which lists every stored login under its exact
+        // key (a logout target must match the key exactly, so a typo is
+        // best fixed by copying the key from that list).
         Err(err @ AuthCommandError::NoStoredCredential { .. }) => {
-            bail!("{err}\nrun `sysand auth status` to list the stored logins and their exact keys")
+            log::warn!(
+                "{err}; run `sysand auth status` to list the stored logins and their exact keys"
+            );
+            Ok(())
         }
         Err(err) => Err(err.into()),
     }
@@ -443,11 +449,10 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
 fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
     let mut entries: Vec<EnvCredentialEntry> = std::env::vars()
         .filter(|(key, _)| {
-            key.strip_prefix("SYSAND_CRED_").is_some_and(|rest| {
-                !rest.ends_with("_BASIC_USER")
-                    && !rest.ends_with("_BASIC_PASS")
-                    && !rest.ends_with("_BEARER_TOKEN")
-            })
+            matches!(
+                crate::cred_env::classify(key),
+                Some((_, crate::cred_env::CredEnvRole::Pattern))
+            )
         })
         .map(|(key, value)| EnvCredentialEntry {
             label: key,
@@ -610,26 +615,10 @@ fn render_auth_status(status: &AuthStatus) {
 /// the command, because the `auth` commands must stay usable to diagnose
 /// exactly those (same stance as `auth status`).
 fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
-    let mut patterns = std::collections::HashMap::new();
-    let mut users = std::collections::HashMap::new();
-    let mut passwords = std::collections::HashMap::new();
-    let mut tokens = std::collections::HashMap::new();
-    for (key, value) in std::env::vars() {
-        if let Some(rest) = key.strip_prefix("SYSAND_CRED_") {
-            if let Some(stem) = rest.strip_suffix("_BASIC_USER") {
-                users.insert(stem.to_owned(), value);
-            } else if let Some(stem) = rest.strip_suffix("_BASIC_PASS") {
-                passwords.insert(stem.to_owned(), value);
-            } else if let Some(stem) = rest.strip_suffix("_BEARER_TOKEN") {
-                tokens.insert(stem.to_owned(), value);
-            } else {
-                patterns.insert(rest.to_owned(), value);
-            }
-        }
-    }
+    let groups = crate::cred_env::collect_env_groups();
 
     let mut builder = StandardHTTPAuthenticationBuilder::new();
-    for (stem, pattern) in &patterns {
+    for (stem, pattern) in &groups.patterns {
         // Pre-compile each pattern individually: `build` below fails
         // wholesale on one bad glob, and one bad group must not hide the
         // other credentials.
@@ -639,10 +628,13 @@ fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
             log::debug!("skipping SYSAND_CRED_{stem}: invalid URL glob pattern");
             continue;
         }
-        if let (Some(user), Some(password)) = (users.get(stem), passwords.get(stem)) {
+        if let (Some(user), Some(password)) = (
+            groups.basic_users.get(stem),
+            groups.basic_passwords.get(stem),
+        ) {
             builder.add_basic_auth(pattern, user, password);
         }
-        if let Some(token) = tokens.get(stem) {
+        if let Some(token) = groups.bearer_tokens.get(stem) {
             builder.add_bearer_auth_labeled(pattern, token, stem);
         }
     }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -19,8 +19,10 @@ use sysand_core::{
         do_auth_whoami, validated_index_key,
     },
     config::Config,
-    credential_store::CredentialStoreError,
+    credential_store::{CredentialStore, CredentialStoreError},
 };
+
+use chrono::{DateTime, Utc};
 
 use crate::{CliAuthPolicy, DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
 
@@ -205,8 +207,49 @@ pub fn command_auth_login(
         Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
             Err(err).context(KEYRING_LOCKED_HINT)
         }
+        Err(AuthCommandError::Store(CredentialStoreError::BlobTooLarge)) => {
+            // The core store reports only the condition (it must not name
+            // CLI commands); the CLI owns the `sysand auth` remediation.
+            let stored = store.list().unwrap_or_default();
+            let entries: Vec<(&str, Option<DateTime<Utc>>)> = stored
+                .iter()
+                .map(|record| (record.key.as_str(), record.expires_at))
+                .collect();
+            bail!("{}", blob_full_message(&entries, Utc::now()))
+        }
         Err(err) => Err(err.into()),
     }
+}
+
+/// Remediation message for the platform credential-store cap on `auth login`
+/// (Windows ~2.5 KB). The core store reports only the condition; naming the
+/// `sysand auth` commands to fix it belongs here in the CLI. Points at
+/// `auth status`/`auth logout` and lists already-expired logins as the
+/// obvious drop candidates. With no stored logins (a single oversized token)
+/// there is nothing to remove, so it does not suggest removing one.
+fn blob_full_message(stored: &[(&str, Option<DateTime<Utc>>)], now: DateTime<Utc>) -> String {
+    let expired: Vec<&str> = stored
+        .iter()
+        .filter(|(_, at)| at.is_some_and(|at| at < now))
+        .map(|(key, _)| *key)
+        .collect();
+    let mut message = if stored.is_empty() {
+        "the token is too large for this platform's credential store \
+         (Windows ~2.5 KB limit); use a smaller token"
+            .to_string()
+    } else {
+        "the credential store is full (Windows ~2.5 KB limit); remove a login with \
+         `sysand auth logout <index>` (run `sysand auth status` to list them) or use \
+         a smaller token"
+            .to_string()
+    };
+    if !expired.is_empty() {
+        message.push_str("\nthese stored logins have expired and are safe to remove:");
+        for key in expired {
+            message.push_str(&format!("\n  sysand auth logout {key}"));
+        }
+    }
+    message
 }
 
 /// Read the login secret: from stdin when `--token-stdin` was given
@@ -686,5 +729,50 @@ pub fn command_auth_whoami(
             "could not reach the index API (`{}`): {detail}",
             outcome.whoami_url
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::blob_full_message;
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn blob_full_first_login_does_not_suggest_removing_a_login() {
+        let message = blob_full_message(&[], Utc::now());
+        assert!(message.contains("use a smaller token"), "{message}");
+        assert!(!message.contains("logout"), "{message}");
+    }
+
+    #[test]
+    fn blob_full_names_the_status_and_logout_commands() {
+        let now = Utc::now();
+        let stored = [("https://a.example/", None), ("https://b.example/", None)];
+        let message = blob_full_message(&stored, now);
+        assert!(message.contains("sysand auth status"), "{message}");
+        assert!(message.contains("sysand auth logout <index>"), "{message}");
+    }
+
+    #[test]
+    fn blob_full_lists_expired_logins_as_drop_candidates() {
+        let now = Utc::now();
+        let stored = [
+            ("https://live.example/", Some(now + Duration::days(30))),
+            ("https://dead.example/", Some(now - Duration::days(1))),
+            ("https://unknown.example/", None),
+        ];
+        let message = blob_full_message(&stored, now);
+        assert!(
+            message.contains("sysand auth logout https://dead.example/"),
+            "{message}"
+        );
+        assert!(
+            !message.contains("logout https://live.example/"),
+            "{message}"
+        );
+        assert!(
+            !message.contains("logout https://unknown.example/"),
+            "{message}"
+        );
     }
 }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -451,12 +451,6 @@ fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
 /// highlighted as a warning.
 const EXPIRES_SOON_DAYS: i64 = 7;
 
-/// Render an expiry timestamp for display, without chrono's sub-second
-/// noise (`11:39:28.149443` reads as `11:39:28`).
-fn format_expiry_timestamp(expires_at: &chrono::DateTime<chrono::Utc>) -> String {
-    expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string()
-}
-
 /// The ` (expired)` / ` (expires in N days)` qualifier for an expiry
 /// timestamp, styled through the house tokens (red for expired, yellow
 /// when expiry is close). Empty when nothing is known.
@@ -556,7 +550,7 @@ fn render_auth_status(status: &AuthStatus) {
             println!(
                 "{:>12} {dim}expires:{dim:#} {}{}",
                 ' ',
-                format_expiry_timestamp(expires_at),
+                sysand_core::utils::format_expiry_utc(expires_at),
                 expiry_qualifier(entry.expired, entry.expires_in_days)
             );
         }
@@ -725,7 +719,7 @@ pub fn command_auth_whoami(
                         println!(
                             "{header}{:>12}{header:#} {}{}",
                             "Expires",
-                            format_expiry_timestamp(&expires_at),
+                            sysand_core::utils::format_expiry_utc(&expires_at),
                             expiry_qualifier(expires_at < now, Some((expires_at - now).num_days()))
                         );
                     }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -35,9 +35,7 @@ const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide 
 /// set, else a `default = true` index from configuration, else the
 /// built-in [`DEFAULT_INDEX_URL`]. If the consulted stage yields more
 /// than one distinct URL, the target is ambiguous and an explicit URL is
-/// required. Read from the environment here rather than a per-subcommand
-/// `--default-index` flag: a flag would only duplicate the positional
-/// index argument.
+/// required.
 pub fn resolve_default_index(config: &Config) -> Result<String> {
     let env_override = std::env::var(crate::env_vars::SYSAND_DEFAULT_INDEX).ok();
     let env_candidates: Vec<&str> = env_override
@@ -117,8 +115,7 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
             read_status,
             basic_challenge,
         } => {
-            // The same read-404 hedge the refusal message carries: a 404
-            // can mean a rejected token, but also no `index.json` at all.
+            // Same read-404 hedge as the refusal message.
             let hedge = if read_status == Some(404) {
                 " (HTTP 404, which can also mean no index exists at this URL)"
             } else {
@@ -165,10 +162,9 @@ pub fn command_auth_login(
     let header = sysand_core::style::get_style_config().header;
     println!("{header}{:>12}{header:#} to index `{key}`", "Logging in");
 
-    // An `http` index sends the bearer token in cleartext, and a one-time
-    // MITM at login could rewrite discovery to a hostile `api_root` that
-    // then gets persisted (design/credential-storage.md section 8). Warn
-    // before the secret is entered so the user can abort.
+    // An `http` index sends the token in cleartext, and a MITM at login
+    // could persist a hostile `api_root` (design/credential-storage.md
+    // section 8). Warn before the secret is entered so the user can abort.
     if key.starts_with("http://") {
         log::warn!(
             "`{key}` uses an unencrypted (http) connection; the token will be \
@@ -189,9 +185,8 @@ pub fn command_auth_login(
             globs,
             validated,
         }) => {
-            // The claim is always scoped to the surfaces that accepted
-            // the credential; never a bare "validated"
-            // (design/credential-storage.md section 5).
+            // The claim is scoped to the surfaces that accepted; never a
+            // bare "validated" (design section 5).
             let claim = if validated.is_empty() {
                 "stored, not validated".to_string()
             } else {
@@ -201,10 +196,8 @@ pub fn command_auth_login(
                     .collect();
                 format!("validated ({})", surfaces.join(", "))
             };
-            // Both lines are the login result: keep them on one channel
-            // (the log) so `--quiet` suppresses the confirmation as a unit,
-            // the way `sysand publish` suppresses "Published", instead of
-            // leaving an orphan "Covers" line on stdout.
+            // Both lines are the login result: one channel (the log), so
+            // `--quiet` suppresses the confirmation as a unit.
             log::info!(
                 "{header}{:>12}{header:#} credential for `{key}` ({claim})",
                 "Stored"
@@ -213,10 +206,9 @@ pub fn command_auth_login(
             Ok(())
         }
         Ok(AuthLoginOutcome::BackendUnavailable { key, globs, reason }) => {
-            // No-keyring host (design/credential-storage.md section 9):
-            // refuse to persist, print the exact `SYSAND_CRED_*` lines to
-            // set instead. The secret is never echoed: stdout on such
-            // hosts typically lands in captured CI job logs.
+            // No-keyring host (design section 9): print the exact
+            // `SYSAND_CRED_*` lines to set instead. The secret is never
+            // echoed: stdout here typically lands in CI job logs.
             println!(
                 "No OS keyring backend is available ({reason}), so the credential \
                  was not stored."
@@ -254,12 +246,10 @@ pub fn command_auth_login(
     }
 }
 
-/// Remediation message for the platform credential-store cap on `auth login`
-/// (Windows ~2.5 KB). The core store reports only the condition; naming the
-/// `sysand auth` commands to fix it belongs here in the CLI. Points at
-/// `auth status`/`auth logout` and lists already-expired logins as the
-/// obvious drop candidates. With no stored credentials (a single oversized token)
-/// there is nothing to remove, so it does not suggest removing one.
+/// Remediation message for the platform credential-store cap on
+/// `auth login` (Windows ~2.5 KB). Naming the `sysand auth` commands
+/// belongs in the CLI, not core. Lists already-expired logins as drop
+/// candidates; with no stored credentials there is nothing to remove.
 fn blob_full_message(stored: &[(&str, Option<DateTime<Utc>>)], now: DateTime<Utc>) -> String {
     let expired: Vec<&str> = stored
         .iter()
@@ -313,12 +303,10 @@ fn read_token(key: &str, token_stdin: bool) -> Result<String> {
 }
 
 /// Derive the `SYSAND_CRED_<NAME>` stem suggested on a no-keyring host
-/// from the index host, plus the port when it is not the scheme default
-/// (for example `HOST_8443`): two indexes on different ports of one host
-/// must not suggest the same variable names, or the second guidance would
-/// silently overwrite the first credential. Hostnames and ports cannot
-/// produce the reserved `_BASIC_USER` / `_BASIC_PASS` / `_BEARER_TOKEN`
-/// suffixes (a port is all digits).
+/// from the index host plus any non-default port: two indexes on
+/// different ports of one host must not suggest the same variable names.
+/// Hostnames and ports cannot produce the reserved `_BASIC_USER` /
+/// `_BASIC_PASS` / `_BEARER_TOKEN` suffixes (a port is all digits).
 fn cred_env_var_stem(key: &str) -> String {
     let url = url::Url::parse(key).ok();
     let host = url
@@ -376,12 +364,9 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
         Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
             Err(err).context(KEYRING_LOCKED_HINT)
         }
-        // Logging out of an index with nothing stored is idempotent: a
-        // warning and exit 0, so cleanup scripts need not swallow a
-        // failure. The core error states the condition; the CLI points at
-        // `auth status`, which lists every stored login under its exact
-        // key (a logout target must match the key exactly, so a typo is
-        // best fixed by copying the key from that list).
+        // Idempotent: a warning and exit 0, so cleanup scripts need not
+        // swallow a failure. The CLI adds the `auth status` pointer (a
+        // logout target must match the stored key exactly).
         Err(err @ AuthCommandError::NoStoredCredential { .. }) => {
             log::warn!(
                 "{err}; run `sysand auth status` to list the stored logins and their exact keys"
@@ -393,11 +378,9 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
 }
 
 pub fn command_auth_status(config: &Config) -> Result<()> {
-    // Resolve the default index only to mark the entries that apply to
-    // it. Status is a diagnostic view, so resolution is lenient: an
+    // Status is diagnostic, so default-index resolution is lenient: an
     // ambiguous chain gets a note instead of the hard error bare
-    // `login`/`logout` raise, and a default that is not a valid HTTP(S)
-    // index key (for example `file://`) simply marks nothing.
+    // `login`/`logout` raise, and an invalid default simply marks nothing.
     let default_key = match resolve_default_index(config) {
         Ok(url) => validated_index_key(&url).ok(),
         // `resolve_default_index` errors only on an ambiguous chain
@@ -420,9 +403,8 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
             }
             Err(err) => return Err(err.into()),
         },
-        // Could not even open the store (no per-user lock path): degrade
-        // to the env-only view like an absent backend. Assembly still
-        // runs so env entries keep their default-index marking.
+        // Could not open the store: degrade to the env-only view like an
+        // absent backend, keeping the env entries' default-index marking.
         Err(err) => {
             let mut status =
                 assemble_auth_status(Vec::new(), env, chrono::Utc::now(), default_key.as_deref());
@@ -437,12 +419,10 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
 }
 
 /// Collect `SYSAND_CRED_*` URL-pattern variables as status entries.
-///
 /// Deliberately tolerant, unlike the eager auth-policy build: `auth
-/// status` is the command for diagnosing credential configuration, so an
-/// incomplete group (a pattern without a scheme variable) is still listed
-/// rather than rejected. Only pattern variables are shown; the `_BASIC_USER`
-/// / `_BASIC_PASS` / `_BEARER_TOKEN` companions hold secrets.
+/// status` diagnoses credential configuration, so an incomplete group is
+/// listed rather than rejected. Only pattern variables are shown; the
+/// companion variables hold secrets.
 fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
     let mut entries: Vec<EnvCredentialEntry> = std::env::vars()
         .filter(|(key, _)| {
@@ -514,19 +494,13 @@ fn validation_claim(validated: &[String]) -> String {
 
 /// Render the unified status view: stored entries tagged `Stored` (key in
 /// the exact form `sysand auth logout <key>` accepts) and env entries
-/// tagged `Env`. Never any secret.
-///
-/// A few non-obvious rules the code below relies on: entry sublines keep a
-/// `label: value` form (unlike `auth whoami`, which puts each label in the
-/// gutter); stored entries are separated by a blank line and carry their
-/// validation claim, plus a dim `(default index)` marker when they apply to
-/// the default index, on the header line. A source with nothing to show is
-/// omitted, and a single combined negative prints only when neither source
-/// has anything; the backend-unavailable note always prints.
+/// tagged `Env`. Never any secret. A source with nothing to show is
+/// omitted; the combined negative prints only when neither source has
+/// anything; the backend-unavailable note always prints.
 ///
 /// Styling goes through `anstream::println`, which strips it on
-/// non-terminal stdout and under `NO_COLOR`, so piped output is exactly the
-/// plain text the CLI tests assert on (the alignment spaces are content).
+/// non-terminal stdout and under `NO_COLOR`, so piped output is exactly
+/// the plain text the CLI tests assert on.
 fn render_auth_status(status: &AuthStatus) {
     let style = sysand_core::style::get_style_config();
     let tag = style.header;
@@ -605,12 +579,10 @@ fn render_auth_status(status: &AuthStatus) {
     }
 }
 
-/// Build the read auth policy for `auth whoami`'s discovery fetch (and its
-/// env bearer map), tolerantly: unlike the eager policy build in
-/// `run_cli`, a malformed `SYSAND_CRED_*` group (an incomplete pair, an
-/// invalid glob pattern) is skipped with a debug log instead of failing
-/// the command, because the `auth` commands must stay usable to diagnose
-/// exactly those (same stance as `auth status`).
+/// Build the read auth policy for `auth whoami`'s discovery fetch (and
+/// its env bearer map), tolerantly: unlike the eager build in `run_cli`,
+/// a malformed `SYSAND_CRED_*` group is skipped with a debug log, because
+/// the `auth` commands must stay usable to diagnose exactly those.
 fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
     let groups = crate::cred_env::collect_env_groups();
 
@@ -666,27 +638,22 @@ pub fn command_auth_whoami(
         .context("could not compile `SYSAND_CRED_*` URL patterns")?;
     // One store read serves both the discovery fetch and credential
     // selection ("at most one keychain touch per command",
-    // design/credential-storage.md section 9): the records read here are
-    // passed to `do_auth_whoami` for selection, and a preloaded snapshot
-    // of the same records backs the discovery policy (a private index may
-    // gate its discovery document, so unlike login the fetch runs with
-    // the regular read policy). On a locked keyring this is the single
-    // unlock prompt.
+    // design/credential-storage.md section 9); on a locked keyring this
+    // is the single unlock prompt.
     let store = open_cli_credential_store().context("could not open the credential store")?;
     let records = match store.list() {
         Ok(records) => records,
-        // No keyring backend: only env credentials can apply. A locked or
-        // denied backend is a hard error instead: "no credential, run
-        // login" would be the wrong remediation for an unlockable store.
+        // No keyring backend: only env credentials can apply. A locked
+        // backend is a hard error instead: "no credential, run login"
+        // would be the wrong remediation for an unlockable store.
         Err(CredentialStoreError::BackendAbsent { .. }) => Vec::new(),
         Err(err @ CredentialStoreError::BackendDenied { .. }) => {
             return Err(err).context(KEYRING_LOCKED_HINT);
         }
         Err(err) => return Err(err.into()),
     };
-    // The policy is preloaded with the records read above, so whoami
-    // performs exactly one store backend read (on a locked keyring, the
-    // single unlock prompt) and its discovery policy never writes.
+    // Preloaded with the records read above: the discovery policy shares
+    // that single read and never touches the store itself.
     let discovery_policy = CliAuthPolicy::preloaded(env_policy, &records);
 
     let outcome = match do_auth_whoami(
@@ -698,10 +665,8 @@ pub fn command_auth_whoami(
         runtime,
     ) {
         Ok(outcome) => outcome,
-        // The core error states the condition without naming a CLI
-        // command; the CLI leads with the `sysand auth login` remediation
-        // (using the index from the error) and names the `SYSAND_CRED_*`
-        // variables second, as the non-interactive path for CI.
+        // Core states the condition; the CLI adds the `auth login`
+        // remediation, with `SYSAND_CRED_*` second as the CI path.
         Err(err @ AuthCommandError::NoWhoamiCredential { .. }) => {
             let AuthCommandError::NoWhoamiCredential { index, .. } = &err else {
                 unreachable!()
@@ -714,9 +679,8 @@ pub fn command_auth_whoami(
         Err(err) => return Err(err.into()),
     };
 
-    // Name the source: an env credential shadows a stored credential, so the
-    // right remediation for a bad credential depends on where it came
-    // from (design/credential-storage.md section 7).
+    // Name the source: env shadows stored, so the right remediation
+    // depends on where the credential came from (design section 7).
     match &outcome.source {
         WhoamiCredentialSource::Env { label: Some(label) } => {
             println!(
@@ -786,11 +750,9 @@ pub fn command_auth_whoami(
                 outcome.whoami_url
             );
         }
-        // "Unreachable" here covers both genuine transport failures and a
-        // server that answered without a usable identity (a redirect, a
-        // 429, an unexpected status like 403). "could not get an identity"
-        // reads correctly for all of them, unlike "could not reach", which
-        // contradicts a 403 the API actually returned.
+        // Covers transport failures and answers without a usable identity
+        // (redirect, 429, unexpected status): "could not get an identity"
+        // reads correctly for all of them, unlike "could not reach".
         WhoamiVerdict::Unreachable { detail } => bail!(
             "could not get an identity from the index API (`{}`): {detail}",
             outcome.whoami_url

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -69,7 +69,6 @@ fn surface_name(surface: ProbeSurface) -> &'static str {
 pub fn command_auth_login(
     index_url: Option<String>,
     token_stdin: bool,
-    validation: Option<bool>,
     default_index: &[String],
     config: &Config,
     client: &reqwest_middleware::ClientWithMiddleware,
@@ -93,67 +92,59 @@ pub fn command_auth_login(
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;
     let index_key = key.clone();
-    let outcome = do_auth_login(
-        &mut store,
-        &key,
-        secret,
-        validation,
-        client,
-        runtime,
-        |notice| {
-            match notice {
-                // Printed before the store write happens.
-                AuthLoginNotice::ReplacingExisting { key } => {
-                    let header = sysand_core::style::get_style_config().header;
-                    println!(
-                        "{header}{:>12}{header:#} existing credential for `{key}`",
-                        "Replacing"
-                    );
-                }
-                AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
-                    "could not read the index configuration ({error}); \
+    let outcome = do_auth_login(&mut store, &key, secret, client, runtime, |notice| {
+        match notice {
+            // Printed before the store write happens.
+            AuthLoginNotice::ReplacingExisting { key } => {
+                let header = sysand_core::style::get_style_config().header;
+                println!(
+                    "{header}{:>12}{header:#} existing credential for `{key}`",
+                    "Replacing"
+                );
+            }
+            AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
+                "could not read the index configuration ({error}); \
                      scoping the credential to the URL-derived pattern"
-                ),
-                AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
-                    "discovery advertises a templated index_root (`{template}`) that \
+            ),
+            AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
+                "discovery advertises a templated index_root (`{template}`) that \
                      cannot be covered safely; no pattern was derived for it"
-                ),
-                AuthLoginNotice::ProbeRedirected { surface, target } => log::warn!(
-                    "the {} probe was redirected to `{target}`; probes do not follow \
+            ),
+            AuthLoginNotice::ProbeRedirected { surface, target } => log::warn!(
+                "the {} probe was redirected to `{target}`; probes do not follow \
                      redirects, so the credential was not validated against that surface",
-                    surface_name(surface)
-                ),
-                AuthLoginNotice::ProbeUnreachable { surface, error } => log::warn!(
-                    "could not probe the {} ({error}); the credential was not \
+                surface_name(surface)
+            ),
+            AuthLoginNotice::ProbeUnreachable { surface, error } => log::warn!(
+                "could not probe the {} ({error}); the credential was not \
                      validated against it",
-                    surface_name(surface)
-                ),
-                AuthLoginNotice::ProbeRateLimited { surface } => log::warn!(
-                    "the {} probe was rate limited (HTTP 429); the credential was \
+                surface_name(surface)
+            ),
+            AuthLoginNotice::ProbeRateLimited { surface } => log::warn!(
+                "the {} probe was rate limited (HTTP 429); the credential was \
                      not validated against it",
-                    surface_name(surface)
-                ),
-                AuthLoginNotice::SurfaceRejected {
-                    surface,
-                    basic_challenge,
-                } => {
-                    log::warn!(
-                        "the {} rejected the credential; it was stored anyway because \
+                surface_name(surface)
+            ),
+            AuthLoginNotice::SurfaceRejected {
+                surface,
+                basic_challenge,
+            } => {
+                log::warn!(
+                    "the {} rejected the credential; it was stored anyway because \
                          another surface accepted it",
-                        surface_name(surface)
-                    );
-                    if basic_challenge {
-                        let stem = cred_env_var_stem(&index_key);
-                        log::warn!(
-                            "this index uses username/password (HTTP basic) authentication; \
+                    surface_name(surface)
+                );
+                if basic_challenge {
+                    let stem = cred_env_var_stem(&index_key);
+                    log::warn!(
+                        "this index uses username/password (HTTP basic) authentication; \
                              configure `SYSAND_CRED_{stem}_BASIC_USER` / \
                              `SYSAND_CRED_{stem}_BASIC_PASS` environment variables instead"
-                        );
-                    }
+                    );
                 }
             }
-        },
-    );
+        }
+    });
     match outcome {
         Ok(AuthLoginOutcome::Stored {
             key,

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-//! CLI wrappers for the `sysand auth` commands (design/credential-storage.md
-//! sections 4, 9): default-index resolution, the OS keyring store handoff
-//! to core, and user-facing rendering. Secrets never appear in any output.
+//! CLI wrappers for the `sysand auth` commands: default-index
+//! resolution, the OS keyring store handoff to core, and user-facing
+//! rendering. Secrets never appear in any output.
 
 use std::io::{IsTerminal, Read};
 use std::sync::Arc;
@@ -30,8 +30,8 @@ const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide 
      `SYSAND_CRED_*` environment variables";
 
 /// Resolve the single index a bare `sysand auth login` / `auth logout`
-/// targets (design/credential-storage.md section 4): the
-/// `SYSAND_DEFAULT_INDEX` environment override (comma-delimited) when
+/// targets: the `SYSAND_DEFAULT_INDEX` environment override
+/// (comma-delimited) when
 /// set, else a `default = true` index from configuration, else the
 /// built-in [`DEFAULT_INDEX_URL`]. If the consulted stage yields more
 /// than one distinct URL, the target is ambiguous and an explicit URL is
@@ -157,14 +157,14 @@ pub fn command_auth_login(
     let key = validated_index_key(&target)?;
     // Echo the resolved index before reading the secret, on both the
     // prompt and the stdin path, so a project-configured default cannot
-    // be targeted silently (design/credential-storage.md section 4).
+    // be targeted silently.
     // Printed, not logged: `--quiet` must not hide it.
     let header = sysand_core::style::get_style_config().header;
     println!("{header}{:>12}{header:#} to index `{key}`", "Logging in");
 
     // An `http` index sends the token in cleartext, and a MITM at login
-    // could persist a hostile `api_root` (design/credential-storage.md
-    // section 8). Warn before the secret is entered so the user can abort.
+    // could persist a hostile `api_root`. Warn before the secret is
+    // entered so the user can abort.
     if key.starts_with("http://") {
         log::warn!(
             "`{key}` uses an unencrypted (http) connection; the token will be \
@@ -186,7 +186,7 @@ pub fn command_auth_login(
             validated,
         }) => {
             // The claim is scoped to the surfaces that accepted; never a
-            // bare "validated" (design section 5).
+            // bare "validated".
             let claim = if validated.is_empty() {
                 "stored, not validated".to_string()
             } else {
@@ -206,7 +206,7 @@ pub fn command_auth_login(
             Ok(())
         }
         Ok(AuthLoginOutcome::BackendUnavailable { key, globs, reason }) => {
-            // No-keyring host (design section 9): print the exact
+            // No-keyring host: print the exact
             // `SYSAND_CRED_*` lines to set instead. The secret is never
             // echoed: stdout here typically lands in CI job logs.
             println!(
@@ -637,9 +637,8 @@ pub fn command_auth_whoami(
         .publish_bearer_auth_map()
         .context("could not compile `SYSAND_CRED_*` URL patterns")?;
     // One store read serves both the discovery fetch and credential
-    // selection ("at most one keychain touch per command",
-    // design/credential-storage.md section 9); on a locked keyring this
-    // is the single unlock prompt.
+    // selection (at most one keychain touch per command); on a locked
+    // keyring this is the single unlock prompt.
     let store = open_cli_credential_store().context("could not open the credential store")?;
     let records = match store.list() {
         Ok(records) => records,
@@ -680,7 +679,7 @@ pub fn command_auth_whoami(
     };
 
     // Name the source: env shadows stored, so the right remediation
-    // depends on where the credential came from (design section 7).
+    // depends on where the credential came from.
     match &outcome.source {
         WhoamiCredentialSource::Env { label: Some(label) } => {
             println!(

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! CLI wrappers for the `sysand auth` commands (design/credential-storage.md
+//! sections 4, 9): default-index resolution, the OS keyring store handoff
+//! to core, and user-facing rendering. Secrets never appear in any output.
+
+use anyhow::{Context, Result, bail};
+use sysand_core::{
+    commands::auth::{
+        AuthCommandError, AuthStatus, EnvCredentialEntry, StoredCredentialsStatus, do_auth_logout,
+        do_auth_status,
+    },
+    config::Config,
+    credential_store::{
+        CredentialStoreError, keyring_store::KeyringCredentialStore, normalize_index_key,
+    },
+};
+
+use crate::DEFAULT_INDEX_URL;
+
+const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide credentials via \
+     `SYSAND_CRED_*` environment variables";
+
+/// Resolve the single index a bare `sysand auth login` / `auth logout`
+/// targets (design/credential-storage.md section 4): the
+/// `--default-index` / `SYSAND_DEFAULT_INDEX` override when given, else a
+/// `default = true` index from configuration, else the built-in
+/// [`DEFAULT_INDEX_URL`]. If the consulted stage yields more than one
+/// distinct URL, the target is ambiguous and an explicit URL is required.
+pub fn resolve_default_index(default_index_override: &[String], config: &Config) -> Result<String> {
+    let mut candidates: Vec<&str> = if default_index_override.is_empty() {
+        config
+            .indexes
+            .iter()
+            .filter(|index| index.default.unwrap_or(false))
+            .map(|index| index.url.as_str())
+            .collect()
+    } else {
+        default_index_override.iter().map(String::as_str).collect()
+    };
+    // Exact duplicates of one URL are still a single target.
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|url| seen.insert(*url));
+
+    match candidates.as_slice() {
+        [] => Ok(DEFAULT_INDEX_URL.to_string()),
+        [single] => Ok((*single).to_string()),
+        many => bail!(
+            "more than one default index is configured ({}); pass an explicit index URL",
+            many.join(", ")
+        ),
+    }
+}
+
+pub fn command_auth_logout(
+    index_url: Option<String>,
+    default_index: &[String],
+    config: &Config,
+) -> Result<()> {
+    let target = match index_url {
+        Some(url) => url,
+        None => resolve_default_index(default_index, config)?,
+    };
+    // Echo the resolved index (normalized to the stored-key form when
+    // possible) so a configured default cannot be targeted silently.
+    // Printed, not logged: `--quiet` must not hide it.
+    let echo = normalize_index_key(&target).unwrap_or_else(|_| target.clone());
+    println!("Logging out from index `{echo}`");
+
+    let mut store =
+        KeyringCredentialStore::open_default().context("could not open the credential store")?;
+    match do_auth_logout(&mut store, &target) {
+        Ok(key) => {
+            let header = sysand_core::style::get_style_config().header;
+            log::info!(
+                "{header}{:>12}{header:#} stored credential for `{key}`",
+                "Removed"
+            );
+            Ok(())
+        }
+        Err(AuthCommandError::Store(CredentialStoreError::BackendAbsent { source })) => bail!(
+            "no OS keyring backend is available ({source}), so this host has no \
+             stored logins; credentials here come from `SYSAND_CRED_*` \
+             environment variables"
+        ),
+        Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
+            Err(err).context(KEYRING_LOCKED_HINT)
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+pub fn command_auth_status() -> Result<()> {
+    let env = collect_env_credential_entries();
+    let status = match KeyringCredentialStore::open_default() {
+        Ok(store) => match do_auth_status(&store, env) {
+            Ok(status) => status,
+            Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
+                return Err(err).context(KEYRING_LOCKED_HINT);
+            }
+            Err(err) => return Err(err.into()),
+        },
+        // Could not even open the store (no per-user lock path): degrade
+        // to the env-only view like an absent backend.
+        Err(err) => AuthStatus {
+            stored: StoredCredentialsStatus::BackendUnavailable {
+                reason: err.to_string(),
+            },
+            env: collect_env_credential_entries(),
+        },
+    };
+    render_auth_status(&status);
+    Ok(())
+}
+
+/// Collect `SYSAND_CRED_*` URL-pattern variables as status entries.
+///
+/// Deliberately tolerant, unlike the eager auth-policy build: `auth
+/// status` is the command for diagnosing credential configuration, so an
+/// incomplete group (a pattern without a scheme variable) is still listed
+/// rather than rejected. Only pattern variables are shown; the `_BASIC_USER`
+/// / `_BASIC_PASS` / `_BEARER_TOKEN` companions hold secrets.
+fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
+    let mut entries: Vec<EnvCredentialEntry> = std::env::vars()
+        .filter(|(key, _)| {
+            key.strip_prefix("SYSAND_CRED_").is_some_and(|rest| {
+                !rest.ends_with("_BASIC_USER")
+                    && !rest.ends_with("_BASIC_PASS")
+                    && !rest.ends_with("_BEARER_TOKEN")
+            })
+        })
+        .map(|(key, value)| EnvCredentialEntry {
+            label: key,
+            pattern: value,
+        })
+        .collect();
+    entries.sort_by(|a, b| a.label.cmp(&b.label));
+    entries
+}
+
+/// Render the unified status view: stored entries tagged `stored` (key in
+/// the exact form `sysand auth logout <key>` accepts), env entries tagged
+/// `env`. Never any secret.
+fn render_auth_status(status: &AuthStatus) {
+    match &status.stored {
+        StoredCredentialsStatus::BackendUnavailable { reason } => {
+            println!(
+                "note: no usable OS keyring backend ({reason}); showing \
+                 `SYSAND_CRED_*` environment credentials only"
+            );
+        }
+        StoredCredentialsStatus::Available(stored) if stored.is_empty() => {
+            println!("No stored index logins.");
+        }
+        StoredCredentialsStatus::Available(stored) => {
+            for entry in stored {
+                println!("stored  {}", entry.key);
+                println!("        patterns: {}", entry.globs.join(", "));
+                if let Some(expires_at) = &entry.expires_at {
+                    let expired = if entry.expired { " (expired)" } else { "" };
+                    println!("        expires: {expires_at}{expired}");
+                }
+                if !entry.shadowed_by.is_empty() {
+                    println!("        shadowed by: {}", entry.shadowed_by.join(", "));
+                }
+            }
+        }
+    }
+    if status.env.is_empty() {
+        println!("No `SYSAND_CRED_*` environment credentials.");
+    } else {
+        for entry in &status.env {
+            println!("env     {}  {}", entry.label, entry.pattern);
+        }
+    }
+}

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -26,7 +26,7 @@ use chrono::{DateTime, Utc};
 
 use crate::{CliAuthPolicy, DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
 
-const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide credentials via \
+const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide credentials via\n\
      `SYSAND_CRED_*` environment variables";
 
 /// Resolve the single index a bare `sysand auth login` / `auth logout`
@@ -88,25 +88,25 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
             );
         }
         AuthLoginNotice::DiscoveryUnreachable { error } => log::warn!(
-            "could not read the index configuration ({error}); \
+            "could not read the index configuration ({error});\n\
                  scoping the credential to the URL-derived pattern"
         ),
         AuthLoginNotice::TemplateIndexRootSkipped { template } => log::warn!(
-            "discovery advertises a templated index_root (`{template}`) that \
+            "discovery advertises a templated index_root (`{template}`) that\n\
                  cannot be covered safely; no pattern was derived for it"
         ),
         AuthLoginNotice::ProbeRedirected { surface, target } => log::warn!(
-            "the {} probe was redirected to `{target}`; probes do not follow \
+            "the {} probe was redirected to `{target}`; probes do not follow\n\
                  redirects, so the credential was not validated against that surface",
             surface_name(surface)
         ),
         AuthLoginNotice::ProbeUnreachable { surface, error } => log::warn!(
-            "could not probe the {} ({error}); the credential was not \
+            "could not probe the {} ({error}); the credential was not\n\
                  validated against it",
             surface_name(surface)
         ),
         AuthLoginNotice::ProbeRateLimited { surface } => log::warn!(
-            "the {} probe was rate limited (HTTP 429); the credential was \
+            "the {} probe was rate limited (HTTP 429); the credential was\n\
                  not validated against it",
             surface_name(surface)
         ),
@@ -122,7 +122,7 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
                 ""
             };
             log::warn!(
-                "the {} rejected the credential{hedge}; it was stored anyway \
+                "the {} rejected the credential{hedge}; it was stored anyway\n\
                      because another surface accepted it",
                 surface_name(surface)
             );
@@ -132,8 +132,8 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
                 // refusal-path variant in core/src/commands/auth.rs
                 // (validation_rejected_message).
                 log::warn!(
-                    "this index uses username/password (HTTP basic) authentication; \
-                         configure `SYSAND_CRED_{stem}_BASIC_USER` / \
+                    "this index uses username/password (HTTP basic) authentication;\n\
+                         configure `SYSAND_CRED_{stem}_BASIC_USER` /\n\
                          `SYSAND_CRED_{stem}_BASIC_PASS` environment variables instead"
                 );
             }
@@ -168,7 +168,7 @@ pub fn command_auth_login(
     // entered so the user can abort.
     if key.as_str().starts_with("http://") {
         log::warn!(
-            "`{key}` uses an unencrypted (http) connection; the token will be \
+            "`{key}` uses an unencrypted (http) connection; the token will be\n\
              sent in cleartext. Prefer an https:// index."
         );
     }
@@ -211,11 +211,11 @@ pub fn command_auth_login(
             // `SYSAND_CRED_*` lines to set instead. The secret is never
             // echoed: stdout here typically lands in CI job logs.
             println!(
-                "No OS keyring backend is available ({reason}), so the credential \
+                "No OS keyring backend is available ({reason}), so the credential\n\
                  was not stored."
             );
             println!(
-                "To authenticate on this host, set these environment variables \
+                "To authenticate on this host, set these environment variables\n\
                  instead, replacing `<token>` with the token you entered:"
             );
             let stem = cred_env_var_stem(&key);
@@ -258,12 +258,12 @@ fn blob_full_message(stored: &[(&str, Option<DateTime<Utc>>)], now: DateTime<Utc
         .map(|(key, _)| *key)
         .collect();
     let mut message = if stored.is_empty() {
-        "the token is too large for this platform's credential store \
+        "the token is too large for this platform's credential store\n\
          (Windows ~2.5 KB limit); use a smaller token"
             .to_string()
     } else {
-        "the credential store is full (Windows ~2.5 KB limit); remove a login with \
-         `sysand auth logout <index>` (run `sysand auth status` to list them) or use \
+        "the credential store is full (Windows ~2.5 KB limit); remove a login with\n\
+         `sysand auth logout <index>` (run `sysand auth status` to list them) or use\n\
          a smaller token"
             .to_string()
     };
@@ -362,8 +362,8 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
             Ok(())
         }
         Err(AuthCommandError::Store(CredentialStoreError::BackendAbsent { source })) => bail!(
-            "no OS keyring backend is available ({source}), so this host has no \
-             stored credentials; credentials here come from `SYSAND_CRED_*` \
+            "no OS keyring backend is available ({source}), so this host has no\n\
+             stored credentials; credentials here come from `SYSAND_CRED_*`\n\
              environment variables"
         ),
         Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
@@ -393,7 +393,7 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
         Err(_) => {
             let note = sysand_core::style::get_style_config().note;
             println!(
-                "{note}note:{note:#} more than one default index is configured; no entry \
+                "{note}note:{note:#} more than one default index is configured; no entry\n\
                  is marked as the default index"
             );
             None
@@ -523,7 +523,7 @@ fn render_auth_status(status: &AuthStatus) {
         StoredCredentialsStatus::BackendUnavailable { reason } => {
             let note = style.note;
             println!(
-                "{note}note:{note:#} no OS keyring backend is available ({reason}); showing \
+                "{note}note:{note:#} no OS keyring backend is available ({reason}); showing\n\
                  `SYSAND_CRED_*` environment credentials only"
             );
             &none
@@ -675,7 +675,7 @@ pub fn command_auth_whoami(
                 unreachable!()
             };
             return Err(anyhow::anyhow!(
-                "{err}\nrun `sysand auth login {index}` to store a credential; \
+                "{err}\nrun `sysand auth login {index}` to store a credential;\n\
                  in CI, set `SYSAND_CRED_*` environment variables instead"
             ));
         }
@@ -724,7 +724,7 @@ pub fn command_auth_whoami(
                     }
                 }
                 None => println!(
-                    "The credential was accepted, but the identity response \
+                    "The credential was accepted, but the identity response\n\
                      could not be parsed."
                 ),
             }

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -400,7 +400,7 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
         }
     };
     let default_key = default_key.as_ref().map(IndexKey::as_str);
-    let env = collect_env_credential_entries();
+    let env = collect_env_credential_entries()?;
     let status = match open_cli_credential_store() {
         Ok(store) => match do_auth_status(&store, env, default_key) {
             Ok(status) => status,
@@ -423,31 +423,26 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
     Ok(())
 }
 
-/// Collect `SYSAND_CRED_*` URL-pattern variables as status entries.
-/// Deliberately tolerant, unlike the eager auth-policy build: `auth
-/// status` diagnoses credential configuration, so an incomplete group is
-/// listed rather than rejected. Only pattern variables are shown; the
-/// companion variables hold secrets.
-fn collect_env_credential_entries() -> Vec<EnvCredentialEntry> {
-    let mut entries: Vec<EnvCredentialEntry> = std::env::vars()
-        .filter(|(key, _)| {
-            matches!(
-                crate::cred_env::classify(key),
-                Some(crate::cred_env::CredEnvName::Grouped(
-                    _,
-                    crate::cred_env::CredEnvRole::Pattern
-                ))
-            )
-        })
-        .map(|(key, value)| EnvCredentialEntry {
-            label: key,
-            pattern: value,
+/// Collect `SYSAND_CRED_*` URL-pattern variables as status entries,
+/// applying the same strict validation as the eager auth-policy build:
+/// a malformed configuration (label-less name, incomplete group) is an
+/// error here too, with the identical message, so `auth status` never
+/// reports less than any credential-using command would reject. Only
+/// pattern variables are shown; the companion variables hold secrets.
+fn collect_env_credential_entries() -> Result<Vec<EnvCredentialEntry>> {
+    let groups = crate::cred_env::validated_env_groups()?;
+    let mut entries: Vec<EnvCredentialEntry> = groups
+        .patterns
+        .into_iter()
+        .map(|(stem, pattern)| EnvCredentialEntry {
+            label: format!("{}{stem}", crate::cred_env::ENV_PREFIX),
+            pattern,
             // Set by status assembly when a default index is known.
             applies_to_default: false,
         })
         .collect();
     entries.sort_by(|a, b| a.label.cmp(&b.label));
-    entries
+    Ok(entries)
 }
 
 /// Days-to-expiry at or under which the `expires in N days` qualifier is
@@ -584,9 +579,10 @@ fn render_auth_status(status: &AuthStatus) {
 }
 
 /// Build the read auth policy for `auth whoami`'s discovery fetch (and
-/// its env bearer map), tolerantly: unlike the eager build in `run_cli`,
-/// a malformed `SYSAND_CRED_*` group is skipped with a debug log, because
-/// the `auth` commands must stay usable to diagnose exactly those.
+/// its env bearer map), tolerantly: unlike the strict validation shared
+/// by `run_cli` and `auth status`, a malformed `SYSAND_CRED_*` group is
+/// skipped with a debug log, because `whoami` must stay usable against a
+/// private index even when an unrelated group is malformed.
 fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
     let groups = crate::cred_env::collect_env_groups();
 
@@ -755,96 +751,5 @@ pub fn command_auth_whoami(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{blob_full_message, cred_env_var_stem};
-    use chrono::{Duration, Utc};
-
-    #[test]
-    fn cred_env_var_stem_uses_the_uppercased_host() {
-        assert_eq!(
-            cred_env_var_stem("https://sysand.example/idx/"),
-            "SYSAND_EXAMPLE"
-        );
-    }
-
-    #[test]
-    fn cred_env_var_stem_includes_a_non_default_port() {
-        // Two indexes on different ports of one host must not suggest the
-        // same variable names.
-        assert_eq!(
-            cred_env_var_stem("https://sysand.example:8443/"),
-            "SYSAND_EXAMPLE_8443"
-        );
-        assert_ne!(
-            cred_env_var_stem("https://sysand.example:8443/"),
-            cred_env_var_stem("https://sysand.example:9000/")
-        );
-    }
-
-    #[test]
-    fn cred_env_var_stem_omits_a_scheme_default_port() {
-        assert_eq!(
-            cred_env_var_stem("https://sysand.example:443/"),
-            "SYSAND_EXAMPLE"
-        );
-        assert_eq!(
-            cred_env_var_stem("http://sysand.example:80/"),
-            "SYSAND_EXAMPLE"
-        );
-    }
-
-    #[test]
-    fn cred_env_var_stem_never_produces_a_reserved_suffix() {
-        // Host characters map to alphanumerics or `_`, and a port adds
-        // only digits, so no stem can end in a reserved secret suffix.
-        for key in [
-            "https://basic.user/",
-            "https://x.example:1234/",
-            "https://bearer-token.example/",
-        ] {
-            let stem = cred_env_var_stem(key);
-            for suffix in ["_BASIC_USER", "_BASIC_PASS", "_BEARER_TOKEN"] {
-                assert!(!stem.ends_with(suffix), "stem {stem} ends in {suffix}");
-            }
-        }
-    }
-
-    #[test]
-    fn blob_full_first_login_does_not_suggest_removing_a_login() {
-        let message = blob_full_message(&[], Utc::now());
-        assert!(message.contains("use a smaller token"), "{message}");
-        assert!(!message.contains("logout"), "{message}");
-    }
-
-    #[test]
-    fn blob_full_names_the_status_and_logout_commands() {
-        let now = Utc::now();
-        let stored = [("https://a.example/", None), ("https://b.example/", None)];
-        let message = blob_full_message(&stored, now);
-        assert!(message.contains("sysand auth status"), "{message}");
-        assert!(message.contains("sysand auth logout <index>"), "{message}");
-    }
-
-    #[test]
-    fn blob_full_lists_expired_logins_as_drop_candidates() {
-        let now = Utc::now();
-        let stored = [
-            ("https://live.example/", Some(now + Duration::days(30))),
-            ("https://dead.example/", Some(now - Duration::days(1))),
-            ("https://unknown.example/", None),
-        ];
-        let message = blob_full_message(&stored, now);
-        assert!(
-            message.contains("sysand auth logout https://dead.example/"),
-            "{message}"
-        );
-        assert!(
-            !message.contains("logout https://live.example/"),
-            "{message}"
-        );
-        assert!(
-            !message.contains("logout https://unknown.example/"),
-            "{message}"
-        );
-    }
-}
+#[path = "./auth_tests.rs"]
+mod tests;

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -653,6 +653,17 @@ pub fn command_auth_whoami(
         Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
             return Err(err).context(KEYRING_LOCKED_HINT);
         }
+        // The core error states the condition (and the `SYSAND_CRED_*`
+        // fallback) without naming a CLI command; the CLI adds the
+        // `sysand auth login` remediation using the index from the error.
+        Err(err @ AuthCommandError::NoWhoamiCredential { .. }) => {
+            let AuthCommandError::NoWhoamiCredential { index, .. } = &err else {
+                unreachable!()
+            };
+            return Err(anyhow::anyhow!(
+                "{err}\nrun `sysand auth login {index}` to store one"
+            ));
+        }
         Err(err) => return Err(err.into()),
     };
 

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 use anstream::println;
 use anyhow::{Context, Result, bail};
 use sysand_core::{
-    auth::{GlobMapBuilder, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder},
+    auth::{
+        GlobMapBuilder, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder,
+        StandardLazyHTTPAuthentication,
+    },
     commands::auth::{
         AuthCommandError, AuthLoginNotice, AuthLoginOutcome, AuthStatus, EnvCredentialEntry,
         ProbeSurface, StoredCredentialStatus, StoredCredentialsStatus, WhoamiCredentialSource,
@@ -19,12 +22,12 @@ use sysand_core::{
         do_auth_whoami, validated_index_key,
     },
     config::Config,
-    credential_store::{CredentialStore, CredentialStoreError},
+    credential_store::{CredentialRecord, CredentialStore, CredentialStoreError},
 };
 
 use chrono::{DateTime, Utc};
 
-use crate::{CliAuthPolicy, DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
+use crate::{DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
 
 const KEYRING_LOCKED_HINT: &str = "unlock your OS keyring and retry, or provide credentials via \
      `SYSAND_CRED_*` environment variables";
@@ -113,15 +116,26 @@ fn render_login_notice(notice: AuthLoginNotice, index_key: &str) {
         ),
         AuthLoginNotice::SurfaceRejected {
             surface,
+            read_status,
             basic_challenge,
         } => {
+            // The same read-404 hedge the refusal message carries: a 404
+            // can mean a rejected token, but also no `index.json` at all.
+            let hedge = if read_status == Some(404) {
+                " (HTTP 404, which can also mean no index exists at this URL)"
+            } else {
+                ""
+            };
             log::warn!(
-                "the {} rejected the credential; it was stored anyway because \
-                     another surface accepted it",
+                "the {} rejected the credential{hedge}; it was stored anyway \
+                     because another surface accepted it",
                 surface_name(surface)
             );
             if basic_challenge {
                 let stem = cred_env_var_stem(index_key);
+                // Keep this basic-auth routing hint consistent with the
+                // refusal-path variant in core/src/commands/auth.rs
+                // (validation_rejected_message).
                 log::warn!(
                     "this index uses username/password (HTTP basic) authentication; \
                          configure `SYSAND_CRED_{stem}_BASIC_USER` / \
@@ -168,7 +182,7 @@ pub fn command_auth_login(
 
     let mut store = open_cli_credential_store().context("could not open the credential store")?;
     let index_key = key.clone();
-    let outcome = do_auth_login(&mut store, &key, secret, client, runtime, |notice| {
+    let outcome = do_auth_login(&mut store, &key, secret, client, &runtime, |notice| {
         render_login_notice(notice, &index_key);
     });
     match outcome {
@@ -301,14 +315,20 @@ fn read_token(key: &str, token_stdin: bool) -> Result<String> {
 }
 
 /// Derive the `SYSAND_CRED_<NAME>` stem suggested on a no-keyring host
-/// from the index host. Hostnames cannot produce the reserved
-/// `_BASIC_USER` / `_BASIC_PASS` / `_BEARER_TOKEN` suffixes.
+/// from the index host, plus the port when it is not the scheme default
+/// (for example `HOST_8443`): two indexes on different ports of one host
+/// must not suggest the same variable names, or the second guidance would
+/// silently overwrite the first credential. Hostnames and ports cannot
+/// produce the reserved `_BASIC_USER` / `_BASIC_PASS` / `_BEARER_TOKEN`
+/// suffixes (a port is all digits).
 fn cred_env_var_stem(key: &str) -> String {
-    let host = url::Url::parse(key)
-        .ok()
-        .and_then(|url| url.host_str().map(str::to_owned))
-        .unwrap_or_else(|| "INDEX".to_string());
-    host.chars()
+    let url = url::Url::parse(key).ok();
+    let host = url
+        .as_ref()
+        .and_then(|url| url.host_str())
+        .unwrap_or("INDEX");
+    let mut stem: String = host
+        .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() {
                 c.to_ascii_uppercase()
@@ -316,7 +336,14 @@ fn cred_env_var_stem(key: &str) -> String {
                 '_'
             }
         })
-        .collect()
+        .collect();
+    // `url::Url` strips a scheme-default port during normalization, so
+    // `port()` is `Some` exactly for non-default ports.
+    if let Some(port) = url.as_ref().and_then(url::Url::port) {
+        stem.push('_');
+        stem.push_str(&port.to_string());
+    }
+    stem
 }
 
 pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result<()> {
@@ -350,6 +377,13 @@ pub fn command_auth_logout(index_url: Option<String>, config: &Config) -> Result
         ),
         Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
             Err(err).context(KEYRING_LOCKED_HINT)
+        }
+        // The core error states the condition; the CLI points at `auth
+        // status`, which lists every stored login under its exact key (a
+        // logout target must match the key exactly, so a typo is best
+        // fixed by copying the key from that list).
+        Err(err @ AuthCommandError::NoStoredCredential { .. }) => {
+            bail!("{err}\nrun `sysand auth status` to list the stored logins and their exact keys")
         }
         Err(err) => Err(err.into()),
     }
@@ -617,6 +651,30 @@ fn lenient_env_auth_policy() -> Result<StandardHTTPAuthentication> {
         .context("could not compile `SYSAND_CRED_*` URL patterns")
 }
 
+/// An already-read snapshot of the credential store, backing `auth
+/// whoami`'s discovery policy so the command performs exactly one store
+/// backend read (the `list` in [`command_auth_whoami`]) instead of a
+/// second one inside the policy's lazy cache. Read-only by construction:
+/// whoami never writes the credential store, so the mutating methods are
+/// unreachable.
+struct PreloadedCredentials {
+    records: Vec<CredentialRecord>,
+}
+
+impl CredentialStore for PreloadedCredentials {
+    fn list(&self) -> Result<Vec<CredentialRecord>, CredentialStoreError> {
+        Ok(self.records.clone())
+    }
+
+    fn upsert(&mut self, _record: CredentialRecord) -> Result<(), CredentialStoreError> {
+        unreachable!("BUG: `auth whoami` never writes the credential store")
+    }
+
+    fn remove(&mut self, _key: &str) -> Result<bool, CredentialStoreError> {
+        unreachable!("BUG: `auth whoami` never writes the credential store")
+    }
+}
+
 pub fn command_auth_whoami(
     index_url: Option<String>,
     config: &Config,
@@ -641,17 +699,35 @@ pub fn command_auth_whoami(
     let env_bearers = env_policy
         .publish_bearer_auth_map()
         .context("could not compile `SYSAND_CRED_*` URL patterns")?;
-    // Two store handles on the same underlying store: one feeds the
-    // discovery policy (a private index may gate its discovery document,
-    // so unlike login the fetch runs with the regular read policy), the
-    // other is read for credential selection.
-    let discovery_store =
-        open_cli_credential_store().context("could not open the credential store")?;
+    // One store read serves both the discovery fetch and credential
+    // selection ("at most one keychain touch per command",
+    // design/credential-storage.md section 9): the records read here are
+    // passed to `do_auth_whoami` for selection, and a preloaded snapshot
+    // of the same records backs the discovery policy (a private index may
+    // gate its discovery document, so unlike login the fetch runs with
+    // the regular read policy). On a locked keyring this is the single
+    // unlock prompt.
     let store = open_cli_credential_store().context("could not open the credential store")?;
-    let discovery_policy = CliAuthPolicy::new(env_policy, discovery_store);
+    let records = match store.list() {
+        Ok(records) => records,
+        // No keyring backend: only env credentials can apply. A locked or
+        // denied backend is a hard error instead: "no credential, run
+        // login" would be the wrong remediation for an unlockable store.
+        Err(CredentialStoreError::BackendAbsent { .. }) => Vec::new(),
+        Err(err @ CredentialStoreError::BackendDenied { .. }) => {
+            return Err(err).context(KEYRING_LOCKED_HINT);
+        }
+        Err(err) => return Err(err.into()),
+    };
+    let discovery_policy = StandardLazyHTTPAuthentication::new(
+        env_policy,
+        PreloadedCredentials {
+            records: records.clone(),
+        },
+    );
 
     let outcome = match do_auth_whoami(
-        &store,
+        &records,
         &target,
         &env_bearers,
         &discovery_policy,
@@ -659,18 +735,17 @@ pub fn command_auth_whoami(
         runtime,
     ) {
         Ok(outcome) => outcome,
-        Err(AuthCommandError::Store(err @ CredentialStoreError::BackendDenied { .. })) => {
-            return Err(err).context(KEYRING_LOCKED_HINT);
-        }
-        // The core error states the condition (and the `SYSAND_CRED_*`
-        // fallback) without naming a CLI command; the CLI adds the
-        // `sysand auth login` remediation using the index from the error.
+        // The core error states the condition without naming a CLI
+        // command; the CLI leads with the `sysand auth login` remediation
+        // (using the index from the error) and names the `SYSAND_CRED_*`
+        // variables second, as the non-interactive path for CI.
         Err(err @ AuthCommandError::NoWhoamiCredential { .. }) => {
             let AuthCommandError::NoWhoamiCredential { index, .. } = &err else {
                 unreachable!()
             };
             return Err(anyhow::anyhow!(
-                "{err}\nrun `sysand auth login {index}` to store one"
+                "{err}\nrun `sysand auth login {index}` to store a credential; \
+                 in CI, set `SYSAND_CRED_*` environment variables instead"
             ));
         }
         Err(err) => return Err(err.into()),
@@ -762,8 +837,58 @@ pub fn command_auth_whoami(
 
 #[cfg(test)]
 mod tests {
-    use super::blob_full_message;
+    use super::{blob_full_message, cred_env_var_stem};
     use chrono::{Duration, Utc};
+
+    #[test]
+    fn cred_env_var_stem_uses_the_uppercased_host() {
+        assert_eq!(
+            cred_env_var_stem("https://sysand.example/idx/"),
+            "SYSAND_EXAMPLE"
+        );
+    }
+
+    #[test]
+    fn cred_env_var_stem_includes_a_non_default_port() {
+        // Two indexes on different ports of one host must not suggest the
+        // same variable names.
+        assert_eq!(
+            cred_env_var_stem("https://sysand.example:8443/"),
+            "SYSAND_EXAMPLE_8443"
+        );
+        assert_ne!(
+            cred_env_var_stem("https://sysand.example:8443/"),
+            cred_env_var_stem("https://sysand.example:9000/")
+        );
+    }
+
+    #[test]
+    fn cred_env_var_stem_omits_a_scheme_default_port() {
+        assert_eq!(
+            cred_env_var_stem("https://sysand.example:443/"),
+            "SYSAND_EXAMPLE"
+        );
+        assert_eq!(
+            cred_env_var_stem("http://sysand.example:80/"),
+            "SYSAND_EXAMPLE"
+        );
+    }
+
+    #[test]
+    fn cred_env_var_stem_never_produces_a_reserved_suffix() {
+        // Host characters map to alphanumerics or `_`, and a port adds
+        // only digits, so no stem can end in a reserved secret suffix.
+        for key in [
+            "https://basic.user/",
+            "https://x.example:1234/",
+            "https://bearer-token.example/",
+        ] {
+            let stem = cred_env_var_stem(key);
+            for suffix in ["_BASIC_USER", "_BASIC_PASS", "_BEARER_TOKEN"] {
+                assert!(!stem.ends_with(suffix), "stem {stem} ends in {suffix}");
+            }
+        }
+    }
 
     #[test]
     fn blob_full_first_login_does_not_suggest_removing_a_login() {

--- a/sysand/src/commands/auth_tests.rs
+++ b/sysand/src/commands/auth_tests.rs
@@ -39,18 +39,20 @@ fn cred_env_var_stem_omits_a_scheme_default_port() {
 }
 
 #[test]
-fn cred_env_var_stem_never_produces_a_reserved_suffix() {
-    // Host characters map to alphanumerics or `_`, and a port adds
-    // only digits, so no stem can end in a reserved secret suffix.
-    for key in [
-        "https://basic.user/",
-        "https://x.example:1234/",
-        "https://bearer-token.example/",
+fn cred_env_var_stem_escapes_reserved_and_labelless_spellings() {
+    // A `_`-mapped host can spell a reserved secret suffix or a bare
+    // role name; the suggested pattern variable `SYSAND_CRED_<stem>`
+    // would then classify as a secret or as label-less. Such stems get
+    // a `_0` tail; ordinary hosts stay untouched.
+    for (key, expected) in [
+        ("http://_basic.pass/", "_BASIC_PASS_0"),
+        ("http://_bearer.token/", "_BEARER_TOKEN_0"),
+        ("https://basic.user/", "BASIC_USER_0"),
+        ("https://x-basic.pass/", "X_BASIC_PASS_0"),
+        ("https://bearer-token.example/", "BEARER_TOKEN_EXAMPLE"),
+        ("https://x.example:1234/", "X_EXAMPLE_1234"),
     ] {
-        let stem = cred_env_var_stem(key);
-        for suffix in ["_BASIC_USER", "_BASIC_PASS", "_BEARER_TOKEN"] {
-            assert!(!stem.ends_with(suffix), "stem {stem} ends in {suffix}");
-        }
+        assert_eq!(cred_env_var_stem(key), expected, "for {key}");
     }
 }
 

--- a/sysand/src/commands/auth_tests.rs
+++ b/sysand/src/commands/auth_tests.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use super::{blob_full_message, cred_env_var_stem};
+use chrono::{Duration, Utc};
+
+#[test]
+fn cred_env_var_stem_uses_the_uppercased_host() {
+    assert_eq!(
+        cred_env_var_stem("https://sysand.example/idx/"),
+        "SYSAND_EXAMPLE"
+    );
+}
+
+#[test]
+fn cred_env_var_stem_includes_a_non_default_port() {
+    // Two indexes on different ports of one host must not suggest the
+    // same variable names.
+    assert_eq!(
+        cred_env_var_stem("https://sysand.example:8443/"),
+        "SYSAND_EXAMPLE_8443"
+    );
+    assert_ne!(
+        cred_env_var_stem("https://sysand.example:8443/"),
+        cred_env_var_stem("https://sysand.example:9000/")
+    );
+}
+
+#[test]
+fn cred_env_var_stem_omits_a_scheme_default_port() {
+    assert_eq!(
+        cred_env_var_stem("https://sysand.example:443/"),
+        "SYSAND_EXAMPLE"
+    );
+    assert_eq!(
+        cred_env_var_stem("http://sysand.example:80/"),
+        "SYSAND_EXAMPLE"
+    );
+}
+
+#[test]
+fn cred_env_var_stem_never_produces_a_reserved_suffix() {
+    // Host characters map to alphanumerics or `_`, and a port adds
+    // only digits, so no stem can end in a reserved secret suffix.
+    for key in [
+        "https://basic.user/",
+        "https://x.example:1234/",
+        "https://bearer-token.example/",
+    ] {
+        let stem = cred_env_var_stem(key);
+        for suffix in ["_BASIC_USER", "_BASIC_PASS", "_BEARER_TOKEN"] {
+            assert!(!stem.ends_with(suffix), "stem {stem} ends in {suffix}");
+        }
+    }
+}
+
+#[test]
+fn blob_full_first_login_does_not_suggest_removing_a_login() {
+    let message = blob_full_message(&[], Utc::now());
+    assert!(message.contains("use a smaller token"), "{message}");
+    assert!(!message.contains("logout"), "{message}");
+}
+
+#[test]
+fn blob_full_names_the_status_and_logout_commands() {
+    let now = Utc::now();
+    let stored = [("https://a.example/", None), ("https://b.example/", None)];
+    let message = blob_full_message(&stored, now);
+    assert!(message.contains("sysand auth status"), "{message}");
+    assert!(message.contains("sysand auth logout <index>"), "{message}");
+}
+
+#[test]
+fn blob_full_lists_expired_logins_as_drop_candidates() {
+    let now = Utc::now();
+    let stored = [
+        ("https://live.example/", Some(now + Duration::days(30))),
+        ("https://dead.example/", Some(now - Duration::days(1))),
+        ("https://unknown.example/", None),
+    ];
+    let message = blob_full_message(&stored, now);
+    assert!(
+        message.contains("sysand auth logout https://dead.example/"),
+        "{message}"
+    );
+    assert!(
+        !message.contains("logout https://live.example/"),
+        "{message}"
+    );
+    assert!(
+        !message.contains("logout https://unknown.example/"),
+        "{message}"
+    );
+}

--- a/sysand/src/commands/mod.rs
+++ b/sysand/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 pub mod add;
+pub mod auth;
 pub mod build;
 pub mod clone;
 pub mod env;

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -9,8 +9,8 @@ use sysand_core::{
     auth::StandardHTTPAuthentication,
     build::default_kpar_path,
     commands::publish::{
-        TrustedPublishingEnvironment, do_publish, prepare_publish_payload, resolve_publish_bearer,
-        validate_api_root_url_shape,
+        PublishBearerSources, TrustedPublishingEnvironment, do_publish, prepare_publish_payload,
+        resolve_publish_bearer, validate_api_root_url_shape,
     },
     context::ProjectContext,
     env::discovery::{ResolvedEndpoints, fetch_index_config},
@@ -69,10 +69,10 @@ pub fn command_publish(
     // extract the publish-specific bearer-credential map (by reference,
     // cloning the tokens). Upload is bearer-only; basic-auth entries are
     // intentionally dropped at this step.
-    let bearer_map = auth_policy.publish_bearer_auth_map()?;
+    let bearer_sources = PublishBearerSources::from_env(auth_policy.publish_bearer_auth_map()?);
     let trusted_publishing_env = TrustedPublishingEnvironment::from_env();
     let bearer = resolve_publish_bearer(
-        &bearer_map,
+        &bearer_sources,
         &api_root,
         trusted_publishing.into(),
         &trusted_publishing_env,

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -65,11 +65,11 @@ pub fn command_publish(
     // Validate the resolved `api_root` shape once here; both credential
     // resolution and the upload build the upload URL from it afterwards.
     validate_api_root_url_shape(&api_root)?;
-    // Only now — after discovery has had access to the full policy —
-    // do we consume the Arc to extract the publish-specific
-    // bearer-credential map. Upload is bearer-only; basic-auth entries
-    // are intentionally dropped at this step.
-    let bearer_map = Arc::unwrap_or_clone(auth_policy).try_into_publish_bearer_auth_map()?;
+    // Only now, after discovery has had access to the full policy, do we
+    // extract the publish-specific bearer-credential map (by reference,
+    // cloning the tokens). Upload is bearer-only; basic-auth entries are
+    // intentionally dropped at this step.
+    let bearer_map = auth_policy.publish_bearer_auth_map()?;
     let trusted_publishing_env = TrustedPublishingEnvironment::from_env();
     let bearer = resolve_publish_bearer(
         &bearer_map,

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -32,27 +32,18 @@ pub fn command_publish(
     if !wrapfs::is_file(&kpar_path)? {
         bail!("KPAR file not found at `{kpar_path}`, run `sysand build` first");
     }
-    // `index` is an `IndexLocation`, so its shape invariants (absolute
-    // HTTP(S), no userinfo) were already enforced when it was parsed. The
-    // `v1/upload` guard still applies to the resolved `api_root` in
-    // `build_upload_url`.
-    //
-    // Validate and prepare the kpar payload before any network work,
-    // so that kpar-content errors (bad semver, invalid publisher/name,
-    // oversized archive) surface before discovery or credential
-    // matching does.
+    // Validate and prepare the kpar payload before any network work, so
+    // kpar-content errors surface before discovery or credential matching.
     let prepared = prepare_publish_payload(&kpar_path)?;
 
     // Resolve `api_root` before credential matching so publish credentials
-    // are matched against the actual upload URL. Discovery uses the full auth
-    // policy because the discovery document may itself be auth-gated.
+    // are matched against the actual upload URL. Discovery uses the full
+    // auth policy because the discovery document may itself be auth-gated.
     let endpoints = runtime.block_on(fetch_index_config(&client, &*auth_policy, &index))?;
     let ResolvedEndpoints { api_root, .. } = endpoints;
-    // Publishing needs an API, which exists only when the discovery
-    // document advertises `api_root`. An index that does not advertise one
-    // serves files only, so there is nothing to upload to. Check before
-    // credential handling so this clearer error is not masked by
-    // credential problems.
+    // No advertised `api_root` means a files-only index with nothing to
+    // upload to; check before credential handling so this clearer error
+    // is not masked by credential problems.
     let Some(api_root) = api_root else {
         bail!(
             "index `{index}` does not advertise a publish endpoint,\n\
@@ -64,13 +55,9 @@ pub fn command_publish(
     // Validate the resolved `api_root` shape once here; both credential
     // resolution and the upload build the upload URL from it afterwards.
     validate_api_root_url_shape(&api_root)?;
-    // Only now, after discovery has had access to the full policy, do we
-    // extract the publish-specific bearer-credential map (by reference,
-    // cloning the tokens). Upload is bearer-only; basic-auth entries are
-    // intentionally dropped at this step. Stored logins are handed over as
-    // a lazy provider so the credential store is read (a single direct
-    // read, outside the request path's cache) only when no env bearer
-    // matches the upload URL.
+    // Upload is bearer-only, so basic-auth entries are dropped here.
+    // Stored logins are handed over as a lazy provider: the credential
+    // store is read only when no env bearer matches the upload URL.
     let env_bearers = auth_policy.env_policy().publish_bearer_auth_map()?;
     let trusted_publishing_env = TrustedPublishingEnvironment::from_env();
     // Captured before `index` moves into `do_publish`, so both hint sites
@@ -122,10 +109,9 @@ fn publish_error_with_hint(err: PublishError, index: &str) -> anyhow::Error {
         PublishError::PublishAuthFailed {
             status, provenance, ..
         } => {
-            // A stale stored credential is refreshed by re-login; an env
-            // credential is not (it shadows stored credentials, which the core
-            // message already explains). A 403 is authorization, so point
-            // at the subject the credential authenticates as.
+            // Re-login refreshes a stored credential but not an env one
+            // (the core message explains the shadowing). A 403 is
+            // authorization: point at the credential's subject.
             let mut lines = Vec::new();
             if let PublishBearerProvenance::Stored { key, .. } = provenance {
                 lines.push(format!(

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -118,7 +118,7 @@ fn publish_error_with_hint(err: PublishError) -> anyhow::Error {
             status, provenance, ..
         } => {
             // A stale stored credential is refreshed by re-login; an env
-            // credential is not (it shadows stored logins, which the core
+            // credential is not (it shadows stored credentials, which the core
             // message already explains). A 403 is authorization, so point
             // at the subject the credential authenticates as.
             let mut lines = Vec::new();

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -8,8 +8,8 @@ use camino::Utf8PathBuf;
 use sysand_core::{
     build::default_kpar_path,
     commands::publish::{
-        TrustedPublishingEnvironment, do_publish, prepare_publish_payload, resolve_publish_bearer,
-        validate_api_root_url_shape,
+        PublishBearerProvenance, PublishError, TrustedPublishingEnvironment, do_publish,
+        prepare_publish_payload, resolve_publish_bearer, validate_api_root_url_shape,
     },
     context::ProjectContext,
     env::discovery::{ResolvedEndpoints, fetch_index_config},
@@ -80,9 +80,11 @@ pub fn command_publish(
         &trusted_publishing_env,
         &client,
         &runtime,
-    )?;
+    )
+    .map_err(publish_error_with_hint)?;
 
-    let response = do_publish(prepared, index, api_root, bearer, client, runtime)?;
+    let response = do_publish(prepared, index, api_root, bearer, client, runtime)
+        .map_err(publish_error_with_hint)?;
 
     let header = sysand_core::style::get_style_config().header;
     if response.is_new_project {
@@ -98,6 +100,48 @@ pub fn command_publish(
     }
 
     Ok(())
+}
+
+/// Add the CLI-specific `sysand auth` remediation to a publish error whose
+/// core message deliberately names no CLI command: the library states the
+/// condition (and the `SYSAND_CRED_*` fallback), and the frontend owns the
+/// command vocabulary.
+fn publish_error_with_hint(err: PublishError) -> anyhow::Error {
+    let hint = match &err {
+        PublishError::NoPublishBearer { .. } => {
+            Some("or run `sysand auth login <index-url>` to store one".to_string())
+        }
+        PublishError::StoredCredentialExpired { key, .. } => Some(format!(
+            "re-run `sysand auth login {key}` to store a fresh token"
+        )),
+        PublishError::PublishAuthFailed {
+            status, provenance, ..
+        } => {
+            // A stale stored credential is refreshed by re-login; an env
+            // credential is not (it shadows stored logins, which the core
+            // message already explains). A 403 is authorization, so point
+            // at the subject the credential authenticates as.
+            let mut lines = Vec::new();
+            if let PublishBearerProvenance::Stored { key, .. } = provenance {
+                lines.push(format!(
+                    "re-run `sysand auth login {key}` to store a fresh token"
+                ));
+            }
+            if *status == 403 {
+                lines.push(
+                    "run `sysand auth status` to see which subject the credential \
+                     authenticates as"
+                        .to_string(),
+                );
+            }
+            (!lines.is_empty()).then(|| lines.join("\n"))
+        }
+        _ => None,
+    };
+    match hint {
+        Some(hint) => anyhow::anyhow!("{err}\n{hint}"),
+        None => err.into(),
+    }
 }
 
 fn resolve_publish_kpar_path(

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -68,8 +68,9 @@ pub fn command_publish(
     // extract the publish-specific bearer-credential map (by reference,
     // cloning the tokens). Upload is bearer-only; basic-auth entries are
     // intentionally dropped at this step. Stored logins are handed over as
-    // a lazy provider so the credential store is read (once, cached on the
-    // policy) only when no env bearer matches the upload URL.
+    // a lazy provider so the credential store is read (a single direct
+    // read, outside the request path's cache) only when no env bearer
+    // matches the upload URL.
     let env_bearers = auth_policy.env_policy().publish_bearer_auth_map()?;
     let trusted_publishing_env = TrustedPublishingEnvironment::from_env();
     // Captured before `index` moves into `do_publish`, so both hint sites
@@ -77,7 +78,7 @@ pub fn command_publish(
     let index_display = index.to_string();
     let bearer = resolve_publish_bearer(
         &env_bearers,
-        || auth_policy.stored_bearer_map_blocking().clone(),
+        || auth_policy.read_stored_bearer_map_direct(),
         &api_root,
         trusted_publishing.into(),
         &trusted_publishing_env,

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -72,6 +72,9 @@ pub fn command_publish(
     // policy) only when no env bearer matches the upload URL.
     let env_bearers = auth_policy.env_policy().publish_bearer_auth_map()?;
     let trusted_publishing_env = TrustedPublishingEnvironment::from_env();
+    // Captured before `index` moves into `do_publish`, so both hint sites
+    // can name the index the user actually targeted.
+    let index_display = index.to_string();
     let bearer = resolve_publish_bearer(
         &env_bearers,
         || auth_policy.stored_bearer_map_blocking().clone(),
@@ -81,10 +84,10 @@ pub fn command_publish(
         &client,
         &runtime,
     )
-    .map_err(publish_error_with_hint)?;
+    .map_err(|err| publish_error_with_hint(err, &index_display))?;
 
     let response = do_publish(prepared, index, api_root, bearer, client, runtime)
-        .map_err(publish_error_with_hint)?;
+        .map_err(|err| publish_error_with_hint(err, &index_display))?;
 
     let header = sysand_core::style::get_style_config().header;
     if response.is_new_project {
@@ -105,11 +108,12 @@ pub fn command_publish(
 /// Add the CLI-specific `sysand auth` remediation to a publish error whose
 /// core message deliberately names no CLI command: the library states the
 /// condition (and the `SYSAND_CRED_*` fallback), and the frontend owns the
-/// command vocabulary.
-fn publish_error_with_hint(err: PublishError) -> anyhow::Error {
+/// command vocabulary. `index` is the index the user targeted, so the
+/// login hint is copy-pasteable.
+fn publish_error_with_hint(err: PublishError, index: &str) -> anyhow::Error {
     let hint = match &err {
         PublishError::NoPublishBearer { .. } => {
-            Some("or run `sysand auth login <index-url>` to store one".to_string())
+            Some(format!("or run `sysand auth login {index}` to store one"))
         }
         PublishError::StoredCredentialExpired { key, .. } => Some(format!(
             "re-run `sysand auth login {key}` to store a fresh token"

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -120,7 +120,7 @@ fn publish_error_with_hint(err: PublishError, index: &str) -> anyhow::Error {
             }
             if *status == 403 {
                 lines.push(
-                    "run `sysand auth status` to see which subject the credential \
+                    "run `sysand auth status` to see which subject the credential\n\
                      authenticates as"
                         .to_string(),
                 );

--- a/sysand/src/commands/publish.rs
+++ b/sysand/src/commands/publish.rs
@@ -6,11 +6,10 @@ use std::sync::Arc;
 use anyhow::{Result, bail};
 use camino::Utf8PathBuf;
 use sysand_core::{
-    auth::StandardHTTPAuthentication,
     build::default_kpar_path,
     commands::publish::{
-        PublishBearerSources, TrustedPublishingEnvironment, do_publish, prepare_publish_payload,
-        resolve_publish_bearer, validate_api_root_url_shape,
+        TrustedPublishingEnvironment, do_publish, prepare_publish_payload, resolve_publish_bearer,
+        validate_api_root_url_shape,
     },
     context::ProjectContext,
     env::discovery::{ResolvedEndpoints, fetch_index_config},
@@ -18,14 +17,14 @@ use sysand_core::{
     project::utils::wrapfs,
 };
 
-use crate::{CliError, cli::TrustedPublishingMode};
+use crate::{CliAuthPolicy, CliError, cli::TrustedPublishingMode};
 
 pub fn command_publish(
     path: Option<Utf8PathBuf>,
     index: IndexLocation,
     trusted_publishing: TrustedPublishingMode,
     ctx: &ProjectContext,
-    auth_policy: Arc<StandardHTTPAuthentication>,
+    auth_policy: Arc<CliAuthPolicy>,
     client: reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
 ) -> Result<()> {
@@ -68,11 +67,14 @@ pub fn command_publish(
     // Only now, after discovery has had access to the full policy, do we
     // extract the publish-specific bearer-credential map (by reference,
     // cloning the tokens). Upload is bearer-only; basic-auth entries are
-    // intentionally dropped at this step.
-    let bearer_sources = PublishBearerSources::from_env(auth_policy.publish_bearer_auth_map()?);
+    // intentionally dropped at this step. Stored logins are handed over as
+    // a lazy provider so the credential store is read (once, cached on the
+    // policy) only when no env bearer matches the upload URL.
+    let env_bearers = auth_policy.env_policy().publish_bearer_auth_map()?;
     let trusted_publishing_env = TrustedPublishingEnvironment::from_env();
     let bearer = resolve_publish_bearer(
-        &bearer_sources,
+        &env_bearers,
+        || auth_policy.stored_bearer_map_blocking().clone(),
         &api_root,
         trusted_publishing.into(),
         &trusted_publishing_env,

--- a/sysand/src/cred_env.rs
+++ b/sysand/src/cred_env.rs
@@ -7,9 +7,11 @@
 //! `run_cli`, the lenient policy for `auth whoami`, and the `auth status`
 //! listing) must agree on which suffixes are reserved for secrets and how
 //! the group stem is derived. This module is the single place that
-//! knowledge lives: a new suffix is added here and nowhere else. What each
-//! consumer does with a malformed or incomplete group (fail hard, skip
-//! with a diagnostic, list anyway) stays with the consumer.
+//! knowledge lives: a new suffix is added here and nowhere else. The
+//! strict group validation shared by the eager policy build and `auth
+//! status` lives here too ([`validated_env_groups`]); only `auth whoami`
+//! keeps its own lenient reading, so it stays usable against a private
+//! index even when an unrelated group is malformed.
 
 use std::collections::HashMap;
 
@@ -88,8 +90,8 @@ pub(crate) struct CredEnvGroups {
     pub(crate) basic_passwords: HashMap<String, String>,
     pub(crate) bearer_tokens: HashMap<String, String>,
     /// Variable names in the namespace but with no label, sorted. Never
-    /// part of any group; the strict consumer rejects them, the lenient
-    /// ones skip them.
+    /// part of any group; the strict consumers reject them, the lenient
+    /// one skips them.
     pub(crate) missing_label: Vec<String>,
 }
 
@@ -116,6 +118,77 @@ pub(crate) fn collect_env_groups() -> CredEnvGroups {
     }
     groups.missing_label.sort();
     groups
+}
+
+/// Validate collected groups the way every credential-using command
+/// does: reject label-less names, secret variables without a URL
+/// pattern, patterns with no complete authentication scheme, and half of
+/// a basic pair. A group carrying both schemes passes with a warning.
+/// Stems are checked in sorted order so the reported error is
+/// deterministic when several groups are malformed. Never interpolate
+/// variable values into these messages: a misnamed variable can put a
+/// secret in any position.
+pub(crate) fn validate_env_groups(groups: &CredEnvGroups) -> anyhow::Result<()> {
+    // Reject label-less names up front: `SYSAND_CRED_BASIC_PASS` would
+    // otherwise read as the pattern of a nonsense `BASIC_PASS` group.
+    if let Some(name) = groups.missing_label.first() {
+        anyhow::bail!(
+            "{name} has no label; env credentials need one, as in SYSAND_CRED_MYINDEX\n\
+             with SYSAND_CRED_MYINDEX_BASIC_USER/SYSAND_CRED_MYINDEX_BASIC_PASS or\n\
+             SYSAND_CRED_MYINDEX_BEARER_TOKEN"
+        );
+    }
+
+    let mut stems: Vec<&String> = [
+        &groups.patterns,
+        &groups.basic_users,
+        &groups.basic_passwords,
+        &groups.bearer_tokens,
+    ]
+    .into_iter()
+    .flat_map(HashMap::keys)
+    .collect();
+    stems.sort();
+    stems.dedup();
+
+    for k in stems {
+        if !groups.patterns.contains_key(k) {
+            anyhow::bail!("please specify URL pattern SYSAND_CRED_{k} for credential");
+        }
+        let has_basic = match (groups.basic_users.get(k), groups.basic_passwords.get(k)) {
+            (Some(_), Some(_)) => true,
+            (None, None) => false,
+            (_, _) => {
+                anyhow::bail!(
+                    "please specify both (or neither) of SYSAND_CRED_{k}_BASIC_USER and SYSAND_CRED_{k}_BASIC_PASS"
+                );
+            }
+        };
+        match (has_basic, groups.bearer_tokens.contains_key(k)) {
+            (false, false) => {
+                anyhow::bail!(
+                    "SYSAND_CRED_{k} has no matching authentication scheme, please specify\n\
+                     SYSAND_CRED_{k}_BASIC_USER/SYSAND_CRED_{k}_BASIC_PASS or\n\
+                     SYSAND_CRED_{k}_BEARER_TOKEN"
+                );
+            }
+            (true, true) => {
+                log::warn!("SYSAND_CRED_{k} has multiple authentication schemes!");
+            }
+            (_, _) => {}
+        }
+    }
+    Ok(())
+}
+
+/// Collect and strictly validate the `SYSAND_CRED_*` environment. The
+/// shared entry point for every consumer that must fail on a malformed
+/// credential configuration (the eager policy build in `run_cli` and
+/// `auth status`).
+pub(crate) fn validated_env_groups() -> anyhow::Result<CredEnvGroups> {
+    let groups = collect_env_groups();
+    validate_env_groups(&groups)?;
+    Ok(groups)
 }
 
 #[cfg(test)]

--- a/sysand/src/cred_env.rs
+++ b/sysand/src/cred_env.rs
@@ -82,41 +82,5 @@ pub(crate) fn collect_env_groups() -> CredEnvGroups {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{CredEnvRole, classify};
-
-    #[test]
-    fn classify_splits_stem_and_role() {
-        for (name, expected) in [
-            (
-                "SYSAND_CRED_TEST",
-                Some(("TEST".to_string(), CredEnvRole::Pattern)),
-            ),
-            (
-                "SYSAND_CRED_TEST_BASIC_USER",
-                Some(("TEST".to_string(), CredEnvRole::BasicUser)),
-            ),
-            (
-                "SYSAND_CRED_TEST_BASIC_PASS",
-                Some(("TEST".to_string(), CredEnvRole::BasicPass)),
-            ),
-            (
-                "SYSAND_CRED_TEST_BEARER_TOKEN",
-                Some(("TEST".to_string(), CredEnvRole::BearerToken)),
-            ),
-            ("SYSAND_DEFAULT_INDEX", None),
-            ("PATH", None),
-        ] {
-            assert_eq!(classify(name), expected, "name: {name}");
-        }
-    }
-
-    #[test]
-    fn classify_matches_a_suffix_only_at_the_end() {
-        // A suffix-looking infix stays part of the pattern stem.
-        assert_eq!(
-            classify("SYSAND_CRED_BEARER_TOKEN_X"),
-            Some(("BEARER_TOKEN_X".to_string(), CredEnvRole::Pattern))
-        );
-    }
-}
+#[path = "./cred_env_tests.rs"]
+mod tests;

--- a/sysand/src/cred_env.rs
+++ b/sysand/src/cred_env.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! Classification of `SYSAND_CRED_*` environment variables.
+//!
+//! Every consumer of these variables (the eager auth-policy build in
+//! `run_cli`, the lenient policy for `auth whoami`, and the `auth status`
+//! listing) must agree on which suffixes are reserved for secrets and how
+//! the group stem is derived. This module is the single place that
+//! knowledge lives: a new suffix is added here and nowhere else. What each
+//! consumer does with a malformed or incomplete group (fail hard, skip
+//! with a diagnostic, list anyway) stays with the consumer.
+
+use std::collections::HashMap;
+
+/// Prefix shared by all credential environment variables.
+pub(crate) const ENV_PREFIX: &str = "SYSAND_CRED_";
+
+/// The role a `SYSAND_CRED_*` variable plays within its credential group.
+/// A reserved suffix marks a secret-bearing variable; without one the
+/// variable holds the group's URL glob pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CredEnvRole {
+    /// No reserved suffix: the URL glob pattern naming the group.
+    Pattern,
+    /// `_BASIC_USER`: the HTTP basic username.
+    BasicUser,
+    /// `_BASIC_PASS`: the HTTP basic password.
+    BasicPass,
+    /// `_BEARER_TOKEN`: the bearer token.
+    BearerToken,
+}
+
+/// The reserved secret suffixes, paired with their roles. Order matters
+/// only in that each variable matches at most one suffix (none of these
+/// is a suffix of another).
+const SECRET_SUFFIXES: [(&str, CredEnvRole); 3] = [
+    ("_BASIC_USER", CredEnvRole::BasicUser),
+    ("_BASIC_PASS", CredEnvRole::BasicPass),
+    ("_BEARER_TOKEN", CredEnvRole::BearerToken),
+];
+
+/// Split a `SYSAND_CRED_*` variable name into its group stem and role.
+/// Returns `None` for variables outside the `SYSAND_CRED_` namespace.
+pub(crate) fn classify(name: &str) -> Option<(String, CredEnvRole)> {
+    let rest = name.strip_prefix(ENV_PREFIX)?;
+    for (suffix, role) in SECRET_SUFFIXES {
+        if let Some(stem) = rest.strip_suffix(suffix) {
+            return Some((stem.to_owned(), role));
+        }
+    }
+    Some((rest.to_owned(), CredEnvRole::Pattern))
+}
+
+/// `SYSAND_CRED_*` variables read from the process environment, grouped
+/// by role and keyed by group stem.
+#[derive(Debug, Default)]
+pub(crate) struct CredEnvGroups {
+    pub(crate) patterns: HashMap<String, String>,
+    pub(crate) basic_users: HashMap<String, String>,
+    pub(crate) basic_passwords: HashMap<String, String>,
+    pub(crate) bearer_tokens: HashMap<String, String>,
+}
+
+/// Collect every `SYSAND_CRED_*` variable from the process environment
+/// into its role map.
+pub(crate) fn collect_env_groups() -> CredEnvGroups {
+    let mut groups = CredEnvGroups::default();
+    for (name, value) in std::env::vars() {
+        let Some((stem, role)) = classify(&name) else {
+            continue;
+        };
+        let map = match role {
+            CredEnvRole::Pattern => &mut groups.patterns,
+            CredEnvRole::BasicUser => &mut groups.basic_users,
+            CredEnvRole::BasicPass => &mut groups.basic_passwords,
+            CredEnvRole::BearerToken => &mut groups.bearer_tokens,
+        };
+        map.insert(stem, value);
+    }
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CredEnvRole, classify};
+
+    #[test]
+    fn classify_splits_stem_and_role() {
+        for (name, expected) in [
+            (
+                "SYSAND_CRED_TEST",
+                Some(("TEST".to_string(), CredEnvRole::Pattern)),
+            ),
+            (
+                "SYSAND_CRED_TEST_BASIC_USER",
+                Some(("TEST".to_string(), CredEnvRole::BasicUser)),
+            ),
+            (
+                "SYSAND_CRED_TEST_BASIC_PASS",
+                Some(("TEST".to_string(), CredEnvRole::BasicPass)),
+            ),
+            (
+                "SYSAND_CRED_TEST_BEARER_TOKEN",
+                Some(("TEST".to_string(), CredEnvRole::BearerToken)),
+            ),
+            ("SYSAND_DEFAULT_INDEX", None),
+            ("PATH", None),
+        ] {
+            assert_eq!(classify(name), expected, "name: {name}");
+        }
+    }
+
+    #[test]
+    fn classify_matches_a_suffix_only_at_the_end() {
+        // A suffix-looking infix stays part of the pattern stem.
+        assert_eq!(
+            classify("SYSAND_CRED_BEARER_TOKEN_X"),
+            Some(("BEARER_TOKEN_X".to_string(), CredEnvRole::Pattern))
+        );
+    }
+}

--- a/sysand/src/cred_env.rs
+++ b/sysand/src/cred_env.rs
@@ -40,16 +40,43 @@ const SECRET_SUFFIXES: [(&str, CredEnvRole); 3] = [
     ("_BEARER_TOKEN", CredEnvRole::BearerToken),
 ];
 
-/// Split a `SYSAND_CRED_*` variable name into its group stem and role.
-/// Returns `None` for variables outside the `SYSAND_CRED_` namespace.
-pub(crate) fn classify(name: &str) -> Option<(String, CredEnvRole)> {
+/// How a variable name relates to the `SYSAND_CRED_` namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CredEnvName {
+    /// A well-formed name: the group label (stem) plus the variable's role.
+    Grouped(String, CredEnvRole),
+    /// In the namespace but with no label: bare `SYSAND_CRED`, a bare
+    /// role suffix such as `SYSAND_CRED_BASIC_PASS`, or an empty stem as
+    /// in `SYSAND_CRED__BEARER_TOKEN`.
+    MissingLabel,
+}
+
+/// Classify a `SYSAND_CRED_*` variable name. Returns `None` for variables
+/// outside the `SYSAND_CRED` namespace.
+pub(crate) fn classify(name: &str) -> Option<CredEnvName> {
+    // The bare prefix carries no trailing underscore, so check it before
+    // the prefix strip.
+    if name == "SYSAND_CRED" {
+        return Some(CredEnvName::MissingLabel);
+    }
     let rest = name.strip_prefix(ENV_PREFIX)?;
+    if rest.is_empty() {
+        return Some(CredEnvName::MissingLabel);
+    }
     for (suffix, role) in SECRET_SUFFIXES {
+        // A bare role suffix (`SYSAND_CRED_BASIC_PASS`) leaves no label
+        // and neither does an empty stem (`SYSAND_CRED__BASIC_PASS`).
+        if rest == &suffix[1..] {
+            return Some(CredEnvName::MissingLabel);
+        }
         if let Some(stem) = rest.strip_suffix(suffix) {
-            return Some((stem.to_owned(), role));
+            if stem.is_empty() {
+                return Some(CredEnvName::MissingLabel);
+            }
+            return Some(CredEnvName::Grouped(stem.to_owned(), role));
         }
     }
-    Some((rest.to_owned(), CredEnvRole::Pattern))
+    Some(CredEnvName::Grouped(rest.to_owned(), CredEnvRole::Pattern))
 }
 
 /// `SYSAND_CRED_*` variables read from the process environment, grouped
@@ -60,6 +87,10 @@ pub(crate) struct CredEnvGroups {
     pub(crate) basic_users: HashMap<String, String>,
     pub(crate) basic_passwords: HashMap<String, String>,
     pub(crate) bearer_tokens: HashMap<String, String>,
+    /// Variable names in the namespace but with no label, sorted. Never
+    /// part of any group; the strict consumer rejects them, the lenient
+    /// ones skip them.
+    pub(crate) missing_label: Vec<String>,
 }
 
 /// Collect every `SYSAND_CRED_*` variable from the process environment
@@ -67,8 +98,13 @@ pub(crate) struct CredEnvGroups {
 pub(crate) fn collect_env_groups() -> CredEnvGroups {
     let mut groups = CredEnvGroups::default();
     for (name, value) in std::env::vars() {
-        let Some((stem, role)) = classify(&name) else {
-            continue;
+        let (stem, role) = match classify(&name) {
+            None => continue,
+            Some(CredEnvName::MissingLabel) => {
+                groups.missing_label.push(name);
+                continue;
+            }
+            Some(CredEnvName::Grouped(stem, role)) => (stem, role),
         };
         let map = match role {
             CredEnvRole::Pattern => &mut groups.patterns,
@@ -78,6 +114,7 @@ pub(crate) fn collect_env_groups() -> CredEnvGroups {
         };
         map.insert(stem, value);
     }
+    groups.missing_label.sort();
     groups
 }
 

--- a/sysand/src/cred_env.rs
+++ b/sysand/src/cred_env.rs
@@ -81,6 +81,17 @@ pub(crate) fn classify(name: &str) -> Option<CredEnvName> {
     Some(CredEnvName::Grouped(rest.to_owned(), CredEnvRole::Pattern))
 }
 
+/// Whether `stem` is safe to suggest as a `SYSAND_CRED_<stem>` group
+/// label: the bare pattern variable must classify back to this group.
+/// Host-derived stems can spell a reserved secret suffix (`_basic.pass`
+/// maps to `_BASIC_PASS`, making the pattern variable read as a secret)
+/// or a bare role name (`basic.user` maps to `BASIC_USER`, which is
+/// label-less).
+pub(crate) fn stem_is_unambiguous(stem: &str) -> bool {
+    classify(&format!("{ENV_PREFIX}{stem}"))
+        == Some(CredEnvName::Grouped(stem.to_owned(), CredEnvRole::Pattern))
+}
+
 /// `SYSAND_CRED_*` variables read from the process environment, grouped
 /// by role and keyed by group stem.
 #[derive(Debug, Default)]

--- a/sysand/src/cred_env_tests.rs
+++ b/sysand/src/cred_env_tests.rs
@@ -1,26 +1,27 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use crate::cred_env::{CredEnvRole, classify};
+use crate::cred_env::{CredEnvName, CredEnvRole, classify};
+
+fn grouped(stem: &str, role: CredEnvRole) -> Option<CredEnvName> {
+    Some(CredEnvName::Grouped(stem.to_string(), role))
+}
 
 #[test]
 fn classify_splits_stem_and_role() {
     for (name, expected) in [
-        (
-            "SYSAND_CRED_TEST",
-            Some(("TEST".to_string(), CredEnvRole::Pattern)),
-        ),
+        ("SYSAND_CRED_TEST", grouped("TEST", CredEnvRole::Pattern)),
         (
             "SYSAND_CRED_TEST_BASIC_USER",
-            Some(("TEST".to_string(), CredEnvRole::BasicUser)),
+            grouped("TEST", CredEnvRole::BasicUser),
         ),
         (
             "SYSAND_CRED_TEST_BASIC_PASS",
-            Some(("TEST".to_string(), CredEnvRole::BasicPass)),
+            grouped("TEST", CredEnvRole::BasicPass),
         ),
         (
             "SYSAND_CRED_TEST_BEARER_TOKEN",
-            Some(("TEST".to_string(), CredEnvRole::BearerToken)),
+            grouped("TEST", CredEnvRole::BearerToken),
         ),
         ("SYSAND_DEFAULT_INDEX", None),
         ("PATH", None),
@@ -34,6 +35,24 @@ fn classify_matches_a_suffix_only_at_the_end() {
     // A suffix-looking infix stays part of the pattern stem.
     assert_eq!(
         classify("SYSAND_CRED_BEARER_TOKEN_X"),
-        Some(("BEARER_TOKEN_X".to_string(), CredEnvRole::Pattern))
+        grouped("BEARER_TOKEN_X", CredEnvRole::Pattern)
     );
+}
+
+#[test]
+fn classify_flags_names_with_no_label() {
+    // The bare prefix, a bare role suffix, and an empty stem all leave no
+    // label; none of them may masquerade as a pattern or secret variable.
+    for name in [
+        "SYSAND_CRED",
+        "SYSAND_CRED_",
+        "SYSAND_CRED_BASIC_USER",
+        "SYSAND_CRED_BASIC_PASS",
+        "SYSAND_CRED_BEARER_TOKEN",
+        "SYSAND_CRED__BASIC_USER",
+        "SYSAND_CRED__BASIC_PASS",
+        "SYSAND_CRED__BEARER_TOKEN",
+    ] {
+        assert_eq!(classify(name), Some(CredEnvName::MissingLabel), "{name}");
+    }
 }

--- a/sysand/src/cred_env_tests.rs
+++ b/sysand/src/cred_env_tests.rs
@@ -56,3 +56,82 @@ fn classify_flags_names_with_no_label() {
         assert_eq!(classify(name), Some(CredEnvName::MissingLabel), "{name}");
     }
 }
+
+// `validate_env_groups`: the strict validation shared by the eager
+// policy build and `auth status`. Groups are built directly so no test
+// mutates the process environment.
+
+use crate::cred_env::{CredEnvGroups, validate_env_groups};
+
+fn add(map: &mut std::collections::HashMap<String, String>, stem: &str, value: &str) {
+    map.insert(stem.to_string(), value.to_string());
+}
+
+#[test]
+fn validate_accepts_complete_groups_of_either_or_both_schemes() {
+    let mut groups = CredEnvGroups::default();
+    add(&mut groups.patterns, "BRR", "https://a.example/**");
+    add(&mut groups.bearer_tokens, "BRR", "tok");
+    add(&mut groups.patterns, "BSC", "https://b.example/**");
+    add(&mut groups.basic_users, "BSC", "user");
+    add(&mut groups.basic_passwords, "BSC", "pass");
+    add(&mut groups.patterns, "BOTH", "https://c.example/**");
+    add(&mut groups.bearer_tokens, "BOTH", "tok");
+    add(&mut groups.basic_users, "BOTH", "user");
+    add(&mut groups.basic_passwords, "BOTH", "pass");
+    assert!(validate_env_groups(&groups).is_ok());
+}
+
+#[test]
+fn validate_rejects_label_less_names_before_group_checks() {
+    let mut groups = CredEnvGroups::default();
+    groups.missing_label.push("SYSAND_CRED".to_string());
+    // Also scheme-less; the label error must win.
+    add(&mut groups.patterns, "A", "https://a.example/**");
+    let err = validate_env_groups(&groups).unwrap_err().to_string();
+    assert!(err.contains("SYSAND_CRED has no label"), "{err}");
+}
+
+#[test]
+fn validate_rejects_a_pattern_without_a_scheme() {
+    let mut groups = CredEnvGroups::default();
+    add(&mut groups.patterns, "A", "https://a.example/**");
+    let err = validate_env_groups(&groups).unwrap_err().to_string();
+    assert!(
+        err.contains("SYSAND_CRED_A has no matching authentication scheme"),
+        "{err}"
+    );
+}
+
+#[test]
+fn validate_rejects_half_of_a_basic_pair() {
+    let mut groups = CredEnvGroups::default();
+    add(&mut groups.patterns, "A", "https://a.example/**");
+    add(&mut groups.basic_users, "A", "user");
+    let err = validate_env_groups(&groups).unwrap_err().to_string();
+    assert!(
+        err.contains("both (or neither) of SYSAND_CRED_A_BASIC_USER and SYSAND_CRED_A_BASIC_PASS"),
+        "{err}"
+    );
+}
+
+#[test]
+fn validate_rejects_a_secret_without_a_pattern() {
+    let mut groups = CredEnvGroups::default();
+    add(&mut groups.bearer_tokens, "A", "tok");
+    let err = validate_env_groups(&groups).unwrap_err().to_string();
+    assert!(
+        err.contains("please specify URL pattern SYSAND_CRED_A for credential"),
+        "{err}"
+    );
+}
+
+#[test]
+fn validate_reports_the_alphabetically_first_malformed_group() {
+    // Deterministic even though the role maps are hash maps.
+    let mut groups = CredEnvGroups::default();
+    add(&mut groups.patterns, "ZULU", "https://z.example/**");
+    add(&mut groups.patterns, "ALFA", "https://a.example/**");
+    let err = validate_env_groups(&groups).unwrap_err().to_string();
+    assert!(err.contains("SYSAND_CRED_ALFA"), "{err}");
+}

--- a/sysand/src/cred_env_tests.rs
+++ b/sysand/src/cred_env_tests.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use crate::cred_env::{CredEnvRole, classify};
+
+#[test]
+fn classify_splits_stem_and_role() {
+    for (name, expected) in [
+        (
+            "SYSAND_CRED_TEST",
+            Some(("TEST".to_string(), CredEnvRole::Pattern)),
+        ),
+        (
+            "SYSAND_CRED_TEST_BASIC_USER",
+            Some(("TEST".to_string(), CredEnvRole::BasicUser)),
+        ),
+        (
+            "SYSAND_CRED_TEST_BASIC_PASS",
+            Some(("TEST".to_string(), CredEnvRole::BasicPass)),
+        ),
+        (
+            "SYSAND_CRED_TEST_BEARER_TOKEN",
+            Some(("TEST".to_string(), CredEnvRole::BearerToken)),
+        ),
+        ("SYSAND_DEFAULT_INDEX", None),
+        ("PATH", None),
+    ] {
+        assert_eq!(classify(name), expected, "name: {name}");
+    }
+}
+
+#[test]
+fn classify_matches_a_suffix_only_at_the_end() {
+    // A suffix-looking infix stays part of the pattern stem.
+    assert_eq!(
+        classify("SYSAND_CRED_BEARER_TOKEN_X"),
+        Some(("BEARER_TOKEN_X".to_string(), CredEnvRole::Pattern))
+    );
+}

--- a/sysand/src/credential_store.rs
+++ b/sysand/src/credential_store.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! The CLI's credential store construction, including a deliberate test
+//! seam: CLI integration tests must never touch the real OS keyring
+//! (macOS prompts per test; CI runners have no Secret Service), so in
+//! debug builds the [`TEST_STORE_ENV_VAR`] environment variable can swap
+//! the OS keyring for a plain-file blob backend.
+//!
+//! The test seam is exactly that: a test seam. The file backend stores
+//! the blob (including secrets) in plaintext, which the design forbids for
+//! real use (design/credential-storage.md section 9, "no plaintext
+//! credentials file, ever"). It is compiled into release builds only as a
+//! hard refusal: a release binary that sees the variable errors rather
+//! than silently using the real keyring (which would let a forgotten
+//! variable make tests scribble on a developer's keychain).
+
+use std::io;
+use std::path::PathBuf;
+
+use sysand_core::credential_store::{
+    CredentialStoreError,
+    keyring_store::{BlobBackend, LockedBlobStore, OsKeyringBackend, default_lock_path},
+};
+
+/// Debug-build-only override selecting the credential store backend for
+/// tests: a path selects a plain-file blob backend (lock file at
+/// `<path>.lock`), the special value `:absent:` simulates a host with no
+/// keyring backend. Not a supported production path.
+pub const TEST_STORE_ENV_VAR: &str = "SYSAND_TEST_CREDENTIAL_STORE";
+
+/// Special [`TEST_STORE_ENV_VAR`] value simulating an absent keyring
+/// backend.
+pub const TEST_STORE_ABSENT: &str = ":absent:";
+
+/// The blob backend the CLI credential store runs on: the OS keyring in
+/// real use, a plain file or a simulated-absent backend under the test
+/// seam.
+#[derive(Debug)]
+pub enum CliBlobBackend {
+    Keyring(OsKeyringBackend),
+    /// Test seam: the blob as a plain JSON file at the given path.
+    File(PathBuf),
+    /// Test seam: every access reports an absent keyring backend.
+    Absent,
+}
+
+impl BlobBackend for CliBlobBackend {
+    fn read(&self) -> Result<Option<String>, CredentialStoreError> {
+        match self {
+            CliBlobBackend::Keyring(keyring) => keyring.read(),
+            CliBlobBackend::File(path) => match std::fs::read_to_string(path) {
+                Ok(raw) => Ok(Some(raw)),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+                Err(err) => Err(CredentialStoreError::Lock(err)),
+            },
+            CliBlobBackend::Absent => Err(absent()),
+        }
+    }
+
+    fn write(&self, raw: &str) -> Result<(), CredentialStoreError> {
+        match self {
+            CliBlobBackend::Keyring(keyring) => keyring.write(raw),
+            CliBlobBackend::File(path) => {
+                std::fs::write(path, raw).map_err(CredentialStoreError::Lock)
+            }
+            CliBlobBackend::Absent => Err(absent()),
+        }
+    }
+
+    fn delete(&self) -> Result<(), CredentialStoreError> {
+        match self {
+            CliBlobBackend::Keyring(keyring) => keyring.delete(),
+            CliBlobBackend::File(path) => match std::fs::remove_file(path) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(CredentialStoreError::Lock(err)),
+            },
+            CliBlobBackend::Absent => Err(absent()),
+        }
+    }
+}
+
+fn absent() -> CredentialStoreError {
+    CredentialStoreError::BackendAbsent {
+        source: "simulated absent backend (test seam)".into(),
+    }
+}
+
+/// The credential store type every CLI command (and the lazy auth policy)
+/// uses.
+pub type CliCredentialStore = LockedBlobStore<CliBlobBackend>;
+
+/// Open the CLI credential store: the OS keyring, unless the debug-only
+/// test seam ([`TEST_STORE_ENV_VAR`]) selects a file-backed or
+/// simulated-absent store.
+pub fn open_cli_credential_store() -> Result<CliCredentialStore, CredentialStoreError> {
+    if let Ok(value) = std::env::var(TEST_STORE_ENV_VAR) {
+        if !cfg!(debug_assertions) {
+            // Fail loudly: silently falling through to the OS keyring
+            // would defeat the seam's whole purpose.
+            return Err(CredentialStoreError::Lock(io::Error::other(format!(
+                "{TEST_STORE_ENV_VAR} is set, but this build does not support the \
+                 test credential store"
+            ))));
+        }
+        if value == TEST_STORE_ABSENT {
+            // The lock file must not land on the real per-user path
+            // either; keep everything test-scoped.
+            let lock_path = std::env::temp_dir()
+                .join(format!("sysand-test-absent-{}.lock", std::process::id()));
+            return Ok(LockedBlobStore::new(CliBlobBackend::Absent, lock_path));
+        }
+        let lock_path = PathBuf::from(format!("{value}.lock"));
+        return Ok(LockedBlobStore::new(
+            CliBlobBackend::File(PathBuf::from(value)),
+            lock_path,
+        ));
+    }
+    Ok(LockedBlobStore::new(
+        CliBlobBackend::Keyring(OsKeyringBackend),
+        default_lock_path()?,
+    ))
+}

--- a/sysand/src/credential_store.rs
+++ b/sysand/src/credential_store.rs
@@ -134,7 +134,7 @@ pub fn open_cli_credential_store() -> Result<CliCredentialStore, CredentialStore
     if std::env::var_os(TEST_STORE_ENV_VAR).is_some() {
         return Err(CredentialStoreError::BackendDenied {
             source: format!(
-                "{TEST_STORE_ENV_VAR} is set, but this build does not support the \
+                "{TEST_STORE_ENV_VAR} is set, but this build does not support the\n\
                  test credential store"
             )
             .into(),

--- a/sysand/src/credential_store.rs
+++ b/sysand/src/credential_store.rs
@@ -9,8 +9,8 @@
 //!
 //! The test seam is exactly that: a test seam. The file backend stores
 //! the blob (including secrets) in plaintext, which the design forbids for
-//! real use (design/credential-storage.md section 9, "no plaintext
-//! credentials file, ever"). It is compiled into release builds only as a
+//! real use (design/credential-storage.md: "no plaintext credentials
+//! file, ever"). It is compiled into release builds only as a
 //! hard refusal: a release binary that sees the variable errors rather
 //! than silently using the real keyring (which would let a forgotten
 //! variable make tests scribble on a developer's keychain).

--- a/sysand/src/credential_store.rs
+++ b/sysand/src/credential_store.rs
@@ -16,7 +16,6 @@
 //! variable make tests scribble on a developer's keychain).
 
 use std::io;
-use std::path::PathBuf;
 
 use camino::Utf8PathBuf;
 use sysand_core::project::utils::FsIoError;
@@ -47,7 +46,7 @@ pub enum CliBlobBackend {
     Keyring(OsKeyringBackend),
     /// Test seam: the blob as a plain JSON file at the given path.
     #[cfg(debug_assertions)]
-    File(PathBuf),
+    File(Utf8PathBuf),
     /// Test seam: every access reports an absent keyring backend.
     #[cfg(debug_assertions)]
     Absent,
@@ -61,7 +60,7 @@ impl BlobBackend for CliBlobBackend {
             CliBlobBackend::File(path) => match std::fs::read_to_string(path) {
                 Ok(raw) => Ok(Some(raw)),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
-                Err(err) => Err(FsIoError::ReadFile(utf8_lossy(path), err).into()),
+                Err(err) => Err(FsIoError::ReadFile(path.clone(), err).into()),
             },
             #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
@@ -73,7 +72,7 @@ impl BlobBackend for CliBlobBackend {
             CliBlobBackend::Keyring(keyring) => keyring.write(raw),
             #[cfg(debug_assertions)]
             CliBlobBackend::File(path) => std::fs::write(path, raw)
-                .map_err(|err| FsIoError::WriteFile(utf8_lossy(path), err).into()),
+                .map_err(|err| FsIoError::WriteFile(path.clone(), err).into()),
             #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
         }
@@ -86,7 +85,7 @@ impl BlobBackend for CliBlobBackend {
             CliBlobBackend::File(path) => match std::fs::remove_file(path) {
                 Ok(()) => Ok(()),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-                Err(err) => Err(FsIoError::RmFile(utf8_lossy(path), err).into()),
+                Err(err) => Err(FsIoError::RmFile(path.clone(), err).into()),
             },
             #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
@@ -116,13 +115,14 @@ pub fn open_cli_credential_store() -> Result<CliCredentialStore, CredentialStore
         if value == TEST_STORE_ABSENT {
             // The lock file must not land on the real per-user path
             // either; keep everything test-scoped.
-            let lock_path = std::env::temp_dir()
+            let lock_path = Utf8PathBuf::from_path_buf(std::env::temp_dir())
+                .unwrap_or_else(|p| Utf8PathBuf::from(p.display().to_string()))
                 .join(format!("sysand-test-absent-{}.lock", std::process::id()));
             return Ok(LockedBlobStore::new(CliBlobBackend::Absent, lock_path));
         }
-        let lock_path = PathBuf::from(format!("{value}.lock"));
+        let lock_path = Utf8PathBuf::from(format!("{value}.lock"));
         return Ok(LockedBlobStore::new(
-            CliBlobBackend::File(PathBuf::from(value)),
+            CliBlobBackend::File(Utf8PathBuf::from(value)),
             lock_path,
         ));
     }
@@ -144,9 +144,4 @@ pub fn open_cli_credential_store() -> Result<CliCredentialStore, CredentialStore
         CliBlobBackend::Keyring(OsKeyringBackend),
         default_lock_path()?,
     ))
-}
-
-/// Render a path for error context; lossy display is fine for messages.
-fn utf8_lossy(path: &std::path::Path) -> Utf8PathBuf {
-    Utf8PathBuf::from(path.display().to_string())
 }

--- a/sysand/src/credential_store.rs
+++ b/sysand/src/credential_store.rs
@@ -18,6 +18,9 @@
 use std::io;
 use std::path::PathBuf;
 
+use camino::Utf8PathBuf;
+use sysand_core::project::utils::FsIoError;
+
 use sysand_core::credential_store::{
     CredentialStoreError,
     keyring_store::{BlobBackend, LockedBlobStore, OsKeyringBackend, default_lock_path},
@@ -58,7 +61,7 @@ impl BlobBackend for CliBlobBackend {
             CliBlobBackend::File(path) => match std::fs::read_to_string(path) {
                 Ok(raw) => Ok(Some(raw)),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
-                Err(err) => Err(CredentialStoreError::Lock(err)),
+                Err(err) => Err(FsIoError::ReadFile(utf8_lossy(path), err).into()),
             },
             #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
@@ -69,9 +72,8 @@ impl BlobBackend for CliBlobBackend {
         match self {
             CliBlobBackend::Keyring(keyring) => keyring.write(raw),
             #[cfg(debug_assertions)]
-            CliBlobBackend::File(path) => {
-                std::fs::write(path, raw).map_err(CredentialStoreError::Lock)
-            }
+            CliBlobBackend::File(path) => std::fs::write(path, raw)
+                .map_err(|err| FsIoError::WriteFile(utf8_lossy(path), err).into()),
             #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
         }
@@ -84,7 +86,7 @@ impl BlobBackend for CliBlobBackend {
             CliBlobBackend::File(path) => match std::fs::remove_file(path) {
                 Ok(()) => Ok(()),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-                Err(err) => Err(CredentialStoreError::Lock(err)),
+                Err(err) => Err(FsIoError::RmFile(utf8_lossy(path), err).into()),
             },
             #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
@@ -130,13 +132,21 @@ pub fn open_cli_credential_store() -> Result<CliCredentialStore, CredentialStore
     // keychain).
     #[cfg(not(debug_assertions))]
     if std::env::var_os(TEST_STORE_ENV_VAR).is_some() {
-        return Err(CredentialStoreError::Lock(io::Error::other(format!(
-            "{TEST_STORE_ENV_VAR} is set, but this build does not support the \
-             test credential store"
-        ))));
+        return Err(CredentialStoreError::BackendDenied {
+            source: format!(
+                "{TEST_STORE_ENV_VAR} is set, but this build does not support the \
+                 test credential store"
+            )
+            .into(),
+        });
     }
     Ok(LockedBlobStore::new(
         CliBlobBackend::Keyring(OsKeyringBackend),
         default_lock_path()?,
     ))
+}
+
+/// Render a path for error context; lossy display is fine for messages.
+fn utf8_lossy(path: &std::path::Path) -> Utf8PathBuf {
+    Utf8PathBuf::from(path.display().to_string())
 }

--- a/sysand/src/credential_store.rs
+++ b/sysand/src/credential_store.rs
@@ -31,17 +31,22 @@ pub const TEST_STORE_ENV_VAR: &str = "SYSAND_TEST_CREDENTIAL_STORE";
 
 /// Special [`TEST_STORE_ENV_VAR`] value simulating an absent keyring
 /// backend.
+#[cfg(debug_assertions)]
 pub const TEST_STORE_ABSENT: &str = ":absent:";
 
 /// The blob backend the CLI credential store runs on: the OS keyring in
 /// real use, a plain file or a simulated-absent backend under the test
-/// seam.
+/// seam. The plaintext-writing test variants are compiled only in debug
+/// builds, so the cleartext path is physically absent from release
+/// binaries (not merely refused at runtime).
 #[derive(Debug)]
 pub enum CliBlobBackend {
     Keyring(OsKeyringBackend),
     /// Test seam: the blob as a plain JSON file at the given path.
+    #[cfg(debug_assertions)]
     File(PathBuf),
     /// Test seam: every access reports an absent keyring backend.
+    #[cfg(debug_assertions)]
     Absent,
 }
 
@@ -49,11 +54,13 @@ impl BlobBackend for CliBlobBackend {
     fn read(&self) -> Result<Option<String>, CredentialStoreError> {
         match self {
             CliBlobBackend::Keyring(keyring) => keyring.read(),
+            #[cfg(debug_assertions)]
             CliBlobBackend::File(path) => match std::fs::read_to_string(path) {
                 Ok(raw) => Ok(Some(raw)),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
                 Err(err) => Err(CredentialStoreError::Lock(err)),
             },
+            #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
         }
     }
@@ -61,9 +68,11 @@ impl BlobBackend for CliBlobBackend {
     fn write(&self, raw: &str) -> Result<(), CredentialStoreError> {
         match self {
             CliBlobBackend::Keyring(keyring) => keyring.write(raw),
+            #[cfg(debug_assertions)]
             CliBlobBackend::File(path) => {
                 std::fs::write(path, raw).map_err(CredentialStoreError::Lock)
             }
+            #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
         }
     }
@@ -71,16 +80,19 @@ impl BlobBackend for CliBlobBackend {
     fn delete(&self) -> Result<(), CredentialStoreError> {
         match self {
             CliBlobBackend::Keyring(keyring) => keyring.delete(),
+            #[cfg(debug_assertions)]
             CliBlobBackend::File(path) => match std::fs::remove_file(path) {
                 Ok(()) => Ok(()),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
                 Err(err) => Err(CredentialStoreError::Lock(err)),
             },
+            #[cfg(debug_assertions)]
             CliBlobBackend::Absent => Err(absent()),
         }
     }
 }
 
+#[cfg(debug_assertions)]
 fn absent() -> CredentialStoreError {
     CredentialStoreError::BackendAbsent {
         source: "simulated absent backend (test seam)".into(),
@@ -95,15 +107,10 @@ pub type CliCredentialStore = LockedBlobStore<CliBlobBackend>;
 /// test seam ([`TEST_STORE_ENV_VAR`]) selects a file-backed or
 /// simulated-absent store.
 pub fn open_cli_credential_store() -> Result<CliCredentialStore, CredentialStoreError> {
+    // Debug builds honor the test seam; the file/absent backends only
+    // exist here (they are `#[cfg(debug_assertions)]`).
+    #[cfg(debug_assertions)]
     if let Ok(value) = std::env::var(TEST_STORE_ENV_VAR) {
-        if !cfg!(debug_assertions) {
-            // Fail loudly: silently falling through to the OS keyring
-            // would defeat the seam's whole purpose.
-            return Err(CredentialStoreError::Lock(io::Error::other(format!(
-                "{TEST_STORE_ENV_VAR} is set, but this build does not support the \
-                 test credential store"
-            ))));
-        }
         if value == TEST_STORE_ABSENT {
             // The lock file must not land on the real per-user path
             // either; keep everything test-scoped.
@@ -116,6 +123,17 @@ pub fn open_cli_credential_store() -> Result<CliCredentialStore, CredentialStore
             CliBlobBackend::File(PathBuf::from(value)),
             lock_path,
         ));
+    }
+    // Release builds have no test backend at all, so seeing the variable
+    // must fail loudly rather than silently use the real keyring (which
+    // would let a forgotten variable make tests scribble on a developer's
+    // keychain).
+    #[cfg(not(debug_assertions))]
+    if std::env::var_os(TEST_STORE_ENV_VAR).is_some() {
+        return Err(CredentialStoreError::Lock(io::Error::other(format!(
+            "{TEST_STORE_ENV_VAR} is set, but this build does not support the \
+             test credential store"
+        ))));
     }
     Ok(LockedBlobStore::new(
         CliBlobBackend::Keyring(OsKeyringBackend),

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -209,9 +209,10 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     // must work even when `SYSAND_CRED_*` variables are malformed (the
     // eager env-policy build below fails hard on those, and `auth status`
     // exists to diagnose them), so they dispatch before that policy is
-    // built. `login` still gets the shared client and runtime: its
-    // discovery fetch is deliberately unauthenticated (no credential
-    // exists for the index yet).
+    // built. `login` still gets the shared client and runtime: core
+    // handles its discovery fetch itself (an unauthenticated baseline
+    // with a forced-bearer retry carrying the just-entered secret), so
+    // no ambient auth policy is needed.
     let command = match args.command {
         Command::Auth { command } => {
             return match command {
@@ -221,15 +222,10 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 AuthCommand::Login {
                     index_url,
                     token_stdin,
-                    no_validation,
                     default_index,
                 } => command_auth_login(
                     index_url,
                     token_stdin,
-                    // Core keeps `Option<bool>` (None = validate) so the
-                    // bindings can expose a clean optional keyword; the
-                    // CLI flag follows the house `--no-<thing>` style.
-                    if no_validation { Some(false) } else { None },
                     &default_index,
                     &config,
                     &client,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -243,8 +243,8 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     // otherwise read as the pattern of a nonsense `BASIC_PASS` group.
     if let Some(name) = missing_label.first() {
         anyhow::bail!(
-            "{name} has no label; env credentials need one, as in SYSAND_CRED_MYINDEX \
-             with SYSAND_CRED_MYINDEX_BASIC_USER/SYSAND_CRED_MYINDEX_BASIC_PASS or \
+            "{name} has no label; env credentials need one, as in SYSAND_CRED_MYINDEX\n\
+             with SYSAND_CRED_MYINDEX_BASIC_USER/SYSAND_CRED_MYINDEX_BASIC_PASS or\n\
              SYSAND_CRED_MYINDEX_BEARER_TOKEN"
         );
     }
@@ -274,7 +274,9 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             // misnamed variable can put a secret in any position.
             (Some(_), None, None, None) => {
                 anyhow::bail!(
-                    "SYSAND_CRED_{k} has no matching authentication scheme, please specify SYSAND_CRED_{k}_BASIC_USER/SYSAND_CRED_{k}_BASIC_PASS or SYSAND_CRED_{k}_BEARER_TOKEN"
+                    "SYSAND_CRED_{k} has no matching authentication scheme, please specify\n\
+                     SYSAND_CRED_{k}_BASIC_USER/SYSAND_CRED_{k}_BASIC_PASS or\n\
+                     SYSAND_CRED_{k}_BEARER_TOKEN"
                 );
             }
             (Some(pattern), maybe_username, maybe_password, maybe_token) => {
@@ -319,7 +321,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         Ok(store) => CliAuthPolicy::new(env_auth_policy, store),
         Err(err) => {
             log::warn!(
-                "credential store unavailable: {err}; \
+                "credential store unavailable: {err};\n\
                  continuing with `SYSAND_CRED_*` credentials only"
             );
             CliAuthPolicy::without_store(env_auth_policy)

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -29,7 +29,6 @@ use sysand_core::{
         local_fs::{get_config, load_configs},
     },
     context::ProjectContext,
-    credential_store::keyring_store::KeyringCredentialStore,
     discover::{discover_project, discover_workspace},
     env::{DEFAULT_ENV_NAME, local_directory::LocalDirectoryEnvironment},
     index::RemoveTarget,
@@ -52,7 +51,7 @@ use crate::{
     cli::{Args, AuthCommand, Command, ExpCommand},
     commands::{
         add::{ExpAddArgs, command_add, exp_command_add},
-        auth::{command_auth_logout, command_auth_status},
+        auth::{command_auth_login, command_auth_logout, command_auth_status},
         build::{command_build_for_project, command_build_for_workspace},
         env::{
             command_env, command_env_install, command_env_install_path, command_env_list,
@@ -77,10 +76,11 @@ pub const DEFAULT_INDEX_URL: &str = "https://sysand.com";
 /// The CLI's composed authentication policy: eager `SYSAND_CRED_*`
 /// credentials first, then lazily read stored logins from the OS keyring
 /// (design/credential-storage.md, section 9).
-pub type CliAuthPolicy = StandardLazyHTTPAuthentication<KeyringCredentialStore>;
+pub type CliAuthPolicy = StandardLazyHTTPAuthentication<credential_store::CliCredentialStore>;
 
 pub mod cli;
 pub mod commands;
+pub mod credential_store;
 pub mod env_vars;
 pub mod logger;
 pub mod style;
@@ -193,24 +193,6 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
 
     config.merge(auto_config);
 
-    // The `auth` commands manage credentials rather than use them: they
-    // must work even when `SYSAND_CRED_*` variables are malformed (the
-    // eager env-policy build below fails hard on those, and `auth status`
-    // exists to diagnose them) and they need no HTTP client or runtime,
-    // so they dispatch before that machinery is built.
-    let command = match args.command {
-        Command::Auth { command } => {
-            return match command {
-                AuthCommand::Status => command_auth_status(),
-                AuthCommand::Logout {
-                    index_url,
-                    default_index,
-                } => command_auth_logout(index_url, &default_index, &config),
-            };
-        }
-        command => command,
-    };
-
     let client = create_reqwest_client()?;
 
     let runtime = Arc::new(
@@ -222,6 +204,38 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     );
 
     let _runtime_keep_alive = runtime.clone();
+
+    // The `auth` commands manage credentials rather than use them: they
+    // must work even when `SYSAND_CRED_*` variables are malformed (the
+    // eager env-policy build below fails hard on those, and `auth status`
+    // exists to diagnose them), so they dispatch before that policy is
+    // built. `login` still gets the shared client and runtime: its
+    // discovery fetch is deliberately unauthenticated (no credential
+    // exists for the index yet).
+    let command = match args.command {
+        Command::Auth { command } => {
+            return match command {
+                AuthCommand::Status => command_auth_status(),
+                AuthCommand::Login {
+                    index_url,
+                    token_stdin,
+                    default_index,
+                } => command_auth_login(
+                    index_url,
+                    token_stdin,
+                    &default_index,
+                    &config,
+                    &client,
+                    runtime,
+                ),
+                AuthCommand::Logout {
+                    index_url,
+                    default_index,
+                } => command_auth_logout(index_url, &default_index, &config),
+            };
+        }
+        command => command,
+    };
 
     // FIXME: This is a temporary implementation to provide credentials until
     //        https://github.com/sensmetry/sysand/pull/157
@@ -309,7 +323,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     // Compose the eager env policy with the lazily read OS keyring store.
     // Opening the store only resolves a lock file path; no keychain access
     // happens until a request actually needs a stored credential.
-    let auth_policy = Arc::new(match KeyringCredentialStore::open_default() {
+    let auth_policy = Arc::new(match credential_store::open_cli_credential_store() {
         Ok(store) => CliAuthPolicy::new(env_auth_policy, store),
         Err(err) => {
             log::warn!(

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -49,9 +49,10 @@ use sysand_core::{
 use url::Url;
 
 use crate::{
-    cli::{Args, Command, ExpCommand},
+    cli::{Args, AuthCommand, Command, ExpCommand},
     commands::{
         add::{ExpAddArgs, command_add, exp_command_add},
+        auth::{command_auth_logout, command_auth_status},
         build::{command_build_for_project, command_build_for_workspace},
         env::{
             command_env, command_env_install, command_env_install_path, command_env_list,
@@ -192,6 +193,24 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
 
     config.merge(auto_config);
 
+    // The `auth` commands manage credentials rather than use them: they
+    // must work even when `SYSAND_CRED_*` variables are malformed (the
+    // eager env-policy build below fails hard on those, and `auth status`
+    // exists to diagnose them) and they need no HTTP client or runtime,
+    // so they dispatch before that machinery is built.
+    let command = match args.command {
+        Command::Auth { command } => {
+            return match command {
+                AuthCommand::Status => command_auth_status(),
+                AuthCommand::Logout {
+                    index_url,
+                    default_index,
+                } => command_auth_logout(index_url, &default_index, &config),
+            };
+        }
+        command => command,
+    };
+
     let client = create_reqwest_client()?;
 
     let runtime = Arc::new(
@@ -301,7 +320,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         }
     });
 
-    match args.command {
+    match command {
         Command::Init {
             path,
             name,
@@ -475,6 +494,9 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 auth_policy,
                 ctx.current_workspace.as_ref(),
             )
+        }
+        Command::Auth { .. } => {
+            unreachable!("`auth` is dispatched before the auth policy is built")
         }
         Command::PrintRoot => command_print_root(ctx.current_directory),
         Command::Info {

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -206,11 +206,12 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
 
     let _runtime_keep_alive = runtime.clone();
 
-    // The `auth` commands manage credentials rather than use them: they
-    // must work even when `SYSAND_CRED_*` variables are malformed (the
-    // eager env-policy build below fails hard on those, and `auth status`
-    // exists to diagnose them), so they dispatch before that policy is
-    // built. `login` still gets the shared client and runtime: core
+    // The `auth` commands manage credentials rather than use them, so
+    // they dispatch before the eager env-policy build below. `status`
+    // applies the same strict `SYSAND_CRED_*` validation on its own;
+    // `login`, `logout`, and `whoami` must keep working even when those
+    // variables are malformed. `login` still gets the shared client and
+    // runtime: core
     // handles its discovery fetch itself (an unauthenticated baseline
     // with a forced-bearer retry carrying the just-entered secret), so
     // no ambient auth policy is needed.
@@ -231,86 +232,23 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         command => command,
     };
 
-    let cred_env::CredEnvGroups {
-        patterns: auth_patterns,
-        basic_users: basic_auth_users,
-        basic_passwords: basic_auth_passwords,
-        bearer_tokens: bearer_auth_tokens,
-        missing_label,
-    } = cred_env::collect_env_groups();
-
-    // Reject label-less names up front: `SYSAND_CRED_BASIC_PASS` would
-    // otherwise read as the pattern of a nonsense `BASIC_PASS` group.
-    if let Some(name) = missing_label.first() {
-        anyhow::bail!(
-            "{name} has no label; env credentials need one, as in SYSAND_CRED_MYINDEX\n\
-             with SYSAND_CRED_MYINDEX_BASIC_USER/SYSAND_CRED_MYINDEX_BASIC_PASS or\n\
-             SYSAND_CRED_MYINDEX_BEARER_TOKEN"
-        );
-    }
-
-    let mut basic_auth_pattern_names = HashSet::new();
-    for x in [
-        &auth_patterns,
-        &basic_auth_users,
-        &basic_auth_passwords,
-        &bearer_auth_tokens,
-    ] {
-        for k in x.keys() {
-            basic_auth_pattern_names.insert(k);
-        }
-    }
-
+    // Validation guarantees every group has a pattern and at least one
+    // complete scheme, so iterating the patterns covers every group.
+    let groups = cred_env::validated_env_groups()?;
     let mut auths_builder: StandardHTTPAuthenticationBuilder =
         StandardHTTPAuthenticationBuilder::new();
-    for k in basic_auth_pattern_names {
-        match (
-            auth_patterns.get(k),
-            basic_auth_users.get(k),
-            basic_auth_passwords.get(k),
-            bearer_auth_tokens.get(k),
-        ) {
-            // Never interpolate variable values into these messages: a
-            // misnamed variable can put a secret in any position.
-            (Some(_), None, None, None) => {
-                anyhow::bail!(
-                    "SYSAND_CRED_{k} has no matching authentication scheme, please specify\n\
-                     SYSAND_CRED_{k}_BASIC_USER/SYSAND_CRED_{k}_BASIC_PASS or\n\
-                     SYSAND_CRED_{k}_BEARER_TOKEN"
-                );
-            }
-            (Some(pattern), maybe_username, maybe_password, maybe_token) => {
-                let mut matched_schemes = 0;
-
-                match (maybe_username, maybe_password) {
-                    (Some(username), Some(password)) => {
-                        matched_schemes += 1;
-                        log::debug!("auth: env vars specify HTTP basic for URL glob `{pattern}`");
-                        auths_builder.add_basic_auth(pattern, username, password)
-                    }
-                    (None, None) => {}
-                    (_, _) => {
-                        anyhow::bail!(
-                            "please specify both (or neither) of SYSAND_CRED_{k}_BASIC_USER and SYSAND_CRED_{k}_BASIC_PASS"
-                        );
-                    }
-                }
-
-                if let Some(token) = maybe_token {
-                    matched_schemes += 1;
-                    log::debug!("auth: env vars specify bearer token for URL glob `{pattern}`");
-                    // The label lets a publish auth failure name the
-                    // `SYSAND_CRED_<LABEL>` variable to fix.
-                    auths_builder.add_bearer_auth(pattern, token, k);
-                }
-
-                if matched_schemes > 1 {
-                    log::warn!("SYSAND_CRED_{k} has multiple authentication schemes!");
-                }
-            }
-            (None, _, _, _) => {
-                anyhow::bail!("please specify URL pattern SYSAND_CRED_{k} for credential");
-            }
+    for (k, pattern) in &groups.patterns {
+        if let (Some(username), Some(password)) =
+            (groups.basic_users.get(k), groups.basic_passwords.get(k))
+        {
+            log::debug!("auth: env vars specify HTTP basic for URL glob `{pattern}`");
+            auths_builder.add_basic_auth(pattern, username, password);
+        }
+        if let Some(token) = groups.bearer_tokens.get(k) {
+            log::debug!("auth: env vars specify bearer token for URL glob `{pattern}`");
+            // The label lets a publish auth failure name the
+            // `SYSAND_CRED_<LABEL>` variable to fix.
+            auths_builder.add_bearer_auth(pattern, token, k);
         }
     }
     let env_auth_policy = auths_builder.build()?;

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -236,7 +236,18 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         basic_users: basic_auth_users,
         basic_passwords: basic_auth_passwords,
         bearer_tokens: bearer_auth_tokens,
+        missing_label,
     } = cred_env::collect_env_groups();
+
+    // Reject label-less names up front: `SYSAND_CRED_BASIC_PASS` would
+    // otherwise read as the pattern of a nonsense `BASIC_PASS` group.
+    if let Some(name) = missing_label.first() {
+        anyhow::bail!(
+            "{name} has no label; env credentials need one, as in SYSAND_CRED_MYINDEX \
+             with SYSAND_CRED_MYINDEX_BASIC_USER/SYSAND_CRED_MYINDEX_BASIC_PASS or \
+             SYSAND_CRED_MYINDEX_BEARER_TOKEN"
+        );
+    }
 
     let mut basic_auth_pattern_names = HashSet::new();
     for x in [
@@ -259,9 +270,11 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             basic_auth_passwords.get(k),
             bearer_auth_tokens.get(k),
         ) {
-            (Some(pattern), None, None, None) => {
+            // Never interpolate variable values into these messages: a
+            // misnamed variable can put a secret in any position.
+            (Some(_), None, None, None) => {
                 anyhow::bail!(
-                    "SYSAND_CRED_{k} (`{pattern}`) has no matching authentication scheme, please specify SYSAND_CRED_{k}_BASIC_USER/SYSAND_CRED_{k}_BASIC_PASS or SYSAND_CRED_{k}_BEARER_TOKEN"
+                    "SYSAND_CRED_{k} has no matching authentication scheme, please specify SYSAND_CRED_{k}_BASIC_USER/SYSAND_CRED_{k}_BASIC_PASS or SYSAND_CRED_{k}_BEARER_TOKEN"
                 );
             }
             (Some(pattern), maybe_username, maybe_password, maybe_token) => {
@@ -286,13 +299,11 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     log::debug!("auth: env vars specify bearer token for URL glob `{pattern}`");
                     // The label lets a publish auth failure name the
                     // `SYSAND_CRED_<LABEL>` variable to fix.
-                    auths_builder.add_bearer_auth_labeled(pattern, token, k);
+                    auths_builder.add_bearer_auth(pattern, token, k);
                 }
 
                 if matched_schemes > 1 {
-                    log::warn!(
-                        "SYSAND_CRED_{k} (`{pattern}`) has multiple authentication schemes!"
-                    );
+                    log::warn!("SYSAND_CRED_{k} has multiple authentication schemes!");
                 }
             }
             (None, _, _, _) => {

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -76,7 +76,7 @@ pub const DEFAULT_INDEX_URL: &str = "https://sysand.com";
 /// The CLI's composed authentication policy: eager `SYSAND_CRED_*`
 /// credentials first, then lazily read stored credentials from the OS keyring
 /// (design/credential-storage.md, section 9).
-pub type CliAuthPolicy = StandardLazyHTTPAuthentication<credential_store::CliCredentialStore>;
+pub type CliAuthPolicy = StandardLazyHTTPAuthentication<credential_store::CliBlobBackend>;
 
 pub mod cli;
 pub mod commands;

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -231,9 +231,6 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         command => command,
     };
 
-    // FIXME: This is a temporary implementation to provide credentials until
-    //        https://github.com/sensmetry/sysand/pull/157
-    //        gets merged.
     let cred_env::CredEnvGroups {
         patterns: auth_patterns,
         basic_users: basic_auth_users,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -74,7 +74,7 @@ use crate::{
 pub const DEFAULT_INDEX_URL: &str = "https://sysand.com";
 
 /// The CLI's composed authentication policy: eager `SYSAND_CRED_*`
-/// credentials first, then lazily read stored logins from the OS keyring
+/// credentials first, then lazily read stored credentials from the OS keyring
 /// (design/credential-storage.md, section 9).
 pub type CliAuthPolicy = StandardLazyHTTPAuthentication<credential_store::CliCredentialStore>;
 

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -219,12 +219,15 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 AuthCommand::Login {
                     index_url,
                     token_stdin,
-                    validation,
+                    no_validation,
                     default_index,
                 } => command_auth_login(
                     index_url,
                     token_stdin,
-                    validation,
+                    // Core keeps `Option<bool>` (None = validate) so the
+                    // bindings can expose a clean optional keyword; the
+                    // CLI flag follows the house `--no-<thing>` style.
+                    if no_validation { Some(false) } else { None },
                     &default_index,
                     &config,
                     &client,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -215,7 +215,9 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     let command = match args.command {
         Command::Auth { command } => {
             return match command {
-                AuthCommand::Status => command_auth_status(),
+                AuthCommand::Status { default_index } => {
+                    command_auth_status(&default_index, &config)
+                }
                 AuthCommand::Login {
                     index_url,
                     token_stdin,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -22,13 +22,14 @@ use fluent_uri::Iri;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use sysand_core::{
-    auth::{HTTPAuthentication, StandardHTTPAuthenticationBuilder},
+    auth::{HTTPAuthentication, StandardHTTPAuthenticationBuilder, StandardLazyHTTPAuthentication},
     commands::lock::DEFAULT_LOCKFILE_NAME,
     config::{
         Config,
         local_fs::{get_config, load_configs},
     },
     context::ProjectContext,
+    credential_store::keyring_store::KeyringCredentialStore,
     discover::{discover_project, discover_workspace},
     env::{DEFAULT_ENV_NAME, local_directory::LocalDirectoryEnvironment},
     index::RemoveTarget,
@@ -71,6 +72,11 @@ use crate::{
 };
 
 pub const DEFAULT_INDEX_URL: &str = "https://sysand.com";
+
+/// The CLI's composed authentication policy: eager `SYSAND_CRED_*`
+/// credentials first, then lazily read stored logins from the OS keyring
+/// (design/credential-storage.md, section 9).
+pub type CliAuthPolicy = StandardLazyHTTPAuthentication<KeyringCredentialStore>;
 
 pub mod cli;
 pub mod commands;
@@ -280,7 +286,20 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             }
         }
     }
-    let auth_policy = Arc::new(auths_builder.build()?);
+    let env_auth_policy = auths_builder.build()?;
+    // Compose the eager env policy with the lazily read OS keyring store.
+    // Opening the store only resolves a lock file path; no keychain access
+    // happens until a request actually needs a stored credential.
+    let auth_policy = Arc::new(match KeyringCredentialStore::open_default() {
+        Ok(store) => CliAuthPolicy::new(env_auth_policy, store),
+        Err(err) => {
+            log::warn!(
+                "credential store unavailable: {err}; \
+                 continuing with `SYSAND_CRED_*` credentials only"
+            );
+            CliAuthPolicy::without_store(env_auth_policy)
+        }
+    });
 
     match args.command {
         Command::Init {

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -74,8 +74,8 @@ use crate::{
 pub const DEFAULT_INDEX_URL: &str = "https://sysand.com";
 
 /// The CLI's composed authentication policy: eager `SYSAND_CRED_*`
-/// credentials first, then lazily read stored credentials from the OS keyring
-/// (design/credential-storage.md, section 9).
+/// credentials first, then lazily read stored credentials from the OS
+/// keyring.
 pub type CliAuthPolicy = StandardLazyHTTPAuthentication<credential_store::CliBlobBackend>;
 
 pub mod cli;

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -51,7 +51,7 @@ use crate::{
     cli::{Args, AuthCommand, Command, ExpCommand},
     commands::{
         add::{ExpAddArgs, command_add, exp_command_add},
-        auth::{command_auth_login, command_auth_logout, command_auth_status},
+        auth::{command_auth_login, command_auth_logout, command_auth_status, command_auth_whoami},
         build::{command_build_for_project, command_build_for_workspace},
         env::{
             command_env, command_env_install, command_env_install_path, command_env_list,
@@ -233,6 +233,10 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                     &client,
                     runtime,
                 ),
+                AuthCommand::Whoami {
+                    index_url,
+                    default_index,
+                } => command_auth_whoami(index_url, &default_index, &config, &client, &runtime),
                 AuthCommand::Logout {
                     index_url,
                     default_index,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -80,6 +80,7 @@ pub type CliAuthPolicy = StandardLazyHTTPAuthentication<credential_store::CliCre
 
 pub mod cli;
 pub mod commands;
+pub(crate) mod cred_env;
 pub mod credential_store;
 pub mod env_vars;
 pub mod logger;
@@ -233,24 +234,12 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     // FIXME: This is a temporary implementation to provide credentials until
     //        https://github.com/sensmetry/sysand/pull/157
     //        gets merged.
-    let mut auth_patterns = HashMap::new();
-    let mut basic_auth_users = HashMap::new();
-    let mut basic_auth_passwords = HashMap::new();
-    let mut bearer_auth_tokens = HashMap::new();
-
-    for (key, value) in std::env::vars() {
-        if let Some(key_rest) = key.strip_prefix("SYSAND_CRED_") {
-            if let Some(key_name) = key_rest.strip_suffix("_BASIC_USER") {
-                basic_auth_users.insert(key_name.to_owned(), value);
-            } else if let Some(key_name) = key_rest.strip_suffix("_BASIC_PASS") {
-                basic_auth_passwords.insert(key_name.to_owned(), value);
-            } else if let Some(key_name) = key_rest.strip_suffix("_BEARER_TOKEN") {
-                bearer_auth_tokens.insert(key_name.to_owned(), value);
-            } else {
-                auth_patterns.insert(key_rest.to_owned(), value);
-            }
-        }
-    }
+    let cred_env::CredEnvGroups {
+        patterns: auth_patterns,
+        basic_users: basic_auth_users,
+        basic_passwords: basic_auth_passwords,
+        bearer_tokens: bearer_auth_tokens,
+    } = cred_env::collect_env_groups();
 
     let mut basic_auth_pattern_names = HashSet::new();
     for x in [

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -216,29 +216,15 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
     let command = match args.command {
         Command::Auth { command } => {
             return match command {
-                AuthCommand::Status { default_index } => {
-                    command_auth_status(&default_index, &config)
-                }
+                AuthCommand::Status => command_auth_status(&config),
                 AuthCommand::Login {
                     index_url,
                     token_stdin,
-                    default_index,
-                } => command_auth_login(
-                    index_url,
-                    token_stdin,
-                    &default_index,
-                    &config,
-                    &client,
-                    runtime,
-                ),
-                AuthCommand::Whoami {
-                    index_url,
-                    default_index,
-                } => command_auth_whoami(index_url, &default_index, &config, &client, &runtime),
-                AuthCommand::Logout {
-                    index_url,
-                    default_index,
-                } => command_auth_logout(index_url, &default_index, &config),
+                } => command_auth_login(index_url, token_stdin, &config, &client, runtime),
+                AuthCommand::Whoami { index_url } => {
+                    command_auth_whoami(index_url, &config, &client, &runtime)
+                }
+                AuthCommand::Logout { index_url } => command_auth_logout(index_url, &config),
             };
         }
         command => command,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -219,10 +219,12 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 AuthCommand::Login {
                     index_url,
                     token_stdin,
+                    validation,
                     default_index,
                 } => command_auth_login(
                     index_url,
                     token_stdin,
+                    validation,
                     &default_index,
                     &config,
                     &client,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -307,7 +307,9 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 if let Some(token) = maybe_token {
                     matched_schemes += 1;
                     log::debug!("auth: env vars specify bearer token for URL glob `{pattern}`");
-                    auths_builder.add_bearer_auth(pattern, token);
+                    // The label lets a publish auth failure name the
+                    // `SYSAND_CRED_<LABEL>` variable to fix.
+                    auths_builder.add_bearer_auth_labeled(pattern, token, k);
                 }
 
                 if matched_schemes > 1 {

--- a/sysand/src/style.rs
+++ b/sysand/src/style.rs
@@ -15,6 +15,7 @@ pub const NOTE: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
 pub const GOOD: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
 pub const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
 pub const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+pub const DIM: Style = Style::new().effects(Effects::DIMMED);
 
 pub const STYLING: Styles = Styles::styled()
     .header(HEADER)
@@ -36,4 +37,5 @@ pub const CONFIG: Config = Config {
     good: GOOD,
     valid: VALID,
     invalid: INVALID,
+    dim: DIM,
 };

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -497,6 +497,69 @@ fn auth_login_validates_the_read_surface_of_a_private_index() -> TestResult {
 }
 
 #[test]
+fn auth_login_status_logout_round_trip_a_template_target() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    let mut server = mockito::Server::new();
+    let template = format!("{}/repo/files/{{path}}/raw?ref=index", server.url());
+    let anchor_glob = format!("{}/repo/files/**", server.url());
+    let ref_query = mockito::Matcher::UrlEncoded("ref".into(), "index".into());
+    let _config = server
+        .mock("GET", "/repo/files/sysand-index-config.json/raw")
+        .match_query(ref_query.clone())
+        .with_status(404)
+        .create();
+    // The GitLab reality: unauthenticated GET answers 404 on a private
+    // repo, the forced bearer retry 200s (the accepted-read path).
+    let _unauth = server
+        .mock("GET", "/repo/files/index.json/raw")
+        .match_query(ref_query.clone())
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(404)
+        .create();
+    let _forced = server
+        .mock("GET", "/repo/files/index.json/raw")
+        .match_query(ref_query)
+        .match_header("authorization", "Bearer template-tok")
+        .with_status(200)
+        .create();
+
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", &template],
+        &env,
+        b"template-tok\n",
+    )?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Logging in to index `{template}`"
+        )))
+        .stdout(predicate::str::contains(&anchor_glob))
+        .stderr(predicate::str::contains("validated (read)"));
+
+    // `status` shows the key in the exact form `logout` accepts.
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(format!("stored  {template}")))
+        .stdout(predicate::str::contains(&anchor_glob));
+
+    let (_t, _c, out) = run_sysand_with(["auth", "logout", &template], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Logging out from index `{template}`"
+        )));
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("No stored index logins."));
+    Ok(())
+}
+
+#[test]
 fn auth_status_shows_identity_learned_by_a_validating_login() -> TestResult {
     let (_store_dir, store_path) = seam_store()?;
     let env = seam_env(&store_path);

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! CLI tests for `sysand auth status` and `sysand auth logout`.
+//!
+//! These tests exercise argument parsing, the default-index resolution
+//! chain, and status rendering of `SYSAND_CRED_*` entries. Logout tests
+//! deliberately fail before any credential store access (parse errors,
+//! non-HTTP(S) targets, ambiguous defaults), so no test requires, or can
+//! ever mutate, a real OS keyring: store behavior itself is covered by the
+//! core tests over `InMemoryCredentialStore`.
+
+use std::fs;
+
+use assert_cmd::prelude::*;
+use indexmap::IndexMap;
+use predicates::prelude::*;
+
+// pub due to https://github.com/rust-lang/rust/issues/46379
+mod common;
+pub use common::*;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+const NOT_HTTP_MESSAGE: &str = "not an HTTP(S) index; nothing to authenticate to";
+const AMBIGUOUS_MESSAGE: &str = "pass an explicit index URL";
+
+fn no_env() -> IndexMap<String, String> {
+    IndexMap::new()
+}
+
+fn default_index_env(value: &str) -> IndexMap<String, String> {
+    let mut env = IndexMap::new();
+    env.insert("SYSAND_DEFAULT_INDEX".to_string(), value.to_string());
+    env
+}
+
+#[test]
+fn auth_requires_a_subcommand() -> TestResult {
+    let (_temp_dir, _cwd, out) = run_sysand(["auth"], None)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage"));
+    Ok(())
+}
+
+#[test]
+fn auth_logout_rejects_an_unparseable_url() -> TestResult {
+    let (_temp_dir, _cwd, out) = run_sysand(["auth", "logout", "not a url"], None)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid index URL"));
+    Ok(())
+}
+
+#[test]
+fn auth_logout_rejects_a_non_http_index() -> TestResult {
+    let (_temp_dir, _cwd, out) = run_sysand(["auth", "logout", "file:///srv/index"], None)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
+    Ok(())
+}
+
+#[test]
+fn auth_logout_with_an_explicit_url_skips_default_index_resolution() -> TestResult {
+    // Two default-index URLs would be ambiguous; the explicit positional
+    // URL must win without consulting the chain at all.
+    let (_temp_dir, _cwd, out) = run_sysand_with(
+        ["auth", "logout", "file:///srv/index"],
+        None,
+        &default_index_env("https://a.example,https://b.example"),
+    )?;
+    out.assert()
+        .failure()
+        .stdout(predicate::str::contains("file:///srv/index"))
+        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE))
+        .stderr(predicate::str::contains(AMBIGUOUS_MESSAGE).not());
+    Ok(())
+}
+
+#[test]
+fn bare_auth_logout_resolves_and_echoes_the_env_default_index() -> TestResult {
+    // A file:// default index exercises the resolution chain and the echo
+    // while failing before any credential store access.
+    let (_temp_dir, _cwd, out) = run_sysand_with(
+        ["auth", "logout"],
+        None,
+        &default_index_env("file:///srv/index"),
+    )?;
+    out.assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "Logging out from index `file:///srv/index`",
+        ))
+        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
+    Ok(())
+}
+
+#[test]
+fn bare_auth_logout_with_multiple_env_defaults_asks_for_an_explicit_url() -> TestResult {
+    let (_temp_dir, _cwd, out) = run_sysand_with(
+        ["auth", "logout"],
+        None,
+        &default_index_env("https://a.example,https://b.example"),
+    )?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("more than one default index"))
+        .stderr(predicate::str::contains(AMBIGUOUS_MESSAGE));
+    Ok(())
+}
+
+#[test]
+fn bare_auth_logout_with_duplicate_env_defaults_is_not_ambiguous() -> TestResult {
+    let (_temp_dir, _cwd, out) = run_sysand_with(
+        ["auth", "logout"],
+        None,
+        &default_index_env("file:///srv/index,file:///srv/index"),
+    )?;
+    out.assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "Logging out from index `file:///srv/index`",
+        ))
+        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
+    Ok(())
+}
+
+#[test]
+fn bare_auth_logout_resolves_a_configured_default_index() -> TestResult {
+    let (_temp_dir, cwd) = new_temp_cwd()?;
+    let config_path = cwd.join("sysand.toml");
+    fs::write(
+        &config_path,
+        "[[index]]\nurl = \"file:///srv/cfg-index\"\ndefault = true\n",
+    )?;
+    let out = run_sysand_in(&cwd, ["auth", "logout"], Some(config_path.as_str()))?;
+    out.assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "Logging out from index `file:///srv/cfg-index`",
+        ))
+        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
+    Ok(())
+}
+
+#[test]
+fn bare_auth_logout_with_two_configured_defaults_asks_for_an_explicit_url() -> TestResult {
+    let (_temp_dir, cwd) = new_temp_cwd()?;
+    let config_path = cwd.join("sysand.toml");
+    fs::write(
+        &config_path,
+        "[[index]]\nurl = \"https://a.example\"\ndefault = true\n\n\
+         [[index]]\nurl = \"https://b.example\"\ndefault = true\n",
+    )?;
+    let out = run_sysand_in(&cwd, ["auth", "logout"], Some(config_path.as_str()))?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("more than one default index"))
+        .stderr(predicate::str::contains(AMBIGUOUS_MESSAGE));
+    Ok(())
+}
+
+#[test]
+fn auth_status_succeeds_without_any_credentials() -> TestResult {
+    let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &no_env())?;
+    out.assert().success().stdout(predicate::str::contains(
+        "No `SYSAND_CRED_*` environment credentials.",
+    ));
+    Ok(())
+}
+
+#[test]
+fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
+    let mut env = IndexMap::new();
+    env.insert(
+        "SYSAND_CRED_TEST".to_string(),
+        "https://example.com/**".to_string(),
+    );
+    env.insert(
+        "SYSAND_CRED_TEST_BEARER_TOKEN".to_string(),
+        "super-secret-token".to_string(),
+    );
+    env.insert(
+        "SYSAND_CRED_BSC".to_string(),
+        "https://basic.example/**".to_string(),
+    );
+    env.insert(
+        "SYSAND_CRED_BSC_BASIC_USER".to_string(),
+        "secret-user-name".to_string(),
+    );
+    env.insert(
+        "SYSAND_CRED_BSC_BASIC_PASS".to_string(),
+        "secret-pass-word".to_string(),
+    );
+    // A pattern without any scheme variable: the eager auth-policy build
+    // rejects this, but `auth status` must stay usable to diagnose it.
+    env.insert(
+        "SYSAND_CRED_LONELY".to_string(),
+        "https://lonely.example/**".to_string(),
+    );
+
+    let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "env     SYSAND_CRED_TEST  https://example.com/**",
+        ))
+        .stdout(predicate::str::contains(
+            "env     SYSAND_CRED_BSC  https://basic.example/**",
+        ))
+        .stdout(predicate::str::contains(
+            "env     SYSAND_CRED_LONELY  https://lonely.example/**",
+        ))
+        .stdout(predicate::str::contains("super-secret-token").not())
+        .stdout(predicate::str::contains("secret-user-name").not())
+        .stdout(predicate::str::contains("secret-pass-word").not());
+    Ok(())
+}

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -407,39 +407,44 @@ fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
     let env = seam_env(&store_path);
 
     let mut server = mockito::Server::new();
+    // A second server stands in for the disjoint API host, so the
+    // advertised-api whoami probe has somewhere real to go.
+    let mut api_server = mockito::Server::new();
+    let api_root = format!("{}/base/", api_server.url());
     let _mock = server
         .mock("GET", "/sysand-index-config.json")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"api_root": "https://api.example.com/base/"}"#)
+        .with_body(format!(r#"{{"api_root": "{api_root}"}}"#))
+        .create();
+    let _index = server.mock("GET", "/index.json").with_status(200).create();
+    let _whoami = api_server
+        .mock("GET", "/base/v1/whoami")
+        .match_header("authorization", "Bearer tok")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(WHOAMI_BODY)
         .create();
     let root = format!("{}/", server.url());
 
-    // `--no-validation`: the advertised api_root is a foreign host
-    // this test must not probe.
     let (_t, _c, out) = run_sysand_stdin(
-        [
-            "auth",
-            "login",
-            "--token-stdin",
-            "--no-validation",
-            &server.url(),
-        ],
+        ["auth", "login", "--token-stdin", &server.url()],
         &env,
         b"tok\n",
     )?;
     out.assert()
         .success()
         .stdout(predicate::str::contains(format!("{root}**")))
-        .stdout(predicate::str::contains("https://api.example.com/base/**"))
-        .stderr(predicate::str::contains(STORED_MESSAGE));
+        .stdout(predicate::str::contains(format!("{api_root}**")))
+        // Public read never exercised the token; the advertised API did.
+        .stderr(predicate::str::contains("validated (api)"));
 
-    // A `--no-validation` login stores no claim: status warns.
+    // The scoped claim is persisted and rendered by status.
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "      Stored {root}  not validated"
+            "      Stored {root}  validated (api)"
         )));
     Ok(())
 }

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -972,13 +972,19 @@ fn auth_login_prompts_hidden_on_a_terminal() -> TestResult {
     session.exp_string("Logging in to index `http://127.0.0.1:1/`")?;
     session.exp_string("Enter token for `http://127.0.0.1:1/`:")?;
     session.send_line("pty-tok")?;
-    session.exp_string(STORED_MESSAGE)?;
+    // The hidden prompt must not echo the secret: capture everything
+    // printed between sending the token and the stored confirmation, and
+    // assert the token never appears there (the only place it may appear
+    // is the seam store file).
+    let after_prompt = session.exp_string(STORED_MESSAGE)?;
+    assert!(
+        !after_prompt.contains("pty-tok"),
+        "secret was echoed to the terminal: {after_prompt:?}"
+    );
     assert!(await_exit(session)?.success());
 
     let blob = fs::read_to_string(&store_path)?;
     assert!(blob.contains(r#""secret":"pty-tok""#), "blob was: {blob}");
-    // The hidden prompt must not have echoed the secret; the only place
-    // it may appear is the seam store file.
     Ok(())
 }
 

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -704,6 +704,165 @@ fn auth_status_with_both_sources_lists_both_without_negatives() -> TestResult {
     Ok(())
 }
 
+// `(default index)` marker
+
+const MARKER: &str = "(default index)";
+
+/// A seam blob with one stored entry for `https://one.example/`.
+fn one_example_blob() -> &'static str {
+    r#"{"version":1,"credentials":[{
+        "key":"https://one.example/",
+        "globs":["https://one.example/**"],
+        "scheme":"bearer",
+        "secret":"tok-one",
+        "validated":["read"]}]}"#
+}
+
+#[test]
+fn auth_status_marks_the_entry_for_a_configured_default_index() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(&store_path, one_example_blob())?;
+    let (_temp_dir, cwd) = new_temp_cwd()?;
+    let config_path = cwd.join("sysand.toml");
+    fs::write(
+        &config_path,
+        "[[index]]\nurl = \"https://one.example\"\ndefault = true\n",
+    )?;
+
+    let out = run_sysand_in_with(
+        &cwd,
+        ["auth", "status"],
+        Some(config_path.as_str()),
+        &seam_env(&store_path),
+    )?;
+    out.assert().success().stdout(predicate::str::contains(
+        "      Stored https://one.example/  validated (read)  (default index)",
+    ));
+    Ok(())
+}
+
+#[test]
+fn auth_status_marks_the_entry_for_an_env_default_index() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(&store_path, one_example_blob())?;
+    let mut env = seam_env(&store_path);
+    env.insert(
+        "SYSAND_DEFAULT_INDEX".to_string(),
+        "https://one.example".to_string(),
+    );
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert().success().stdout(predicate::str::contains(
+        "      Stored https://one.example/  validated (read)  (default index)",
+    ));
+    Ok(())
+}
+
+#[test]
+fn auth_status_marks_the_entry_for_the_built_in_default_index() -> TestResult {
+    // No override, no configured default: the chain falls through to the
+    // built-in `https://sysand.com`, whose normalized key must match.
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(
+        &store_path,
+        r#"{"version":1,"credentials":[{
+            "key":"https://sysand.com/",
+            "globs":["https://sysand.com/**"],
+            "scheme":"bearer",
+            "secret":"tok"}]}"#,
+    )?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
+    out.assert().success().stdout(predicate::str::contains(
+        "      Stored https://sysand.com/  not validated  (default index)",
+    ));
+    Ok(())
+}
+
+#[test]
+fn auth_status_marks_a_stored_entry_whose_glob_covers_the_default_index() -> TestResult {
+    // Keyed elsewhere, but a disjoint glob (the `api_root` shape) covers
+    // the built-in default index root: marked without key equality.
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(
+        &store_path,
+        r#"{"version":1,"credentials":[{
+            "key":"https://other.example/",
+            "globs":["https://other.example/**","https://sysand.com/**"],
+            "scheme":"bearer",
+            "secret":"tok"}]}"#,
+    )?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
+    out.assert().success().stdout(predicate::str::contains(
+        "      Stored https://other.example/  not validated  (default index)",
+    ));
+    Ok(())
+}
+
+#[test]
+fn auth_status_marks_an_env_entry_whose_pattern_covers_the_default_index() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let mut env = seam_env(&store_path);
+    env.insert(
+        "SYSAND_CRED_HIT".to_string(),
+        "https://sysand.com/**".to_string(),
+    );
+    env.insert(
+        "SYSAND_CRED_MISS".to_string(),
+        "https://elsewhere.example/**".to_string(),
+    );
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "         Env SYSAND_CRED_HIT  https://sysand.com/**  (default index)",
+        ))
+        .stdout(predicate::str::contains(
+            "         Env SYSAND_CRED_MISS  https://elsewhere.example/**\n",
+        ));
+    Ok(())
+}
+
+#[test]
+fn auth_status_with_an_ambiguous_default_chain_notes_and_marks_nothing() -> TestResult {
+    // Bare `login`/`logout` would error here; status is diagnostic and
+    // must still succeed, with a note instead of a marker.
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(&store_path, one_example_blob())?;
+    let mut env = seam_env(&store_path);
+    env.insert(
+        "SYSAND_DEFAULT_INDEX".to_string(),
+        "https://one.example,https://two.example".to_string(),
+    );
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "note: more than one default index is configured; no entry is marked as \
+             the default index",
+        ))
+        .stdout(predicate::str::contains(MARKER).not());
+    Ok(())
+}
+
+#[test]
+fn auth_status_without_a_matching_entry_shows_no_marker() -> TestResult {
+    // A stored entry that neither is nor covers the built-in default:
+    // output is unchanged, no marker, no note.
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(&store_path, one_example_blob())?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(MARKER).not())
+        .stdout(predicate::str::contains("note:").not());
+    Ok(())
+}
+
 #[test]
 fn auth_login_fails_fast_when_stdin_is_not_a_terminal() -> TestResult {
     let (_store_dir, store_path) = seam_store()?;

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -136,6 +136,43 @@ fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn auth_status_errors_on_a_label_less_env_credential() -> TestResult {
+    // Status applies the same strict `SYSAND_CRED_*` validation as every
+    // credential-using command, with the identical message.
+    let (_store_dir, store_path) = seam_store()?;
+    let mut env = seam_env(&store_path);
+    env.insert("SYSAND_CRED".to_string(), "https://a.org".to_string());
+
+    let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert().failure().stderr(predicate::str::contains(
+        "SYSAND_CRED has no label; env credentials need one, as in SYSAND_CRED_MYINDEX",
+    ));
+    Ok(())
+}
+
+#[test]
+fn auth_status_errors_on_an_env_pattern_without_a_scheme() -> TestResult {
+    // A pattern with no secret companion is rejected, and its value is
+    // never echoed: a misnamed variable can put a secret in any position.
+    let (_store_dir, store_path) = seam_store()?;
+    let mut env = seam_env(&store_path);
+    env.insert(
+        "SYSAND_CRED_TEST".to_string(),
+        "accidental-secret-value".to_string(),
+    );
+
+    let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "SYSAND_CRED_TEST has no matching authentication scheme",
+        ))
+        .stderr(predicate::str::contains("accidental-secret-value").not())
+        .stdout(predicate::str::contains("accidental-secret-value").not());
+    Ok(())
+}
+
 // `sysand auth login`
 
 const SEAM_ENV_VAR: &str = "SYSAND_TEST_CREDENTIAL_STORE";

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -25,10 +25,6 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 const NOT_HTTP_MESSAGE: &str = "not an HTTP(S) index; nothing to authenticate to";
 const AMBIGUOUS_MESSAGE: &str = "pass an explicit index URL";
 
-fn no_env() -> IndexMap<String, String> {
-    IndexMap::new()
-}
-
 fn default_index_env(value: &str) -> IndexMap<String, String> {
     let mut env = IndexMap::new();
     env.insert("SYSAND_DEFAULT_INDEX".to_string(), value.to_string());
@@ -163,17 +159,23 @@ fn bare_auth_logout_with_two_configured_defaults_asks_for_an_explicit_url() -> T
 }
 
 #[test]
-fn auth_status_succeeds_without_any_credentials() -> TestResult {
-    let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &no_env())?;
-    out.assert().success().stdout(predicate::str::contains(
-        "No `SYSAND_CRED_*` environment credentials.",
+fn auth_status_with_nothing_configured_prints_a_single_line() -> TestResult {
+    // The seam store file does not exist: no stored logins, no env
+    // credentials. The two per-source negatives collapse into exactly
+    // one combined line.
+    let (_store_dir, store_path) = seam_store()?;
+    let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
+    out.assert().success().stdout(predicate::eq(
+        "No credentials configured (no stored logins, no `SYSAND_CRED_*` variables).\n",
     ));
     Ok(())
 }
 
 #[test]
 fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
-    let mut env = IndexMap::new();
+    // Seam store file does not exist: env credentials only.
+    let (_store_dir, store_path) = seam_store()?;
+    let mut env = seam_env(&store_path);
     env.insert(
         "SYSAND_CRED_TEST".to_string(),
         "https://example.com/**".to_string(),
@@ -217,7 +219,11 @@ fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
         ))
         .stdout(predicate::str::contains("super-secret-token").not())
         .stdout(predicate::str::contains("secret-user-name").not())
-        .stdout(predicate::str::contains("secret-pass-word").not());
+        .stdout(predicate::str::contains("secret-pass-word").not())
+        // Env credentials exist, so the stored-side negative is omitted
+        // entirely (no "no stored logins" noise, no combined negative).
+        .stdout(predicate::str::contains("No credentials configured").not())
+        .stdout(predicate::str::contains("Stored").not());
     Ok(())
 }
 
@@ -310,7 +316,9 @@ fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
         .stdout(predicate::str::contains("      Stored http://127.0.0.1:1/"))
         .stdout(predicate::str::contains(
             "             patterns: http://127.0.0.1:1/**",
-        ));
+        ))
+        // A stored login exists, so the env-side negative is omitted.
+        .stdout(predicate::str::contains("SYSAND_CRED").not());
     Ok(())
 }
 
@@ -389,7 +397,7 @@ fn auth_login_then_logout_removes_the_stored_entry() -> TestResult {
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains("No stored index logins."));
+        .stdout(predicate::str::contains("No credentials configured"));
     Ok(())
 }
 
@@ -425,6 +433,14 @@ fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
         .stdout(predicate::str::contains(format!("{root}**")))
         .stdout(predicate::str::contains("https://api.example.com/base/**"))
         .stderr(predicate::str::contains(STORED_MESSAGE));
+
+    // A `--no-validation` login stores no claim: status warns.
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "      Stored {root}  not validated"
+        )));
     Ok(())
 }
 
@@ -497,6 +513,15 @@ fn auth_login_validates_the_read_surface_of_a_private_index() -> TestResult {
         blob.contains(r#""secret":"sekrit-tok""#),
         "blob was: {blob}"
     );
+
+    // The claim was persisted and status renders it per entry.
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "      Stored {}/  validated (read)",
+            server.url()
+        )));
     Ok(())
 }
 
@@ -559,7 +584,7 @@ fn auth_login_status_logout_round_trip_a_template_target() -> TestResult {
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains("No stored index logins."));
+        .stdout(predicate::str::contains("No credentials configured"));
     Ok(())
 }
 
@@ -588,7 +613,94 @@ fn auth_status_shows_identity_learned_by_a_validating_login() -> TestResult {
         .stdout(predicate::str::contains("subject: user alice"))
         .stdout(predicate::str::contains("token prefix: sysand_u_1a2b3c4d"))
         .stdout(predicate::str::contains("expires in"))
+        // A pre-B12 blob has no `validated` field: shown as the
+        // security-relevant "not validated", never a silent default.
+        .stdout(predicate::str::contains("not validated"))
         .stdout(predicate::str::contains("sekrit-status-tok").not());
+    Ok(())
+}
+
+#[test]
+fn auth_status_renders_one_stored_entry_without_separators_or_negatives() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(
+        &store_path,
+        r#"{"version":1,"credentials":[{
+            "key":"https://one.example/",
+            "globs":["https://one.example/**"],
+            "scheme":"bearer",
+            "secret":"tok-one",
+            "validated":["read","api"]}]}"#,
+    )?;
+
+    // Exact plain output: no blank line around a single entry, and no
+    // negative for the empty env side.
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
+    out.assert().success().stdout(predicate::eq(concat!(
+        "      Stored https://one.example/  validated (read, api)\n",
+        "             patterns: https://one.example/**\n",
+    )));
+    Ok(())
+}
+
+#[test]
+fn auth_status_separates_multiple_stored_entries_with_a_blank_line() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(
+        &store_path,
+        r#"{"version":1,"credentials":[{
+            "key":"https://a.example/",
+            "globs":["https://a.example/**"],
+            "scheme":"bearer",
+            "secret":"tok-a"
+        },{
+            "key":"https://b.example/",
+            "globs":["https://b.example/**"],
+            "scheme":"bearer",
+            "secret":"tok-b",
+            "validated":["read"]}]}"#,
+    )?;
+
+    // Exact plain output: one blank line between the entries, none after
+    // the last.
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
+    out.assert().success().stdout(predicate::eq(concat!(
+        "      Stored https://a.example/  not validated\n",
+        "             patterns: https://a.example/**\n",
+        "\n",
+        "      Stored https://b.example/  validated (read)\n",
+        "             patterns: https://b.example/**\n",
+    )));
+    Ok(())
+}
+
+#[test]
+fn auth_status_with_both_sources_lists_both_without_negatives() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(
+        &store_path,
+        r#"{"version":1,"credentials":[{
+            "key":"https://one.example/",
+            "globs":["https://one.example/**"],
+            "scheme":"bearer",
+            "secret":"tok-one"}]}"#,
+    )?;
+    let mut env = seam_env(&store_path);
+    env.insert(
+        "SYSAND_CRED_CI".to_string(),
+        "https://ci.example/**".to_string(),
+    );
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "      Stored https://one.example/",
+        ))
+        .stdout(predicate::str::contains(
+            "         Env SYSAND_CRED_CI  https://ci.example/**",
+        ))
+        .stdout(predicate::str::contains("No credentials configured").not());
     Ok(())
 }
 

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -698,3 +698,180 @@ fn auth_login_prompts_hidden_on_a_terminal() -> TestResult {
     // it may appear is the seam store file.
     Ok(())
 }
+
+// `sysand auth whoami`
+//
+// Query-only live identity check against `api_root/v1/whoami`. Discovery
+// and the whoami request go to a local mockito server; credentials come
+// from the seam store or `SYSAND_CRED_*` variables, never a real keyring.
+
+const WHOAMI_BODY: &str = r#"{
+    "subject": {"type": "user", "name": "alice"},
+    "token": {"name": "laptop", "prefix": "sysand_u_1a2b3c4d",
+              "expires_at": "2999-09-01T00:00:00Z"}}"#;
+
+/// Discovery answering with an advertised `api_root` under `/api/` on the
+/// same server.
+fn mock_api_discovery(server: &mut mockito::Server) -> mockito::Mock {
+    server
+        .mock("GET", "/sysand-index-config.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"api_root": "{}/api/"}}"#, server.url()))
+        .create()
+}
+
+/// A seam store blob holding one stored login for the server root.
+fn seed_stored_login(
+    store_path: &camino::Utf8Path,
+    server_url: &str,
+    secret: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    fs::write(
+        store_path,
+        format!(
+            r#"{{"version":1,"credentials":[{{
+                "key":"{server_url}/",
+                "globs":["{server_url}/**"],
+                "scheme":"bearer",
+                "secret":"{secret}"}}]}}"#
+        ),
+    )?;
+    Ok(())
+}
+
+#[test]
+fn auth_whoami_with_a_stored_login_renders_the_identity() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+    let mut server = mockito::Server::new();
+    let _config = mock_api_discovery(&mut server);
+    let _whoami = server
+        .mock("GET", "/api/v1/whoami")
+        .match_header("authorization", "Bearer sekrit-whoami-tok")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(WHOAMI_BODY)
+        .create();
+    seed_stored_login(&store_path, &server.url(), "sekrit-whoami-tok")?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "whoami", &server.url()], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Checking identity on index `{}/`",
+            server.url()
+        )))
+        .stdout(predicate::str::contains(format!(
+            "using stored login for `{}/`",
+            server.url()
+        )))
+        .stdout(predicate::str::contains("subject: user alice"))
+        .stdout(predicate::str::contains("token name: laptop"))
+        .stdout(predicate::str::contains("token prefix: sysand_u_1a2b3c4d"))
+        .stdout(predicate::str::contains("expires in"))
+        .stdout(predicate::str::contains("sekrit-whoami-tok").not());
+    Ok(())
+}
+
+#[test]
+fn auth_whoami_reports_a_rejected_credential_with_the_source() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+    let mut server = mockito::Server::new();
+    let _config = mock_api_discovery(&mut server);
+    let _whoami = server
+        .mock("GET", "/api/v1/whoami")
+        .with_status(401)
+        .create();
+    seed_stored_login(&store_path, &server.url(), "stale-tok")?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "whoami", &server.url()], None, &env)?;
+    out.assert()
+        .failure()
+        .stdout(predicate::str::contains("using stored login for"))
+        .stderr(predicate::str::contains("rejected the credential"))
+        .stderr(predicate::str::contains("sysand auth login"));
+    Ok(())
+}
+
+#[test]
+fn auth_whoami_env_credential_wins_over_a_stored_login() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let mut server = mockito::Server::new();
+    let mut env = seam_env(&store_path);
+    env.insert(
+        "SYSAND_CRED_WTEST".to_string(),
+        format!("{}/**", server.url()),
+    );
+    env.insert(
+        "SYSAND_CRED_WTEST_BEARER_TOKEN".to_string(),
+        "env-tok".to_string(),
+    );
+    let _config = mock_api_discovery(&mut server);
+    // The mock only matches the env token: a stored-token request would
+    // 501, so success proves source precedence.
+    let _whoami = server
+        .mock("GET", "/api/v1/whoami")
+        .match_header("authorization", "Bearer env-tok")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(WHOAMI_BODY)
+        .create();
+    seed_stored_login(&store_path, &server.url(), "shadowed-stored-tok")?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "whoami", &server.url()], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "using credential from `SYSAND_CRED_WTEST`",
+        ))
+        .stdout(predicate::str::contains("subject: user alice"));
+    Ok(())
+}
+
+#[test]
+fn auth_whoami_without_a_matching_credential_suggests_login() -> TestResult {
+    // The seam store file does not exist: no stored logins.
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+    let mut server = mockito::Server::new();
+    let _config = mock_api_discovery(&mut server);
+
+    let (_t, _c, out) = run_sysand_with(["auth", "whoami", &server.url()], None, &env)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("no credential matches"))
+        .stderr(predicate::str::contains("sysand auth login"));
+    Ok(())
+}
+
+#[test]
+fn auth_whoami_errors_when_the_index_does_not_advertise_an_api() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+    let mut server = mockito::Server::new();
+    // No discovery document: the plain-URL runtime default is not an
+    // advertised API, so there is nothing to ask.
+    let _config = server
+        .mock("GET", "/sysand-index-config.json")
+        .with_status(404)
+        .create();
+    seed_stored_login(&store_path, &server.url(), "tok")?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "whoami", &server.url()], None, &env)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("does not advertise an API"));
+    Ok(())
+}
+
+#[test]
+fn auth_whoami_rejects_a_non_http_index() -> TestResult {
+    // Fails during target validation, before any credential store access.
+    let (_temp_dir, _cwd, out) = run_sysand(["auth", "whoami", "file:///srv/index"], None)?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
+    Ok(())
+}

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -160,13 +160,13 @@ fn bare_auth_logout_with_two_configured_defaults_asks_for_an_explicit_url() -> T
 
 #[test]
 fn auth_status_with_nothing_configured_prints_a_single_line() -> TestResult {
-    // The seam store file does not exist: no stored logins, no env
+    // The seam store file does not exist: no stored credentials, no env
     // credentials. The two per-source negatives collapse into exactly
     // one combined line.
     let (_store_dir, store_path) = seam_store()?;
     let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
     out.assert().success().stdout(predicate::eq(
-        "No credentials configured (no stored logins, no `SYSAND_CRED_*` variables).\n",
+        "No credentials configured (no stored credentials, no `SYSAND_CRED_*` variables).\n",
     ));
     Ok(())
 }
@@ -221,7 +221,7 @@ fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
         .stdout(predicate::str::contains("secret-user-name").not())
         .stdout(predicate::str::contains("secret-pass-word").not())
         // Env credentials exist, so the stored-side negative is omitted
-        // entirely (no "no stored logins" noise, no combined negative).
+        // entirely (no "no stored credentials" noise, no combined negative).
         .stdout(predicate::str::contains("No credentials configured").not())
         .stdout(predicate::str::contains("Stored").not());
     Ok(())
@@ -294,11 +294,12 @@ fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
     )?;
     out.assert()
         .success()
+        // The echo is printed (stdout, shown even under `--quiet`); the
+        // result lines ("Stored", "Covers") are log output (stderr).
         .stdout(predicate::str::contains(
             "  Logging in to index `http://127.0.0.1:1/`",
         ))
-        .stdout(predicate::str::contains("Covers http://127.0.0.1:1/**"))
-        // The styled confirmation is log output (stderr).
+        .stderr(predicate::str::contains("Covers http://127.0.0.1:1/**"))
         .stderr(predicate::str::contains(STORED_MESSAGE));
 
     // The stored secret is exactly the piped bytes minus one trailing
@@ -434,8 +435,9 @@ fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
     )?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains(format!("{root}**")))
-        .stdout(predicate::str::contains(format!("{api_root}**")))
+        // The "Covers" globs are part of the login result (log output).
+        .stderr(predicate::str::contains(format!("{root}**")))
+        .stderr(predicate::str::contains(format!("{api_root}**")))
         // Public read never exercised the token; the advertised API did.
         .stderr(predicate::str::contains("validated (api)"));
 
@@ -569,7 +571,8 @@ fn auth_login_status_logout_round_trip_a_template_target() -> TestResult {
         .stdout(predicate::str::contains(format!(
             "Logging in to index `{template}`"
         )))
-        .stdout(predicate::str::contains(&anchor_glob))
+        // The "Covers" glob is part of the login result (log output).
+        .stderr(predicate::str::contains(&anchor_glob))
         .stderr(predicate::str::contains("validated (read)"));
 
     // `status` shows the key in the exact form `logout` accepts.
@@ -1043,7 +1046,7 @@ fn auth_whoami_with_a_stored_login_renders_the_identity() -> TestResult {
             server.url()
         )))
         .stdout(predicate::str::contains(format!(
-            "       Using stored login for `{}/`",
+            "       Using stored credential for `{}/`",
             server.url()
         )))
         .stdout(predicate::str::contains("     Subject user alice"))
@@ -1069,7 +1072,7 @@ fn auth_whoami_reports_a_rejected_credential_with_the_source() -> TestResult {
     let (_t, _c, out) = run_sysand_with(["auth", "whoami", &server.url()], None, &env)?;
     out.assert()
         .failure()
-        .stdout(predicate::str::contains("Using stored login for"))
+        .stdout(predicate::str::contains("Using stored credential for"))
         .stderr(predicate::str::contains("rejected the credential"))
         .stderr(predicate::str::contains("sysand auth login"));
     Ok(())
@@ -1112,7 +1115,7 @@ fn auth_whoami_env_credential_wins_over_a_stored_login() -> TestResult {
 
 #[test]
 fn auth_whoami_without_a_matching_credential_suggests_login() -> TestResult {
-    // The seam store file does not exist: no stored logins.
+    // The seam store file does not exist: no stored credentials.
     let (_store_dir, store_path) = seam_store()?;
     let env = seam_env(&store_path);
     let mut server = mockito::Server::new();

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -204,14 +204,16 @@ fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
     let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
+        // The leading spaces are the 12-column gutter, part of plain
+        // piped output (as in all alignment predicates in this file).
         .stdout(predicate::str::contains(
-            "env     SYSAND_CRED_TEST  https://example.com/**",
+            "         Env SYSAND_CRED_TEST  https://example.com/**",
         ))
         .stdout(predicate::str::contains(
-            "env     SYSAND_CRED_BSC  https://basic.example/**",
+            "         Env SYSAND_CRED_BSC  https://basic.example/**",
         ))
         .stdout(predicate::str::contains(
-            "env     SYSAND_CRED_LONELY  https://lonely.example/**",
+            "         Env SYSAND_CRED_LONELY  https://lonely.example/**",
         ))
         .stdout(predicate::str::contains("super-secret-token").not())
         .stdout(predicate::str::contains("secret-user-name").not())
@@ -287,9 +289,9 @@ fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
     out.assert()
         .success()
         .stdout(predicate::str::contains(
-            "Logging in to index `http://127.0.0.1:1/`",
+            "  Logging in to index `http://127.0.0.1:1/`",
         ))
-        .stdout(predicate::str::contains("http://127.0.0.1:1/**"))
+        .stdout(predicate::str::contains("Covers http://127.0.0.1:1/**"))
         // The styled confirmation is log output (stderr).
         .stderr(predicate::str::contains(STORED_MESSAGE));
 
@@ -305,8 +307,10 @@ fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains("stored  http://127.0.0.1:1/"))
-        .stdout(predicate::str::contains("patterns: http://127.0.0.1:1/**"));
+        .stdout(predicate::str::contains("      Stored http://127.0.0.1:1/"))
+        .stdout(predicate::str::contains(
+            "             patterns: http://127.0.0.1:1/**",
+        ));
     Ok(())
 }
 
@@ -349,7 +353,7 @@ fn auth_login_twice_reports_the_replacement_and_overwrites() -> TestResult {
     )?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains("replacing existing credential").not());
+        .stdout(predicate::str::contains("Replacing existing credential").not());
 
     let (_t, _c, out) = run_sysand_stdin(
         // A different spelling of the same index normalizes to one key.
@@ -358,7 +362,7 @@ fn auth_login_twice_reports_the_replacement_and_overwrites() -> TestResult {
         b"new-tok\n",
     )?;
     out.assert().success().stdout(predicate::str::contains(
-        "replacing existing credential for `http://127.0.0.1:1/`",
+        "   Replacing existing credential for `http://127.0.0.1:1/`",
     ));
 
     let blob = fs::read_to_string(&store_path)?;
@@ -542,14 +546,14 @@ fn auth_login_status_logout_round_trip_a_template_target() -> TestResult {
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains(format!("stored  {template}")))
+        .stdout(predicate::str::contains(format!("      Stored {template}")))
         .stdout(predicate::str::contains(&anchor_glob));
 
     let (_t, _c, out) = run_sysand_with(["auth", "logout", &template], None, &env)?;
     out.assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "Logging out from index `{template}`"
+            " Logging out from index `{template}`"
         )));
 
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
@@ -759,16 +763,16 @@ fn auth_whoami_with_a_stored_login_renders_the_identity() -> TestResult {
     out.assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "Checking identity on index `{}/`",
+            "    Checking identity on index `{}/`",
             server.url()
         )))
         .stdout(predicate::str::contains(format!(
-            "using stored login for `{}/`",
+            "       Using stored login for `{}/`",
             server.url()
         )))
-        .stdout(predicate::str::contains("subject: user alice"))
-        .stdout(predicate::str::contains("token name: laptop"))
-        .stdout(predicate::str::contains("token prefix: sysand_u_1a2b3c4d"))
+        .stdout(predicate::str::contains("     Subject user alice"))
+        .stdout(predicate::str::contains("  Token name laptop"))
+        .stdout(predicate::str::contains("Token prefix sysand_u_1a2b3c4d"))
         .stdout(predicate::str::contains("expires in"))
         .stdout(predicate::str::contains("sekrit-whoami-tok").not());
     Ok(())
@@ -789,7 +793,7 @@ fn auth_whoami_reports_a_rejected_credential_with_the_source() -> TestResult {
     let (_t, _c, out) = run_sysand_with(["auth", "whoami", &server.url()], None, &env)?;
     out.assert()
         .failure()
-        .stdout(predicate::str::contains("using stored login for"))
+        .stdout(predicate::str::contains("Using stored login for"))
         .stderr(predicate::str::contains("rejected the credential"))
         .stderr(predicate::str::contains("sysand auth login"));
     Ok(())
@@ -824,9 +828,9 @@ fn auth_whoami_env_credential_wins_over_a_stored_login() -> TestResult {
     out.assert()
         .success()
         .stdout(predicate::str::contains(
-            "using credential from `SYSAND_CRED_WTEST`",
+            "Using credential from `SYSAND_CRED_WTEST`",
         ))
-        .stdout(predicate::str::contains("subject: user alice"));
+        .stdout(predicate::str::contains("Subject user alice"));
     Ok(())
 }
 

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -403,15 +403,126 @@ fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
         .create();
     let root = format!("{}/", server.url());
 
+    // `--validation false`: the advertised api_root is a foreign host
+    // this test must not probe.
     let (_t, _c, out) = run_sysand_stdin(
-        ["auth", "login", "--token-stdin", &server.url()],
+        [
+            "auth",
+            "login",
+            "--token-stdin",
+            "--validation",
+            "false",
+            &server.url(),
+        ],
         &env,
         b"tok\n",
     )?;
     out.assert()
         .success()
         .stdout(predicate::str::contains(format!("{root}**")))
-        .stdout(predicate::str::contains("https://api.example.com/base/**"));
+        .stdout(predicate::str::contains("https://api.example.com/base/**"))
+        .stderr(predicate::str::contains(STORED_MESSAGE));
+    Ok(())
+}
+
+#[test]
+fn auth_login_refuses_a_credential_every_exercised_surface_rejected() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    let mut server = mockito::Server::new();
+    let _config = server
+        .mock("GET", "/sysand-index-config.json")
+        .with_status(404)
+        .create();
+    // Unauth baseline 401, forced bearer retry 401: rejected everywhere
+    // it was exercised, so the login must refuse and store nothing.
+    let _index = server
+        .mock("GET", "/index.json")
+        .with_status(401)
+        .expect(2)
+        .create();
+
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", &server.url()],
+        &env,
+        b"bad-tok\n",
+    )?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("rejected"))
+        .stderr(predicate::str::contains("nothing was stored"));
+    assert!(
+        !store_path.exists(),
+        "a refused login must not write the store"
+    );
+    Ok(())
+}
+
+#[test]
+fn auth_login_validates_the_read_surface_of_a_private_index() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    let mut server = mockito::Server::new();
+    let _config = server
+        .mock("GET", "/sysand-index-config.json")
+        .with_status(404)
+        .create();
+    let _unauth = server
+        .mock("GET", "/index.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(401)
+        .create();
+    let _forced = server
+        .mock("GET", "/index.json")
+        .match_header("authorization", "Bearer sekrit-tok")
+        .with_status(200)
+        .create();
+
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", &server.url()],
+        &env,
+        b"sekrit-tok\n",
+    )?;
+    out.assert()
+        .success()
+        // Scoped claim: validated on the read surface only.
+        .stderr(predicate::str::contains("validated (read)"));
+    let blob = fs::read_to_string(&store_path)?;
+    assert!(
+        blob.contains(r#""secret":"sekrit-tok""#),
+        "blob was: {blob}"
+    );
+    Ok(())
+}
+
+#[test]
+fn auth_status_shows_identity_learned_by_a_validating_login() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    // A blob as a validating login writes it (identity from whoami).
+    fs::write(
+        &store_path,
+        r#"{"version":1,"credentials":[{
+            "key":"https://example.com/",
+            "globs":["https://example.com/**"],
+            "scheme":"bearer",
+            "secret":"sekrit-status-tok",
+            "expires_at":"2999-09-01T00:00:00Z",
+            "subject":{"type":"user","name":"alice"},
+            "token_name":"laptop",
+            "token_prefix":"sysand_u_1a2b3c4d"}]}"#,
+    )?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("subject: user alice"))
+        .stdout(predicate::str::contains("token prefix: sysand_u_1a2b3c4d"))
+        .stdout(predicate::str::contains("expires in"))
+        .stdout(predicate::str::contains("sekrit-status-tok").not());
     Ok(())
 }
 

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-//! CLI tests for `sysand auth status` and `sysand auth logout`.
+//! CLI tests for `sysand auth login`, `status`, `logout`, and `whoami`.
 //!
-//! These tests exercise argument parsing, the default-index resolution
-//! chain, and status rendering of `SYSAND_CRED_*` entries. Logout tests
-//! deliberately fail before any credential store access (parse errors,
-//! non-HTTP(S) targets, ambiguous defaults), so no test requires, or can
-//! ever mutate, a real OS keyring: store behavior itself is covered by the
-//! core tests over an in-memory blob backend.
+//! These tests pin the CLI-level contracts: end-to-end flows (login
+//! stores, status lists, logout removes), exit codes per failure class,
+//! and secret-safety (secrets never appear in any output). Exact output
+//! formatting is deliberately not pinned, apart from one compact golden
+//! canary for `auth status`. Tests that touch the credential store run
+//! against the debug-only seam (`SYSAND_TEST_CREDENTIAL_STORE`,
+//! sysand/src/credential_store.rs): a file-backed blob store, or a
+//! simulated-absent backend, so no test can ever touch a real OS keyring.
 
 use std::fs;
 
@@ -32,15 +34,6 @@ fn default_index_env(value: &str) -> IndexMap<String, String> {
 }
 
 #[test]
-fn auth_requires_a_subcommand() -> TestResult {
-    let (_temp_dir, _cwd, out) = run_sysand(["auth"], None)?;
-    out.assert()
-        .failure()
-        .stderr(predicate::str::contains("Usage"));
-    Ok(())
-}
-
-#[test]
 fn auth_logout_rejects_an_unparseable_url() -> TestResult {
     let (_temp_dir, _cwd, out) = run_sysand(["auth", "logout", "not a url"], None)?;
     out.assert()
@@ -55,23 +48,6 @@ fn auth_logout_rejects_a_non_http_index() -> TestResult {
     out.assert()
         .failure()
         .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
-    Ok(())
-}
-
-#[test]
-fn auth_logout_with_an_explicit_url_skips_default_index_resolution() -> TestResult {
-    // Two default-index URLs would be ambiguous; the explicit positional
-    // URL must win without consulting the chain at all.
-    let (_temp_dir, _cwd, out) = run_sysand_with(
-        ["auth", "logout", "file:///srv/index"],
-        None,
-        &default_index_env("https://a.example,https://b.example"),
-    )?;
-    out.assert()
-        .failure()
-        .stdout(predicate::str::contains("file:///srv/index"))
-        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE))
-        .stderr(predicate::str::contains(AMBIGUOUS_MESSAGE).not());
     Ok(())
 }
 
@@ -108,66 +84,14 @@ fn bare_auth_logout_with_multiple_env_defaults_asks_for_an_explicit_url() -> Tes
 }
 
 #[test]
-fn bare_auth_logout_with_duplicate_env_defaults_is_not_ambiguous() -> TestResult {
-    let (_temp_dir, _cwd, out) = run_sysand_with(
-        ["auth", "logout"],
-        None,
-        &default_index_env("file:///srv/index,file:///srv/index"),
-    )?;
-    out.assert()
-        .failure()
-        .stdout(predicate::str::contains(
-            "Logging out from index `file:///srv/index`",
-        ))
-        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
-    Ok(())
-}
-
-#[test]
-fn bare_auth_logout_resolves_a_configured_default_index() -> TestResult {
-    let (_temp_dir, cwd) = new_temp_cwd()?;
-    let config_path = cwd.join("sysand.toml");
-    fs::write(
-        &config_path,
-        "[[index]]\nurl = \"file:///srv/cfg-index\"\ndefault = true\n",
-    )?;
-    let out = run_sysand_in(&cwd, ["auth", "logout"], Some(config_path.as_str()))?;
-    out.assert()
-        .failure()
-        .stdout(predicate::str::contains(
-            "Logging out from index `file:///srv/cfg-index`",
-        ))
-        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
-    Ok(())
-}
-
-#[test]
-fn bare_auth_logout_with_two_configured_defaults_asks_for_an_explicit_url() -> TestResult {
-    let (_temp_dir, cwd) = new_temp_cwd()?;
-    let config_path = cwd.join("sysand.toml");
-    fs::write(
-        &config_path,
-        "[[index]]\nurl = \"https://a.example\"\ndefault = true\n\n\
-         [[index]]\nurl = \"https://b.example\"\ndefault = true\n",
-    )?;
-    let out = run_sysand_in(&cwd, ["auth", "logout"], Some(config_path.as_str()))?;
-    out.assert()
-        .failure()
-        .stderr(predicate::str::contains("more than one default index"))
-        .stderr(predicate::str::contains(AMBIGUOUS_MESSAGE));
-    Ok(())
-}
-
-#[test]
 fn auth_status_with_nothing_configured_prints_a_single_line() -> TestResult {
     // The seam store file does not exist: no stored credentials, no env
-    // credentials. The two per-source negatives collapse into exactly
-    // one combined line.
+    // credentials.
     let (_store_dir, store_path) = seam_store()?;
     let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
-    out.assert().success().stdout(predicate::eq(
-        "No credentials configured (no stored credentials, no `SYSAND_CRED_*` variables).\n",
-    ));
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("No credentials configured"));
     Ok(())
 }
 
@@ -196,43 +120,23 @@ fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
         "SYSAND_CRED_BSC_BASIC_PASS".to_string(),
         "secret-pass-word".to_string(),
     );
-    // A pattern without any scheme variable: the eager auth-policy build
-    // rejects this, but `auth status` must stay usable to diagnose it.
-    env.insert(
-        "SYSAND_CRED_LONELY".to_string(),
-        "https://lonely.example/**".to_string(),
-    );
 
     let (_temp_dir, _cwd, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
-        // The leading spaces are the 12-column gutter, part of plain
-        // piped output (as in all alignment predicates in this file).
         .stdout(predicate::str::contains(
-            "         Env SYSAND_CRED_TEST  https://example.com/**",
+            "SYSAND_CRED_TEST  https://example.com/**",
         ))
         .stdout(predicate::str::contains(
-            "         Env SYSAND_CRED_BSC  https://basic.example/**",
-        ))
-        .stdout(predicate::str::contains(
-            "         Env SYSAND_CRED_LONELY  https://lonely.example/**",
+            "SYSAND_CRED_BSC  https://basic.example/**",
         ))
         .stdout(predicate::str::contains("super-secret-token").not())
         .stdout(predicate::str::contains("secret-user-name").not())
-        .stdout(predicate::str::contains("secret-pass-word").not())
-        // Env credentials exist, so the stored-side negative is omitted
-        // entirely (no "no stored credentials" noise, no combined negative).
-        .stdout(predicate::str::contains("No credentials configured").not())
-        .stdout(predicate::str::contains("Stored").not());
+        .stdout(predicate::str::contains("secret-pass-word").not());
     Ok(())
 }
 
 // `sysand auth login`
-//
-// These tests run against the debug-only credential store seam
-// (`SYSAND_TEST_CREDENTIAL_STORE`, sysand/src/credential_store.rs): a
-// file-backed blob store, or a simulated-absent backend, so no test can
-// ever touch the real OS keyring.
 
 const SEAM_ENV_VAR: &str = "SYSAND_TEST_CREDENTIAL_STORE";
 const NO_TTY_MESSAGE: &str = "no terminal for prompt; pass the token with `--token-stdin`";
@@ -294,10 +198,8 @@ fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
     )?;
     out.assert()
         .success()
-        // The echo is printed (stdout, shown even under `--quiet`); the
-        // result lines ("Stored", "Covers") are log output (stderr).
         .stdout(predicate::str::contains(
-            "  Logging in to index `http://127.0.0.1:1/`",
+            "Logging in to index `http://127.0.0.1:1/`",
         ))
         .stderr(predicate::str::contains("Covers http://127.0.0.1:1/**"))
         .stderr(predicate::str::contains(STORED_MESSAGE));
@@ -314,12 +216,9 @@ fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains("      Stored http://127.0.0.1:1/"))
-        .stdout(predicate::str::contains(
-            "             covers: http://127.0.0.1:1/**",
-        ))
-        // A stored login exists, so the env-side negative is omitted.
-        .stdout(predicate::str::contains("SYSAND_CRED").not());
+        .stdout(predicate::str::contains("Stored http://127.0.0.1:1/"))
+        .stdout(predicate::str::contains("covers: http://127.0.0.1:1/**"))
+        .stdout(predicate::str::contains("sekrit-tok").not());
     Ok(())
 }
 
@@ -370,34 +269,13 @@ fn auth_login_twice_reports_the_replacement_and_overwrites() -> TestResult {
         &env,
         b"new-tok\n",
     )?;
-    // The notice is informational (log output, stderr), not stdout: the
-    // stdout channel carries only the pre-prompt target echo.
-    out.assert().success().stderr(predicate::str::contains(
-        "   Replacing existing credential for `http://127.0.0.1:1/`",
-    ));
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Replacing existing credential"));
 
     let blob = fs::read_to_string(&store_path)?;
     assert!(blob.contains(r#""secret":"new-tok""#), "blob was: {blob}");
     assert!(!blob.contains("old-tok"), "blob was: {blob}");
-
-    // Under `--quiet` a re-login is exit-code-only apart from the target
-    // echo: the replacement notice is suppressed with the result lines.
-    let (_t, _c, out) = run_sysand_stdin(
-        [
-            "--quiet",
-            "auth",
-            "login",
-            "--token-stdin",
-            "http://127.0.0.1:1",
-        ],
-        &env,
-        b"third-tok\n",
-    )?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains("Logging in to index"))
-        .stderr(predicate::str::contains("Replacing").not())
-        .stderr(predicate::str::contains("Stored").not());
     Ok(())
 }
 
@@ -427,67 +305,16 @@ fn auth_login_then_logout_removes_the_stored_entry() -> TestResult {
 fn auth_logout_of_an_unknown_index_warns_and_succeeds() -> TestResult {
     // The seam store file does not exist: nothing is stored. Logout is
     // idempotent: a warning and exit 0, so cleanup scripts need not
-    // swallow a failure. The warning still points at `auth status`,
-    // whose listing shows every stored key in the exact spelling logout
-    // accepts (the fix for a typoed URL).
+    // swallow a failure.
     let (_store_dir, store_path) = seam_store()?;
     let (_t, _c, out) = run_sysand_with(
         ["auth", "logout", "https://nothing.example"],
         None,
         &seam_env(&store_path),
     )?;
-    out.assert()
-        .success()
-        .stderr(predicate::str::contains(
-            "warning: no stored credential for `https://nothing.example/`",
-        ))
-        .stderr(predicate::str::contains(
-            "run `sysand auth status` to list the stored logins and their exact keys",
-        ));
-    Ok(())
-}
-
-#[test]
-fn auth_login_stored_anyway_hedges_a_read_404() -> TestResult {
-    let (_store_dir, store_path) = seam_store()?;
-    let env = seam_env(&store_path);
-
-    let mut server = mockito::Server::new();
-    let _config = server
-        .mock("GET", "/sysand-index-config.json")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(format!(r#"{{"api_root": "{}/api/"}}"#, server.url()))
-        .create();
-    // The read surface answers 404 with and without the token. A 404 can
-    // mean a rejected token (GitLab-style hosts) or no `index.json` at
-    // all, so the stored-anyway warning must carry the same hedge the
-    // refusal message has. The advertised API accepts, so the login
-    // stores the credential.
-    let _index = server
-        .mock("GET", "/index.json")
-        .with_status(404)
-        .expect(2)
-        .create();
-    let _whoami = server
-        .mock("GET", "/api/v1/whoami")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(WHOAMI_BODY)
-        .create();
-
-    let (_t, _c, out) = run_sysand_stdin(
-        ["auth", "login", "--token-stdin", &server.url()],
-        &env,
-        b"tok\n",
-    )?;
-    out.assert()
-        .success()
-        .stderr(predicate::str::contains(
-            "HTTP 404, which can also mean no index exists at this URL",
-        ))
-        .stderr(predicate::str::contains("stored anyway"))
-        .stderr(predicate::str::contains("validated (api)"));
+    out.assert().success().stderr(predicate::str::contains(
+        "warning: no stored credential for `https://nothing.example/`",
+    ));
     Ok(())
 }
 
@@ -524,19 +351,11 @@ fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
     )?;
     out.assert()
         .success()
-        // The "Covers" globs are part of the login result (log output).
+        // The credential covers both the index root and the disjoint API.
         .stderr(predicate::str::contains(format!("{root}**")))
         .stderr(predicate::str::contains(format!("{api_root}**")))
         // Public read never exercised the token; the advertised API did.
         .stderr(predicate::str::contains("validated (api)"));
-
-    // The scoped claim is persisted and rendered by status.
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(format!(
-            "      Stored {root}  validated (api)"
-        )));
     Ok(())
 }
 
@@ -609,79 +428,6 @@ fn auth_login_validates_the_read_surface_of_a_private_index() -> TestResult {
         blob.contains(r#""secret":"sekrit-tok""#),
         "blob was: {blob}"
     );
-
-    // The claim was persisted and status renders it per entry.
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(format!(
-            "      Stored {}/  validated (read)",
-            server.url()
-        )));
-    Ok(())
-}
-
-#[test]
-fn auth_login_status_logout_round_trip_a_template_target() -> TestResult {
-    let (_store_dir, store_path) = seam_store()?;
-    let env = seam_env(&store_path);
-
-    let mut server = mockito::Server::new();
-    let template = format!("{}/repo/files/{{path}}/raw?ref=index", server.url());
-    let anchor_glob = format!("{}/repo/files/**", server.url());
-    let ref_query = mockito::Matcher::UrlEncoded("ref".into(), "index".into());
-    let _config = server
-        .mock("GET", "/repo/files/sysand-index-config.json/raw")
-        .match_query(ref_query.clone())
-        .with_status(404)
-        .create();
-    // The GitLab reality: unauthenticated GET answers 404 on a private
-    // repo, the forced bearer retry 200s (the accepted-read path).
-    let _unauth = server
-        .mock("GET", "/repo/files/index.json/raw")
-        .match_query(ref_query.clone())
-        .match_header("authorization", mockito::Matcher::Missing)
-        .with_status(404)
-        .create();
-    let _forced = server
-        .mock("GET", "/repo/files/index.json/raw")
-        .match_query(ref_query)
-        .match_header("authorization", "Bearer template-tok")
-        .with_status(200)
-        .create();
-
-    let (_t, _c, out) = run_sysand_stdin(
-        ["auth", "login", "--token-stdin", &template],
-        &env,
-        b"template-tok\n",
-    )?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(format!(
-            "Logging in to index `{template}`"
-        )))
-        // The "Covers" glob is part of the login result (log output).
-        .stderr(predicate::str::contains(&anchor_glob))
-        .stderr(predicate::str::contains("validated (read)"));
-
-    // `status` shows the key in the exact form `logout` accepts.
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(format!("      Stored {template}")))
-        .stdout(predicate::str::contains(&anchor_glob));
-
-    let (_t, _c, out) = run_sysand_with(["auth", "logout", &template], None, &env)?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(format!(
-            " Logging out from index `{template}`"
-        )));
-
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains("No credentials configured"));
     Ok(())
 }
 
@@ -719,6 +465,10 @@ fn auth_status_shows_identity_learned_by_a_validating_login() -> TestResult {
 
 #[test]
 fn auth_status_renders_one_stored_entry_without_separators_or_negatives() -> TestResult {
+    // The single golden-output canary for `auth status`: exact plain
+    // piped output (12-column gutter, no blank line around a single
+    // entry, no negative for the empty env side). All other tests assert
+    // substrings only.
     let (_store_dir, store_path) = seam_store()?;
     fs::write(
         &store_path,
@@ -730,74 +480,11 @@ fn auth_status_renders_one_stored_entry_without_separators_or_negatives() -> Tes
             "validated":["read","api"]}]}"#,
     )?;
 
-    // Exact plain output: no blank line around a single entry, and no
-    // negative for the empty env side.
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
     out.assert().success().stdout(predicate::eq(concat!(
         "      Stored https://one.example/  validated (read, api)\n",
         "             covers: https://one.example/**\n",
     )));
-    Ok(())
-}
-
-#[test]
-fn auth_status_separates_multiple_stored_entries_with_a_blank_line() -> TestResult {
-    let (_store_dir, store_path) = seam_store()?;
-    fs::write(
-        &store_path,
-        r#"{"version":1,"credentials":[{
-            "key":"https://a.example/",
-            "globs":["https://a.example/**"],
-            "scheme":"bearer",
-            "secret":"tok-a"
-        },{
-            "key":"https://b.example/",
-            "globs":["https://b.example/**"],
-            "scheme":"bearer",
-            "secret":"tok-b",
-            "validated":["read"]}]}"#,
-    )?;
-
-    // Exact plain output: one blank line between the entries, none after
-    // the last.
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
-    out.assert().success().stdout(predicate::eq(concat!(
-        "      Stored https://a.example/  not validated\n",
-        "             covers: https://a.example/**\n",
-        "\n",
-        "      Stored https://b.example/  validated (read)\n",
-        "             covers: https://b.example/**\n",
-    )));
-    Ok(())
-}
-
-#[test]
-fn auth_status_with_both_sources_lists_both_without_negatives() -> TestResult {
-    let (_store_dir, store_path) = seam_store()?;
-    fs::write(
-        &store_path,
-        r#"{"version":1,"credentials":[{
-            "key":"https://one.example/",
-            "globs":["https://one.example/**"],
-            "scheme":"bearer",
-            "secret":"tok-one"}]}"#,
-    )?;
-    let mut env = seam_env(&store_path);
-    env.insert(
-        "SYSAND_CRED_CI".to_string(),
-        "https://ci.example/**".to_string(),
-    );
-
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "      Stored https://one.example/",
-        ))
-        .stdout(predicate::str::contains(
-            "         Env SYSAND_CRED_CI  https://ci.example/**",
-        ))
-        .stdout(predicate::str::contains("No credentials configured").not());
     Ok(())
 }
 
@@ -816,30 +503,7 @@ fn one_example_blob() -> &'static str {
 }
 
 #[test]
-fn auth_status_marks_the_entry_for_a_configured_default_index() -> TestResult {
-    let (_store_dir, store_path) = seam_store()?;
-    fs::write(&store_path, one_example_blob())?;
-    let (_temp_dir, cwd) = new_temp_cwd()?;
-    let config_path = cwd.join("sysand.toml");
-    fs::write(
-        &config_path,
-        "[[index]]\nurl = \"https://one.example\"\ndefault = true\n",
-    )?;
-
-    let out = run_sysand_in_with(
-        &cwd,
-        ["auth", "status"],
-        Some(config_path.as_str()),
-        &seam_env(&store_path),
-    )?;
-    out.assert().success().stdout(predicate::str::contains(
-        "      Stored https://one.example/  validated (read)  (default index)",
-    ));
-    Ok(())
-}
-
-#[test]
-fn auth_status_marks_the_entry_for_an_env_default_index() -> TestResult {
+fn auth_status_marks_the_entry_for_the_default_index() -> TestResult {
     let (_store_dir, store_path) = seam_store()?;
     fs::write(&store_path, one_example_blob())?;
     let mut env = seam_env(&store_path);
@@ -850,75 +514,8 @@ fn auth_status_marks_the_entry_for_an_env_default_index() -> TestResult {
 
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert().success().stdout(predicate::str::contains(
-        "      Stored https://one.example/  validated (read)  (default index)",
+        "Stored https://one.example/  validated (read)  (default index)",
     ));
-    Ok(())
-}
-
-#[test]
-fn auth_status_marks_the_entry_for_the_built_in_default_index() -> TestResult {
-    // No override, no configured default: the chain falls through to the
-    // built-in `https://sysand.com`, whose normalized key must match.
-    let (_store_dir, store_path) = seam_store()?;
-    fs::write(
-        &store_path,
-        r#"{"version":1,"credentials":[{
-            "key":"https://sysand.com/",
-            "globs":["https://sysand.com/**"],
-            "scheme":"bearer",
-            "secret":"tok"}]}"#,
-    )?;
-
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
-    out.assert().success().stdout(predicate::str::contains(
-        "      Stored https://sysand.com/  not validated  (default index)",
-    ));
-    Ok(())
-}
-
-#[test]
-fn auth_status_marks_a_stored_entry_whose_glob_covers_the_default_index() -> TestResult {
-    // Keyed elsewhere, but a disjoint glob (the `api_root` shape) covers
-    // the built-in default index root: marked without key equality.
-    let (_store_dir, store_path) = seam_store()?;
-    fs::write(
-        &store_path,
-        r#"{"version":1,"credentials":[{
-            "key":"https://other.example/",
-            "globs":["https://other.example/**","https://sysand.com/**"],
-            "scheme":"bearer",
-            "secret":"tok"}]}"#,
-    )?;
-
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
-    out.assert().success().stdout(predicate::str::contains(
-        "      Stored https://other.example/  not validated  (default index)",
-    ));
-    Ok(())
-}
-
-#[test]
-fn auth_status_marks_an_env_entry_whose_pattern_covers_the_default_index() -> TestResult {
-    let (_store_dir, store_path) = seam_store()?;
-    let mut env = seam_env(&store_path);
-    env.insert(
-        "SYSAND_CRED_HIT".to_string(),
-        "https://sysand.com/**".to_string(),
-    );
-    env.insert(
-        "SYSAND_CRED_MISS".to_string(),
-        "https://elsewhere.example/**".to_string(),
-    );
-
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "         Env SYSAND_CRED_HIT  https://sysand.com/**  (default index)",
-        ))
-        .stdout(predicate::str::contains(
-            "         Env SYSAND_CRED_MISS  https://elsewhere.example/**\n",
-        ));
     Ok(())
 }
 
@@ -937,26 +534,8 @@ fn auth_status_with_an_ambiguous_default_chain_notes_and_marks_nothing() -> Test
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains(
-            "note: more than one default index is configured; no entry is marked as \
-             the default index",
-        ))
+        .stdout(predicate::str::contains("more than one default index"))
         .stdout(predicate::str::contains(MARKER).not());
-    Ok(())
-}
-
-#[test]
-fn auth_status_without_a_matching_entry_shows_no_marker() -> TestResult {
-    // A stored entry that neither is nor covers the built-in default:
-    // output is unchanged, no marker, no note.
-    let (_store_dir, store_path) = seam_store()?;
-    fs::write(&store_path, one_example_blob())?;
-
-    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
-    out.assert()
-        .success()
-        .stdout(predicate::str::contains(MARKER).not())
-        .stdout(predicate::str::contains("note:").not());
     Ok(())
 }
 
@@ -971,10 +550,6 @@ fn auth_login_fails_fast_when_stdin_is_not_a_terminal() -> TestResult {
     )?;
     out.assert()
         .failure()
-        // The resolved index is echoed even though no secret was read.
-        .stdout(predicate::str::contains(
-            "Logging in to index `http://127.0.0.1:1/`",
-        ))
         .stderr(predicate::str::contains(NO_TTY_MESSAGE));
     assert!(!store_path.exists(), "nothing may be stored");
     Ok(())
@@ -1044,35 +619,6 @@ fn auth_login_without_keyring_backend_prints_env_lines_with_a_placeholder() -> T
             "the secret leaked into command output"
         );
     }
-    Ok(())
-}
-
-#[test]
-fn auth_login_without_keyring_distinguishes_ports_in_the_env_stem() -> TestResult {
-    // Two indexes on different ports of one host must get different
-    // variable stems, or the second guidance would silently overwrite
-    // the first credential.
-    let mut env = IndexMap::new();
-    env.insert(SEAM_ENV_VAR.to_string(), ":absent:".to_string());
-
-    let (_t, _c, out) = run_sysand_stdin(
-        [
-            "auth",
-            "login",
-            "--token-stdin",
-            "https://sysand.example:8443/idx",
-        ],
-        &env,
-        b"tok\n",
-    )?;
-    out.assert()
-        .failure()
-        .stdout(predicate::str::contains(
-            "SYSAND_CRED_SYSAND_EXAMPLE_8443=https://sysand.example:8443/idx/**",
-        ))
-        .stdout(predicate::str::contains(
-            "SYSAND_CRED_SYSAND_EXAMPLE_8443_BEARER_TOKEN=<token>",
-        ));
     Ok(())
 }
 
@@ -1166,15 +712,10 @@ fn auth_whoami_with_a_stored_login_renders_the_identity() -> TestResult {
     out.assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "    Checking identity on index `{}/`",
+            "Using stored credential for `{}/`",
             server.url()
         )))
-        .stdout(predicate::str::contains(format!(
-            "       Using stored credential for `{}/`",
-            server.url()
-        )))
-        .stdout(predicate::str::contains("     Subject user alice"))
-        .stdout(predicate::str::contains("  Token name laptop"))
+        .stdout(predicate::str::contains("Subject user alice"))
         .stdout(predicate::str::contains("Token prefix sysand_u_1a2b3c4d"))
         .stdout(predicate::str::contains("expires in"))
         .stdout(predicate::str::contains("sekrit-whoami-tok").not());
@@ -1249,13 +790,7 @@ fn auth_whoami_without_a_matching_credential_suggests_login() -> TestResult {
     out.assert()
         .failure()
         .stderr(predicate::str::contains("no credential matches"))
-        // The hint leads with the interactive fix and names the
-        // `SYSAND_CRED_*` variables second, as the CI path.
-        .stderr(predicate::str::contains(format!(
-            "run `sysand auth login {}/` to store a credential; \
-             in CI, set `SYSAND_CRED_*` environment variables instead",
-            server.url()
-        )));
+        .stderr(predicate::str::contains("sysand auth login"));
     Ok(())
 }
 
@@ -1276,15 +811,5 @@ fn auth_whoami_errors_when_the_index_does_not_advertise_an_api() -> TestResult {
     out.assert()
         .failure()
         .stderr(predicate::str::contains("does not advertise an API"));
-    Ok(())
-}
-
-#[test]
-fn auth_whoami_rejects_a_non_http_index() -> TestResult {
-    // Fails during target validation, before any credential store access.
-    let (_temp_dir, _cwd, out) = run_sysand(["auth", "whoami", "file:///srv/index"], None)?;
-    out.assert()
-        .failure()
-        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
     Ok(())
 }

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -422,6 +422,8 @@ fn auth_login_refuses_a_credential_every_exercised_surface_rejected() -> TestRes
     out.assert()
         .failure()
         .stderr(predicate::str::contains("rejected"))
+        // The refusal names the status the rejecting surface answered.
+        .stderr(predicate::str::contains("answered HTTP 401"))
         .stderr(predicate::str::contains("nothing was stored"));
     assert!(
         !store_path.exists(),

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -316,7 +316,7 @@ fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
         .success()
         .stdout(predicate::str::contains("      Stored http://127.0.0.1:1/"))
         .stdout(predicate::str::contains(
-            "             patterns: http://127.0.0.1:1/**",
+            "             covers: http://127.0.0.1:1/**",
         ))
         // A stored login exists, so the env-side negative is omitted.
         .stdout(predicate::str::contains("SYSAND_CRED").not());
@@ -646,7 +646,7 @@ fn auth_status_renders_one_stored_entry_without_separators_or_negatives() -> Tes
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
     out.assert().success().stdout(predicate::eq(concat!(
         "      Stored https://one.example/  validated (read, api)\n",
-        "             patterns: https://one.example/**\n",
+        "             covers: https://one.example/**\n",
     )));
     Ok(())
 }
@@ -674,10 +674,10 @@ fn auth_status_separates_multiple_stored_entries_with_a_blank_line() -> TestResu
     let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
     out.assert().success().stdout(predicate::eq(concat!(
         "      Stored https://a.example/  not validated\n",
-        "             patterns: https://a.example/**\n",
+        "             covers: https://a.example/**\n",
         "\n",
         "      Stored https://b.example/  validated (read)\n",
-        "             patterns: https://b.example/**\n",
+        "             covers: https://b.example/**\n",
     )));
     Ok(())
 }

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -362,7 +362,7 @@ fn auth_login_twice_reports_the_replacement_and_overwrites() -> TestResult {
     )?;
     out.assert()
         .success()
-        .stdout(predicate::str::contains("Replacing existing credential").not());
+        .stderr(predicate::str::contains("Replacing existing credential").not());
 
     let (_t, _c, out) = run_sysand_stdin(
         // A different spelling of the same index normalizes to one key.
@@ -370,13 +370,34 @@ fn auth_login_twice_reports_the_replacement_and_overwrites() -> TestResult {
         &env,
         b"new-tok\n",
     )?;
-    out.assert().success().stdout(predicate::str::contains(
+    // The notice is informational (log output, stderr), not stdout: the
+    // stdout channel carries only the pre-prompt target echo.
+    out.assert().success().stderr(predicate::str::contains(
         "   Replacing existing credential for `http://127.0.0.1:1/`",
     ));
 
     let blob = fs::read_to_string(&store_path)?;
     assert!(blob.contains(r#""secret":"new-tok""#), "blob was: {blob}");
     assert!(!blob.contains("old-tok"), "blob was: {blob}");
+
+    // Under `--quiet` a re-login is exit-code-only apart from the target
+    // echo: the replacement notice is suppressed with the result lines.
+    let (_t, _c, out) = run_sysand_stdin(
+        [
+            "--quiet",
+            "auth",
+            "login",
+            "--token-stdin",
+            "http://127.0.0.1:1",
+        ],
+        &env,
+        b"third-tok\n",
+    )?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("Logging in to index"))
+        .stderr(predicate::str::contains("Replacing").not())
+        .stderr(predicate::str::contains("Stored").not());
     Ok(())
 }
 
@@ -403,10 +424,12 @@ fn auth_login_then_logout_removes_the_stored_entry() -> TestResult {
 }
 
 #[test]
-fn auth_logout_of_an_unknown_index_points_at_status() -> TestResult {
-    // The seam store file does not exist: nothing is stored. The error
-    // must point at `auth status`, whose listing shows every stored key
-    // in the exact spelling logout accepts (the fix for a typoed URL).
+fn auth_logout_of_an_unknown_index_warns_and_succeeds() -> TestResult {
+    // The seam store file does not exist: nothing is stored. Logout is
+    // idempotent: a warning and exit 0, so cleanup scripts need not
+    // swallow a failure. The warning still points at `auth status`,
+    // whose listing shows every stored key in the exact spelling logout
+    // accepts (the fix for a typoed URL).
     let (_store_dir, store_path) = seam_store()?;
     let (_t, _c, out) = run_sysand_with(
         ["auth", "logout", "https://nothing.example"],
@@ -414,9 +437,9 @@ fn auth_logout_of_an_unknown_index_points_at_status() -> TestResult {
         &seam_env(&store_path),
     )?;
     out.assert()
-        .failure()
+        .success()
         .stderr(predicate::str::contains(
-            "no stored credential for `https://nothing.example/`",
+            "warning: no stored credential for `https://nothing.example/`",
         ))
         .stderr(predicate::str::contains(
             "run `sysand auth status` to list the stored logins and their exact keys",

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -464,6 +464,32 @@ fn auth_status_shows_identity_learned_by_a_validating_login() -> TestResult {
 }
 
 #[test]
+fn auth_status_renders_unknown_subject_and_surface_values_verbatim() -> TestResult {
+    // A newer sysand or server may write subject types and validated
+    // surfaces this build does not know; status must render them as
+    // their stored strings, never fail or drop them.
+    let (_store_dir, store_path) = seam_store()?;
+    fs::write(
+        &store_path,
+        r#"{"version":1,"credentials":[{
+            "key":"https://example.com/",
+            "globs":["https://example.com/**"],
+            "scheme":"bearer",
+            "secret":"sekrit-unknown-tok",
+            "subject":{"type":"robot","name":"bot-7"},
+            "validated":["read","novel-surface"]}]}"#,
+    )?;
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &seam_env(&store_path))?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("subject: robot bot-7"))
+        .stdout(predicate::str::contains("validated (read, novel-surface)"))
+        .stdout(predicate::str::contains("sekrit-unknown-tok").not());
+    Ok(())
+}
+
+#[test]
 fn auth_status_renders_one_stored_entry_without_separators_or_negatives() -> TestResult {
     // The single golden-output canary for `auth status`: exact plain
     // piped output (12-column gutter, no blank line around a single

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -218,3 +218,310 @@ fn auth_status_lists_env_credentials_and_never_secrets() -> TestResult {
         .stdout(predicate::str::contains("secret-pass-word").not());
     Ok(())
 }
+
+// `sysand auth login`
+//
+// These tests run against the debug-only credential store seam
+// (`SYSAND_TEST_CREDENTIAL_STORE`, sysand/src/credential_store.rs): a
+// file-backed blob store, or a simulated-absent backend, so no test can
+// ever touch the real OS keyring.
+
+const SEAM_ENV_VAR: &str = "SYSAND_TEST_CREDENTIAL_STORE";
+const NO_TTY_MESSAGE: &str = "no terminal for prompt; pass the token with `--token-stdin`";
+const STORED_MESSAGE: &str = "stored, not validated";
+
+fn seam_env(store_path: &camino::Utf8Path) -> IndexMap<String, String> {
+    let mut env = IndexMap::new();
+    env.insert(SEAM_ENV_VAR.to_string(), store_path.to_string());
+    env
+}
+
+/// Run sysand with piped stdin (so stdin is not a TTY) and the given
+/// bytes written to it.
+fn run_sysand_stdin<'a, I: IntoIterator<Item = &'a str>>(
+    args: I,
+    env: &IndexMap<String, String>,
+    input: &[u8],
+) -> Result<
+    (
+        camino_tempfile::Utf8TempDir,
+        camino::Utf8PathBuf,
+        std::process::Output,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    use std::io::Write as _;
+    let (temp_dir, cwd, mut cmd) = sysand_cmd(args, None, env)?;
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn()?;
+    child
+        .stdin
+        .take()
+        .expect("stdin was piped")
+        .write_all(input)?;
+    Ok((temp_dir, cwd, child.wait_with_output()?))
+}
+
+/// A temp home for the seam store file, outliving the commands under test.
+fn seam_store()
+-> Result<(camino_tempfile::Utf8TempDir, camino::Utf8PathBuf), Box<dyn std::error::Error>> {
+    let dir = camino_tempfile::Utf8TempDir::with_prefix("sysand_cred_seam_")?;
+    let path = dir.path().join("creds.json");
+    Ok((dir, path))
+}
+
+#[test]
+fn auth_login_token_stdin_stores_and_status_lists_the_entry() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    // Port 1 answers nothing, so discovery falls back to the URL-derived
+    // pattern with a warning; no network beyond localhost is touched.
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", "http://127.0.0.1:1"],
+        &env,
+        b"sekrit-tok\n",
+    )?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Logging in to index `http://127.0.0.1:1/`",
+        ))
+        .stdout(predicate::str::contains("http://127.0.0.1:1/**"))
+        // The styled confirmation is log output (stderr).
+        .stderr(predicate::str::contains(STORED_MESSAGE));
+
+    // The stored secret is exactly the piped bytes minus one trailing
+    // newline (observable only through the seam file; `status` never
+    // shows secrets).
+    let blob = fs::read_to_string(&store_path)?;
+    assert!(
+        blob.contains(r#""secret":"sekrit-tok""#),
+        "blob was: {blob}"
+    );
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("stored  http://127.0.0.1:1/"))
+        .stdout(predicate::str::contains("patterns: http://127.0.0.1:1/**"));
+    Ok(())
+}
+
+#[test]
+fn auth_login_token_stdin_trims_exactly_one_trailing_newline() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    // CRLF counts as one newline.
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", "http://127.0.0.1:1"],
+        &env,
+        b"crlf-tok\r\n",
+    )?;
+    out.assert().success();
+    let blob = fs::read_to_string(&store_path)?;
+    assert!(blob.contains(r#""secret":"crlf-tok""#), "blob was: {blob}");
+
+    // Only one trailing newline is trimmed; an inner one is kept.
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", "http://127.0.0.1:1"],
+        &env,
+        b"odd-tok\n\n",
+    )?;
+    out.assert().success();
+    let blob = fs::read_to_string(&store_path)?;
+    assert!(blob.contains(r#""secret":"odd-tok\n""#), "blob was: {blob}");
+    Ok(())
+}
+
+#[test]
+fn auth_login_twice_reports_the_replacement_and_overwrites() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", "http://127.0.0.1:1"],
+        &env,
+        b"old-tok\n",
+    )?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("replacing existing credential").not());
+
+    let (_t, _c, out) = run_sysand_stdin(
+        // A different spelling of the same index normalizes to one key.
+        ["auth", "login", "--token-stdin", "http://127.0.0.1:1/"],
+        &env,
+        b"new-tok\n",
+    )?;
+    out.assert().success().stdout(predicate::str::contains(
+        "replacing existing credential for `http://127.0.0.1:1/`",
+    ));
+
+    let blob = fs::read_to_string(&store_path)?;
+    assert!(blob.contains(r#""secret":"new-tok""#), "blob was: {blob}");
+    assert!(!blob.contains("old-tok"), "blob was: {blob}");
+    Ok(())
+}
+
+#[test]
+fn auth_login_then_logout_removes_the_stored_entry() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", "http://127.0.0.1:1"],
+        &env,
+        b"tok\n",
+    )?;
+    out.assert().success();
+
+    let (_t, _c, out) = run_sysand_with(["auth", "logout", "http://127.0.0.1:1"], None, &env)?;
+    out.assert().success();
+
+    let (_t, _c, out) = run_sysand_with(["auth", "status"], None, &env)?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("No stored index logins."));
+    Ok(())
+}
+
+#[test]
+fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    let mut server = mockito::Server::new();
+    let _mock = server
+        .mock("GET", "/sysand-index-config.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"api_root": "https://api.example.com/base/"}"#)
+        .create();
+    let root = format!("{}/", server.url());
+
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", &server.url()],
+        &env,
+        b"tok\n",
+    )?;
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains(format!("{root}**")))
+        .stdout(predicate::str::contains("https://api.example.com/base/**"));
+    Ok(())
+}
+
+#[test]
+fn auth_login_fails_fast_when_stdin_is_not_a_terminal() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    // `run_sysand_with` runs with a null stdin: not a TTY.
+    let (_t, _c, out) = run_sysand_with(
+        ["auth", "login", "http://127.0.0.1:1"],
+        None,
+        &seam_env(&store_path),
+    )?;
+    out.assert()
+        .failure()
+        // The resolved index is echoed even though no secret was read.
+        .stdout(predicate::str::contains(
+            "Logging in to index `http://127.0.0.1:1/`",
+        ))
+        .stderr(predicate::str::contains(NO_TTY_MESSAGE));
+    assert!(!store_path.exists(), "nothing may be stored");
+    Ok(())
+}
+
+#[test]
+fn auth_login_rejects_an_empty_token() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    for input in [b"".as_slice(), b"\n".as_slice()] {
+        let (_t, _c, out) = run_sysand_stdin(
+            ["auth", "login", "--token-stdin", "http://127.0.0.1:1"],
+            &seam_env(&store_path),
+            input,
+        )?;
+        out.assert()
+            .failure()
+            .stderr(predicate::str::contains("empty token"));
+    }
+    assert!(!store_path.exists(), "nothing may be stored");
+    Ok(())
+}
+
+#[test]
+fn auth_login_rejects_a_non_http_index_before_reading_a_secret() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", "file:///srv/index"],
+        &seam_env(&store_path),
+        b"tok\n",
+    )?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(NOT_HTTP_MESSAGE));
+    assert!(!store_path.exists(), "nothing may be stored");
+    Ok(())
+}
+
+#[test]
+fn auth_login_without_keyring_backend_prints_env_lines_with_a_placeholder() -> TestResult {
+    let mut env = IndexMap::new();
+    env.insert(SEAM_ENV_VAR.to_string(), ":absent:".to_string());
+
+    let (_t, _c, out) = run_sysand_stdin(
+        [
+            "auth",
+            "login",
+            "--token-stdin",
+            "https://sysand.example/idx",
+        ],
+        &env,
+        b"hush-secret\n",
+    )?;
+    let assert = out
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "SYSAND_CRED_SYSAND_EXAMPLE=https://sysand.example/idx/**",
+        ))
+        .stdout(predicate::str::contains(
+            "SYSAND_CRED_SYSAND_EXAMPLE_BEARER_TOKEN=<token>",
+        ));
+    // The entered secret must never be echoed anywhere.
+    let output = assert.get_output();
+    for stream in [&output.stdout, &output.stderr] {
+        assert!(
+            !String::from_utf8_lossy(stream).contains("hush-secret"),
+            "the secret leaked into command output"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn auth_login_prompts_hidden_on_a_terminal() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+
+    let (_t, _c, mut session) = run_sysand_interactive_with(
+        ["auth", "login", "http://127.0.0.1:1"],
+        Some(30_000),
+        None,
+        &seam_env(&store_path),
+    )?;
+    session.exp_string("Logging in to index `http://127.0.0.1:1/`")?;
+    session.exp_string("Enter token for `http://127.0.0.1:1/`:")?;
+    session.send_line("pty-tok")?;
+    session.exp_string(STORED_MESSAGE)?;
+    assert!(await_exit(session)?.success());
+
+    let blob = fs::read_to_string(&store_path)?;
+    assert!(blob.contains(r#""secret":"pty-tok""#), "blob was: {blob}");
+    // The hidden prompt must not have echoed the secret; the only place
+    // it may appear is the seam store file.
+    Ok(())
+}

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -8,7 +8,7 @@
 //! deliberately fail before any credential store access (parse errors,
 //! non-HTTP(S) targets, ambiguous defaults), so no test requires, or can
 //! ever mutate, a real OS keyring: store behavior itself is covered by the
-//! core tests over `InMemoryCredentialStore`.
+//! core tests over an in-memory blob backend.
 
 use std::fs;
 

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -403,6 +403,72 @@ fn auth_login_then_logout_removes_the_stored_entry() -> TestResult {
 }
 
 #[test]
+fn auth_logout_of_an_unknown_index_points_at_status() -> TestResult {
+    // The seam store file does not exist: nothing is stored. The error
+    // must point at `auth status`, whose listing shows every stored key
+    // in the exact spelling logout accepts (the fix for a typoed URL).
+    let (_store_dir, store_path) = seam_store()?;
+    let (_t, _c, out) = run_sysand_with(
+        ["auth", "logout", "https://nothing.example"],
+        None,
+        &seam_env(&store_path),
+    )?;
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no stored credential for `https://nothing.example/`",
+        ))
+        .stderr(predicate::str::contains(
+            "run `sysand auth status` to list the stored logins and their exact keys",
+        ));
+    Ok(())
+}
+
+#[test]
+fn auth_login_stored_anyway_hedges_a_read_404() -> TestResult {
+    let (_store_dir, store_path) = seam_store()?;
+    let env = seam_env(&store_path);
+
+    let mut server = mockito::Server::new();
+    let _config = server
+        .mock("GET", "/sysand-index-config.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"api_root": "{}/api/"}}"#, server.url()))
+        .create();
+    // The read surface answers 404 with and without the token. A 404 can
+    // mean a rejected token (GitLab-style hosts) or no `index.json` at
+    // all, so the stored-anyway warning must carry the same hedge the
+    // refusal message has. The advertised API accepts, so the login
+    // stores the credential.
+    let _index = server
+        .mock("GET", "/index.json")
+        .with_status(404)
+        .expect(2)
+        .create();
+    let _whoami = server
+        .mock("GET", "/api/v1/whoami")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(WHOAMI_BODY)
+        .create();
+
+    let (_t, _c, out) = run_sysand_stdin(
+        ["auth", "login", "--token-stdin", &server.url()],
+        &env,
+        b"tok\n",
+    )?;
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "HTTP 404, which can also mean no index exists at this URL",
+        ))
+        .stderr(predicate::str::contains("stored anyway"))
+        .stderr(predicate::str::contains("validated (api)"));
+    Ok(())
+}
+
+#[test]
 fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
     let (_store_dir, store_path) = seam_store()?;
     let env = seam_env(&store_path);
@@ -958,6 +1024,35 @@ fn auth_login_without_keyring_backend_prints_env_lines_with_a_placeholder() -> T
     Ok(())
 }
 
+#[test]
+fn auth_login_without_keyring_distinguishes_ports_in_the_env_stem() -> TestResult {
+    // Two indexes on different ports of one host must get different
+    // variable stems, or the second guidance would silently overwrite
+    // the first credential.
+    let mut env = IndexMap::new();
+    env.insert(SEAM_ENV_VAR.to_string(), ":absent:".to_string());
+
+    let (_t, _c, out) = run_sysand_stdin(
+        [
+            "auth",
+            "login",
+            "--token-stdin",
+            "https://sysand.example:8443/idx",
+        ],
+        &env,
+        b"tok\n",
+    )?;
+    out.assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "SYSAND_CRED_SYSAND_EXAMPLE_8443=https://sysand.example:8443/idx/**",
+        ))
+        .stdout(predicate::str::contains(
+            "SYSAND_CRED_SYSAND_EXAMPLE_8443_BEARER_TOKEN=<token>",
+        ));
+    Ok(())
+}
+
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn auth_login_prompts_hidden_on_a_terminal() -> TestResult {
@@ -1131,7 +1226,13 @@ fn auth_whoami_without_a_matching_credential_suggests_login() -> TestResult {
     out.assert()
         .failure()
         .stderr(predicate::str::contains("no credential matches"))
-        .stderr(predicate::str::contains("sysand auth login"));
+        // The hint leads with the interactive fix and names the
+        // `SYSAND_CRED_*` variables second, as the CI path.
+        .stderr(predicate::str::contains(format!(
+            "run `sysand auth login {}/` to store a credential; \
+             in CI, set `SYSAND_CRED_*` environment variables instead",
+            server.url()
+        )));
     Ok(())
 }
 

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -334,7 +334,7 @@ fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
         .with_header("content-type", "application/json")
         .with_body(format!(r#"{{"api_root": "{api_root}"}}"#))
         .create();
-    let _index = server.mock("GET", "/index.json").with_status(200).create();
+    let _index = server.mock("HEAD", "/index.json").with_status(200).create();
     let _whoami = api_server
         .mock("GET", "/base/v1/whoami")
         .match_header("authorization", "Bearer tok")
@@ -372,7 +372,7 @@ fn auth_login_refuses_a_credential_every_exercised_surface_rejected() -> TestRes
     // Unauth baseline 401, forced bearer retry 401: rejected everywhere
     // it was exercised, so the login must refuse and store nothing.
     let _index = server
-        .mock("GET", "/index.json")
+        .mock("HEAD", "/index.json")
         .with_status(401)
         .expect(2)
         .create();
@@ -404,12 +404,12 @@ fn auth_login_validates_the_read_surface_of_a_private_index() -> TestResult {
         .with_status(404)
         .create();
     let _unauth = server
-        .mock("GET", "/index.json")
+        .mock("HEAD", "/index.json")
         .match_header("authorization", mockito::Matcher::Missing)
         .with_status(401)
         .create();
     let _forced = server
-        .mock("GET", "/index.json")
+        .mock("HEAD", "/index.json")
         .match_header("authorization", "Bearer sekrit-tok")
         .with_status(200)
         .create();

--- a/sysand/tests/cli_auth.rs
+++ b/sysand/tests/cli_auth.rs
@@ -403,15 +403,14 @@ fn auth_login_covers_a_disjoint_api_root_from_discovery() -> TestResult {
         .create();
     let root = format!("{}/", server.url());
 
-    // `--validation false`: the advertised api_root is a foreign host
+    // `--no-validation`: the advertised api_root is a foreign host
     // this test must not probe.
     let (_t, _c, out) = run_sysand_stdin(
         [
             "auth",
             "login",
             "--token-stdin",
-            "--validation",
-            "false",
+            "--no-validation",
             &server.url(),
         ],
         &env,

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -842,6 +842,9 @@ fn publish_rejects_ambiguous_bearer_credentials() -> TestResult {
         .stderr(predicate::str::contains(
             "multiple bearer token credentials from `SYSAND_CRED_*` environment variables configured for publish URL",
         ))
+        // The error names every conflicting `SYSAND_CRED_<LABEL>` variable.
+        .stderr(predicate::str::contains("SYSAND_CRED_A"))
+        .stderr(predicate::str::contains("SYSAND_CRED_B"))
         .stderr(predicate::str::contains("HTTP request failed").not());
 
     publish_mock.assert();

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -707,6 +707,54 @@ fn publish_ignores_basic_auth_credentials() -> TestResult {
 }
 
 #[test]
+fn publish_uses_stored_credential_when_no_env_bearer_matches() -> TestResult {
+    // A stored login (seeded through the debug-only file-backed store
+    // seam, see cli_auth.rs) must reach the upload's Authorization header
+    // when no `SYSAND_CRED_*` bearer matches: publish reads the store
+    // directly, exactly once, during credential selection.
+    let (_temp_dir, cwd) = setup_built_project("publish-stored-credential")?;
+
+    let mut server = Server::new();
+    let config_mock = mock_index_config_api_at_api(&mut server);
+    let publish_mock = mock_publish_with_bearer(&mut server, "stored-tok");
+
+    let store_dir = camino_tempfile::Utf8TempDir::with_prefix("sysand_cred_seam_")?;
+    let store_path = store_dir.path().join("creds.json");
+    // The blob as `sysand auth login` persists it, covering the whole
+    // index host, so the derived glob matches the upload URL.
+    fs::write(
+        &store_path,
+        format!(
+            r#"{{"version":1,"credentials":[{{
+                "key":"{url}/",
+                "globs":["{url}/**"],
+                "scheme":"bearer",
+                "secret":"stored-tok",
+                "validated":["publish"]}}]}}"#,
+            url = server.url()
+        ),
+    )?;
+
+    let mut env = IndexMap::new();
+    env.insert(
+        "SYSAND_TEST_CREDENTIAL_STORE".to_string(),
+        store_path.to_string(),
+    );
+
+    let out = run_sysand_in_with(
+        &cwd,
+        ["publish", "--index", server.url().as_str()],
+        None,
+        &env,
+    )?;
+    out.assert().success();
+    publish_mock.assert();
+    config_mock.assert();
+
+    Ok(())
+}
+
+#[test]
 fn publish_rejects_ambiguous_bearer_credentials() -> TestResult {
     let (_temp_dir, cwd) = setup_built_project("publish-ambiguous-bearer")?;
 

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -776,23 +776,37 @@ fn assert_publish_error_status(
 
 #[test]
 fn publish_401_maps_to_auth_error() -> TestResult {
+    // The bearer came from the `SYSAND_CRED_TEST` environment credential,
+    // so the failure names that source with the env remediation
+    // (design/credential-storage.md section 7).
     assert_publish_error_status(
         "publish-auth-401",
         401,
         "unauthorized",
         None,
-        &["authentication failed", "unauthorized"],
+        &[
+            "authentication failed",
+            "unauthorized",
+            "came from `SYSAND_CRED_TEST`",
+            "SYSAND_CRED_TEST_BEARER_TOKEN",
+        ],
     )
 }
 
 #[test]
 fn publish_403_maps_to_auth_error() -> TestResult {
+    // 403 additionally points at `sysand auth status`.
     assert_publish_error_status(
         "publish-auth-403",
         403,
         "forbidden",
         None,
-        &["authentication failed", "forbidden"],
+        &[
+            "authorization failed",
+            "forbidden",
+            "came from `SYSAND_CRED_TEST`",
+            "run `sysand auth status`",
+        ],
     )
 }
 

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -724,7 +724,7 @@ fn publish_rejects_ambiguous_bearer_credentials() -> TestResult {
     out.assert()
         .failure()
         .stderr(predicate::str::contains(
-            "multiple bearer token credentials configured for publish URL",
+            "multiple bearer token credentials from `SYSAND_CRED_*` environment variables configured for publish URL",
         ))
         .stderr(predicate::str::contains("HTTP request failed").not());
 

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -692,8 +692,12 @@ fn publish_ignores_basic_auth_credentials() -> TestResult {
             "no bearer token credentials configured for publish URL",
         ))
         // The CLI adds the `sysand auth login` remediation the core message
-        // deliberately omits (core/CLI message split).
-        .stderr(predicate::str::contains("run `sysand auth login"))
+        // deliberately omits (core/CLI message split), naming the actual
+        // index URL so the hint is copy-pasteable.
+        .stderr(predicate::str::contains(format!(
+            "run `sysand auth login {}",
+            server.url()
+        )))
         .stderr(predicate::str::contains("HTTP request failed").not());
 
     publish_mock.assert();

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -363,6 +363,67 @@ fn publish_malformed_explicit_credentials_abort_before_trusted_publishing() -> T
 }
 
 #[test]
+fn env_credentials_without_a_label_get_a_labels_are_required_error() -> TestResult {
+    // Label-less names must not be misread as a pattern for a nonsense
+    // group; the error explains the label grammar instead.
+    let (_temp_dir, cwd) = setup_built_project("publish-label-less-creds")?;
+    let mut env = IndexMap::new();
+    env.insert("SYSAND_CRED".to_string(), "https://a.org".to_string());
+    env.insert("SYSAND_CRED_BASIC_USER".to_string(), "user-a".to_string());
+    env.insert(
+        "SYSAND_CRED_BASIC_PASS".to_string(),
+        "secret-pass-b".to_string(),
+    );
+
+    let out = run_sysand_in_with(
+        &cwd,
+        ["publish", "--index", "http://localhost:1"],
+        None,
+        &env,
+    )?;
+
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "SYSAND_CRED has no label; env credentials need one, as in SYSAND_CRED_MYINDEX",
+        ))
+        .stderr(predicate::str::contains("no matching authentication scheme").not())
+        // Never any variable's value, in particular not the password.
+        .stderr(predicate::str::contains("secret-pass-b").not())
+        .stderr(predicate::str::contains("user-a").not());
+
+    Ok(())
+}
+
+#[test]
+fn env_credential_scheme_errors_never_print_the_variable_values() -> TestResult {
+    // A pattern variable with no secret companion errors without echoing
+    // its value: a misnamed variable can put a secret in any position.
+    let (_temp_dir, cwd) = setup_built_project("publish-pattern-value-secrecy")?;
+    let mut env = IndexMap::new();
+    env.insert(
+        "SYSAND_CRED_TEST".to_string(),
+        "accidental-secret-value".to_string(),
+    );
+
+    let out = run_sysand_in_with(
+        &cwd,
+        ["publish", "--index", "http://localhost:1"],
+        None,
+        &env,
+    )?;
+
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "SYSAND_CRED_TEST has no matching authentication scheme",
+        ))
+        .stderr(predicate::str::contains("accidental-secret-value").not());
+
+    Ok(())
+}
+
+#[test]
 fn publish_with_explicit_index_succeeds() -> TestResult {
     let (_temp_dir, cwd) = setup_built_project("test-publish")?;
     let mut server = Server::new();

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -691,6 +691,9 @@ fn publish_ignores_basic_auth_credentials() -> TestResult {
         .stderr(predicate::str::contains(
             "no bearer token credentials configured for publish URL",
         ))
+        // The CLI adds the `sysand auth login` remediation the core message
+        // deliberately omits (core/CLI message split).
+        .stderr(predicate::str::contains("run `sysand auth login"))
         .stderr(predicate::str::contains("HTTP request failed").not());
 
     publish_mock.assert();
@@ -795,7 +798,9 @@ fn publish_401_maps_to_auth_error() -> TestResult {
 
 #[test]
 fn publish_403_maps_to_auth_error() -> TestResult {
-    // 403 additionally points at `sysand auth status`.
+    // 403 additionally points at `sysand auth status` (added by the CLI, per
+    // the core/CLI message split: core states the condition, the frontend
+    // names the command).
     assert_publish_error_status(
         "publish-auth-403",
         403,

--- a/sysand/tests/common/mod.rs
+++ b/sysand/tests/common/mod.rs
@@ -88,6 +88,10 @@ pub fn sysand_cmd_in_with<'a, I: IntoIterator<Item = &'a str>>(
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("sysand"));
 
     cmd.env("NO_COLOR", "1");
+    // A developer's ambient default-index override must not leak into
+    // tests (it would inject markers or ambiguity notes into asserted
+    // output); tests that need it set it explicitly via `env`.
+    cmd.env_remove("SYSAND_DEFAULT_INDEX");
     cmd.envs(env);
 
     cmd.args(args);

--- a/sysand/tests/common/mod.rs
+++ b/sysand/tests/common/mod.rs
@@ -92,6 +92,12 @@ pub fn sysand_cmd_in_with<'a, I: IntoIterator<Item = &'a str>>(
     // tests (it would inject markers or ambiguity notes into asserted
     // output); tests that need it set it explicitly via `env`.
     cmd.env_remove("SYSAND_DEFAULT_INDEX");
+    // Default the debug-only credential store seam
+    // (sysand/src/credential_store.rs) to a simulated-absent keyring so
+    // no test ever reads the developer's real OS keyring (which could
+    // alter assertions, or pop a keychain prompt on macOS). Tests that
+    // need a working store override this via `env` (see cli_auth.rs).
+    cmd.env("SYSAND_TEST_CREDENTIAL_STORE", ":absent:");
     cmd.envs(env);
 
     cmd.args(args);


### PR DESCRIPTION
I did initial planning of the UX and rough implementation for this feature (in https://github.com/sensmetry/sysand/issues/437#issuecomment-5011192677), then but Andrius did an amazing review effort getting it into a mergable state.

- fixes #437 

## PR description

Implements credential storage and the sysand auth command family
(login, logout, status, whoami), v1 of the design settled in #437 and
maintained in design/credential-storage.md on this branch.

Store an index credential once with sysand auth login and sysand
reuses it across runs on Windows, macOS, and Linux, with the secret
held by the OS keyring, never a plaintext file. Bearer-only v1;
SYSAND_CRED_* environment variables keep working unchanged and take
precedence, so CI overrides an interactive login.

Command surface:

- auth login [INDEX_URL] [--token-stdin]: hidden prompt or stdin,
  never an inline argument; resolves the default-index chain when no
  URL is given and always echoes the target before reading a secret.
  On hosts without a usable keyring backend it refuses to persist
  and prints exact SYSAND_CRED_* lines with a <token> placeholder.
- auth logout [INDEX_URL]: removes a stored login; idempotent.
- auth status: one unified, secret-free view of stored and env
  credentials, with per-surface validation claims, expiry,
  env-shadowing, and a default-index marker.
- auth whoami [INDEX_URL]: live identity check against v1/whoami
  using runtime credential selection (env over stored, naming the
  source used); read-only.

Storage is a single versioned JSON blob in one OS-keyring entry,
fail-closed on unreadable or newer-versioned blobs, guarded by a
cross-process file lock, with platform size limits mapped to clear
errors. The OS backend sits behind a non-default keyring feature;
record types and the LockedBlobStore seam are unconditional core, so
the js/wasm binding stays green.

Consumption is lazy: the existing env policy runs first, and only an
auth-relevant 4xx triggers one cached blob read per process and a
forced bearer retry when a stored glob matches. No matching record
returns the original response with zero extra requests. Local,
offline, public, and never-logged-in flows never touch the keyring.

Login validation is always on and discovery-first: per-surface
probes (read via HEAD, whoami via GET) exercise the credential only
when the unauthenticated baseline was 4xx; 429 and redirects are
never verdicts. Store if any exercised surface accepted; refuse only
when at least one rejected and none accepted; nothing exercised
stores as "stored, not validated". A successful whoami persists
subject, token name/prefix, and expiry for auth status. Basic-auth
challenges route the user to SYSAND_CRED_*_BASIC_* variables.

Index locations share one validation path: IndexLocation::parse owns
all invariants (absolute HTTP(S), no userinfo, no fragment; a query
is allowed on plain roots and templates alike) and normalizes both
forms so keys round-trip through login, status, and logout. Errors
redact embedded userinfo. Template keys normalize the literal prefix
and always anchor at scheme://authority/ or deeper; derived globs
are globset-escaped, anchored on query-stripped roots, and extended
with the resolved index_root/api_root only when not already covered.
Stored globs are the login-time snapshot, never auto-updated.

Publish selects bearers by source precedence (env, then stored;
ambiguity within a source errors and names every candidate), carries
provenance into 401/403 messages, and stops early on a clearly
expired stored token. Trusted publishing is unchanged.

The index API protocol gains a Token Identity section specifying
GET v1/whoami; the endpoint is implemented in the sysand-index repo
and already deployed on sysand.com.

Deferred (design section 10): auth set/unset, basic-auth login,
--pattern, and py/java binding exposure. User-facing docs are
written and reviewed on the sysand-index docs/sysand-auth branch,
gated on the release carrying this change.

Verified with 546 sysand-core and 204 sysand CLI tests, plus
no-keyring, wasm, and each-feature lanes. CLI tests never touch the
real OS keyring: a debug-only SYSAND_TEST_CREDENTIAL_STORE seam
backs end-to-end tests, including a PTY-driven hidden-prompt test
and a no-secret-leak assertion on the no-keyring path.
