### PR TITLE
chore: drop needless borrows flagged by clippy 1.97

### DIFF
--- a/bindings/js/src/local_storage_utils.rs
+++ b/bindings/js/src/local_storage_utils.rs
@@ -58,7 +58,7 @@ pub fn get_local_browser_storage<S: AsRef<str>>(
 
 impl LocalStorageVFS {
     pub fn to_key<P: AsRef<Utf8UnixPath>>(&self, path: P) -> String {
-        format!("{}{}", &self.prefix, path.as_ref())
+        format!("{}{}", self.prefix, path.as_ref())
     }
 
     pub fn exists<P: AsRef<Utf8UnixPath>>(&self, path: P) -> Result<bool, LocalStorageError> {

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -396,7 +396,7 @@ pub fn get_project_version<R: ResolveRead>(
                     Err(e) => {
                         log::warn!(
                             "skipping candidate project with invalid SemVer version {}: {e}",
-                            &info.version
+                            info.version
                         );
                         continue;
                     }

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -1337,8 +1337,8 @@ fn info_multi_index_url_config() -> Result<(), Box<dyn Error>> {
     url = "{}"
     default = true
     "#,
-        &server.url(),
-        &server_alt.url()
+        server.url(),
+        server_alt.url()
     );
 
     let cfg_path = cwd.join(sysand_core::config::local_fs::CONFIG_FILE);

--- a/sysand/tests/cli_sync.rs
+++ b/sysand/tests/cli_sync.rs
@@ -261,7 +261,7 @@ sources = [
     {{ remote_src = "{}", checksum = "3bd4c3c6b54690d38eeb035e136b667b4307063451b140feb2f49d266f653a26" }},
 ]
 "#,
-            &server.url()
+            server.url()
         ),
     )?;
 
@@ -376,7 +376,7 @@ sources = [
     {{ remote_src = "{}", checksum = "3bd4c3c6b54690d38eeb035e136b667b4307063451b140feb2f49d266f653a26" }},
 ]
 "#,
-            &server.url()
+            server.url()
         )
         .as_bytes(),
     )?;
@@ -481,7 +481,7 @@ sources = [
     {{ remote_src = "{}", checksum = "3bd4c3c6b54690d38eeb035e136b667b4307063451b140feb2f49d266f653a26" }},
 ]
 "#,
-            &server.url()
+            server.url()
         ),
     )?;
 


### PR DESCRIPTION
Clippy with Rust 1.97 makes a few fixes, and currenty prek in our CI system makes use of Rust 1.97 even though we mean to have us pinned to 1.96. This is fixed by #454. However, this PR applies the things clippy 1.97 did.