### PR TITLE
ci: pin the prek job's Rust toolchain to rust-toolchain.toml

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -21,6 +21,14 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+
+      # prek's rust hooks use their language_version pin, not
+      # rust-toolchain.toml; preinstall the pinned toolchain so prek
+      # finds it. Do not drop this step: prek's own mid-hook download is
+      # profile-minimal and lacks the rustfmt/clippy components.
+      - name: Install the Rust toolchain pinned by rust-toolchain.toml
+        run: rustup toolchain install
+
       - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5
 
   ci-gate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,9 @@ repos:
         types_or: [rust, python, java, groovy, shell, xml, javascript]
 
   # Autoformat: rust
+  #
+  # rust hooks ignore rust-toolchain.toml; language_version is what pins
+  # them. Keep it in sync with rust-toolchain.toml.
   - repo: local
     hooks:
       - id: cargo-fmt
@@ -56,6 +59,7 @@ repos:
         entry: cargo fmt
         description: Formats all bin and lib files of the current workspace using rustfmt.
         language: rust
+        language_version: "1.96"
         types: [rust]
         args: ["--"]
 
@@ -64,6 +68,7 @@ repos:
         entry: cargo clippy
         description: Checks all packages in the workspace to catch common mistakes and improve your Rust code.
         language: rust
+        language_version: "1.96"
         types: [rust]
         args:
           - --workspace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,6 +7,9 @@
 #
 # - Check latest stable version: rustup check
 #
+# When bumping channel, also bump language_version for the rust hooks in
+# .pre-commit-config.yaml (prek does not read this file).
+#
 [toolchain]
 channel = "1.96"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
The prek job's `language: rust` hooks do not use the toolchain pinned by `rust-toolchain.toml`: prek picks a toolchain itself from what is installed, preferring the runner image's latest stable. When a newer stable clippy adds an auto-fixable lint, the `cargo clippy --fix` hook rewrites files and fails the gate with "files were modified". This hit #453 after the runner image moved to 1.97, forcing it to carry four unrelated lint fixes.

Two changes, verified locally by reproducing the failure and confirming the fix against prek's trace output:

- `language_version: "1.96"` on the rust hooks in `.pre-commit-config.yaml`: prek's own selector, the part that actually pins.
- A `rustup toolchain install` step in the workflow so the pinned toolchain (with the rustfmt/clippy components) exists for prek to find. Without it, prek downloads a profile-minimal toolchain lacking those components and cargo silently falls through to another toolchain's binaries.

The pin now lives in two places; `rust-toolchain.toml` and the hook config cross-reference each other so they get bumped together.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfyrkJkeo3mRngVoppJjUN