### PR TITLE
refactor: make `ProjectRead::project_root()` required

### DIFF
--- a/bindings/js/src/io/local_storage.rs
+++ b/bindings/js/src/io/local_storage.rs
@@ -167,6 +167,11 @@ impl ProjectRead for ProjectLocalBrowserStorage {
             },
         }
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        // LocalStorage should not be treated as a filesystem
+        None
+    }
 }
 
 impl ProjectMut for ProjectLocalBrowserStorage {

--- a/core/src/project/cached.rs
+++ b/core/src/project/cached.rs
@@ -92,4 +92,8 @@ impl<Local: ProjectRead, Remote: ProjectRead> ProjectRead for CachedProject<Loca
     fn checksum_canonical_variant(&self) -> Result<super::ProjectChecksum, Self::Error> {
         self.local.checksum_canonical_variant()
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        self.remote.project_root()
+    }
 }

--- a/core/src/project/editable.rs
+++ b/core/src/project/editable.rs
@@ -86,4 +86,8 @@ impl<P: ProjectRead> ProjectRead for EditableProject<P> {
     fn checksum_canonical_variant(&self) -> Result<super::ProjectChecksum, Self::Error> {
         self.inner.checksum_canonical_variant()
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        self.inner.project_root()
+    }
 }

--- a/core/src/project/gix_git_download.rs
+++ b/core/src/project/gix_git_download.rs
@@ -87,6 +87,8 @@ impl GixDownloadedProject {
         let tmp_dir = camino_tempfile::tempdir().map_err(FsIoError::MkTempDir)?;
 
         Ok(GixDownloadedProject {
+            // TODO: gix::url::parse() accepts bare local paths; we should verify before that
+            // it's URL or path as we expected instead of relying on gix::url::Parse to error out
             url: gix::url::parse(url.as_ref().into())
                 .map_err(|e| GixDownloadedError::UrlParse(url.as_ref().into(), Box::new(e)))?,
             inner: LocalSrcProject {
@@ -159,6 +161,13 @@ impl ProjectRead for GixDownloadedProject {
         self.ensure_downloaded()?;
 
         Ok(self.inner.checksum_canonical_variant()?)
+    }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        // FIXME: the URL can be `file:`, but it's tricky to
+        // get an absolute path from that, as it's unclear how Windows drive prefixes
+        // are handled in gix::url::parse()
+        None
     }
 }
 

--- a/core/src/project/index_entry.rs
+++ b/core/src/project/index_entry.rs
@@ -198,6 +198,10 @@ impl<Policy: HTTPAuthentication> ProjectReadAsync for IndexEntryProject<Policy> 
             self.advertised.kpar_digest.as_hex().to_string(),
         ))
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -282,6 +282,12 @@ impl ProjectRead for LocalKParProject {
             Err(e) => Err(e),
         }
     }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        // TODO: is this appropriate? KPAR is not really meant
+        // to be tied to a specific folder
+        Some(&self.archive_path)
+    }
 }
 
 impl LocalKParProjectRaw {
@@ -539,6 +545,12 @@ impl ProjectRead for LocalKParProjectRaw {
 
     /// This always panics. Wrapper is responsible for providing the checksum
     fn checksum_canonical_variant(&self) -> Result<ProjectChecksum, Self::Error> {
+        panic!()
+    }
+
+    /// This always panics. Wrapper is responsible for deciding whether to
+    /// provide a path
+    fn project_root(&self) -> Option<&Utf8Path> {
         panic!()
     }
 }

--- a/core/src/project/memory.rs
+++ b/core/src/project/memory.rs
@@ -174,4 +174,8 @@ impl ProjectRead for InMemoryProject {
             .ok_or(InMemoryError::MissingInfoMeta)?;
         Ok(ProjectChecksum::Project(checksum))
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
+    }
 }

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -205,9 +205,7 @@ pub trait ProjectRead {
     // Optional and helpers
 
     /// Returns the local filesystem root path of this project, if available.
-    fn project_root(&self) -> Option<&Utf8Path> {
-        None
-    }
+    fn project_root(&self) -> Option<&Utf8Path>;
 
     fn get_info(&self) -> Result<Option<InterchangeProjectInfoRaw>, Self::Error> {
         Ok(self.get_project()?.0)
@@ -397,6 +395,10 @@ impl<T: ProjectRead> ProjectRead for &T {
     fn checksum_canonical_variant(&self) -> Result<ProjectChecksum, Self::Error> {
         (*self).checksum_canonical_variant()
     }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        (*self).project_root()
+    }
 }
 
 impl<T: ProjectRead> ProjectRead for &mut T {
@@ -476,6 +478,10 @@ impl<T: ProjectRead> ProjectRead for &mut T {
 
     fn checksum_canonical_variant(&self) -> Result<ProjectChecksum, Self::Error> {
         (**self).checksum_canonical_variant()
+    }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        (**self).project_root()
     }
 }
 
@@ -650,6 +656,9 @@ pub trait ProjectReadAsync {
         &self,
     ) -> impl Future<Output = Result<ProjectChecksum, Self::Error>>;
 
+    // Async doesn't make sense for this
+    fn project_root(&self) -> Option<&Utf8Path>;
+
     /// Treat this `ProjectReadAsync` as a `ProjectRead` using the provided tokio runtime.
     fn to_tokio_sync(self, runtime: Arc<tokio::runtime::Runtime>) -> AsSyncProjectTokio<Self>
     where
@@ -760,6 +769,10 @@ impl<T: ProjectReadAsync> ProjectReadAsync for &T {
     ) -> impl Future<Output = Result<ProjectChecksum, Self::Error>> {
         (**self).checksum_canonical_variant_async()
     }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        (**self).project_root()
+    }
 }
 
 impl<T: ProjectReadAsync> ProjectReadAsync for &mut T {
@@ -859,6 +872,10 @@ impl<T: ProjectReadAsync> ProjectReadAsync for &mut T {
         &self,
     ) -> impl Future<Output = Result<ProjectChecksum, Self::Error>> {
         (**self).checksum_canonical_variant_async()
+    }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        (**self).project_root()
     }
 }
 
