### PR TITLE
fix!: drop relative_path_root from the file resolver and info bindings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@
 # - Register git hooks:    prek install
 #
 # FIXME: transition to a prek official config as we now require prek
+#        Blocked until renovate gets prek.toml support:
+#        https://github.com/renovatebot/renovate/pull/42254
 # FIXME: ensure hooks gets updated over time automatically
 #
 fail_fast: true

--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/BasicTest.java
@@ -92,12 +92,8 @@ public class BasicTest {
             assertExpectedProject(project);
 
             java.net.URI fileUri = tempDir.toUri();
-            com.sensmetry.sysand.model.InterchangeProject project2 = com.sensmetry.sysand.Sysand.info(fileUri,
-                    tempDir);
+            com.sensmetry.sysand.model.InterchangeProject project2 = com.sensmetry.sysand.Sysand.info(fileUri);
             assertExpectedProject(project2);
-
-            com.sensmetry.sysand.model.InterchangeProject project3 = com.sensmetry.sysand.Sysand.info(fileUri);
-            assertExpectedProject(project3);
         } catch (java.io.IOException e) {
             fail("Failed during temporary directory operations or Sysand.info: " + e.getMessage());
         } catch (com.sensmetry.sysand.exceptions.SysandException e) {
@@ -115,8 +111,7 @@ public class BasicTest {
             assertExpectedProject(project);
 
             java.net.URI fileUri = tempDir.toUri();
-            com.sensmetry.sysand.model.InterchangeProject project2 = com.sensmetry.sysand.Sysand.info(fileUri,
-                    tempDir);
+            com.sensmetry.sysand.model.InterchangeProject project2 = com.sensmetry.sysand.Sysand.info(fileUri);
             assertExpectedProject(project2);
 
             com.sensmetry.sysand.Sysand.buildProject(tempDir.resolve("sysand-test-build.kpar"), tempDir, CompressionMethod.DEFLATED);

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/Sysand.java
@@ -86,13 +86,10 @@ public class Sysand {
      * Get the project information and metadata at the given URI.
      *
      * @param uri              The URI of the project.
-     * @param relativeFileRoot The path which should be used as the root for
-     *                         relative file URIs.
      * @return The project information and metadata.
      */
     public static native com.sensmetry.sysand.model.InterchangeProject info(
             String uri,
-            String relativeFileRoot,
             String indexUrl)
             throws com.sensmetry.sysand.exceptions.SysandException;
 
@@ -100,13 +97,10 @@ public class Sysand {
      * Get the project information and metadata at the given URI.
      *
      * @param uri              The URI of the project.
-     * @param relativeFileRoot The path which should be used as the root for
-     *                         relative file URIs.
      * @return The project information and metadata.
      */
     public static com.sensmetry.sysand.model.InterchangeProject info(
             java.net.URI uri,
-            java.nio.file.Path relativeFileRoot,
             java.net.URL indexUrl)
             throws com.sensmetry.sysand.exceptions.SysandException {
         String indexUrlString;
@@ -115,36 +109,20 @@ public class Sysand {
         } else {
             indexUrlString = null;
         }
-        return info(uri.toString(), relativeFileRoot.toString(), indexUrlString);
+        return info(uri.toString(), indexUrlString);
     }
 
     /**
      * Get the project information and metadata at the given URI.
-     *
-     * @param uri              The URI of the project.
-     * @param relativeFileRoot The path which should be used as the root for
-     *                         relative file URIs.
-     * @return The project information and metadata.
-     */
-    public static com.sensmetry.sysand.model.InterchangeProject info(
-            java.net.URI uri,
-            java.nio.file.Path relativeFileRoot)
-            throws com.sensmetry.sysand.exceptions.SysandException {
-        return info(uri, relativeFileRoot, null);
-    }
-
-    /**
-     * Get the project information and metadata at the given URI. Uses the current
-     * directory as the relative file root.
      *
      * @param uri The URI of the project.
      * @return The project information and metadata.
      */
     public static com.sensmetry.sysand.model.InterchangeProject info(java.net.URI uri)
             throws com.sensmetry.sysand.exceptions.SysandException {
-        java.nio.file.Path relativeFileRoot = java.nio.file.Paths.get(".");
-        return info(uri, relativeFileRoot, null);
+        return info(uri, null);
     }
+
 
     /**
      * Get absolute paths of all projects in a workspace.

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -211,7 +211,6 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     uri: JString<'local>,
-    relative_file_root: JString<'local>,
     index_url: JString<'local>,
 ) -> JObject<'local> {
     let Some(uri) = env.get_str(&uri, "uri") else {
@@ -242,10 +241,6 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
         Arc::new(r)
     };
 
-    let Some(relative_file_root) = env.get_str(&relative_file_root, "relativeFileRoot") else {
-        return JObject::default();
-    };
-
     let index_base_url = if index_url.is_null() {
         None
     } else {
@@ -265,7 +260,6 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_info<'local>(
     };
 
     let combined_resolver = match standard_resolver(
-        Some(Utf8PathBuf::from(relative_file_root)),
         None,
         Some(client),
         index_base_url.map(|x| vec![x]),

--- a/bindings/py/python/sysand/_info.py
+++ b/bindings/py/python/sysand/_info.py
@@ -9,7 +9,6 @@ import sysand._sysand_core as sysand_rs  # type: ignore
 
 import typing
 from pathlib import Path
-from os import getcwd
 
 
 def info_path(
@@ -21,16 +20,12 @@ def info_path(
 def info(
     uri: str,
     *,
-    relative_file_root: str | Path | None = None,
     index_urls: str | typing.List[str] | None = None,
 ) -> typing.Tuple[InterchangeProjectInfo, InterchangeProjectMetadata]:
-    if relative_file_root is None:
-        relative_file_root = getcwd()
-
     if isinstance(index_urls, str):
         index_urls = [index_urls]
 
-    return sysand_rs.do_info_py(uri, relative_file_root, index_urls)  # type: ignore
+    return sysand_rs.do_info_py(uri, index_urls)  # type: ignore
 
 
 __all__ = [

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -150,12 +150,11 @@ fn do_info_py_path(
 
 #[pyfunction(name = "do_info_py")]
 #[pyo3(
-    signature = (uri, relative_file_root, index_urls),
+    signature = (uri, index_urls),
 )]
 fn do_info_py(
     py: Python,
     uri: String,
-    relative_file_root: String,
     index_urls: Option<Vec<String>>,
 ) -> PyResult<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
     let _ = pyo3_log::try_init();
@@ -180,7 +179,6 @@ fn do_info_py(
             .map_err(|err| PyValueError::new_err(format_err(err)))?;
 
         let combined_resolver = standard_resolver(
-            Some(relative_file_root.into()),
             None,
             Some(client),
             index_url,

--- a/core/src/resolve/file.rs
+++ b/core/src/resolve/file.rs
@@ -28,8 +28,6 @@ use crate::{
 /// Resolver for resolving `file://` URIs.
 #[derive(Debug)]
 pub struct FileResolver {
-    /// Relative URIs are resolved with respect to this root.
-    pub relative_path_root: Option<Utf8PathBuf>,
     /// This field enables sandboxing the resolved path. If field is not `None`,
     /// the resolved path must be inside at least one of these directories.
     pub sandbox_roots: Option<Vec<Utf8PathBuf>>,
@@ -81,29 +79,13 @@ impl FileResolver {
         &self,
         path: Utf8PathBuf,
     ) -> Result<ResolutionOutcome<Utf8PathBuf>, FileResolverError> {
-        // Try to resolve relative paths
-        let project_path = if path.is_relative() {
-            if let Some(root_part) = &self.relative_path_root {
-                root_part.join(&path)
-            } else {
-                return Ok(ResolutionOutcome::UnsupportedUsageType {
-                    reason: format!(
-                        "cannot resolve relative file without a specified root directory: {}",
-                        path
-                    ),
-                });
-            }
-        } else {
-            path
-        };
-
         // Use canonicalised paths to check that the tentative project path is within the "jail"
         if let Some(sandboxed_roots) = &self.sandbox_roots {
             let mut found = false;
             let mut sandbox_roots_canonical = Vec::new();
             for sandbox_root in sandboxed_roots {
                 let sandbox_root_canonical = wrapfs::canonicalize(sandbox_root)?;
-                let project_path_canonical = wrapfs::canonicalize(&project_path)?;
+                let project_path_canonical = wrapfs::canonicalize(&path)?;
 
                 if project_path_canonical.starts_with(&sandbox_root_canonical) {
                     found = true;
@@ -115,14 +97,14 @@ impl FileResolver {
                 return Ok(ResolutionOutcome::Unresolvable {
                     reason: format!(
                         "refusing to resolve path `{}`, is not inside in any of the allowed directories\n{}",
-                        project_path,
+                        path,
                         sandbox_roots_canonical.join("; "),
                     ),
                 });
             }
         }
 
-        Ok(ResolutionOutcome::Resolved(project_path))
+        Ok(ResolutionOutcome::Resolved(path))
     }
 
     fn resolve_general(

--- a/core/src/resolve/standard.rs
+++ b/core/src/resolve/standard.rs
@@ -3,7 +3,6 @@
 
 use std::{fmt, result::Result, sync::Arc};
 
-use camino::Utf8PathBuf;
 use reqwest_middleware::ClientWithMiddleware;
 
 use crate::{
@@ -60,10 +59,9 @@ impl<Policy: HTTPAuthentication> ResolveRead for StandardResolver<Policy> {
     }
 }
 
-pub fn standard_file_resolver(cwd: Option<Utf8PathBuf>) -> FileResolver {
+pub fn standard_file_resolver() -> FileResolver {
     FileResolver {
         sandbox_roots: None,
-        relative_path_root: cwd,
     }
 }
 
@@ -116,14 +114,13 @@ pub fn standard_index_resolver<Policy: HTTPAuthentication>(
 
 // TODO: Replace most of these arguments by some general CLIOptions object
 pub fn standard_resolver<Policy: HTTPAuthentication>(
-    cwd: Option<Utf8PathBuf>,
     local_env: Option<LocalDirectoryEnvironment>,
     client: Option<ClientWithMiddleware>,
     index_urls: Option<Vec<IndexLocation>>,
     runtime: Arc<tokio::runtime::Runtime>,
     auth_policy: Arc<Policy>,
 ) -> Result<StandardResolver<Policy>, DiscoveryError> {
-    let file_resolver = standard_file_resolver(cwd);
+    let file_resolver = standard_file_resolver();
     let local_resolver = local_env.map(standard_local_resolver);
     let remote_resolver = client
         .clone()

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -87,7 +87,6 @@ pub fn command_add<Policy: HTTPAuthentication>(
             Some(config.index_urls(index, vec![DEFAULT_INDEX_URL.to_string()], default_index)?)
         };
         let std_resolver = standard_resolver(
-            None,
             // TODO: why not use env here?
             None,
             Some(client.clone()),

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -254,7 +254,6 @@ fn obtain_project<Policy: HTTPAuthentication>(
 
     let std_resolver = standard_resolver(
         None,
-        None,
         Some(client.clone()),
         index_urls,
         runtime.clone(),

--- a/sysand/src/commands/env.rs
+++ b/sysand/src/commands/env.rs
@@ -121,7 +121,6 @@ pub fn command_env_install<Policy: HTTPAuthentication>(
         override_resolver,
         standard_resolver(
             None,
-            None,
             Some(client.clone()),
             index_urls,
             runtime.clone(),
@@ -309,7 +308,6 @@ pub fn command_env_install_path<Policy: HTTPAuthentication>(
         let resolver = PriorityResolver::new(
             override_resolver,
             standard_resolver(
-                Some(path),
                 None,
                 Some(client.clone()),
                 index_urls,

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -172,14 +172,7 @@ pub fn command_info_uri<Policy: HTTPAuthentication>(
 
     let combined_resolver = PriorityResolver::new(
         MemoryResolver::from(overrides),
-        standard_resolver(
-            Some(ctx.current_directory),
-            ctx.env,
-            Some(client),
-            index_urls,
-            runtime,
-            auth_policy,
-        )?,
+        standard_resolver(ctx.env, Some(client), index_urls, runtime, auth_policy)?,
     );
 
     let (info, _) = do_info(&uri, &combined_resolver)?;
@@ -244,14 +237,7 @@ pub fn command_info_verb_uri<Policy: HTTPAuthentication>(
         InfoCommandVerb::Get(get_verb) => {
             let combined_resolver = PriorityResolver::new(
                 MemoryResolver::from(overrides),
-                standard_resolver(
-                    Some(ctx.current_directory),
-                    ctx.env,
-                    Some(client),
-                    index_urls,
-                    runtime,
-                    auth_policy,
-                )?,
+                standard_resolver(ctx.env, Some(client), index_urls, runtime, auth_policy)?,
             );
 
             match get_verb {

--- a/sysand/src/commands/lock.rs
+++ b/sysand/src/commands/lock.rs
@@ -147,7 +147,6 @@ pub fn create_resolver<R: AsRef<Utf8Path>, Policy: HTTPAuthentication>(
     let wrapped_resolver = PriorityResolver::new(
         override_resolver,
         standard_resolver(
-            None,
             // TODO: borrow?
             ctx.env.to_owned(),
             Some(client),


### PR DESCRIPTION
FileResolver's relative_path_root was meant to resolve relative file:// URIs against a caller-supplied root, but url::Url::parse always normalizes file: URIs to absolute paths, so the is_relative() branch guarding on it could effectively never be taken (it could technically be reached on Windows, but since it's OS-specific, not worth keeping), making the field useless.

This is technically a breaking change for bindings, but it affects `info` functions only, which are unlikely to be in use currently.