### PR TITLE
fix(ux): tone down and reduce the amount of warnings about ignored std libs

### DIFF
--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -8,9 +8,8 @@ use crate::{
     },
     project::ProjectMut,
     purl::{PKG_SYSAND_PREFIX, SysandPurlError, parse_sysand_purl},
+    utils::SP,
 };
-
-const SP: char = ' ';
 
 #[derive(Error, Debug)]
 pub enum AddError<ProjectError> {

--- a/core/src/commands/sync.rs
+++ b/core/src/commands/sync.rs
@@ -197,10 +197,8 @@ where
             }
         }
 
-        let mut no_supported = true;
         // TODO: does it make sense to install the same project from all the sources?
         for source in &project.sources {
-            let supported = true;
             match source {
                 Source::Editable { editable } => {
                     // Nothing to install for editable
@@ -345,16 +343,6 @@ where
                         })?;
                 }
             }
-            if supported {
-                no_supported = false;
-            }
-        }
-        if no_supported {
-            return Err(SyncError::UnsupportedSources(
-                main_uri
-                    .cloned()
-                    .unwrap_or_else(|| "project without IRI".to_string()),
-            ));
         }
         updated = true;
     }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -240,3 +240,5 @@ pub fn to_pretty_json_string<T: Serialize>(value: &T) -> String {
     serialized.push('\n');
     serialized
 }
+
+pub const SP: char = ' ';

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -29,6 +29,7 @@ use crate::{
     CliError, DEFAULT_INDEX_URL,
     cli::{ProjectSourceOptions, ResolutionOptions},
     commands::{lock::create_resolver, sync::command_sync},
+    style::GOOD,
 };
 
 // TODO: Collect common arguments
@@ -183,17 +184,6 @@ pub fn command_add<Policy: HTTPAuthentication>(
         });
     }
 