@@ -1039,6 +1056,10 @@ where
     async fn checksum_canonical_variant_async(&self) -> Result<ProjectChecksum, Self::Error> {
         self.inner.checksum_canonical_variant()
     }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        self.inner.project_root()
+    }
 }
 
 /// Wrapper intended to wrap a `ProjectReadAsync`, indicating that it be treated as
@@ -1129,6 +1150,10 @@ impl<T: ProjectReadAsync> ProjectRead for AsSyncProjectTokio<T> {
     fn checksum_canonical_variant(&self) -> Result<ProjectChecksum, Self::Error> {
         self.runtime
             .block_on(self.inner.checksum_canonical_variant_async())
+    }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        self.inner.project_root()
     }
 }
 

--- a/core/src/project/null.rs
+++ b/core/src/project/null.rs
@@ -84,6 +84,10 @@ impl ProjectRead for NullProject {
     fn checksum_canonical_variant(&self) -> Result<ProjectChecksum, Self::Error> {
         match self.nothing {}
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
+    }
 }
 
 impl ProjectReadAsync for NullProject {
@@ -119,5 +123,9 @@ impl ProjectReadAsync for NullProject {
 
     async fn checksum_canonical_variant_async(&self) -> Result<ProjectChecksum, Self::Error> {
         match self.nothing {}
+    }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
     }
 }

--- a/core/src/project/reference.rs
+++ b/core/src/project/reference.rs
@@ -67,6 +67,10 @@ impl<Project: ProjectRead> ProjectRead for ProjectReference<Project> {
     fn checksum_canonical_variant(&self) -> Result<super::ProjectChecksum, Self::Error> {
         self.project.checksum_canonical_variant()
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        self.project.project_root()
+    }
 }
 
 #[cfg(feature = "filesystem")]

--- a/core/src/project/reqwest_kpar_download.rs
+++ b/core/src/project/reqwest_kpar_download.rs
@@ -400,6 +400,10 @@ impl<Policy: HTTPAuthentication> ProjectReadAsync for ReqwestRemoteKparDownloade
             Err(e) => Err(e),
         }
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
+    }
 }
 
 impl<Policy: HTTPAuthentication> ReqwestIndexKparDownloadedProject<Policy> {
@@ -611,6 +615,10 @@ impl<Policy: HTTPAuthentication> ProjectReadAsync for ReqwestIndexKparDownloaded
             Ok(_) => Ok(ProjectChecksum::Kpar(self.expected_kpar_sha256.clone())),
             Err(e) => Err(e),
         }
+    }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
     }
 }
 

