### PR TITLE
feat(core): resolve typed usages instead of assuming an IRI

### DIFF
--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -110,9 +110,14 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
                 None => Err(InfoError::NoSemanticVersionsFound(non_semantic_versions)),
             }
         }
-        ResolutionOutcome::UnsupportedIRIType(e) => {
-            Err(InfoError::UnsupportedIri(uri.as_ref().into(), e))
+        ResolutionOutcome::UnsupportedUsageType { reason } => {
+            Err(InfoError::UnsupportedIri(uri.as_ref().into(), reason))
         }
-        ResolutionOutcome::Unresolvable(e) => Err(InfoError::NoResolve(uri.as_ref().into(), e)),
+        ResolutionOutcome::NotFound { reason } => {
+            Err(InfoError::NoResolve(uri.as_ref().into(), reason))
+        }
+        ResolutionOutcome::Unresolvable { reason } => {
+            Err(InfoError::NoResolve(uri.as_ref().into(), reason))
+        }
     }
 }

--- a/core/src/resolve/combined.rs
+++ b/core/src/resolve/combined.rs
@@ -12,14 +12,18 @@ use crate::{
     lock::Source,
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::{ProjectRead, cached::CachedProject},
-    resolve::{ResolutionOutcome, ResolveRead, null::NullResolver},
+    resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead, null::NullResolver},
     utils::format_err,
 };
 
 /// Implements "standard" resolution logic given a set of individual resolvers.
 /// Use sysand::resolve::null::NullResolver to skip any of the steps.
 /// The logic is as follows:
-/// 1. Do not resolve any further if file_resolver is successful, otherwise go to step 2.
+/// 1. Do not resolve any further if file_resolver is successful, or rejected the usage
+///    (i.e. it is a path). NotFound allows fallthrough to other resolvers mainly to
+///    accomodate environment resolver, which may resolve the usage by its identifier only
+///    (no other resolvers should resolve such a usage, environment is special here).
+///    Otherwise go to step 2.
 /// 2. If remote_resolver produces any results, discard any that do not point to a valid
 ///    project (i.e. do not produce both a info and meta). If at least one project is found
 ///    proceed to step 4. (skipping 3.)
@@ -233,7 +237,7 @@ impl<
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         let mut at_least_one_supports = false;
 
@@ -242,23 +246,28 @@ impl<
         // TODO: autodetect git (and possibly other VCSs), and use appropriate (e.g. git) resolver for them.
         if let Some(file_resolver) = &self.file_resolver {
             match file_resolver
-                .resolve_read(uri)
+                .resolve_read(resolve)
                 .map_err(CombinedResolverError::File)?
             {
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    log::debug!("file resolver rejected IRI `{uri}`: {msg}");
-                } // Just continue
                 ResolutionOutcome::Resolved(r) => {
-                    //at_least_one_supports = true;
                     return Ok(ResolutionOutcome::Resolved(CombinedIterator {
                         state: CombinedIteratorState::ResolvedFile(r.into_iter()),
                         locals: IndexMap::new(),
                     }));
                 }
-                ResolutionOutcome::Unresolvable(msg) => {
-                    return Ok(ResolutionOutcome::Unresolvable(format!(
-                        "failed to resolve as file: {msg}"
-                    )));
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    log::debug!("file resolver does not support usage type of {resolve}: {reason}");
+                }
+                ResolutionOutcome::NotFound { reason } => {
+                    log::debug!("file resolver did not find the project: {reason}");
+                    at_least_one_supports = true;
+                }
+                ResolutionOutcome::Unresolvable { reason } => {
+                    return Ok(ResolutionOutcome::Unresolvable {
+                        reason: format!(
+                            "file resolver refused to resolve the project, no other sources will be tried: {reason}"
+                        ),
+                    });
                 }
             }
         }
@@ -268,7 +277,7 @@ impl<
 
         if let Some(local_resolver) = &self.local_resolver {
             match local_resolver
-                .resolve_read(uri)
+                .resolve_read(resolve)
                 .map_err(CombinedResolverError::Local)?
             {
                 ResolutionOutcome::Resolved(projects) => {
@@ -277,7 +286,7 @@ impl<
                         match res {
                             Err(err) => {
                                 log::debug!(
-                                    "local resolver rejected project with IRI `{uri}`: {}",
+                                    "local resolver rejected project {resolve}: {}",
                                     format_err(err)
                                 );
                             }
@@ -287,12 +296,12 @@ impl<
                                 }
                                 Ok(None) => {
                                     log::debug!(
-                                        "local resolver rejected project with IRI `{uri}`: no `.project.json` or `.meta.json`",
+                                        "local resolver rejected project {resolve}: no `.project.json` or `.meta.json`",
                                     );
                                 }
                                 Err(err) => {
                                     log::debug!(
-                                        "local resolver rejected project with IRI `{uri}`: {}",
+                                        "local resolver rejected project {resolve}: {}",
                                         format_err(err)
                                     );
                                 }
@@ -300,12 +309,18 @@ impl<
                         }
                     }
                 }
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    log::debug!("local resolver rejected IRI `{uri}`: {msg}");
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    log::debug!(
+                        "local resolver does not support usage type of {resolve}: {reason}"
+                    );
                 }
-                ResolutionOutcome::Unresolvable(msg) => {
+                ResolutionOutcome::NotFound { reason } => {
                     at_least_one_supports = true;
-                    log::debug!("local resolver unable to resolve IRI `{uri}`: {msg}");
+                    log::debug!("local resolver did not find {resolve}: {reason}");
+                }
+                ResolutionOutcome::Unresolvable { reason } => {
+                    at_least_one_supports = true;
+                    log::debug!("local resolver rejected {resolve}: {reason}")
                 }
             };
         }
@@ -316,15 +331,15 @@ impl<
         if let Some(remote_resolver) = &self.remote_resolver {
             // Skip over remote resolution if unresolvable or if only invalid projects are produced.
             match remote_resolver
-                .resolve_read(uri)
+                .resolve_read(resolve)
                 .map_err(CombinedResolverError::Remote)?
             {
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    log::debug!("remote resolver rejected IRI `{uri}`: {msg}");
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    log::debug!("remote resolver rejected {resolve}: {reason}");
                 }
-                ResolutionOutcome::Unresolvable(msg) => {
+                ResolutionOutcome::NotFound { reason } => {
                     at_least_one_supports = true;
-                    log::debug!("remote resolver unable to resolve IRI `{uri}`: {msg}");
+                    log::debug!("remote resolver unable to resolve {resolve}: {reason}");
                 }
                 ResolutionOutcome::Resolved(remote_projects) => {
                     at_least_one_supports = true;
@@ -335,7 +350,7 @@ impl<
                         match remote_projects.peek() {
                             Some(Err(err)) => {
                                 log::debug!(
-                                    "remote resolver skipping project for IRI `{uri}` due to: {}",
+                                    "remote resolver skipping project for {resolve} due to: {}",
                                     format_err(err)
                                 );
                                 remote_projects.next();
@@ -358,13 +373,13 @@ impl<
                                     }
                                     Ok(_) => {
                                         log::debug!(
-                                            "remote resolver skipping project for IRI `{uri}` due to missing info/meta"
+                                            "remote resolver skipping project for {resolve} due to missing info/meta"
                                         );
                                         remote_projects.next();
                                     }
                                     Err(err) => {
                                         log::debug!(
-                                            "remote resolver skipping project for IRI `{uri}`: {}",
+                                            "remote resolver skipping project for {resolve}: {}",
                                             format_err(err)
                                         );
                                         remote_projects.next();
@@ -373,12 +388,16 @@ impl<
                             }
                             None => {
                                 log::debug!(
-                                    "remote resolver unable to find valid project for IRI `{uri}`"
+                                    "remote resolver unable to find valid project for {resolve}"
                                 );
                                 break;
                             }
                         }
                     }
+                }
+                ResolutionOutcome::Unresolvable { reason } => {
+                    at_least_one_supports = true;
+                    log::debug!("remote resolver rejected {resolve}: {reason}")
                 }
             }
         }