-    let provided_iris = if !resolution_opts.include_std {
-        let sysml_std = crate::known_std_libs();
-        if sysml_std.contains_key(iri) {
-            crate::logger::warn_std(iri);
-            return Ok(());
-        }
-        sysml_std
-    } else {
-        HashMap::default()
-    };
-
     let usage_raw = InterchangeProjectUsageRaw::Resource {
         resource: iri.to_owned(),
         version_constraint,
@@ -206,6 +196,22 @@ pub fn command_add<Policy: HTTPAuthentication>(
         if !added {
             return Ok(());
         }
+
+        let provided_iris = if !resolution_opts.include_std {
+            let sysml_std = crate::known_std_libs();
+            if sysml_std.contains_key(iri) {
+                log::info!(
+                    "{GOOD}note{GOOD:#}: SysMLv2/KerML standard libraries will not be installed during sync"
+                );
+                // Can't skip either locking or syncing, since lockfile needs to add the usage,
+                // and std version being added may affect version resolution of other packages
+                // in the dependency graph (e.g. older versions used older std, newer use some
+                // newer version)
+            }
+            sysml_std
+        } else {
+            HashMap::default()
+        };
 
         let alias_iris = if let Some(w) = &ctx.current_workspace {
             w.projects()

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -24,6 +24,7 @@ use sysand_core::{
         priority::PriorityResolver,
         standard::{StandardResolver, standard_resolver},
     },
+    utils::SP,
 };
 
 use crate::{
@@ -31,6 +32,7 @@ use crate::{
     cli::{CloneProjectLocatorArgs, ResolutionOptions},
     commands::sync::command_sync,
     get_or_create_env,
+    style::GOOD,
 };
 
 pub enum ProjectLocator {
@@ -140,14 +142,18 @@ pub fn command_clone<Policy: HTTPAuthentication>(
             &provided_iris,
             &ctx,
         )?;
-        // Warn if we have any std lib dependencies
+        // If we have any std lib dependencies, they will not be installed
         if !provided_iris.is_empty()
             && lock
                 .projects
                 .iter()
                 .any(|x| x.identifiers.iter().any(|y| provided_iris.contains_key(y)))
         {
-            crate::logger::warn_std_deps();
+            log::info!(
+                "{GOOD}note{GOOD:#}: SysMLv2/KerML standard library packages will not be installed during sync,\n\
+                {SP:>5} since they should be provided by the tooling. If you want to install them,\n\
+                {SP:>5} run `sysand sync --include-std`"
+            );
         }
         let lock = lock.canonicalize();
         wrapfs::write(

--- a/sysand/src/commands/env.rs
+++ b/sysand/src/commands/env.rs
@@ -28,6 +28,7 @@ use sysand_core::{
         priority::PriorityResolver,
         standard::standard_resolver,
     },
+    utils::SP,
 };
 use typed_path::Utf8UnixPathBuf;
 
@@ -82,7 +83,7 @@ pub fn command_env_install<Policy: HTTPAuthentication>(
     let provided_iris = if !include_std {
         let sysml_std = crate::known_std_libs();
         if sysml_std.contains_key(iri.as_ref()) {
-            crate::logger::warn_std(iri.as_ref());
+            warn_std_install(iri.as_ref());
             return Ok(());
         }
         sysml_std
@@ -144,7 +145,7 @@ pub fn command_env_install<Policy: HTTPAuthentication>(
             allow_multiple,
         )?;
     } else {
-        let usages = vec![InterchangeProjectUsage::Resource {
+        let usages = [InterchangeProjectUsage::Resource {
             resource: fluent_uri::Iri::from_str(iri.as_ref())?,
             version_constraint: version.map(|v| semver::VersionReq::parse(&v)).transpose()?,
         }];
@@ -162,13 +163,18 @@ pub fn command_env_install<Policy: HTTPAuthentication>(
         // Find if we added any std lib dependencies. This relies on `Lock::default()`
         // and `do_lock_extend()` to not read the existing lockfile, i.e. `lock` contains
         // only `iri` and `iri`'s dependencies.
+        // This is unreachable if `iri` is an std lib, so this warning will not duplicate
+        // the above one
         if !provided_iris.is_empty()
             && lock
                 .projects
                 .iter()
                 .any(|x| x.identifiers.iter().any(|y| provided_iris.contains_key(y)))
         {
-            crate::logger::warn_std_deps();
+            // TODO: this could be more helpful, currently it suggests `--include-std`,
+            // but that by itself will not work, since the project will be already installed,
+            // so `sysand env install <original iri> --allow-overwrite --include-std` is needed
+            crate::logger::note_std_deps_no_install();
         }
         command_sync(
             &lock,
@@ -244,7 +250,7 @@ pub fn command_env_install_path<Policy: HTTPAuthentication>(
     let provided_iris = if !include_std {
         let sysml_std = crate::known_std_libs();
         if sysml_std.contains_key(iri.as_ref()) {
-            crate::logger::warn_std(&iri);
+            warn_std_install(&iri);
             return Ok(());
         }
         sysml_std
@@ -360,4 +366,16 @@ pub fn command_env_list(env: Option<LocalDirectoryEnvironment>) -> Result<()> {
         println!("`{uri}` {}", version.unwrap_or("".to_string()));
     }
     Ok(())
+}
+
+fn warn_std_install(iri: impl AsRef<str>) {
+    log::warn!(
+        "it's not recommended to install SysML v2/KerML standard
+        {SP:>8} library package `{}`,\n\
+        {SP:>8} as installing it may break other tooling, since standard library\n\
+        {SP:>8} is usually provided by default, and the tool will therefore see two\n\
+        {SP:>8} conflicting copies of the same library;\n\
+        {SP:>8} to proceed anyway, pass `--include-std`",
+        iri.as_ref()
+    );
 }

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -82,7 +82,13 @@ pub fn pprint_interchange_project(
             })
             .collect();
         if has_ignored_usages && usages_to_print.is_empty() {
-            println!("All usages are ignored");
+            // TODO: distinguish between provided iris in general and std libs in
+            // particular. Here it's assumed that non-empty excluded_iris == std is ignored,
+            // which may not continue to be the case
+            println!(
+                "All usages are ignored. Standard library usages are not\n\
+                shown by default, unless `--include-std` is passed"
+            );
         } else {
             println!("{header}Usages:{header:#}");
             for usage in usages_to_print.iter() {
@@ -101,7 +107,11 @@ pub fn pprint_interchange_project(
                 }
             }
             if has_ignored_usages {
-                println!("Some usages are ignored");
+                // Same caveat as for "All usages are ignored"
+                println!(
+                    "Some usages are ignored. Standard library usages are not\n\
+                    shown by default, unless `--include-std` is passed"
+                );
             }
         }
     }

--- a/sysand/src/commands/sources.rs
+++ b/sysand/src/commands/sources.rs
@@ -69,9 +69,6 @@ pub fn command_sources_env<S: AsRef<str>>(
             bail!("project is missing project information")
         };
 
-        if dependencies == Dependencies::Deps {
-            crate::logger::warn_std_deps();
-        }
         for dep in resolve_dependencies(info.validate()?.usage, env, dependencies)? {
             for src_path in do_sources_local_src_project_no_deps(&dep, true)? {
                 println!("{}", src_path);

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -41,14 +41,13 @@ use sysand_core::{
         utils::wrapfs,
     },
     resolve::net_utils::create_reqwest_client,
-    sources::Dependencies,
     stdlib::known_std_libs,
     workspace::Workspace,
 };
 use url::Url;
 
 use crate::{
-    cli::{Args, Command, InfoCommand},
+    cli::{Args, Command},
     commands::{
         add::command_add,
         build::{command_build_for_project, command_build_for_workspace},
@@ -409,9 +408,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             }
         }
         Command::Sync { resolution_opts } => {
-            // TODO: only print this if we actually skip install of any std libs
             let provided_iris = if !resolution_opts.include_std {
-                crate::logger::warn_std_deps();
                 known_std_libs()
             } else {
                 HashMap::default()
@@ -484,21 +481,6 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 )?)
             };
             let excluded_iris: HashSet<_> = if !include_std {
-                // Only print std warning when command is to print all info
-                // or just usages.
-                // These are the only cases where stdlib usages affect output
-                // TODO: be more precise, this warning is annoying
-                match subcommand {
-                    None
-                    | Some(InfoCommand::Usage {
-                        clear: None,
-                        add: None,
-                        set: None,
-                        remove: None,
-                        numbered: _,
-                    }) => crate::logger::warn_std_deps(),
-                    _ => (),
-                }
                 known_std_libs().into_keys().collect()
             } else {
                 HashSet::default()
@@ -730,11 +712,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
             runtime,
         ),
         Command::Sources { sources_opts } => {
-            let dependencies = sources_opts.dependencies();
-            if dependencies == Dependencies::Deps {
-                crate::logger::warn_std_omit();
-            }
-            command_sources_project(sources_opts.no_own(), dependencies, ctx)
+            command_sources_project(sources_opts.no_own(), sources_opts.dependencies(), ctx)
         }
         Command::Clone {
             locator,

--- a/sysand/src/logger.rs
+++ b/sysand/src/logger.rs
@@ -4,8 +4,9 @@
 use env_logger::{Builder, Target, fmt::Formatter};
 use log::{LevelFilter, Record, SetLoggerError};
 use std::io::{self, Write};
+use sysand_core::utils::SP;
 
-use crate::style;
+use crate::style::{self, GOOD};
 
 pub fn init(level: LevelFilter) -> Result<(), SetLoggerError> {
     Builder::new()
@@ -41,29 +42,11 @@ fn format(buf: &mut Formatter, record: &Record<'_>) -> Result<(), io::Error> {
     }
 }
 
-const SP: char = ' ';
-
-/// Print a warning that standard library package `iri` is ignored
-pub fn warn_std(iri: impl AsRef<str>) {
-    log::warn!(
-        "SysML v2/KerML standard library package `{}` is ignored\n\
-        {SP:>8} by default. If you want to process it, pass `--include-std` flag",
-        iri.as_ref()
-    );
-}
-
-/// Print a warning that standard library packages are omitted from output
-pub fn warn_std_omit() {
-    log::warn!(
-        "SysML v2/KerML standard library packages are omitted by default.\n\
-        {SP:>8} If you want to include them, pass `--include-std` flag"
-    );
-}
-
 /// Print a warning that dependencies on standard library packages are ignored
-pub fn warn_std_deps() {
-    log::warn!(
-        "Direct or transitive usages of SysML v2/KerML standard library packages are\n\
-        {SP:>8} ignored by default. If you want to process them, pass `--include-std` flag"
+pub fn note_std_deps_no_install() {
+    log::info!(
+        "{GOOD}note{GOOD:#}: SysML v2/KerML standard library packages will not be installed during sync,\n\
+        {SP:>5} since they should be provided by the tooling. If you want to install them,\n\
+        {SP:>5} pass `--include-std` flag"
     );
 }

--- a/sysand/tests/cli_clone.rs
+++ b/sysand/tests/cli_clone.rs
@@ -201,11 +201,50 @@ fn clone_not_found() -> Result<(), Box<dyn std::error::Error>> {
 //     todo!()
 // }
 
-// warn if deps of cloned project include std libs
-// #[test]
-// fn clone_std_warn() -> Result<(), Box<dyn std::error::Error>> {
-//     todo!()
-// }
+// note if deps of cloned project include std libs
+#[test]
+fn clone_std_deps_note() -> Result<(), Box<dyn std::error::Error>> {
+    let (_dep_temp_dir, cwd_dep, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "clone_std_note_dep"],
+        None,
+    )?;
+    out.assert().success();
+
+    std::fs::write(
+        cwd_dep.join("CloneStdNoteDep.sysml"),
+        "package CloneStdNoteDep;",
+    )?;
+    run_sysand_in(&cwd_dep, ["include", "CloneStdNoteDep.sysml"], None)?
+        .assert()
+        .success();
+
+    run_sysand_in(
+        &cwd_dep,
+        [
+            "add",
+            "--no-lock",
+            "--include-std",
+            "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar",
+        ],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let dep_path_str = cwd_dep.as_str();
+    let (_temp_dir, cwd, out) = run_sysand(["clone", dep_path_str], None)?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "note: SysMLv2/KerML standard library packages will not be installed during sync,",
+        ))
+        .stderr(predicate::str::contains("run `sysand sync --include-std`"));
+
+    assert!(cwd.join(DEFAULT_ENV_NAME).is_dir());
+
+    Ok(())
+}
 
 // do not warn about std deps if `--include-std` is given
 // TODO: should also check that they are installed (mock them)

--- a/sysand/tests/cli_std_notices.rs
+++ b/sysand/tests/cli_std_notices.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! Tests for notices about ignored std libs
+
+use assert_cmd::prelude::*;
+use predicates::prelude::{
+    predicate::str::{contains, is_empty},
+    *,
+};
+use sysand_core::{
+    commands::lock::DEFAULT_LOCKFILE_NAME,
+    config::{self, ConfigProject, OverrideSource},
+    lock::Lock,
+};
+
+// pub due to https://github.com/rust-lang/rust/issues/46379
+mod common;
+pub use common::*;
+
+const FUNCTION_LIBRARY_IRI: &str = "https://www.omg.org/spec/KerML/20250201/Function-Library.kpar";
+
+/// `sysand add <std-iri>` (with lock) records the usage, prints a plain
+/// `note:` (not a `warning:`), and produces a lockfile recording the lib as a
+/// provided (source-less) dependency
+#[test]
+fn add_std_lib_direct_note_still_locks_skips_sync() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "add_std_direct"],
+        None,
+    )?;
+    out.assert().success();
+
+    let out = run_sysand_in(&cwd, ["add", FUNCTION_LIBRARY_IRI], None)?;
+
+    out.assert()
+        .success()
+        .stderr(contains(
+            "note: SysMLv2/KerML standard libraries will not be installed during sync",
+        ))
+        .stderr(contains("warning:").not());
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        format!(
+            r#"{{
+  "name": "add_std_direct",
+  "publisher": "untitled",
+  "version": "1.2.3",
+  "usage": [
+    {{
+      "resource": "{FUNCTION_LIBRARY_IRI}"
+    }}
+  ]
+}}
+"#
+        )
+    );
+
+    let lock_file: Lock =
+        toml::from_str(&std::fs::read_to_string(cwd.join(DEFAULT_LOCKFILE_NAME))?)?;
+    let std_project = lock_file
+        .projects
+        .iter()
+        .find(|p| p.identifiers.iter().any(|i| i == FUNCTION_LIBRARY_IRI))
+        .unwrap_or_else(|| {
+            panic!(
+                "lockfile should still record the std lib dependency:\n{:#?}",
+                lock_file.projects
+            )
+        });
+    assert!(
+        std_project.sources.is_empty(),
+        "std lib entry should have no sources, since it is provided rather than installed"
+    );
+
+    Ok(())
+}
+
+/// `sysand env install <std-iri>` (with and without `--path`) warns that installing std
+/// libs directly is not recommended, and does not install anything.
+#[test]
+fn env_install_std_lib_direct_no_path_warns_and_skips() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, _) = run_sysand(["env"], None)?;
+
+    let out = run_sysand_in(
+        &cwd,
+        ["env", "install", FUNCTION_LIBRARY_IRI, "--no-index"],
+        None,
+    )?;
+
+    out.assert()
+        .success()
+        .stderr(contains(
+            "it's not recommended to install SysML v2/KerML standard",
+        ))
+        .stderr(contains(format!(
+            "library package `{FUNCTION_LIBRARY_IRI}`,"
+        )))
+        .stderr(contains("to proceed anyway, pass `--include-std`"));
+
+    let test_path = fixture_path("test_lib");
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "env",
+            "install",
+            FUNCTION_LIBRARY_IRI,
+            "--path",
+            test_path.as_str(),
+        ],
+        None,
+    )?;
+
+    out.assert()
+        .success()
+        .stderr(contains(
+            "it's not recommended to install SysML v2/KerML standard",
+        ))
+        .stderr(contains(format!(
+            "library package `{FUNCTION_LIBRARY_IRI}`,"
+        )));
+
+    run_sysand_in(&cwd, ["env", "list"], None)?
+        .assert()
+        .success()
+        .stdout(is_empty());
+
+    Ok(())
+}
+
+/// `sysand env install <iri>` (no `--path`), where `<iri>`'s own
+/// dependencies transitively include a std lib, prints a `note:` that the
+/// std lib will not be installed, distinct from the warning given when the
+/// std lib itself is installed directly.
+#[test]
+fn env_install_transitive_std_deps_note() -> Result<(), Box<dyn std::error::Error>> {
+    // A project that itself depends on a standard library.
+    let (_dep_temp_dir, cwd_dep, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--name",
+            "env_install_std_dep",
+        ],
+        None,
+    )?;
+    out.assert().success();
+
+    std::fs::write(cwd_dep.join("EnvInstallStdDep.sysml"), "package Dep;")?;
+    run_sysand_in(&cwd_dep, ["include", "EnvInstallStdDep.sysml"], None)?
+        .assert()
+        .success();
+
+    run_sysand_in(
+        &cwd_dep,
+        ["add", "--no-lock", "--include-std", FUNCTION_LIBRARY_IRI],
+        None,
+    )?
+    .assert()
+    .success();
+
+    // Register the dependency project as a config override so it can be
+    // resolved by IRI without an index.
+    let (_temp_dir, cwd, _) = run_sysand(["env"], None)?;
+    let cfg_path = cwd.join("sysand.toml");
+    let cfg = toml::to_string(&config::Config {
+        indexes: vec![],
+        projects: vec![ConfigProject {
+            identifiers: vec!["urn:kpar:env_install_std_dep".to_string()],
+            sources: vec![OverrideSource::LocalSrc {
+                src_path: cwd_dep.as_str().into(),
+            }],
+        }],
+    })?;
+    std::fs::write(&cfg_path, cfg)?;
+
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "env",
+            "install",
+            "urn:kpar:env_install_std_dep",
+            "--no-index",
+        ],
+        Some(cfg_path.as_str()),
+    )?;
+
+    out.assert()
+        .success()
+        .stderr(contains(
+            "note: SysML v2/KerML standard library packages will not be installed during sync,",
+        ))
+        .stderr(contains("pass `--include-std` flag"))
+        // The direct-install warning must not also fire for a transitive dep.
+        .stderr(contains("it's not recommended to install").not());
+
+    Ok(())
+}
+
+/// `sysand info` on a project whose only usage is a std lib prints the
+/// "All usages are ignored" note instead of an empty/misleading usage list.
+#[test]
+fn info_all_usages_ignored_std_only() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = run_sysand(
+        ["init", "--version", "1.2.3", "--name", "info_std_only"],
+        None,
+    )?;
+    out.assert().success();
+
+    run_sysand_in(
+        &cwd,
+        ["add", "--no-lock", "--include-std", FUNCTION_LIBRARY_IRI],
+        None,
+    )?
+    .assert()
+    .success();
+
+    run_sysand_in(&cwd, ["info"], None)?.assert().success().stdout(
+        contains(
+            "All usages are ignored. Standard library usages are not\nshown by default, unless `--include-std` is passed",
+        ),
+    );
+
+    // With --include-std, the usage is shown instead of being ignored.
+    run_sysand_in(&cwd, ["info", "--include-std"], None)?
+        .assert()
+        .success()
+        .stdout(contains("Usages:"))
+        .stdout(contains(FUNCTION_LIBRARY_IRI))
+        .stdout(contains("All usages are ignored").not());
+
+    Ok(())
+}
+
+/// `sysand info` on a project with a mix of a normal usage and a std lib
+/// usage prints the normal usage plus the "Some usages are ignored" note.
+#[test]
+fn info_some_usages_ignored_mixed() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) =
+        run_sysand(["init", "--version", "1.2.3", "--name", "info_mixed"], None)?;
+    out.assert().success();
+
+    run_sysand_in(&cwd, ["add", "--no-lock", "urn:kpar:normal-dep"], None)?
+        .assert()
+        .success();
+    run_sysand_in(
+        &cwd,
+        ["add", "--no-lock", "--include-std", FUNCTION_LIBRARY_IRI],
+        None,
+    )?
+    .assert()
+    .success();
+
+    run_sysand_in(&cwd, ["info"], None)?
+        .assert()
+        .success()
+        .stdout(contains("Usages:"))
+        .stdout(contains("urn:kpar:normal-dep"))
+        .stdout(contains(FUNCTION_LIBRARY_IRI).not())
+        .stdout(contains(
+            "Some usages are ignored. Standard library usages are not\nshown by default, unless `--include-std` is passed",
+        ));
+
+    Ok(())
+}


### PR DESCRIPTION
- `add` no longer ignores attempts to add std libs (adding+locking+syncing is now performed like for all other usages); since they will still not be installed during sync, it only informs about that
- `clone` now informs if any (possibly transitive) dependencies will not be installed
- `env install` now has a more specific warning for direct std installation, and warning about std deps becomes a `note`
- `info` now informs about ignored std libs only when they are actually ignored

The only remaining `warnings` about std libs are for `env install`, as that may break other tooling, as explained in the warnings. All other cases are now informational.

Closes #431.