### PR TITLE
docs(design): specify v1/whoami in the index API protocol

### DIFF
--- a/design/index-api-protocol.md
+++ b/design/index-api-protocol.md
@@ -1,7 +1,8 @@
 # Sysand Index API Protocol
 
 > **Status: partial.** The upload endpoint is described at a high level;
-> the rest of the API surface is not yet specified.
+> the trusted publishing token exchange and `v1/whoami` are specified
+> below; the rest of the API surface is not yet specified.
 
 ## Scope
 
@@ -102,3 +103,62 @@ The client discovers `api_root` before attempting trusted publishing.
 Therefore trusted publishing does not help with an auth-gated
 `sysand-index-config.json`; such discovery still requires separately
 configured credentials.
+
+## Token Identity
+
+An index server that supports bearer-token authentication exposes:
+
+```text
+GET v1/whoami
+```
+
+under the resolved `api_root`. The endpoint returns the identity behind
+a bearer token, so a client can validate a stored credential and report
+who it authenticates as (for example in `sysand auth status`).
+
+The request carries the credential in an `Authorization: Bearer <token>`
+header and has no body. Only `GET` is accepted; servers SHOULD reject
+other methods with 405.
+
+Successful response body:
+
+```json
+{
+  "subject": { "type": "user", "name": "alice" },
+  "token": {
+    "name": "laptop",
+    "prefix": "sysand_u_1a2b3c4d",
+    "expires_at": "2026-09-01T00:00:00Z"
+  }
+}
+```
+
+`subject` identifies the principal the token authenticates as:
+
+- `subject.type` is `user`, `project`, or `oidc`.
+- `subject.name` depends on the token type: for a user token it is the
+  owning user's username; for a project token it is the project id of
+  the scoped project as normalized `<publisher-id>/<name-id>`; for a
+  trusted-publishing (`oidc`) token it is the matched trusted
+  publisher's path (for example the repository full name on GitHub or
+  the project path on GitLab), with a `<provider>:<immutable-id>`
+  fallback when the publisher configuration no longer exists.
+
+`token` describes the credential itself:
+
+- `token.name` is the user-given token label, or `null` for tokens that
+  have no label (exchanged trusted-publishing tokens).
+- `token.prefix` is the token's non-secret display prefix.
+- `token.expires_at` is the token's expiration time as an ISO 8601 UTC
+  timestamp with a `Z` suffix.
+
+A missing, malformed, unrecognized, expired, or already-consumed token
+yields 401. The 401 response body is unspecified; clients MUST NOT
+depend on its contents and SHOULD treat any 401 as the credential being
+rejected.
+
+The endpoint is read-only and MUST NOT consume single-use credentials:
+presenting an exchanged trusted-publishing token to `v1/whoami` leaves
+it usable for the subsequent upload. Servers MAY rate limit the
+endpoint (429), since it can be probed without a valid credential and
+acts as a token-validity oracle.

--- a/design/index-api-protocol.md
+++ b/design/index-api-protocol.md
@@ -159,6 +159,6 @@ rejected.
 
 The endpoint is read-only and MUST NOT consume single-use credentials:
 presenting an exchanged trusted-publishing token to `v1/whoami` leaves
-it usable for the subsequent upload. Servers MAY rate limit the
+it usable for the subsequent upload. Servers SHOULD rate limit the
 endpoint (429), since it can be probed without a valid credential and
 acts as a token-validity oracle.


### PR DESCRIPTION
Written by erik:

This is a useful endpoint for the client to validate credentials against, where for example using a token for test.sysand.com on sysand.com would otherwise not error on a "sysand auth login" command, because there would be no way to validate it before serious use - and that delay is a bad UX -- better fail early!

Extracted from #453 

Ai text below

## What

Adds a **Token Identity** section to `design/index-api-protocol.md`
specifying the `GET v1/whoami` endpoint:

- bearer authentication
- the `200` body shape: `subject` (type/name semantics per token type)
  and `token` (name, prefix, `expires_at`)
- the unspecified `401` body
- optional rate limiting
- the requirement that the endpoint never consumes single-use credentials

## Why now

The endpoint is already **live on the index server** (sysand.com and
staging), so the protocol spec should be documented in `main` rather than
waiting behind the larger client-side credential-storage work. This PR
extracts just the `index-api-protocol.md` addition from that branch so it
can land on its own.

Spec-only change: no code, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)