@@ -386,7 +405,7 @@ impl<
         // Finally try the sysand index if neither file/remote gave anything useful
         if let Some(index_resolver) = &self.index_resolver {
             match index_resolver
-                .resolve_read(uri)
+                .resolve_read(resolve)
                 .map_err(CombinedResolverError::Index)?
             {
                 ResolutionOutcome::Resolved(x) => {
@@ -395,25 +414,31 @@ impl<
                         locals,
                     }));
                 }
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    log::debug!("index resolver rejected IRI `{uri}` due to: {msg}");
-                }
-                ResolutionOutcome::Unresolvable(msg) => {
+                ResolutionOutcome::Unresolvable { reason } => {
                     at_least_one_supports = true;
-                    log::debug!("index resolver unable to resolve IRI `{uri}`: {msg}");
+                    log::debug!("index resolver unable to resolve {resolve}: {reason}");
+                }
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    log::debug!("index resolver rejected {resolve}: {reason}");
+                }
+                ResolutionOutcome::NotFound { reason } => {
+                    at_least_one_supports = true;
+                    log::debug!("index resolver unable to resolve {resolve}: {reason}");
                 }
             };
         }
 
         // As a last resort, use only locally cached projects, if any were found
         if !at_least_one_supports {
-            Ok(ResolutionOutcome::UnsupportedIRIType(
-                "no resolver accepted the IRI".to_owned(),
-            ))
+            Ok(ResolutionOutcome::UnsupportedUsageType {
+                reason: String::from("no resolver supports the project type"),
+            })
         } else if locals.is_empty() {
-            Ok(ResolutionOutcome::Unresolvable(
-                "no resolver was able to resolve the IRI".to_owned(),
-            ))
+            // TODO: this is not alywas correct. Project resolution can fail in various
+            // ways by different resolvers. How to represent it here?
+            Ok(ResolutionOutcome::NotFound {
+                reason: String::from("no resolver was able to resolve the project"),
+            })
         } else {
             Ok(ResolutionOutcome::Resolved(CombinedIterator {
                 state: CombinedIteratorState::Done,

--- a/core/src/resolve/combined_tests.rs
+++ b/core/src/resolve/combined_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::memory::InMemoryProject,
     resolve::{
-        ResolveRead,
+        ResolutionInfo, ResolutionOutcome, ResolveRead,
         combined::{CombinedResolver, NO_RESOLVER},
         memory::{AcceptAll, MemoryResolver},
     },
@@ -80,106 +80,70 @@ fn multiple_projects_any_resolver<S: AsRef<str>>(
     })
 }
 
-// fn single_project_file_resolver<S: AsRef<str>>(
-//     uri: S,
-//     project: ProjectMemoryStorage,
-// ) -> MemoryResolver<AcceptScheme<'static>, ProjectMemoryStorage> {
-//     let uri = fluent_uri::Iri::parse(uri.as_ref().to_string()).unwrap();
-
-//     if uri.scheme() != SCHEME_FILE {
-//         panic!("Invalid IRI for file resolver");
-//     }
-
-//     let mut projects = HashMap::new();
-
-//     projects.insert(uri, project);
-
-//     MemoryResolver {
-//         iri_predicate: AcceptScheme {
-//             scheme: SCHEME_FILE,
-//         },
-//         projects: projects,
-//     }
-// }
+fn iri(iri: &str) -> Iri<String> {
+    Iri::parse(iri).unwrap().into()
+}
 
 #[test]
 fn prefer_file_resolver_when_successful() {
-    let example_uri = "http://example.com";
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.2.3");
     let project_b = minimal_project("b", "3.2.1");
 
     let resolver = CombinedResolver {
-        file_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        remote_resolver: single_project_any_resolver(example_uri, project_b.clone()),
-        local_resolver: single_project_any_resolver(example_uri, project_b.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_b.clone()),
+        file_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+        remote_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
+        local_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
+        index_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "a");
 }
 
 #[test]
-fn prefer_file_resolver_even_when_unresolved() {
-    let example_uri = "http://example.com";
-
-    let project_a = minimal_project("a", "1.2.3");
-
-    let resolver = CombinedResolver {
-        file_resolver: empty_any_resolver(),
-        remote_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        local_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-    };
-
-    let xs = do_info(example_uri, &resolver);
-
-    assert!(xs.is_err())
-}
-
-#[test]
 fn skip_file_resolver_if_unsupported_iri() {
-    let example_uri = "http://example.com";
+    let example_uri = iri("http://example.com");
 
     //let project_a = minimal_project("a", "1.2.3");
     let project_b = minimal_project("b", "3.2.1");
 
     let resolver = CombinedResolver {
         file_resolver: NO_RESOLVER,
-        remote_resolver: single_project_any_resolver(example_uri, project_b.clone()),
-        local_resolver: single_project_any_resolver(example_uri, project_b.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_b.clone()),
+        remote_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
+        local_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
+        index_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "b");
 }
 
 #[test]
 fn prefer_remote_over_index_if_valid_cached() {
-    let example_uri = "http://example.com";
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.2.3");
     let project_b = minimal_project("b", "3.2.1");
 
     let resolver = CombinedResolver {
         file_resolver: NO_RESOLVER,
-        remote_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        local_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_b.clone()),
+        remote_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+        local_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+        index_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "a");
 }
 
 #[test]
 fn prefer_remote_over_index_if_valid_uncached() {
-    let example_uri = "http://example.com";
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.2.3");
     let project_b = minimal_project("b", "3.2.1");
@@ -187,19 +151,19 @@ fn prefer_remote_over_index_if_valid_uncached() {
 
     let resolver = CombinedResolver {
         file_resolver: NO_RESOLVER,
-        remote_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        local_resolver: single_project_any_resolver(example_uri, project_b.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_c.clone()),
+        remote_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+        local_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
+        index_resolver: single_project_any_resolver(&example_uri, project_c.clone()),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "b");
 }
 
 #[test]
 fn skip_remote_if_unsupported_uncached() {
-    let example_uri = "http://example.com";
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.2.3");
     let project_b = minimal_project("b", "3.2.1");
@@ -207,53 +171,61 @@ fn skip_remote_if_unsupported_uncached() {
     let resolver = CombinedResolver {
         file_resolver: NO_RESOLVER,
         remote_resolver: NO_RESOLVER,
-        local_resolver: single_project_any_resolver(example_uri, project_b.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_a.clone()),
+        local_resolver: single_project_any_resolver(&example_uri, project_b.clone()),
+        index_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "b");
 }
 
 #[test]
 fn skip_remote_if_unsupported_cached() {
-    let example_uri = "http://example.com";
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.2.3");
 
     let resolver = CombinedResolver {
         file_resolver: NO_RESOLVER,
         remote_resolver: NO_RESOLVER,
-        local_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_a.clone()),
+        local_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+        index_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "a");
 }
 
 #[test]
 fn skip_remote_if_unresolved_cached() {
-    let example_uri = "http://example.com";
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.2.3");
 
     let resolver = CombinedResolver {
         file_resolver: NO_RESOLVER,
         remote_resolver: empty_any_resolver(),
-        local_resolver: single_project_any_resolver(example_uri, project_a.clone()),
-        index_resolver: single_project_any_resolver(example_uri, project_a.clone()),
+        local_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
+        index_resolver: single_project_any_resolver(&example_uri, project_a.clone()),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "a");
 }
 
+fn resolve<R: ResolveRead>(
+    resolver: &R,
+    iri: &str,
+) -> Result<ResolutionOutcome<R::ResolvedStorages>, R::Error> {
+    let resolve = ResolutionInfo::iri(Iri::parse(iri).unwrap().into());
+    resolver.resolve_read(&resolve)
+}
+
 #[test]
-fn unsupported_iri_test() {
+fn unsupported_iri() {
     let example_uri = "http://example.com";
 
     let resolver = CombinedResolver {
@@ -263,15 +235,15 @@ fn unsupported_iri_test() {
         index_resolver: NO_RESOLVER,
     };
 
-    let Ok(crate::resolve::ResolutionOutcome::UnsupportedIRIType(_)) =
-        resolver.resolve_read_raw(example_uri)
+    let Ok(crate::resolve::ResolutionOutcome::UnsupportedUsageType { .. }) =
+        resolve(&resolver, example_uri)
     else {
         panic!()
     };
 }
 
 #[test]
-fn unresolved_iri_test() {
+fn unresolved_iri() {
     let example_uri = "http://example.com";
 
     let resolver = CombinedResolver {
@@ -281,23 +253,22 @@ fn unresolved_iri_test() {
         index_resolver: empty_any_resolver(),
     };
 
-    let Ok(crate::resolve::ResolutionOutcome::Unresolvable(_)) =
-        resolver.resolve_read_raw(example_uri)
+    let Ok(crate::resolve::ResolutionOutcome::NotFound { .. }) = resolve(&resolver, example_uri)
     else {
         panic!()
     };
 }
 
 #[test]
-fn skip_non_semantic_versions_test() {
-    let example_uri = "http://example.com";
+fn skip_non_semantic_versions() {
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.2.3");
     let project_b = minimal_project("b", "3.2.1.H");
 
     let resolver = CombinedResolver {
         file_resolver: multiple_projects_any_resolver(
-            example_uri,
+            &example_uri,
             vec![project_a.clone(), project_b.clone()],
         ),
         remote_resolver: empty_any_resolver(),
@@ -305,21 +276,21 @@ fn skip_non_semantic_versions_test() {
         index_resolver: empty_any_resolver(),
     };
 
-    let (info, _) = do_info(example_uri, &resolver).unwrap();
+    let (info, _) = do_info(&example_uri, &resolver).unwrap();
 
     assert_eq!(info.name, "a");
 }
 
 #[test]
-fn no_semantic_versions_error_test() {
-    let example_uri = "http://example.com";
+fn no_semantic_versions_error() {
+    let example_uri = iri("http://example.com");
 
     let project_a = minimal_project("a", "1.23");
     let project_b = minimal_project("b", "3.2.1.H");
 
     let resolver = CombinedResolver {
         file_resolver: multiple_projects_any_resolver(
-            example_uri,
+            &example_uri,
             vec![project_a.clone(), project_b.clone()],
         ),
         remote_resolver: empty_any_resolver(),
@@ -327,7 +298,7 @@ fn no_semantic_versions_error_test() {
         index_resolver: empty_any_resolver(),
     };
 
-    let info_meta = do_info(example_uri, &resolver);
+    let info_meta = do_info(&example_uri, &resolver);
 
     assert_matches!(info_meta, Err(InfoError::NoSemanticVersionsFound(_)));
 }

--- a/core/src/resolve/env.rs
+++ b/core/src/resolve/env.rs
@@ -4,7 +4,8 @@
 // Resolve IRIs in an environment
 use crate::{
     env::{ReadEnvironment, ReadEnvironmentAsync},
-    resolve::{ResolutionOutcome, ResolveRead, ResolveReadAsync},
+    model::InterchangeProjectUsage,
+    resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead, ResolveReadAsync},
 };
 
 #[derive(Debug)]
@@ -21,8 +22,10 @@ impl<Env: ReadEnvironment> ResolveRead for EnvResolver<Env> {
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
+        let InterchangeProjectUsage::Resource { resource: uri, .. } = resolve.usage();
+
         let versions = self.env.versions(uri)?;
 
         let projects: Self::ResolvedStorages = versions
@@ -34,9 +37,9 @@ impl<Env: ReadEnvironment> ResolveRead for EnvResolver<Env> {
             )
             .collect();
         if projects.is_empty() {
-            Ok(ResolutionOutcome::Unresolvable(format!(
-                "no versions of `{uri}` found in environment"
-            )))
+            Ok(ResolutionOutcome::NotFound {
+                reason: format!("no versions of `{uri}` found in environment"),
+            })
         } else {
             Ok(ResolutionOutcome::Resolved(projects))
         }
@@ -59,15 +62,17 @@ impl<Env: ReadEnvironmentAsync> ResolveReadAsync for EnvResolver<Env> {
 
     async fn resolve_read_async(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         use futures::StreamExt as _;
 
+        let InterchangeProjectUsage::Resource { resource: uri, .. } = resolve.usage();
+
         let versions: Vec<Result<String, _>> = self.env.versions_async(uri).await?.collect().await;
         if versions.is_empty() {
-            return Ok(ResolutionOutcome::Unresolvable(format!(
-                "no versions of `{uri}` found in environment"
-            )));
+            return Ok(ResolutionOutcome::NotFound {
+                reason: format!("no versions of `{uri}` found in environment"),
+            });
         }
 
         let projects = futures::future::join_all(

--- a/core/src/resolve/file.rs
+++ b/core/src/resolve/file.rs
@@ -14,14 +14,14 @@ use thiserror::Error;
 use crate::{
     context::ProjectContext,
     lock::Source,
-    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
+    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw, InterchangeProjectUsage},
     project::{
         self, ProjectRead,
         local_kpar::{KparInnerPath, LocalKParError, LocalKParProject},
         local_src::{LocalSrcError, LocalSrcProject},
         utils::{FsIoError, ProjectDeserializationError, RelativizePathError, wrapfs},
     },
-    resolve::{ResolutionOutcome, ResolveRead},
+    resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead},
     utils::scheme::SCHEME_FILE,
 };
 
@@ -86,10 +86,12 @@ impl FileResolver {
             if let Some(root_part) = &self.relative_path_root {
                 root_part.join(&path)
             } else {
-                return Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                    "cannot resolve relative file without a specified root directory: {}",
-                    path
-                )));
+                return Ok(ResolutionOutcome::UnsupportedUsageType {
+                    reason: format!(
+                        "cannot resolve relative file without a specified root directory: {}",
+                        path
+                    ),
+                });
             }
         } else {
             path
@@ -110,11 +112,13 @@ impl FileResolver {
                 sandbox_roots_canonical.push(sandbox_root_canonical.to_string());
             }
             if !found {
-                return Ok(ResolutionOutcome::Unresolvable(format!(
-                    "refusing to resolve path `{}`, is not inside in any of the allowed directories\n{}",
-                    project_path,
-                    sandbox_roots_canonical.join("; "),
-                )));
+                return Ok(ResolutionOutcome::Unresolvable {
+                    reason: format!(
+                        "refusing to resolve path `{}`, is not inside in any of the allowed directories\n{}",
+                        project_path,
+                        sandbox_roots_canonical.join("; "),
+                    ),
+                });
             }
         }
 
@@ -127,9 +131,9 @@ impl FileResolver {
     ) -> Result<ResolutionOutcome<Utf8PathBuf>, FileResolverError> {
         match try_file_uri_to_path(uri)? {
             Some(path) => self.resolve_platform_path(path),
-            None => Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                "`{uri}` is not a file URL",
-            ))),
+            None => Ok(ResolutionOutcome::UnsupportedUsageType {
+                reason: format!("`{uri}` is not a file URL"),
+            }),
         }
     }
 }
@@ -325,8 +329,10 @@ impl ResolveRead for FileResolver {
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
+        let InterchangeProjectUsage::Resource { resource: uri, .. } = resolve.usage();
+
         Ok(match self.resolve_general(uri)? {
             ResolutionOutcome::Resolved(path) => ResolutionOutcome::Resolved(vec![
                 Ok(FileResolverProject::LocalSrcProject(LocalSrcProject {
@@ -338,10 +344,13 @@ impl ResolveRead for FileResolver {
                     LocalKParProject::new(path, KparInnerPath::Guess, None, None),
                 )),
             ]),
-            ResolutionOutcome::UnsupportedIRIType(msg) => {
-                ResolutionOutcome::UnsupportedIRIType(msg)
+            ResolutionOutcome::UnsupportedUsageType { reason } => {
+                ResolutionOutcome::UnsupportedUsageType { reason }
             }
-            ResolutionOutcome::Unresolvable(msg) => ResolutionOutcome::Unresolvable(msg),
+            ResolutionOutcome::Unresolvable { reason } => {
+                ResolutionOutcome::Unresolvable { reason }
+            }
+            ResolutionOutcome::NotFound { reason } => ResolutionOutcome::NotFound { reason },
         })
     }
 }

--- a/core/src/resolve/gix_git.rs
+++ b/core/src/resolve/gix_git.rs
@@ -4,8 +4,9 @@
 use thiserror::Error;
 
 use crate::{
+    model::InterchangeProjectUsage,
     project::gix_git_download::{GixDownloadedError, GixDownloadedProject},
-    resolve::{ResolutionOutcome, ResolveRead},
+    resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead},
     utils::scheme::{
         SCHEME_FILE, SCHEME_GIT_FILE, SCHEME_GIT_HTTP, SCHEME_GIT_HTTPS, SCHEME_GIT_SSH,
         SCHEME_HTTP, SCHEME_HTTPS, SCHEME_SSH,
@@ -30,8 +31,10 @@ impl ResolveRead for GitResolver {
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<super::ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
+        let InterchangeProjectUsage::Resource { resource: uri, .. } = resolve.usage();
+
         let scheme = uri.scheme();
 
         if ![
@@ -46,11 +49,13 @@ impl ResolveRead for GitResolver {
         ]
         .contains(&scheme)
         {
-            return Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                "url scheme `{}` of IRI `{}` is not known to be git-compatible",
-                scheme,
-                uri.as_str()
-            )));
+            return Ok(ResolutionOutcome::UnsupportedUsageType {
+                reason: format!(
+                    "url scheme `{}` of IRI `{}` is not known to be git-compatible",
+                    scheme,
+                    uri.as_str()
+                ),
+            });
         }
 
         Ok(ResolutionOutcome::Resolved(std::iter::once(

--- a/core/src/resolve/memory.rs
+++ b/core/src/resolve/memory.rs
@@ -6,8 +6,9 @@ use std::{collections::HashMap, convert::Infallible};
 use fluent_uri::{Iri, component::Scheme};
 
 use crate::{
+    model::InterchangeProjectUsage,
     project::ProjectRead,
-    resolve::{ResolutionOutcome, ResolveRead},
+    resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead},
 };
 
 #[derive(Debug)]
@@ -85,17 +86,21 @@ impl<Predicate: IRIPredicate, ProjectStorage: ProjectRead + Clone> ResolveRead
 
     fn resolve_read(
         &self,
-        uri: &Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
+        let InterchangeProjectUsage::Resource { resource: uri, .. } = resolve.usage();
+
         if !self.iri_predicate.accept_iri(uri) {
-            return Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                "invalid IRI `{uri}` for this memory resolver"
-            )));
+            return Ok(ResolutionOutcome::UnsupportedUsageType {
+                reason: format!("invalid IRI `{uri}` for this memory resolver"),
+            });
         }
 
         Ok(match self.projects.get(uri) {
             Some(xs) => ResolutionOutcome::Resolved(xs.iter().map(|x| Ok(x.clone())).collect()),
-            None => ResolutionOutcome::Unresolvable(uri.to_string()),
+            None => ResolutionOutcome::NotFound {
+                reason: format!("no project found for IRI `{uri}` in this memory resolver"),
+            },
         })
     }
 }

--- a/core/src/resolve/mod.rs
+++ b/core/src/resolve/mod.rs
@@ -5,9 +5,13 @@ use std::{fmt::Debug, sync::Arc};
 
 use crate::{
     env::{SyncStreamIter, utils::ErrorBound},
-    project::{AsAsyncProject, AsSyncProjectTokio, ProjectRead, ProjectReadAsync},
+    model::InterchangeProjectUsage,
+    project::{
+        AsAsyncProject, AsSyncProjectTokio, ProjectRead, ProjectReadAsync, utils::Identifier,
+    },
 };
 
+use fluent_uri::Iri;
 use futures::stream::StreamExt as _;
 
 pub mod combined;
@@ -33,19 +37,69 @@ pub enum ResolutionOutcome<T> {
     /// Successfully resolved a `T`. If `T` is a collection/iterator,
     /// it must contain at least one element
     Resolved(T),
-    /// Resolution failed due to an unsupported type of IRI
-    UnsupportedIRIType(String),
-    /// Resolution failed due to an invalid IRI that is in principle supported
-    Unresolvable(String),
+    /// Resolution failed due to an unsupported type of usage
+    UnsupportedUsageType { reason: String },
+    /// Usage is supported, but was not found
+    NotFound { reason: String },
+    /// Resolution failed due to an invalid usage that is in principle supported
+    Unresolvable { reason: String },
 }
 
 impl<T> ResolutionOutcome<T> {
     pub fn map<U, F: FnOnce(T) -> U>(self, op: F) -> ResolutionOutcome<U> {
         match self {
             Self::Resolved(t) => ResolutionOutcome::Resolved(op(t)),
-            Self::UnsupportedIRIType(e) => ResolutionOutcome::UnsupportedIRIType(e),
-            Self::Unresolvable(e) => ResolutionOutcome::Unresolvable(e),
+            Self::UnsupportedUsageType { reason } => {
+                ResolutionOutcome::UnsupportedUsageType { reason }
+            }
+            Self::NotFound { reason } => ResolutionOutcome::NotFound { reason },
+            Self::Unresolvable { reason } => ResolutionOutcome::Unresolvable { reason },
         }
+    }
+}
+
+/// Information needed to resolve a usage
+#[derive(Debug, Clone)]
+pub struct ResolutionInfo {
+    usage: InterchangeProjectUsage,
+}
+
+impl ResolutionInfo {
+    pub fn new(usage: InterchangeProjectUsage) -> Self {
+        Self { usage }
+    }
+
+    pub fn iri(iri: Iri<String>) -> Self {
+        Self {
+            usage: InterchangeProjectUsage::Resource {
+                resource: iri,
+                version_constraint: None,
+            },
+        }
+    }
+
+    pub fn usage(&self) -> &InterchangeProjectUsage {
+        &self.usage
+    }
+
+    /// Identifier of this usage, to be used in lock/env.
+    // TODO: how to take versions/requirements into account here?
+    pub fn id(&self) -> Identifier {
+        Identifier::from(&self.usage)
+    }
+}
+
+impl std::fmt::Display for ResolutionInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let InterchangeProjectUsage::Resource {
+            resource,
+            version_constraint,
+        } = &self.usage;
+        write!(f, "IRI `{resource}`")?;
+        if let Some(vc) = version_constraint {
+            write!(f, " ({vc})")?;
+        }
+        Ok(())
     }
 }
 
@@ -60,11 +114,10 @@ pub trait ResolveRead {
         uri: S,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         match fluent_uri::Iri::parse(uri.as_ref().to_string()) {
-            Ok(uri) => self.resolve_read(&uri),
-            Err((err, val)) => Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                "unable to parse IRI `{}`: {}",
-                val, err
-            ))),
+            Ok(uri) => self.resolve_read(&ResolutionInfo::iri(uri)),
+            Err((err, val)) => Ok(ResolutionOutcome::UnsupportedUsageType {
+                reason: format!("unable to parse IRI `{}`: {}", val, err),
+            }),
         }
     }
 
