### PR TITLE
chore: match pre-commit to rust-toolchain Rust version as intended

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         entry: cargo fmt
         description: Formats all bin and lib files of the current workspace using rustfmt.
         language: rust
-        language_version: "1.96"
+        language_version: "1.97.1"
         types: [rust]
         args: ["--"]
 
@@ -68,7 +68,7 @@ repos:
         entry: cargo clippy
         description: Checks all packages in the workspace to catch common mistakes and improve your Rust code.
         language: rust
-        language_version: "1.96"
+        language_version: "1.97.1"
         types: [rust]
         args:
           - --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["sysand", "core"]
 [workspace.package]
 version = "0.1.7"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97"
 publish = false
 authors = ["Sensmetry <opensource@sensmetry.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
rust-version in Cargo.toml is also bumped to allow usage of newer APIs.

(forgot to do this in #459)