--- a/core/src/project/reqwest_src.rs
+++ b/core/src/project/reqwest_src.rs
@@ -206,6 +206,10 @@ impl<Policy: HTTPAuthentication> ProjectReadAsync for ReqwestSrcProjectAsync<Pol
             .ok_or(ReqwestSrcError::MissingInfoMeta)?;
         Ok(ProjectChecksum::Project(checksum))
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/core/src/resolve/file.rs
+++ b/core/src/resolve/file.rs
@@ -307,6 +307,13 @@ impl ProjectRead for FileResolverProject {
             FileResolverProject::LocalKParProject(proj) => Ok(proj.checksum_canonical_variant()?),
         }
     }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        match self {
+            FileResolverProject::LocalSrcProject(proj) => proj.project_root(),
+            FileResolverProject::LocalKParProject(proj) => proj.project_root(),
+        }
+    }
 }
 
 impl ResolveRead for FileResolver {

--- a/core/src/resolve/priority.rs
+++ b/core/src/resolve/priority.rs
@@ -229,6 +229,13 @@ impl<HigherProject: ProjectRead, LowerProject: ProjectRead> ProjectRead
                 .map_err(PriorityError::Lower),
         }
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        match self {
+            PriorityProject::HigherProject(project) => project.project_root(),
+            PriorityProject::LowerProject(project) => project.project_root(),
+        }
+    }
 }
 
 impl<Higher: ResolveRead, Lower: ResolveRead> ResolveRead for PriorityResolver<Higher, Lower> {

--- a/core/src/resolve/remote.rs
+++ b/core/src/resolve/remote.rs
@@ -195,6 +195,13 @@ impl<HTTPProject: ProjectRead, GitProject: ProjectRead> ProjectRead
                 .map_err(RemoteProjectError::GitRead),
         }
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        match self {
+            RemoteProject::HTTPProject(project) => project.project_root(),
+            RemoteProject::GitProject(project) => project.project_root(),
+        }
+    }
 }
 
 pub struct ResolvedRemote<HTTPResolver: ResolveRead, GitResolver: ResolveRead> {

--- a/core/src/resolve/reqwest_http.rs
+++ b/core/src/resolve/reqwest_http.rs
@@ -231,6 +231,13 @@ impl<Policy: HTTPAuthentication> ProjectReadAsync for HTTPProjectAsync<Policy> {
                 .map_err(HTTPProjectError::KparDownloaded),
         }
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        match self {
+            HTTPProjectAsync::HTTPSrcProject(proj) => proj.project_root(),
+            HTTPProjectAsync::HTTPKParProjectDownloaded(proj) => proj.project_root(),
+        }
+    }
 }
 
 pub struct HTTPProjects<Policy> {

--- a/core/tests/project_derive.rs
+++ b/core/tests/project_derive.rs
@@ -243,6 +243,10 @@ impl ProjectRead for FixedDigestProject {
     fn checksum_canonical_variant(&self) -> Result<ProjectChecksum, Self::Error> {
         Ok(ProjectChecksum::Project(self.digest.clone()))
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        None
+    }
 }
 
 #[derive(ProjectRead)]

--- a/core/tests/project_no_derive.rs
+++ b/core/tests/project_no_derive.rs
@@ -141,6 +141,14 @@ where
                 .map_err(GenericProjectError::Variant3),
         }
     }
+
+    fn project_root(&self) -> Option<&camino::Utf8Path> {
+        match self {
+            GenericProject::Variant1(project) => project.project_root(),
+            GenericProject::Variant2(project) => project.project_root(),
+            GenericProject::Variant3(project) => project.project_root(),
+        }
+    }
 }
 
 impl<A, B> ProjectMut for GenericProject<A, B>

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -3,6 +3,7 @@
 
 use itertools::Itertools;
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, parse_macro_input};
 
@@ -94,7 +95,28 @@ pub fn project_read_derive(input: TokenStream) -> TokenStream {
         enum_ident.span(),
     );
 
-    let variant_parts: Result<Vec<_>, _> = variants
+    #[derive(Clone)]
+    struct VariantParts {
+        variant_list_part: TokenStream2,
+        error_variants_part: TokenStream2,
+        error_args_part: TokenStream2,
+        source_reader_variants_part: TokenStream2,
+        variants_read_part: TokenStream2,
+        source_reader_match_part: TokenStream2,
+        source_reader_args_part: TokenStream2,
+        get_project_match_part: TokenStream2,
+        read_source_match_part: TokenStream2,
+        sources_match_part: TokenStream2,
+        project_root_match_part: TokenStream2,
+        get_info_match_part: TokenStream2,
+        get_meta_match_part: TokenStream2,
+        version_match_part: TokenStream2,
+        usage_match_part: TokenStream2,
+        checksum_canonical_hex_match_part: TokenStream2,
+        checksum_canonical_variant_match_part: TokenStream2,
+    }
+
+    let variant_parts: Result<Vec<VariantParts>, _> = variants
         .iter()
         .map(|variant| {
             let variant_ident = variant.ident.clone();
@@ -113,93 +135,78 @@ pub fn project_read_derive(input: TokenStream) -> TokenStream {
                     ));
                 }
             };