@@ -77,7 +130,7 @@ pub trait ResolveRead {
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error>;
 
     /// Treat this `ResolveRead` as a (trivial) `ResolveReadAsync`
@@ -101,11 +154,10 @@ pub trait ResolveReadAsync {
     ) -> impl Future<Output = Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error>> {
         async move {
             match fluent_uri::Iri::parse(uri.as_ref().to_string()) {
-                Ok(uri) => self.resolve_read_async(&uri).await,
-                Err((err, val)) => Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                    "unable to parse IRI `{}`: {}",
-                    val, err
-                ))),
+                Ok(uri) => self.resolve_read_async(&ResolutionInfo::iri(uri)).await,
+                Err((err, val)) => Ok(ResolutionOutcome::UnsupportedUsageType {
+                    reason: format!("unable to parse IRI `{}`: {}", val, err),
+                }),
             }
         }
     }
@@ -119,7 +171,7 @@ pub trait ResolveReadAsync {
 
     fn resolve_read_async(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> impl Future<Output = Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error>>;
 
     // Maybe make this return an associated type instead? Would, for example, allow
@@ -167,9 +219,9 @@ where
 
     async fn resolve_read_async(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
-        Ok(match self.inner.resolve_read(uri)? {
+        Ok(match self.inner.resolve_read(resolve)? {
             ResolutionOutcome::Resolved(projects) => ResolutionOutcome::Resolved({
                 let projects_map: std::iter::Map<_, fn(_) -> _> = projects
                     .into_iter()
@@ -177,10 +229,13 @@ where
 
                 futures::stream::iter(projects_map)
             }),
-            ResolutionOutcome::UnsupportedIRIType(msg) => {
-                ResolutionOutcome::UnsupportedIRIType(msg)
+            ResolutionOutcome::UnsupportedUsageType { reason } => {
+                ResolutionOutcome::UnsupportedUsageType { reason }
             }
-            ResolutionOutcome::Unresolvable(msg) => ResolutionOutcome::Unresolvable(msg),
+            ResolutionOutcome::Unresolvable { reason } => {
+                ResolutionOutcome::Unresolvable { reason }
+            }
+            ResolutionOutcome::NotFound { reason } => ResolutionOutcome::NotFound { reason },
         })
         //let bar = foo.map(|x| futures::stream::iter(x.into_iter());
         //Ok(bar)
@@ -220,10 +275,13 @@ where
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         Ok(
-            match self.runtime.block_on(self.inner.resolve_read_async(uri))? {
+            match self
+                .runtime
+                .block_on(self.inner.resolve_read_async(resolve))?
+            {
                 ResolutionOutcome::Resolved(storages) => {
                     let runtime_clone = self.runtime.clone();
 
@@ -240,10 +298,13 @@ where
                         inner,
                     })
                 }
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    ResolutionOutcome::UnsupportedIRIType(msg)
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    ResolutionOutcome::UnsupportedUsageType { reason }
                 }
-                ResolutionOutcome::Unresolvable(msg) => ResolutionOutcome::Unresolvable(msg),
+                ResolutionOutcome::Unresolvable { reason } => {
+                    ResolutionOutcome::Unresolvable { reason }
+                }
+                ResolutionOutcome::NotFound { reason } => ResolutionOutcome::NotFound { reason },
             },
         )
     }

--- a/core/src/resolve/null.rs
+++ b/core/src/resolve/null.rs
@@ -3,7 +3,10 @@
 
 use std::convert::Infallible;
 
-use crate::{project::null::NullProject, resolve::ResolveRead};
+use crate::{
+    project::null::NullProject,
+    resolve::{ResolutionInfo, ResolveRead},
+};
 
 #[derive(Debug)]
 pub struct NullResolver {}
@@ -17,10 +20,10 @@ impl ResolveRead for NullResolver {
 
     fn resolve_read(
         &self,
-        _uri: &fluent_uri::Iri<String>,
+        _resolve: &ResolutionInfo,
     ) -> Result<super::ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
-        Ok(super::ResolutionOutcome::UnsupportedIRIType(
-            "null resolver".to_string(),
-        ))
+        Ok(super::ResolutionOutcome::UnsupportedUsageType {
+            reason: String::from("null resolver"),
+        })
     }
 }

--- a/core/src/resolve/priority.rs
+++ b/core/src/resolve/priority.rs
@@ -14,7 +14,7 @@ use crate::{
     lock::Source,
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
     project::{CanonicalizationError, ProjectRead},
-    resolve::ResolveRead,
+    resolve::{ResolutionInfo, ResolveRead},
 };
 
 use super::ResolutionOutcome;
@@ -247,11 +247,11 @@ impl<Higher: ResolveRead, Lower: ResolveRead> ResolveRead for PriorityResolver<H
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         match self
             .higher
-            .resolve_read(uri)
+            .resolve_read(resolve)
             .map_err(PriorityError::Higher)?
         {
             ResolutionOutcome::Resolved(resolved) => {
@@ -259,17 +259,20 @@ impl<Higher: ResolveRead, Lower: ResolveRead> ResolveRead for PriorityResolver<H
                     PriorityIterator::HigherIterator(resolved.into_iter()),
                 ));
             }
-            ResolutionOutcome::UnsupportedIRIType(msg) => {
-                log::debug!("higher priority resolver rejected IRI: {msg}")
+            ResolutionOutcome::UnsupportedUsageType { reason } => {
+                log::debug!("higher priority resolver rejected usage {resolve}: {reason}")
             }
-            ResolutionOutcome::Unresolvable(msg) => {
-                log::debug!("higher priority resolver failed to resolve IRI: {msg}")
+            ResolutionOutcome::NotFound { reason } => {
+                log::debug!("higher priority resolver did not find usage {resolve}: {reason}")
+            }
+            ResolutionOutcome::Unresolvable { reason } => {
+                log::debug!("cannot resolve usage {resolve}: {reason}")
             }
         };
 
         Ok(self
             .lower
-            .resolve_read(uri)
+            .resolve_read(resolve)
             .map_err(PriorityError::Lower)?
             .map(|resolved| PriorityIterator::LowerIterator(resolved.into_iter())))
     }

--- a/core/src/resolve/remote.rs
+++ b/core/src/resolve/remote.rs
@@ -9,7 +9,7 @@ use crate::{
     context::ProjectContext,
     lock::Source,
     project::{CanonicalizationError, ProjectRead},
-    resolve::{ResolveRead, null::NullResolver},
+    resolve::{ResolutionInfo, ResolveRead, null::NullResolver},
 };
 
 use super::ResolutionOutcome;
@@ -289,20 +289,24 @@ impl<HTTPResolver: ResolveRead, GitResolver: ResolveRead> ResolveRead
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         let resolved_http = if let Some(http_resolver) = &self.http_resolver {
             match http_resolver
-                .resolve_read(uri)
+                .resolve_read(resolve)
                 .map_err(RemoteResolverError::HTTPResolver)?
             {
                 ResolutionOutcome::Resolved(resolved) => Some(resolved.into_iter()),
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    log::debug!("HTTP resolver rejected IRI: {msg}");
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    log::debug!("HTTP resolver rejected usage {resolve}: {reason}");
                     None
                 }
-                ResolutionOutcome::Unresolvable(msg) => {
-                    log::debug!("HTTP resolver failed to resolve IRI: {msg}");
+                ResolutionOutcome::NotFound { reason } => {
+                    log::debug!("HTTP resolver did not find usage {resolve}: {reason}");
+                    None
+                }
+                ResolutionOutcome::Unresolvable { reason } => {
+                    log::debug!("HTTP resolver refused to resolve usage {resolve}: {reason}");
                     None
                 }
             }
@@ -312,16 +316,20 @@ impl<HTTPResolver: ResolveRead, GitResolver: ResolveRead> ResolveRead
 
         let resolved_git = if let Some(git_resolver) = &self.git_resolver {
             match git_resolver
-                .resolve_read(uri)
+                .resolve_read(resolve)
                 .map_err(RemoteResolverError::GitResolver)?
             {
                 ResolutionOutcome::Resolved(resolved) => Some(resolved.into_iter()),
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    log::debug!("git resolver rejected IRI: {msg}");
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    log::debug!("git resolver rejected usage {resolve}: {reason}");
                     None
                 }
-                ResolutionOutcome::Unresolvable(msg) => {
-                    log::debug!("git resolver failed to resolve IRI: {msg}");
+                ResolutionOutcome::NotFound { reason } => {
+                    log::debug!("git resolver did not find usage {resolve}: {reason}");
+                    None
+                }
+                ResolutionOutcome::Unresolvable { reason } => {
+                    log::debug!("git resolver refused to resolve usage {resolve}: {reason}");
                     None
                 }
             }

--- a/core/src/resolve/reqwest_http.rs
+++ b/core/src/resolve/reqwest_http.rs
@@ -10,13 +10,13 @@ use crate::{
     auth::HTTPAuthentication,
     context::ProjectContext,
     lock::Source,
-    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
+    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw, InterchangeProjectUsage},
     project::{
         CanonicalizationError, ProjectReadAsync,
         reqwest_kpar_download::ReqwestRemoteKparDownloadedProject,
         reqwest_src::ReqwestSrcProjectAsync,
     },
-    resolve::ResolveReadAsync,
+    resolve::{ResolutionInfo, ResolveReadAsync},
     utils::scheme::{SCHEME_HTTP, SCHEME_HTTPS},
 };
 
@@ -359,28 +359,32 @@ impl<Policy: HTTPAuthentication> ResolveReadAsync for HTTPResolverAsync<Policy> 
 
     async fn resolve_read_async(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
+        let InterchangeProjectUsage::Resource { resource: iri, .. } = resolve.usage();
+
         // Try to resolve as a HTTP src project.
-        Ok(
-            if uri.scheme() == SCHEME_HTTP || uri.scheme() == SCHEME_HTTPS {
-                if let Ok(url) = reqwest::Url::parse(uri.as_str()) {
-                    ResolutionOutcome::Resolved(futures::stream::iter(HTTPProjects {
-                        client: self.client.clone(),
-                        url,
-                        src_done: false,
-                        kpar_done: false,
-                        lax: self.lax,
-                        auth_policy: self.auth_policy.clone(),
-                        // prefer_ranged: self.prefer_ranged,
-                    }))
-                } else {
-                    ResolutionOutcome::UnsupportedIRIType("invalid http(s) URL".to_string())
-                }
-            } else {
-                ResolutionOutcome::UnsupportedIRIType("not an http(s) URL".to_string())
-            },
-        )
+        let outcome = if iri.scheme() == SCHEME_HTTP || iri.scheme() == SCHEME_HTTPS {
+            match reqwest::Url::parse(iri.as_str()) {
+                Ok(url) => ResolutionOutcome::Resolved(futures::stream::iter(HTTPProjects {
+                    client: self.client.clone(),
+                    url,
+                    src_done: false,
+                    kpar_done: false,
+                    lax: self.lax,
+                    auth_policy: self.auth_policy.clone(),
+                    // prefer_ranged: self.prefer_ranged,
+                })),
+                Err(e) => ResolutionOutcome::Unresolvable {
+                    reason: format!("invalid http(s) URL: {e}"),
+                },
+            }
+        } else {
+            ResolutionOutcome::UnsupportedUsageType {
+                reason: String::from("not an http(s) URL"),
+            }
+        };
+        Ok(outcome)
     }
 }
 

--- a/core/src/resolve/sequential.rs
+++ b/core/src/resolve/sequential.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use crate::resolve::{ResolutionOutcome, ResolveRead, ResolveReadAsync};
+use crate::resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead, ResolveReadAsync};
 use futures::StreamExt as _;
 use std::iter::Flatten;
 
