### PR TITLE
refactor(core): add Identifier newtype for project resolution identity

### DIFF
--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -1,14 +1,22 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::io::{self, Read};
+use std::{
+    borrow::Borrow,
+    fmt::Display,
+    io::{self, Read},
+    ops::Deref,
+};
 
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
-use serde::Deserialize;
+use fluent_uri::Iri;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typed_path::Utf8UnixPathBuf;
 #[cfg(feature = "filesystem")]
 use zip::{self, result::ZipError};
+
+use crate::model::InterchangeProjectUsage;
 
 /// A file that is guaranteed to exist as long as the lifetime.
 /// Intended to be used with temporary files that are automatically
@@ -502,6 +510,104 @@ pub fn relativize_path<P: AsRef<Utf8Path>, R: AsRef<Utf8Path>>(
     }
 
     Ok(result.into_string().into())
+}
+
+/// Project identifier IRI. Always a valid IRI.
+// TODO: construction steps
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+pub struct Identifier(String);
+
+impl From<&Identifier> for toml_edit::Value {
+    fn from(val: &Identifier) -> Self {
+        toml_edit::Value::from(&val.0)
+    }
+}
+
+impl Borrow<str> for Identifier {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<String> for Identifier {
+    fn borrow(&self) -> &String {
+        &self.0
+    }
+}
+
+impl From<&InterchangeProjectUsage> for Identifier {
+    fn from(value: &InterchangeProjectUsage) -> Self {
+        let InterchangeProjectUsage::Resource { resource, .. } = value;
+        Self(resource.to_string())
+    }
+}
+
+impl From<InterchangeProjectUsage> for Identifier {
+    fn from(value: InterchangeProjectUsage) -> Self {
+        let InterchangeProjectUsage::Resource { resource, .. } = value;
+        Self(resource.into_string())
+    }
+}
+
+impl Identifier {
+    pub fn from_iri_owned(iri: Iri<String>) -> Identifier {
+        Self(iri.into_string())
+    }
+
+    pub fn from_iri(iri: &Iri<&str>) -> Identifier {
+        Self(iri.to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    /// Construct `Identifier` from a String, assuming it's a valid IRI
+    pub fn from_iri_unchecked(iri: String) -> Identifier {
+        Self(iri)
+    }
+
+    /// Construct `Identifier` from `&str`, assuming it's a valid IRI
+    pub fn from_iri_unchecked_str(iri: &str) -> Identifier {
+        Self(iri.to_owned())
+    }
+}
+
+impl AsRef<str> for Identifier {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for Identifier {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Iri<String>> for Identifier {
+    fn from(value: Iri<String>) -> Self {
+        Self(value.into_string())
+    }
+}
+
+impl From<Identifier> for Iri<String> {
+    fn from(value: Identifier) -> Self {
+        // Identifier is always valid IRI
+        Iri::parse(value.0).unwrap()
+    }
+}
+
+impl Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
 }
 
 #[cfg(test)]

--- a/core/src/project/utils_tests.rs
+++ b/core/src/project/utils_tests.rs
@@ -4,8 +4,12 @@
 use std::error::Error;
 
 use camino::Utf8Path;
+use fluent_uri::Iri;
 
-use crate::project::utils::relativize_path;
+use crate::{
+    model::InterchangeProjectUsage,
+    project::utils::{Identifier, relativize_path},
+};
 
 #[test]
 fn simple_relativize_path() -> Result<(), Box<dyn Error>> {
@@ -137,4 +141,30 @@ fn relativize_path_error_non_common_prefix() -> Result<(), Box<dyn Error>> {
     assert_eq!(*err_path, *path);
     assert_eq!(*err_root, *root);
     Ok(())
+}
+
+// --- Identifier constructors ---
+
+#[test]
+fn identifier_from_resource_usage_returns_iri_as_is() {
+    let resource = Iri::parse("urn:kpar:test".to_owned()).unwrap();
+    let usage = InterchangeProjectUsage::Resource {
+        resource,
+        version_constraint: None,
+    };
+    assert_eq!(Identifier::from(usage).as_str(), "urn:kpar:test");
+}
+
+#[test]
+fn identifier_from_iri_unchecked_str() {
+    assert_eq!(
+        Identifier::from_iri_unchecked_str("urn:kpar:test").as_str(),
+        "urn:kpar:test"
+    );
+}
+
+#[test]
+fn identifier_from_iri_owned() {
+    let iri = Iri::parse("urn:kpar:test".to_owned()).unwrap();
+    assert_eq!(Identifier::from_iri_owned(iri).as_str(), "urn:kpar:test");
 }


### PR DESCRIPTION
Introduce `Identifier` (in `project::utils`) as a dedicated type for a project's resolution identity, ahead of the resolution machinery and Directory-usage work that will build on it. For now it can only wrap a project's IRI (`Resource` usages).

Split out from #426.