### PR TITLE
fix(test): stop the load_configs test reading the developer's real config

### DIFF
--- a/core/src/config/local_fs.rs
+++ b/core/src/config/local_fs.rs
@@ -53,8 +53,7 @@ pub fn load_configs<P: AsRef<Utf8Path>>(working_dir: P) -> Result<Config, Config
     load_configs_from(user_config.as_deref(), working_dir)
 }
 
-/// [`load_configs`] with the user configuration file location injected,
-/// so tests never read the developer's real configuration.
+/// [`load_configs`] with the user configuration file location injected
 pub(crate) fn load_configs_from<P: AsRef<Utf8Path>>(
     user_config: Option<&Utf8Path>,
     working_dir: P,

--- a/core/src/config/local_fs.rs
+++ b/core/src/config/local_fs.rs
@@ -45,14 +45,21 @@ pub fn get_config<P: AsRef<Utf8Path>>(path: P) -> Result<Config, ConfigReadError
 }
 
 pub fn load_configs<P: AsRef<Utf8Path>>(working_dir: P) -> Result<Config, ConfigReadError> {
-    let mut config = dirs::config_dir().map_or_else(
-        || Ok(Config::default()),
-        |mut path| {
-            path.push(CONFIG_DIR);
-            path.push(CONFIG_FILE);
-            get_config(Utf8PathBuf::from_path_buf(path).unwrap())
-        },
-    )?;
+    let user_config = dirs::config_dir().map(|mut path| {
+        path.push(CONFIG_DIR);
+        path.push(CONFIG_FILE);
+        Utf8PathBuf::from_path_buf(path).unwrap()
+    });
+    load_configs_from(user_config.as_deref(), working_dir)
+}
+
+/// [`load_configs`] with the user configuration file location injected,
+/// so tests never read the developer's real configuration.
+pub(crate) fn load_configs_from<P: AsRef<Utf8Path>>(
+    user_config: Option<&Utf8Path>,
+    working_dir: P,
+) -> Result<Config, ConfigReadError> {
+    let mut config = user_config.map_or_else(|| Ok(Config::default()), get_config)?;
     config.merge(get_config(working_dir.as_ref().join(CONFIG_FILE))?);
 
     Ok(config)

--- a/core/src/config/local_fs_tests.rs
+++ b/core/src/config/local_fs_tests.rs
@@ -46,8 +46,7 @@ fn load_configs_merges_user_config_before_working_dir() -> Result<(), Box<dyn Er
         }],
         projects: vec![],
     };
-    wrapfs::File::create(&user_path)?
-        .write_all(toml::to_string_pretty(&user_config)?.as_bytes())?;
+    wrapfs::write(&user_path, toml::to_string(&user_config)?)?;
 
     let working_dir = tempdir()?;
     let working_config = Config {
@@ -57,8 +56,7 @@ fn load_configs_merges_user_config_before_working_dir() -> Result<(), Box<dyn Er
         }],
         projects: vec![],
     };
-    wrapfs::File::create(working_dir.path().join(local_fs::CONFIG_FILE))?
-        .write_all(toml::to_string_pretty(&working_config)?.as_bytes())?;
+    wrapfs::write(working_dir.path().join(local_fs::CONFIG_FILE), toml::to_string(&working_config)?)?;
 
     let config_read = local_fs::load_configs_from(Some(&user_path), working_dir.path())?;
 

--- a/core/src/config/local_fs_tests.rs
+++ b/core/src/config/local_fs_tests.rs
@@ -56,7 +56,10 @@ fn load_configs_merges_user_config_before_working_dir() -> Result<(), Box<dyn Er
         }],
         projects: vec![],
     };
-    wrapfs::write(working_dir.path().join(local_fs::CONFIG_FILE), toml::to_string(&working_config)?)?;
+    wrapfs::write(
+        working_dir.path().join(local_fs::CONFIG_FILE),
+        toml::to_string(&working_config)?,
+    )?;
 
     let config_read = local_fs::load_configs_from(Some(&user_path), working_dir.path())?;
 

--- a/core/src/config/local_fs_tests.rs
+++ b/core/src/config/local_fs_tests.rs
@@ -25,9 +25,46 @@ fn load_configs() -> Result<(), Box<dyn Error>> {
     };
     config_file.write_all(toml::to_string_pretty(&config)?.as_bytes())?;
 
-    let config_read = local_fs::load_configs(dir.path())?;
+    // `None` user config: `load_configs` itself would read the
+    // developer's real `~/.config/sysand/sysand.toml` and make the
+    // assertion environment-dependent.
+    let config_read = local_fs::load_configs_from(None, dir.path())?;
 
     assert_eq!(config_read, config);
+
+    Ok(())
+}
+
+#[test]
+fn load_configs_merges_user_config_before_working_dir() -> Result<(), Box<dyn Error>> {
+    let user_dir = tempdir()?;
+    let user_path = user_dir.path().join(local_fs::CONFIG_FILE);
+    let user_config = Config {
+        indexes: vec![Index {
+            url: "http://user.example.com".to_string(),
+            ..Default::default()
+        }],
+        projects: vec![],
+    };
+    wrapfs::File::create(&user_path)?
+        .write_all(toml::to_string_pretty(&user_config)?.as_bytes())?;
+
+    let working_dir = tempdir()?;
+    let working_config = Config {
+        indexes: vec![Index {
+            url: "http://working.example.com".to_string(),
+            ..Default::default()
+        }],
+        projects: vec![],
+    };
+    wrapfs::File::create(working_dir.path().join(local_fs::CONFIG_FILE))?
+        .write_all(toml::to_string_pretty(&working_config)?.as_bytes())?;
+
+    let config_read = local_fs::load_configs_from(Some(&user_path), working_dir.path())?;
+
+    let mut expected = user_config;
+    expected.merge(working_config);
+    assert_eq!(config_read, expected);
 
     Ok(())
 }


### PR DESCRIPTION
`config::local_fs::tests::load_configs` calls `load_configs`, which merges the user configuration from `dirs::config_dir()` before asserting equality against a fixture. The assertion therefore depends on whatever `~/.config/sysand/sysand.toml` happens to contain: green on CI runners (no user config), red on any developer machine where sysand is actually used, with the developer's own index entries showing up in the assertion diff.

Fix by injection rather than environment mutation (mutating `HOME`/`XDG_CONFIG_HOME` in tests is racy under the multithreaded test runner): the loader is split into `load_configs_from(user_config: Option<&Utf8Path>, working_dir)`, and `load_configs` delegates to it with the `dirs` lookup, so public behavior is unchanged. The existing test passes `None`; a new test exercises the user-then-working-dir merge through the injected path, which was previously untestable in isolation.

Verified on a machine with a real user config (which reproduced the failure before the fix): the config tests and the full core suite pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfyrkJkeo3mRngVoppJjUN