@@ -30,24 +30,29 @@ impl<R: ResolveRead> ResolveRead for SequentialResolver<R> {
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         let mut iters = vec![];
         let mut any_supported = false;
         let mut msgs = vec![];
 
         for resolver in &self.inner {
-            match resolver.resolve_read(uri)? {
+            match resolver.resolve_read(resolve)? {
                 ResolutionOutcome::Resolved(storages) => {
                     any_supported = true;
                     iters.push(storages)
                 }
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    msgs.push(msg);
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    msgs.push(reason);
                 }
-                ResolutionOutcome::Unresolvable(msg) => {
+                ResolutionOutcome::Unresolvable { reason } => {
                     any_supported = true;
-                    msgs.push(msg);
+                    msgs.push(reason);
+                }
+                ResolutionOutcome::NotFound { reason } => {
+                    // TODO: should this be treated differently?
+                    any_supported = true;
+                    msgs.push(reason);
                 }
             }
         }
@@ -55,15 +60,13 @@ impl<R: ResolveRead> ResolveRead for SequentialResolver<R> {
         if !iters.is_empty() {
             Ok(ResolutionOutcome::Resolved(iters.into_iter().flatten()))
         } else if any_supported {
-            Ok(ResolutionOutcome::Unresolvable(format!(
-                "unresolvable: {:?}",
-                msgs
-            )))
+            Ok(ResolutionOutcome::Unresolvable {
+                reason: format!("{msgs:?}"),
+            })
         } else {
-            Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                "unsupported IRI: {:?}",
-                msgs
-            )))
+            Ok(ResolutionOutcome::UnsupportedUsageType {
+                reason: format!("{msgs:?}"),
+            })
         }
     }
 }