-            Ok((
-                // variant_list
-                quote! {
+            Ok(VariantParts {
+                variant_list_part: quote! {
                     #variant_ident
                 },
-                // error_variants
-                quote! {
+                error_variants_part: quote! {
                     #[error(transparent)]
                     #variant_ident(#variant_ident)
                 },
-                // error_args
-                quote! {
+                error_args_part: quote! {
                     <#variant_type as ProjectRead>::Error
                 },
-                // source_reader_variants
-                quote! {
+                source_reader_variants_part: quote! {
                     #variant_ident(#variant_ident)
                 },
-                // variants_read
-                quote! {
+                variants_read_part: quote! {
                     #variant_ident: ::std::io::Read
                 },
-                // source_reader_match
-                quote! {
+                source_reader_match_part: quote! {
                     #source_reader_ident::#variant_ident(reader) => reader.read(buf)
                 },
-                // source_reader_args
-                quote! {
+                source_reader_args_part: quote! {
                     <#variant_type as ProjectRead>::SourceReader<'a>
                 },
-                // get_project_match
-                quote! {
+                get_project_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .get_project()
                         .map_err(#error_ident::#variant_ident)
                 },
-                // read_source_match
-                quote! {
+                read_source_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .read_source(path)
                         .map(#source_reader_ident::#variant_ident)
                         .map_err(#error_ident::#variant_ident)
                 },
-                // sources_match
-                quote! {
+                sources_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project.sources(ctx)
                         .map_err(#error_ident::#variant_ident)
                 },
-                // get_info_match
-                quote! {
+                project_root_match_part: quote! {
+                    #enum_ident::#variant_ident(project) => project.project_root()
+                },
+                get_info_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .get_info()
                         .map_err(#error_ident::#variant_ident)
                 },
-                // get_meta_match
-                quote! {
+                get_meta_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .get_meta()
                         .map_err(#error_ident::#variant_ident)
                 },
-                // version_match
-                quote! {
+                version_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .version()
                         .map_err(#error_ident::#variant_ident)
                 },
-                // usage_match
-                quote! {
+                usage_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .usage()
                         .map_err(#error_ident::#variant_ident)
                 },
-                // checksum_canonical_hex_match — forward so that any leaf
-                // override (e.g. a remote-index project with a prefetched
-                // digest) isn't bypassed by the trait default.
-                quote! {
+                checksum_canonical_hex_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .checksum_canonical_hex()
                         .map_err(|e| e.map_project_read(#error_ident::#variant_ident))
                 },
-                // checksum_canonical_variant match
-                quote! {
+                checksum_canonical_variant_match_part: quote! {
                     #enum_ident::#variant_ident(project) => project
                         .checksum_canonical_variant()
                         .map_err(#error_ident::#variant_ident)
                 },
-            ))
+            })
         })
         .collect();
 
@@ -218,6 +225,7 @@ pub fn project_read_derive(input: TokenStream) -> TokenStream {
     let mut variants_read = vec![];
     let mut source_reader_match = vec![];
     let mut source_reader_args = vec![];
+    let mut project_root_match = vec![];
     let mut get_project_match = vec![];
     let mut read_source_match = vec![];
     let mut sources_match = vec![];
@@ -228,7 +236,7 @@ pub fn project_read_derive(input: TokenStream) -> TokenStream {
     let mut checksum_canonical_hex_match = vec![];
     let mut checksum_canonical_variant_match = vec![];
 
-    for (
+    for VariantParts {
         variant_list_part,
         error_variants_part,
         error_args_part,
@@ -239,13 +247,14 @@ pub fn project_read_derive(input: TokenStream) -> TokenStream {
         get_project_match_part,
         read_source_match_part,
         sources_match_part,
+        project_root_match_part,
         get_info_match_part,
         get_meta_match_part,
         version_match_part,
         usage_match_part,
         checksum_canonical_hex_match_part,
         checksum_canonical_variant_match_part,
-    ) in variant_parts.iter().cloned()
+    } in variant_parts.iter().cloned()
     {
         variant_list.push(variant_list_part);
         error_variants.push(error_variants_part);
@@ -254,6 +263,7 @@ pub fn project_read_derive(input: TokenStream) -> TokenStream {
         variants_read.push(variants_read_part);
         source_reader_match.push(source_reader_match_part);
         source_reader_args.push(source_reader_args_part);
+        project_root_match.push(project_root_match_part);
         get_project_match.push(get_project_match_part);
         read_source_match.push(read_source_match_part);
         sources_match.push(sources_match_part);
@@ -330,6 +340,12 @@ pub fn project_read_derive(input: TokenStream) -> TokenStream {
             fn sources(&self, ctx: &ProjectContext) -> ::std::result::Result<::std::vec::Vec<Source>, Self::Error> {
                 match self {
                     #( #sources_match ),*
+                }
+            }
+
+            fn project_root(&self) -> ::std::option::Option<&::camino::Utf8Path> {
+                match self {
+                    #( #project_root_match ),*
                 }
             }
 


### PR DESCRIPTION
Helps ensure that we don't forget to pass it through various wrappers.

Split out from #426.