@@ -79,12 +82,12 @@ impl<R: ResolveReadAsync> ResolveReadAsync for SequentialResolver<R> {
 
     async fn resolve_read_async(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
         let outcomes = futures::future::join_all(
             self.inner
                 .iter()
-                .map(|resolver| resolver.resolve_read_async(uri)),
+                .map(|resolver| resolver.resolve_read_async(resolve)),
         )
         .await;
 
@@ -98,12 +101,17 @@ impl<R: ResolveReadAsync> ResolveReadAsync for SequentialResolver<R> {
                     any_supported = true;
                     streams.push(storages)
                 }
-                ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    msgs.push(msg);
+                ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    msgs.push(reason);
                 }
-                ResolutionOutcome::Unresolvable(msg) => {
+                ResolutionOutcome::Unresolvable { reason } => {
                     any_supported = true;
-                    msgs.push(msg);
+                    msgs.push(reason);
+                }
+                ResolutionOutcome::NotFound { reason } => {
+                    // TODO: should this be treated differently?
+                    any_supported = true;
+                    msgs.push(reason);
                 }
             }
         }
@@ -113,15 +121,13 @@ impl<R: ResolveReadAsync> ResolveReadAsync for SequentialResolver<R> {
                 futures::stream::iter(streams).flatten(),
             ))
         } else if any_supported {
-            Ok(ResolutionOutcome::Unresolvable(format!(
-                "unresolvable: {:?}",
-                msgs
-            )))
+            Ok(ResolutionOutcome::Unresolvable {
+                reason: format!("{msgs:?}"),
+            })
         } else {
-            Ok(ResolutionOutcome::UnsupportedIRIType(format!(
-                "unsupported IRI: {:?}",
-                msgs
-            )))
+            Ok(ResolutionOutcome::UnsupportedUsageType {
+                reason: format!("{msgs:?}"),
+            })
         }
     }
 }

--- a/core/src/resolve/standard.rs
+++ b/core/src/resolve/standard.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     index_location::IndexLocation,
     resolve::{
-        AsSyncResolveTokio, ResolveRead, ResolveReadAsync,
+        AsSyncResolveTokio, ResolutionInfo, ResolveRead, ResolveReadAsync,
         combined::CombinedResolver,
         env::EnvResolver,
         file::FileResolver,
@@ -54,9 +54,9 @@ impl<Policy: HTTPAuthentication> ResolveRead for StandardResolver<Policy> {
 
     fn resolve_read(
         &self,
-        uri: &fluent_uri::Iri<String>,
+        resolve: &ResolutionInfo,
     ) -> Result<crate::resolve::ResolutionOutcome<Self::ResolvedStorages>, Self::Error> {
-        self.0.resolve_read(uri)
+        self.0.resolve_read(resolve)
     }
 }
 

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -15,7 +15,11 @@ use std::{
 
 use thiserror::Error;
 
-use crate::{model::InterchangeProjectUsage, project::ProjectRead, resolve::ResolveRead};
+use crate::{
+    model::InterchangeProjectUsage,
+    project::ProjectRead,
+    resolve::{ResolutionInfo, ResolveRead},
+};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum DependencyIdentifier {
@@ -208,6 +212,7 @@ pub struct ProjectSolver<R: ResolveRead> {
 }
 
 /// Returned Vec will have `len >= 1`
+#[expect(clippy::result_large_err)]
 fn resolve_candidates<R: ResolveRead>(
     resolver: &R,
     uri: &fluent_uri::Iri<String>,
@@ -224,17 +229,22 @@ fn resolve_candidates<R: ResolveRead>(
         Entry::Vacant(vacant_entry) => {
             let mut found = vec![];
 
+            let resolve_info = ResolutionInfo::iri(uri.clone());
             match resolver
-                .resolve_read(uri)
+                .resolve_read(&resolve_info)
                 .map_err(InternalSolverError::Resolution)?
             {
-                crate::resolve::ResolutionOutcome::UnsupportedIRIType(msg) => {
-                    return Err(InternalSolverError::UnsupportedIriType(format!(
-                        "unsupported IRI type of `{uri}`: {msg}"
-                    )));
+                crate::resolve::ResolutionOutcome::UnsupportedUsageType { reason } => {
+                    return Err(InternalSolverError::UnsupportedUsageType {
+                        usage: resolve_info,
+                        reason,
+                    });
                 }
-                crate::resolve::ResolutionOutcome::Unresolvable(msg) => {
-                    return Err(InternalSolverError::NotFound(uri.as_str().into(), msg));
+                crate::resolve::ResolutionOutcome::NotFound { reason } => {
+                    return Err(InternalSolverError::NotFound(resolve_info, reason));
+                }
+                crate::resolve::ResolutionOutcome::Unresolvable { reason } => {
+                    return Err(InternalSolverError::NotFound(resolve_info, reason));
                 }
                 crate::resolve::ResolutionOutcome::Resolved(alternatives) => {
                     for alternative in alternatives {
@@ -302,7 +312,7 @@ fn resolve_candidates<R: ResolveRead>(
                         });
                     }
                     if found.is_empty() {
-                        return Err(InternalSolverError::NoValidCandidates(uri.as_str().into()));
+                        return Err(InternalSolverError::NoValidCandidates(resolve_info));
                     }
                 }
             }
@@ -316,6 +326,7 @@ fn resolve_candidates<R: ResolveRead>(
     }
 }
 
+#[expect(clippy::result_large_err)]
 fn compute_deps<R: ResolveRead + fmt::Debug>(
     resolver: &R,
     usages: &Vec<InterchangeProjectUsage>,
@@ -458,17 +469,20 @@ pub enum InternalSolverError<R: ResolveRead> {
     // InvalidProject,
     /// Project not found by current resolver
     /// Value is the formatted error message
-    #[error("project with IRI `{0}` not found: {1}")]
-    NotFound(Box<str>, String),
+    #[error("project {0} not found: {1}")]
+    NotFound(ResolutionInfo, String),
     /// Project candidates were found, but none of them were
     /// valid.
     /// Value is the formatted error message
-    #[error("no valid candidates found for project `{0}`")]
-    NoValidCandidates(Box<str>),
+    #[error("no valid candidates found for project {0}")]
+    NoValidCandidates(ResolutionInfo),
     /// Project not found by current resolver
     /// Value is the formatted error message
-    #[error("IRI is of type not supported by this resolver: {0}")]
-    UnsupportedIriType(String),
+    #[error("usage {usage} is of type not supported by this resolver: {reason}")]
+    UnsupportedUsageType {
+        usage: ResolutionInfo,
+        reason: String,
+    },
     /// Project is found, but the requested version is not
     /// Value is the formatted error message
     #[error("requested version unavailable: {0}")]

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -21,7 +21,7 @@ use sysand_core::{
         ProjectRead,
         utils::{relativize_path, wrapfs},
     },
-    resolve::{ResolutionOutcome, ResolveRead, standard::standard_resolver},
+    resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead, standard::standard_resolver},
     utils::format_err,
 };
 
@@ -95,7 +95,8 @@ pub fn command_add<Policy: HTTPAuthentication>(
             runtime.clone(),
             auth_policy.clone(),
         )?;
-        let outcome = std_resolver.resolve_read(&url)?;
+        let resolve_info = ResolutionInfo::iri(url.clone());
+        let outcome = std_resolver.resolve_read(&resolve_info)?;
         let mut source = None;
         match outcome {
             ResolutionOutcome::Resolved(alternatives) => {
@@ -111,9 +112,14 @@ pub fn command_add<Policy: HTTPAuthentication>(
                     }
                 }
             }
-            ResolutionOutcome::UnsupportedIRIType(e) => bail!("unsupported URL `{url}`:\n{e}"),
-            ResolutionOutcome::Unresolvable(e) => {
-                bail!("failed to resolve URL `{url}`:\n{e}")
+            ResolutionOutcome::UnsupportedUsageType { reason } => {
+                bail!("unsupported URL `{url}`:\n{reason}")
+            }
+            ResolutionOutcome::NotFound { reason } => {
+                bail!("failed to resolve URL `{url}`:\n{reason}")
+            }
+            ResolutionOutcome::Unresolvable { reason } => {
+                bail!("failed to resolve URL `{url}`:\n{reason}")
             }
         }
         if source.is_none() {

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -19,7 +19,7 @@ use sysand_core::{
         local_src::LocalSrcProject, utils::wrapfs,
     },
     resolve::{
-        ResolutionOutcome, ResolveRead,
+        ResolutionInfo, ResolutionOutcome, ResolveRead,
         memory::{AcceptAll, MemoryResolver},
         priority::PriorityResolver,
         standard::{StandardResolver, standard_resolver},
@@ -357,7 +357,8 @@ pub fn get_project_version<R: ResolveRead>(
     version: Option<String>,
     resolver: &R,
 ) -> Result<(semver::Version, R::ProjectStorage), anyhow::Error> {
-    match resolver.resolve_read(iri)? {
+    let resolve_info = ResolutionInfo::iri(iri.clone());
+    match resolver.resolve_read(&resolve_info)? {
         ResolutionOutcome::Resolved(alternatives) => {
             // If no version is supplied, choose the highest
             // Else, choose version that is supplied
@@ -433,13 +434,16 @@ pub fn get_project_version<R: ResolveRead>(
                 }
             }
         }
-        ResolutionOutcome::UnsupportedIRIType(e) => bail!(
-            "IRI scheme `{}` of `{}` is not supported: {e}",
+        ResolutionOutcome::UnsupportedUsageType { reason } => bail!(
+            "IRI scheme `{}` of `{}` is not supported: {reason}",
             iri.scheme(),
             iri
         ),
-        ResolutionOutcome::Unresolvable(e) => {
-            bail!("failed to resolve project `{iri}`: {e}")
+        ResolutionOutcome::NotFound { reason } => {
+            bail!("failed to resolve project `{iri}`: {reason}")
+        }
+        ResolutionOutcome::Unresolvable { reason } => {
+            bail!("failed to resolve project `{iri}`: {reason}")
         }
     }
 }

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -302,7 +302,7 @@ fn install_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     out.assert().failure().stderr(predicate::str::contains(
-        "no resolver was able to resolve the IRI",
+        "no resolver was able to resolve the project",
     ));
 
     Ok(())

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -861,7 +861,7 @@ fn info_basic_index_url() -> Result<(), Box<dyn Error>> {
     )?;
 
     out.assert().failure().stderr(predicate::str::contains(
-        "failed to resolve IRI `urn:kpar:other`: no resolver was able to resolve the IRI",
+        "failed to resolve IRI `urn:kpar:other`: no resolver was able to resolve the project",
     ));
     config_mock.assert();
     missing_versions_mock.assert();
@@ -1020,7 +1020,7 @@ fn info_multi_index_url_noauth() -> Result<(), Box<dyn Error>> {
     )?;
 
     out.assert().failure().stderr(predicate::str::contains(
-        "failed to resolve IRI `urn:kpar:other`: no resolver was able to resolve the IRI",
+        "failed to resolve IRI `urn:kpar:other`: no resolver was able to resolve the project",
     ));
     config_mock.assert();
     config_mock_alt.assert();


### PR DESCRIPTION
Give resolvers a more detailed resolution result and a typed handle on what is being resolved, in preparation for introducing non-IRI (relative path) usages:

- `ResolutionOutcome` gains a `NotFound` variant, distinct from `Unresolvable`. It's used by `MemoryResolver` for missing projects and `CombinedResolver` lets file-resolver `NotFound` fall through to the other resolvers instead of aborting
- `ResolutionInfo` wraps an `InterchangeProjectUsage`, and is what `ResolveRead`/`ResolveReadAsync` now take instead of a bare IRI

Split out from #426.