### PR TITLE
feat!: require publisher to be specified when initializing the project

### DIFF
--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -49,16 +49,8 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_init<'local>(
     let Some(name) = env.get_str(&name, "name") else {
         return;
     };
-    // If `publisher` is `null`, no publisher is specified
-    let publisher: Option<String> = match env.get_string(&publisher) {
-        Ok(s) => Some(s.into()),
-        Err(e) => match e {
-            Error::NullPtr(_) => None,
-            _ => {
-                env.throw_runtime_exception(format!("failed to get argument `publisher`: {}", e));
-                return;
-            }
-        },
+    let Some(publisher) = env.get_str(&publisher, "publisher") else {
+        return;
     };
     let Some(version) = env.get_str(&version, "version") else {
         return;

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -35,7 +35,7 @@ pub fn clear_local_storage(prefix: &str) -> Result<(), JsValue> {
 #[wasm_bindgen(js_name = do_init_js_local_storage)]
 pub fn do_init_js_local_storage(
     name: String,
-    publisher: Option<String>,
+    publisher: String,
     version: String,
     prefix: &str,
     root_path: &str,

--- a/bindings/js/tests/basic_browser.rs
+++ b/bindings/js/tests/basic_browser.rs
@@ -23,7 +23,7 @@ mod browser_tests {
     fn basic_init() -> Result<(), Box<dyn Error>> {
         do_init_js_local_storage(
             "basic_init".to_string(),
-            Some(String::from("a")),
+            "a".into(),
             "1.2.3".to_string(),
             "sysand_storage",
             "/",

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -57,7 +57,7 @@ fn run_cli(args: Vec<String>) -> PyResult<bool> {
 )]
 fn do_init_py_local_file(
     name: String,
-    publisher: Option<String>,
+    publisher: String,
     version: String,
     path: String,
     license: Option<String>,

--- a/core/src/commands/init.rs
+++ b/core/src/commands/init.rs
@@ -17,8 +17,6 @@ use crate::project::local_src::{LocalSrcError, LocalSrcProject};
 
 use thiserror::Error;
 
-const DEFAULT_PUBLISHER: &str = "untitled";
-
 #[derive(Error, Debug)]
 pub enum InitError<ProjectError: ErrorBound> {
     #[error("failed to parse `{0}` as a Semantic Version: {1}")]
@@ -31,7 +29,7 @@ pub enum InitError<ProjectError: ErrorBound> {
 
 pub fn do_init_ext<P: ProjectMut>(
     name: String,
-    publisher: Option<String>,
+    publisher: String,
     version: String,
     no_semver: bool,
     license: Option<String>,
@@ -50,7 +48,6 @@ pub fn do_init_ext<P: ProjectMut>(
     } else {
         None
     };
-    let publisher = publisher.unwrap_or_else(|| String::from(DEFAULT_PUBLISHER));
 
     let creating = "Creating";
     let header = crate::style::get_style_config().header;
@@ -85,7 +82,7 @@ pub fn do_init_ext<P: ProjectMut>(
 
 pub fn do_init<P: ProjectMut>(
     name: String,
-    publisher: Option<String>,
+    publisher: String,
     version: String,
     license: Option<String>,
     storage: &mut P,
@@ -95,7 +92,7 @@ pub fn do_init<P: ProjectMut>(
 
 pub fn do_init_memory<N: AsRef<str>, P: AsRef<str>, V: AsRef<str>>(
     name: N,
-    publisher: Option<P>,
+    publisher: P,
     version: V,
     license: Option<String>,
 ) -> Result<InMemoryProject, InitError<crate::project::memory::InMemoryError>> {
@@ -103,7 +100,7 @@ pub fn do_init_memory<N: AsRef<str>, P: AsRef<str>, V: AsRef<str>>(
 
     do_init(
         name.as_ref().to_owned(),
-        publisher.map(|p| String::from(p.as_ref())),
+        publisher.as_ref().to_owned(),
         version.as_ref().to_owned(),
         license,
         &mut storage,
@@ -115,7 +112,7 @@ pub fn do_init_memory<N: AsRef<str>, P: AsRef<str>, V: AsRef<str>>(
 #[cfg(feature = "filesystem")]
 pub fn do_init_local_file(
     name: String,
-    publisher: Option<String>,
+    publisher: String,
     version: String,
     license: Option<String>,
     path: Utf8PathBuf,

--- a/core/src/env/memory.rs
+++ b/core/src/env/memory.rs
@@ -75,8 +75,8 @@ pub enum TryFromError<Project: ProjectRead> {
 /// # use sysand_core::env::memory::MemoryStorageEnvironment;
 /// # use sysand_core::env::ReadEnvironment;
 /// # use sysand_core::project::memory::InMemoryProject;
-/// let project1 = do_init_memory("First", Some("a"), "0.0.1", None).unwrap();
-/// let project2 = do_init_memory("First", None::<&str>, "0.1.0", None).unwrap();
+/// let project1 = do_init_memory("First", "a", "0.0.1", None).unwrap();
+/// let project2 = do_init_memory("First", "b", "0.1.0", None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::try_from([
 ///     ("urn:kpar:first".into(), project1.clone()),
 ///     ("urn:kpar:first".into(), project2.clone()),
@@ -122,8 +122,8 @@ impl<Project: ProjectRead + Clone, const N: usize> TryFrom<[(String, Project); N
 /// # use sysand_core::env::memory::MemoryStorageEnvironment;
 /// # use sysand_core::env::ReadEnvironment;
 /// # use sysand_core::project::memory::InMemoryProject;
-/// let project1 = do_init_memory("First", Some("a"), "0.0.1", None).unwrap();
-/// let project2 = do_init_memory("First", None::<&str>, "0.1.0", None).unwrap();
+/// let project1 = do_init_memory("First", "a", "0.0.1", None).unwrap();
+/// let project2 = do_init_memory("First", "b", "0.1.0", None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::try_from(vec![
 ///     ("urn:kpar:first".into(), project1.clone()),
 ///     ("urn:kpar:first".into(), project2.clone()),
@@ -179,8 +179,8 @@ impl<Project: ProjectRead + Clone> FromIterator<(String, String, Project)>
 /// # use sysand_core::project::memory::InMemoryProject;
 /// let version1 = "0.0.1".to_string();
 /// let version2 = "0.1.0".to_string();
-/// let project1 = do_init_memory("First", Some("a"), &version1, None).unwrap();
-/// let project2 = do_init_memory("First", None::<&str>, &version2, None).unwrap();
+/// let project1 = do_init_memory("First", "a", &version1, None).unwrap();
+/// let project2 = do_init_memory("First", "b", &version2, None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::from([
 ///     ("urn:kpar:first".into(), version1.clone(), project1.clone()),
 ///     ("urn:kpar:first".into(), version2.clone(), project2.clone()),
@@ -221,8 +221,8 @@ impl<Project: ProjectRead + Clone, const N: usize> From<[(String, String, Projec
 /// # use sysand_core::project::memory::InMemoryProject;
 /// let version1 = "0.0.1".to_string();
 /// let version2 = "0.1.0".to_string();
-/// let project1 = do_init_memory("First", Some("a"), &version1, None).unwrap();
-/// let project2 = do_init_memory("First", None::<&str>, &version2, None).unwrap();
+/// let project1 = do_init_memory("First", "a", &version1, None).unwrap();
+/// let project2 = do_init_memory("First", "b", &version2, None).unwrap();
 /// let env = MemoryStorageEnvironment::<InMemoryProject>::from(vec![
 ///     ("urn:kpar:first".into(), version1.clone(), project1.clone()),
 ///     ("urn:kpar:first".into(), version2.clone(), project2.clone()),

--- a/core/src/env/memory_tests.rs
+++ b/core/src/env/memory_tests.rs
@@ -25,9 +25,9 @@ fn write_environment() {
     let uri1 = "urn:kpar:first".to_string();
     let uri2 = "urn:kpar:second".to_string();
     let version = "0.0.1".to_string();
-    let project1 = do_init_memory("First", Some("a"), &version, None).unwrap();
+    let project1 = do_init_memory("First", "a", &version, None).unwrap();
     let c1 = project1.checksum_canonical_variant().unwrap();
-    let project2 = do_init_memory("Second", None::<&str>, &version, None).unwrap();
+    let project2 = do_init_memory("Second", "b", &version, None).unwrap();
     let c2 = project2.checksum_canonical_variant().unwrap();
     let mut env = new_env();
 
@@ -72,7 +72,7 @@ fn write_environment() {
 fn read_environment() {
     let iri = "urn:kpar:first".to_string();
     let version = "0.0.1".to_string();
-    let project = do_init_memory("First", Some("a"), &version, None).unwrap();
+    let project = do_init_memory("First", "a", &version, None).unwrap();
     let env = MemoryStorageEnvironment {
         projects: HashMap::from([(
             iri.clone(),
@@ -106,9 +106,9 @@ fn from() {
     let version1 = "0.0.1".to_string();
     let version2 = "0.1.0".to_string();
     let version3 = "0.0.1".to_string();
-    let project1 = do_init_memory("First 0.0.1", Some("a"), &version1, None).unwrap();
-    let project2 = do_init_memory("First 0.1.0", None::<&str>, &version2, None).unwrap();
-    let project3 = do_init_memory("Second", Some("a"), &version3, None).unwrap();
+    let project1 = do_init_memory("First 0.0.1", "a", &version1, None).unwrap();
+    let project2 = do_init_memory("First 0.1.0", "a", &version2, None).unwrap();
+    let project3 = do_init_memory("Second", "a", &version3, None).unwrap();
     let env = MemoryStorageEnvironment::<InMemoryProject>::from([
         ("urn:kpar:first".into(), version1.clone(), project1.clone()),
         ("urn:kpar:first".into(), version2.clone(), project2.clone()),
@@ -133,9 +133,9 @@ fn from() {
 
 #[test]
 fn try_from() {
-    let project1 = do_init_memory("First 0.0.1", Some("a"), "0.0.1", None).unwrap();
-    let project2 = do_init_memory("First 0.1.0", Some("a"), "0.1.0", None).unwrap();
-    let project3 = do_init_memory("Second", Some("a"), "0.0.1", None).unwrap();
+    let project1 = do_init_memory("First 0.0.1", "a", "0.0.1", None).unwrap();
+    let project2 = do_init_memory("First 0.1.0", "a", "0.1.0", None).unwrap();
+    let project3 = do_init_memory("Second", "a", "0.0.1", None).unwrap();
     let env = MemoryStorageEnvironment::<InMemoryProject>::try_from([
         ("urn:kpar:first".into(), project1.clone()),
         ("urn:kpar:first".into(), project2.clone()),

--- a/core/tests/memory_init.rs
+++ b/core/tests/memory_init.rs
@@ -9,18 +9,14 @@ use sysand_core::{commands::init::do_init, init::do_init_memory, model::Intercha
 /// and .meta.json files in the current working directory. (Non-interactive use)
 #[test]
 fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
-    let memory_storage = do_init_memory(
-        "init_basic",
-        None::<&str>,
-        "1.2.3",
-        Some("Apache-2.0".to_string()),
-    )?;
+    let memory_storage =
+        do_init_memory("init_basic", "e", "1.2.3", Some("Apache-2.0".to_string()))?;
 
     assert_eq!(
         memory_storage.info.unwrap(),
         InterchangeProjectInfo {
             name: "init_basic".to_string(),
-            publisher: Some("untitled".to_owned()),
+            publisher: Some("e".to_owned()),
             description: None,
             version: Version::parse("1.2.3").unwrap(),
             license: Some("Apache-2.0".to_string()),
@@ -63,7 +59,7 @@ fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
 fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
     let mut memory_storage = do_init_memory(
         "init_fail_on_double_init",
-        Some("a"),
+        "a",
         "1.2.3",
         Some("Apache-2.0 OR MIT".to_string()),
     )?;
@@ -73,7 +69,7 @@ fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
 
     let second_result = do_init(
         "init_fail_on_double_init".to_string(),
-        Some("a".to_owned()),
+        "a".into(),
         "1.2.3".to_string(),
         Some("Apache-2.0 OR MIT".to_string()),
         &mut memory_storage,
@@ -86,9 +82,8 @@ fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
         ))
     );
 
-    assert_eq!(memory_storage.info, original_info,);
-
-    assert_eq!(memory_storage.meta, original_meta,);
+    assert_eq!(memory_storage.info, original_info);
+    assert_eq!(memory_storage.meta, original_meta);
 
     Ok(())
 }

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -70,9 +70,12 @@ pub enum Command {
         /// The name of the project. Defaults to the directory name
         #[arg(long)]
         name: Option<String>,
-        /// The publisher of the project. Defaults to `untitled`
-        #[arg(long)]
-        publisher: Option<String>,
+        /// The publisher of the project. Should be the person/team/organization
+        /// developing the project. It is (together with name) used
+        /// to uniquely refer to a project by other projects when added as a
+        /// usage (dependency)
+        #[arg(long, verbatim_doc_comment)]
+        publisher: String,
         /// Set the version in SemVer 2.0 format. Defaults to `0.0.1`
         #[arg(long)]
         version: Option<String>,
@@ -299,7 +302,7 @@ pub enum Command {
 #[group(required = true, multiple = false)]
 pub struct AddProjectLocatorArgs {
     /// IRI/URI/URL identifying the project to be used, or
-    /// <publisher>/<name> shorthand for pkg:sysand/<publisher>/<name>.
+    /// `<publisher>/<name>` shorthand for `pkg:sysand/<publisher>/<name>`.
     /// Paths must use `--path`
     #[clap(default_value = None, value_parser = parse_usage_locator_suggest_path)]
     pub iri: Option<Iri<String>>,
@@ -321,7 +324,7 @@ pub struct AddProjectLocatorArgs {
 #[group(required = true, multiple = false)]
 pub struct RemoveProjectLocatorArgs {
     /// IRI identifying the project usage to be removed, or
-    /// <publisher>/<name> shorthand for pkg:sysand/<publisher>/<name>.
+    /// `<publisher>/<name>` shorthand for `pkg:sysand/<publisher>/<name>`.
     /// Paths must use `--path`
     #[clap(default_value = None, value_parser = parse_usage_locator_suggest_path)]
     pub iri: Option<Iri<String>>,
@@ -512,8 +515,9 @@ pub enum InfoCommand {
     Publisher {
         #[arg(long, value_name = "PUBLISHER", default_value=None)]
         set: Option<String>,
-        #[arg(long, default_value = None)]
-        clear: bool,
+        #[arg(hide = true, long, num_args=0, default_missing_value="None", value_parser=
+            invalid_command("`publisher` cannot be unset"))]
+        clear: Option<Infallible>,
         // Only for better error messages
         #[arg(hide=true, long, default_value=None, value_parser=
             invalid_command("`publisher` is not a list, consider using `sysand info publisher --set`?"))]
@@ -1066,11 +1070,7 @@ impl InfoCommand {
             } => pack_info(
                 GetInfoVerb::GetPublisher,
                 set.map(SetInfoVerb::SetPublisher),
-                if clear {
-                    Some(ClearInfoVerb::ClearPublisher)
-                } else {
-                    None
-                },
+                impossible(clear),
                 impossible(add),
                 impossible(remove),
             ),
@@ -1443,22 +1443,20 @@ pub enum IndexCommand {
     Init {
         /// Path to the index directory. If not provided, current working directory is used.
         /// If the directory does not exist, it is created
-        #[clap(verbatim_doc_comment)]
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         index_root: Option<Utf8PathBuf>,
     },
     /// Add a KPAR to a local sysand index
     #[clap(verbatim_doc_comment)]
     Add {
-        /// Project identifier. Default is pkg:sysand/<publisher>/<name>, if publisher is
+        /// Project identifier. Default is `pkg:sysand/<publisher>/<name>`, if publisher is
         /// specified in .project.json. Omitting both publisher and IRI is an error
         #[clap(verbatim_doc_comment)]
         iri: Option<String>,
         // The type is str, not Iri so that a better error can be reported in some cases
         // for example when the publisher contains a space
-        #[clap(verbatim_doc_comment)]
         /// Path to KPAR
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         kpar_path: Utf8PathBuf,
         /// Path to the index directory. If not provided, current working directory is used
         #[arg(long)]

--- a/sysand/src/commands/init.rs
+++ b/sysand/src/commands/init.rs
@@ -10,7 +10,7 @@ const DEFAULT_VERSION: &str = "0.0.1";
 
 pub fn command_init(
     name: Option<String>,
-    publisher: Option<String>,
+    publisher: String,
     version: Option<String>,
     no_semver: bool,
     license: Option<String>,

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -11,7 +11,15 @@ pub use common::*;
 #[test]
 fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "e",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -29,7 +37,7 @@ fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "e",
   "version": "1.2.3",
   "usage": [
     {
@@ -53,7 +61,7 @@ fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "e",
   "version": "1.2.3"
 }
 "#
@@ -65,7 +73,15 @@ fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn add_accepts_sysand_shorthand_without_lock() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_shorthand"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "f",
+            "--name",
+            "add_shorthand",
+        ],
         None,
     )?;
 
@@ -83,7 +99,7 @@ fn add_accepts_sysand_shorthand_without_lock() -> Result<(), Box<dyn std::error:
         info_json,
         r#"{
   "name": "add_shorthand",
-  "publisher": "untitled",
+  "publisher": "f",
   "version": "1.2.3",
   "usage": [
     {
@@ -104,6 +120,8 @@ fn add_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::erro
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "g",
             "--name",
             "reject_add_shorthand",
         ],
@@ -125,7 +143,7 @@ fn add_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::erro
         info_json,
         r#"{
   "name": "reject_add_shorthand",
-  "publisher": "untitled",
+  "publisher": "g",
   "version": "1.2.3"
 }
 "#
@@ -148,7 +166,15 @@ fn add_path_like_positional_suggests_path_option() -> Result<(), Box<dyn std::er
 #[test]
 fn remove_accepts_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "remove_shorthand"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "h",
+            "--name",
+            "remove_shorthand",
+        ],
         None,
     )?;
 
@@ -174,7 +200,7 @@ fn remove_accepts_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "remove_shorthand",
-  "publisher": "untitled",
+  "publisher": "h",
   "version": "1.2.3"
 }
 "#
@@ -190,6 +216,8 @@ fn remove_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::e
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "h",
             "--name",
             "reject_remove_shorthand",
         ],
@@ -219,7 +247,7 @@ fn remove_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::e
         info_json,
         r#"{
   "name": "reject_remove_shorthand",
-  "publisher": "untitled",
+  "publisher": "h",
   "version": "1.2.3",
   "usage": [
     {
@@ -252,6 +280,8 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "i",
             "--name",
             "add_and_remove_path1",
         ],
@@ -262,6 +292,8 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "i",
             "--name",
             "add_and_remove_path2",
         ],
@@ -287,16 +319,15 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
         format!(
             r#"{{
   "name": "add_and_remove_path1",
-  "publisher": "untitled",
+  "publisher": "i",
   "version": "1.2.3",
   "usage": [
     {{
-      "resource": "{}"
+      "resource": "{file_url}"
     }}
   ]
 }}
-"#,
-            file_url
+"#
         )
     );
 
@@ -316,7 +347,7 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove_path1",
-  "publisher": "untitled",
+  "publisher": "i",
   "version": "1.2.3"
 }
 "#
@@ -328,7 +359,15 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn add_and_remove_as_editable() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "j",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -362,7 +401,7 @@ fn add_and_remove_as_editable() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "j",
   "version": "1.2.3",
   "usage": [
     {
@@ -408,7 +447,7 @@ sources = [
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "j",
   "version": "1.2.3"
 }
 "#
@@ -422,7 +461,15 @@ sources = [
 #[test]
 fn add_and_remove_as_local_src() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "k",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -456,7 +503,7 @@ fn add_and_remove_as_local_src() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "k",
   "version": "1.2.3",
   "usage": [
     {
@@ -502,7 +549,7 @@ sources = [
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "k",
   "version": "1.2.3"
 }
 "#
@@ -516,7 +563,15 @@ sources = [
 #[test]
 fn add_and_remove_as_local_kpar() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "l",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -550,7 +605,7 @@ fn add_and_remove_as_local_kpar() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "l",
   "version": "1.2.3",
   "usage": [
     {
@@ -596,7 +651,7 @@ sources = [
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "l",
   "version": "1.2.3"
 }
 "#
@@ -610,7 +665,15 @@ sources = [
 #[test]
 fn add_and_remove_as_remote_src() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "m",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -644,7 +707,7 @@ fn add_and_remove_as_remote_src() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "m",
   "version": "1.2.3",
   "usage": [
     {
@@ -690,7 +753,7 @@ sources = [
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "m",
   "version": "1.2.3"
 }
 "#
@@ -704,7 +767,15 @@ sources = [
 #[test]
 fn add_and_remove_as_remote_kpar() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "n",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -738,7 +809,7 @@ fn add_and_remove_as_remote_kpar() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "n",
   "version": "1.2.3",
   "usage": [
     {
@@ -784,7 +855,7 @@ sources = [
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "n",
   "version": "1.2.3"
 }
 "#
@@ -798,7 +869,15 @@ sources = [
 #[test]
 fn add_and_remove_as_remote_git() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "n",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -832,7 +911,7 @@ fn add_and_remove_as_remote_git() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "n",
   "version": "1.2.3",
   "usage": [
     {
@@ -878,7 +957,7 @@ sources = [
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "n",
   "version": "1.2.3"
 }
 "#
@@ -892,7 +971,15 @@ sources = [
 #[test]
 fn add_and_remove_from_path() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_and_remove"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "o",
+            "--name",
+            "add_and_remove",
+        ],
         None,
     )?;
 
@@ -949,7 +1036,7 @@ fn add_and_remove_from_path() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "o",
   "version": "1.2.3",
   "usage": [
     {
@@ -1020,7 +1107,7 @@ sources = [
         info_json,
         r#"{
   "name": "add_and_remove",
-  "publisher": "untitled",
+  "publisher": "o",
   "version": "1.2.3"
 }
 "#
@@ -1038,13 +1125,29 @@ sources = [
 #[test]
 fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir_dep, cwd_dep, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_from_url_dep"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "p",
+            "--name",
+            "add_from_url_dep",
+        ],
         None,
     )?;
     out.assert().success();
 
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_from_url"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "p",
+            "--name",
+            "add_from_url",
+        ],
         None,
     )?;
     out.assert().success();
@@ -1077,7 +1180,7 @@ fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_from_url",
-  "publisher": "untitled",
+  "publisher": "p",
   "version": "1.2.3",
   "usage": [
     {
@@ -1115,7 +1218,7 @@ fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
         info_json,
         r#"{
   "name": "add_from_url",
-  "publisher": "untitled",
+  "publisher": "p",
   "version": "1.2.3"
 }
 "#
@@ -1132,7 +1235,15 @@ fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_full_purl"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "q",
+            "--name",
+            "add_full_purl",
+        ],
         None,
     )?;
 
@@ -1154,7 +1265,7 @@ fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::err
         info_json,
         r#"{
   "name": "add_full_purl",
-  "publisher": "untitled",
+  "publisher": "q",
   "version": "1.2.3",
   "usage": [
     {
@@ -1178,7 +1289,7 @@ fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::err
         info_json,
         r#"{
   "name": "add_full_purl",
-  "publisher": "untitled",
+  "publisher": "q",
   "version": "1.2.3"
 }
 "#
@@ -1194,8 +1305,18 @@ fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::err
 #[test]
 fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dyn std::error::Error>>
 {
-    let (_temp_dir, cwd, out) =
-        run_sysand(["init", "--version", "1.2.3", "--name", "urn_slash"], None)?;
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "r",
+            "--name",
+            "urn_slash",
+        ],
+        None,
+    )?;
 
     out.assert().success();
 
@@ -1215,7 +1336,7 @@ fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dy
         info_json,
         r#"{
   "name": "urn_slash",
-  "publisher": "untitled",
+  "publisher": "r",
   "version": "1.2.3",
   "usage": [
     {
@@ -1239,7 +1360,7 @@ fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dy
         info_json,
         r#"{
   "name": "urn_slash",
-  "publisher": "untitled",
+  "publisher": "r",
   "version": "1.2.3"
 }
 "#
@@ -1258,6 +1379,8 @@ fn add_shorthand_then_remove_full_purl() -> Result<(), Box<dyn std::error::Error
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "s",
             "--name",
             "shorthand_then_full_purl",
         ],
@@ -1282,7 +1405,7 @@ fn add_shorthand_then_remove_full_purl() -> Result<(), Box<dyn std::error::Error
         info_json,
         r#"{
   "name": "shorthand_then_full_purl",
-  "publisher": "untitled",
+  "publisher": "s",
   "version": "1.2.3"
 }
 "#
@@ -1300,6 +1423,8 @@ fn remove_nonexistent_shorthand() -> Result<(), Box<dyn std::error::Error>> {
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "remove_nonexistent_shorthand",
         ],
@@ -1324,6 +1449,8 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "add_and_remove_with_lock_preinstall_dep",
         ],
@@ -1350,6 +1477,8 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "t",
             "--name",
             "add_and_remove_with_lock_preinstall",
         ],
@@ -1393,7 +1522,7 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
         info_json,
         r#"{
   "name": "add_and_remove_with_lock_preinstall",
-  "publisher": "untitled",
+  "publisher": "t",
   "version": "1.2.3",
   "usage": [
     {
@@ -1418,7 +1547,7 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
         info_json,
         r#"{
   "name": "add_and_remove_with_lock_preinstall",
-  "publisher": "untitled",
+  "publisher": "t",
   "version": "1.2.3"
 }
 "#
@@ -1430,7 +1559,15 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
 #[test]
 fn add_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_nonexistent"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "add_nonexistent",
+        ],
         None,
     )?;
 
@@ -1448,7 +1585,15 @@ fn add_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn remove_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "remove_nonexistent"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "remove_nonexistent",
+        ],
         None,
     )?;
 

--- a/sysand/tests/cli_add_remove.rs
+++ b/sysand/tests/cli_add_remove.rs
@@ -10,18 +10,7 @@ pub use common::*;
 
 #[test]
 fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "e",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("e", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -72,18 +61,7 @@ fn add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn add_accepts_sysand_shorthand_without_lock() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "f",
-            "--name",
-            "add_shorthand",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("f", "add_shorthand", "1.2.3")?;
 
     out.assert().success();
 
@@ -115,18 +93,7 @@ fn add_accepts_sysand_shorthand_without_lock() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn add_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "g",
-            "--name",
-            "reject_add_shorthand",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("g", "reject_add_shorthand", "1.2.3")?;
 
     out.assert().success();
 
@@ -165,18 +132,7 @@ fn add_path_like_positional_suggests_path_option() -> Result<(), Box<dyn std::er
 
 #[test]
 fn remove_accepts_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "h",
-            "--name",
-            "remove_shorthand",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("h", "remove_shorthand", "1.2.3")?;
 
     out.assert().success();
 
@@ -211,18 +167,7 @@ fn remove_accepts_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn remove_rejects_non_normalized_sysand_shorthand() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "h",
-            "--name",
-            "reject_remove_shorthand",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("h", "reject_remove_shorthand", "1.2.3")?;
 
     out.assert().success();
 
@@ -275,30 +220,8 @@ fn remove_path_like_positional_suggests_path_option() -> Result<(), Box<dyn std:
 /// Add and remove usages with `--path <path>`
 #[test]
 fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir1, cwd1, out1) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "i",
-            "--name",
-            "add_and_remove_path1",
-        ],
-        None,
-    )?;
-    let (_temp_dir2, cwd2, out2) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "i",
-            "--name",
-            "add_and_remove_path2",
-        ],
-        None,
-    )?;
+    let (_temp_dir1, cwd1, out1) = cli_init_project_basic("i", "add_and_remove_path1", "1.2.3")?;
+    let (_temp_dir2, cwd2, out2) = cli_init_project_basic("i", "add_and_remove_path2", "1.2.3")?;
     let file_url = file_url_from_path(&cwd2);
 
     out1.assert().success();
@@ -358,18 +281,7 @@ fn add_and_remove_path() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn add_and_remove_as_editable() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "j",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("j", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -460,18 +372,7 @@ sources = [
 
 #[test]
 fn add_and_remove_as_local_src() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "k",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("k", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -562,18 +463,7 @@ sources = [
 
 #[test]
 fn add_and_remove_as_local_kpar() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "l",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("l", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -664,18 +554,7 @@ sources = [
 
 #[test]
 fn add_and_remove_as_remote_src() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "m",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("m", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -766,18 +645,7 @@ sources = [
 
 #[test]
 fn add_and_remove_as_remote_kpar() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "n",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("n", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -868,18 +736,7 @@ sources = [
 
 #[test]
 fn add_and_remove_as_remote_git() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "n",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("n", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -970,18 +827,7 @@ sources = [
 
 #[test]
 fn add_and_remove_from_path() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "o",
-            "--name",
-            "add_and_remove",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("o", "add_and_remove", "1.2.3")?;
 
     out.assert().success();
 
@@ -1124,32 +970,10 @@ sources = [
 /// configuration file, similar to `--path` but driven by the URL resolver.
 #[test]
 fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir_dep, cwd_dep, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "p",
-            "--name",
-            "add_from_url_dep",
-        ],
-        None,
-    )?;
+    let (_temp_dir_dep, cwd_dep, out) = cli_init_project_basic("p", "add_from_url_dep", "1.2.3")?;
     out.assert().success();
 
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "p",
-            "--name",
-            "add_from_url",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("p", "add_from_url", "1.2.3")?;
     out.assert().success();
 
     let dep_url = file_url_from_path(&cwd_dep);
@@ -1234,18 +1058,7 @@ fn add_and_remove_from_url() -> Result<(), Box<dyn std::error::Error>> {
 /// `publisher/name` shorthand heuristic, so the value is stored verbatim.
 #[test]
 fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "q",
-            "--name",
-            "add_full_purl",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("q", "add_full_purl", "1.2.3")?;
 
     out.assert().success();
 
@@ -1305,18 +1118,7 @@ fn add_and_remove_full_purl_sysand_without_lock() -> Result<(), Box<dyn std::err
 #[test]
 fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dyn std::error::Error>>
 {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "r",
-            "--name",
-            "urn_slash",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("r", "urn_slash", "1.2.3")?;
 
     out.assert().success();
 
@@ -1374,18 +1176,7 @@ fn add_and_remove_urn_with_slash_not_treated_as_shorthand() -> Result<(), Box<dy
 /// identical regardless of which form was used on input.
 #[test]
 fn add_shorthand_then_remove_full_purl() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "s",
-            "--name",
-            "shorthand_then_full_purl",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("s", "shorthand_then_full_purl", "1.2.3")?;
 
     out.assert().success();
 
@@ -1418,18 +1209,8 @@ fn add_shorthand_then_remove_full_purl() -> Result<(), Box<dyn std::error::Error
 /// the expanded PURL form so the user understands what was looked up.
 #[test]
 fn remove_nonexistent_shorthand() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "remove_nonexistent_shorthand",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "remove_nonexistent_shorthand", "1.2.3")?;
 
     out.assert().success();
 
@@ -1444,18 +1225,8 @@ fn remove_nonexistent_shorthand() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir_dep, cwd_dep, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "add_and_remove_with_lock_preinstall_dep",
-        ],
-        None,
-    )?;
+    let (_temp_dir_dep, cwd_dep, out) =
+        cli_init_project_basic("a", "add_and_remove_with_lock_preinstall_dep", "1.2.3")?;
 
     out.assert().success();
 
@@ -1472,18 +1243,8 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
     .assert()
     .success();
 
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "t",
-            "--name",
-            "add_and_remove_with_lock_preinstall",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("t", "add_and_remove_with_lock_preinstall", "1.2.3")?;
 
     out.assert().success();
 
@@ -1558,18 +1319,7 @@ fn add_and_remove_with_lock_preinstall() -> Result<(), Box<dyn std::error::Error
 
 #[test]
 fn add_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "add_nonexistent",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "add_nonexistent", "1.2.3")?;
 
     out.assert().success();
 
@@ -1584,18 +1334,7 @@ fn add_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn remove_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "remove_nonexistent",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "remove_nonexistent", "1.2.3")?;
 
     out.assert().success();
 

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -42,18 +42,7 @@ fn expected_index() -> IndexMap<String, String> {
 
 #[test]
 fn project_build() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_build",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_build", "1.2.3")?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -132,18 +121,7 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
 /// inside the built kpar, not minified onto a single line.
 #[test]
 fn project_build_pretty_prints_project_and_meta_json() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_pretty",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_pretty", "1.2.3")?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -177,18 +155,8 @@ fn project_build_pretty_prints_project_and_meta_json() -> Result<(), Box<dyn std
 
 #[test]
 fn build_errors_when_index_symbol_is_missing_from_file() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_build_missing_index_symbol",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "test_build_missing_index_symbol", "1.2.3")?;
     out.assert().success();
 
     std::fs::write(cwd.join("test.sysml"), b"package Present;\n")?;
@@ -230,18 +198,8 @@ fn build_errors_when_index_symbol_is_missing_from_file() -> Result<(), Box<dyn s
 #[test]
 fn project_build_warns_when_file_symbol_is_missing_from_index()
 -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_build_missing_index_entry",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "test_build_missing_index_entry", "1.2.3")?;
     out.assert().success();
 
     std::fs::write(cwd.join("test.sysml"), b"package Present;\n")?;
@@ -269,30 +227,8 @@ fn project_build_warns_when_file_symbol_is_missing_from_index()
 /// Build a project that has a path (`file:`) usage
 #[test]
 fn project_build_path_usage() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir1, cwd1, out1) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_build1",
-        ],
-        None,
-    )?;
-    let (_temp_dir2, cwd2, out2) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_build2",
-        ],
-        None,
-    )?;
+    let (_temp_dir1, cwd1, out1) = cli_init_project_basic("a", "test_build1", "1.2.3")?;
+    let (_temp_dir2, cwd2, out2) = cli_init_project_basic("a", "test_build2", "1.2.3")?;
 
     out1.assert().success();
     out2.assert().success();
@@ -386,17 +322,12 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
 
     for project_cwd in [&project1_cwd, &project2_cwd, &project3_cwd] {
         std::fs::create_dir(project_cwd)?;
-        let out = run_sysand_in(
+        let out = cli_init_project_in(
             project_cwd,
-            [
-                "init",
-                "--version",
-                "1.2.3",
-                "--publisher",
-                "a",
-                "--name",
-                project_cwd.file_name().unwrap(),
-            ],
+            None,
+            "a",
+            Some(project_cwd.file_name().unwrap()),
+            Some("1.2.3"),
             None,
         )?;
         out.assert().success();
@@ -524,17 +455,12 @@ fn workspace_build_with_metamodel() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     std::fs::create_dir(&project1_cwd)?;
-    let out = run_sysand_in(
+    let out = cli_init_project_in(
         &project1_cwd,
-        [
-            "init",
-            "--version",
-            "1.0.0",
-            "--publisher",
-            "a",
-            "--name",
-            "project1",
-        ],
+        None,
+        "a",
+        Some("project1"),
+        Some("1.0.0"),
         None,
     )?;
     out.assert().success();
@@ -588,17 +514,12 @@ fn workspace_build_with_unknown_metamodel() -> Result<(), Box<dyn std::error::Er
     )?;
 
     std::fs::create_dir(&project1_cwd)?;
-    let out = run_sysand_in(
+    let out = cli_init_project_in(
         &project1_cwd,
-        [
-            "init",
-            "--version",
-            "1.0.0",
-            "--publisher",
-            "a",
-            "--name",
-            "project1",
-        ],
+        None,
+        "a",
+        Some("project1"),
+        Some("1.0.0"),
         None,
     )?;
     out.assert().success();
@@ -654,17 +575,12 @@ fn workspace_build_metamodel_conflict() -> Result<(), Box<dyn std::error::Error>
     )?;
 
     std::fs::create_dir(&project1_cwd)?;
-    let out = run_sysand_in(
+    let out = cli_init_project_in(
         &project1_cwd,
-        [
-            "init",
-            "--version",
-            "1.0.0",
-            "--publisher",
-            "a",
-            "--name",
-            "project1",
-        ],
+        None,
+        "a",
+        Some("project1"),
+        Some("1.0.0"),
         None,
     )?;
     out.assert().success();
@@ -712,17 +628,12 @@ fn workspace_build_metamodel_same_no_conflict() -> Result<(), Box<dyn std::error
     )?;
 
     std::fs::create_dir(&project1_cwd)?;
-    let out = run_sysand_in(
+    let out = cli_init_project_in(
         &project1_cwd,
-        [
-            "init",
-            "--version",
-            "1.0.0",
-            "--publisher",
-            "a",
-            "--name",
-            "project1",
-        ],
+        None,
+        "a",
+        Some("project1"),
+        Some("1.0.0"),
         None,
     )?;
     out.assert().success();
@@ -771,17 +682,12 @@ fn workspace_build_metamodel_idempotent() -> Result<(), Box<dyn std::error::Erro
     )?;
 
     std::fs::create_dir(&project1_cwd)?;
-    let out = run_sysand_in(
+    let out = cli_init_project_in(
         &project1_cwd,
-        [
-            "init",
-            "--version",
-            "1.0.0",
-            "--publisher",
-            "a",
-            "--name",
-            "project1",
-        ],
+        None,
+        "a",
+        Some("project1"),
+        Some("1.0.0"),
         None,
     )?;
     out.assert().success();
@@ -847,18 +753,7 @@ fn compression_methods() -> Result<(), Box<dyn std::error::Error>> {
 /// Build a project with a README.md at the project root
 #[test]
 fn project_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_readme",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_readme", "1.2.3")?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
     std::fs::write(cwd.join("README.md"), b"# My Project\nHello world\n")?;
@@ -885,18 +780,7 @@ fn project_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
 /// Build a project without any README file — should succeed
 #[test]
 fn project_build_without_readme() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_no_readme",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_no_readme", "1.2.3")?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -934,17 +818,12 @@ fn workspace_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
     ] {
         std::fs::create_dir(project_cwd)?;
         let project_name = project_cwd.file_name().unwrap();
-        let out = run_sysand_in(
+        let out = cli_init_project_in(
             project_cwd,
-            [
-                "init",
-                "--version",
-                "1.2.3",
-                "--publisher",
-                "a",
-                "--name",
-                project_name,
-            ],
+            None,
+            "a",
+            Some(project_name),
+            Some("1.2.3"),
             None,
         )?;
         out.assert().success();
@@ -984,18 +863,7 @@ fn workspace_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
 /// Build a project with a CHANGELOG.md at the project root
 #[test]
 fn project_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_changelog",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_changelog", "1.2.3")?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
     std::fs::write(
@@ -1025,18 +893,7 @@ fn project_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
 /// Build a project without any CHANGELOG file — should succeed
 #[test]
 fn project_build_without_changelog() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_no_changelog",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_no_changelog", "1.2.3")?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -1074,17 +931,12 @@ fn workspace_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
     ] {
         std::fs::create_dir(project_cwd)?;
         let project_name = project_cwd.file_name().unwrap();
-        let out = run_sysand_in(
+        let out = cli_init_project_in(
             project_cwd,
-            [
-                "init",
-                "--version",
-                "1.2.3",
-                "--publisher",
-                "a",
-                "--name",
-                project_name,
-            ],
+            None,
+            "a",
+            Some(project_name),
+            Some("1.2.3"),
             None,
         )?;
         out.assert().success();
@@ -1129,20 +981,8 @@ fn workspace_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
 /// `LICENSES/<id>.txt` is included in the KPAR.
 #[test]
 fn project_build_with_single_license() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_license",
-            "--license",
-            "MIT",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project(None, "a", Some("test_license"), Some("1.2.3"), Some("MIT"))?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
     std::fs::create_dir(cwd.join("LICENSES"))?;
@@ -1171,19 +1011,12 @@ fn project_build_with_single_license() -> Result<(), Box<dyn std::error::Error>>
 /// are included.
 #[test]
 fn project_build_with_compound_license() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_compound_license",
-            "--license",
-            "MIT OR Apache-2.0",
-        ],
+    let (_temp_dir, cwd, out) = cli_init_project(
         None,
+        "a",
+        Some("test_compound_license"),
+        Some("1.2.3"),
+        Some("MIT OR Apache-2.0"),
     )?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
@@ -1220,19 +1053,12 @@ fn project_build_with_compound_license() -> Result<(), Box<dyn std::error::Error
 /// exception file are included.
 #[test]
 fn project_build_with_license_exception() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_license_with",
-            "--license",
-            "GPL-2.0-only WITH Classpath-exception-2.0",
-        ],
+    let (_temp_dir, cwd, out) = cli_init_project(
         None,
+        "a",
+        Some("test_license_with"),
+        Some("1.2.3"),
+        Some("GPL-2.0-only WITH Classpath-exception-2.0"),
     )?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
@@ -1269,19 +1095,12 @@ fn project_build_with_license_exception() -> Result<(), Box<dyn std::error::Erro
 /// file is bundled verbatim.
 #[test]
 fn project_build_with_license_ref() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_license_ref",
-            "--license",
-            "LicenseRef-MyCustom",
-        ],
+    let (_temp_dir, cwd, out) = cli_init_project(
         None,
+        "a",
+        Some("test_license_ref"),
+        Some("1.2.3"),
+        Some("LicenseRef-MyCustom"),
     )?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
@@ -1312,19 +1131,12 @@ fn project_build_with_license_ref() -> Result<(), Box<dyn std::error::Error>> {
 /// the build succeeds and warns about the missing license file.
 #[test]
 fn project_build_with_license_file_missing() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_missing_license",
-            "--license",
-            "MIT",
-        ],
+    let (_temp_dir, cwd, out) = cli_init_project(
         None,
+        "a",
+        Some("test_missing_license"),
+        Some("1.2.3"),
+        Some("MIT"),
     )?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
@@ -1347,18 +1159,7 @@ fn project_build_with_license_file_missing() -> Result<(), Box<dyn std::error::E
 /// Build a project without any license — no LICENSES/* entries are added.
 #[test]
 fn project_build_without_license() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_no_license",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_no_license", "1.2.3")?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -1412,18 +1213,7 @@ fn assert_kpar_no_licenses_dir(kpar_path: &camino::Utf8Path) {
 }
 
 fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "a",
-            "--name",
-            "test_build",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "test_build", "1.2.3")?;
 
     {
         let mut sysml_file = std::fs::File::create(cwd.join("test.sysml"))?;

--- a/sysand/tests/cli_build.rs
+++ b/sysand/tests/cli_build.rs
@@ -42,8 +42,18 @@ fn expected_index() -> IndexMap<String, String> {
 
 #[test]
 fn project_build() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) =
-        run_sysand(["init", "--version", "1.2.3", "--name", "test_build"], None)?;
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_build",
+        ],
+        None,
+    )?;
 
     std::fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -123,7 +133,15 @@ fn project_build() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn project_build_pretty_prints_project_and_meta_json() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_pretty"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_pretty",
+        ],
         None,
     )?;
 
@@ -164,6 +182,8 @@ fn build_errors_when_index_symbol_is_missing_from_file() -> Result<(), Box<dyn s
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "test_build_missing_index_symbol",
         ],
@@ -215,6 +235,8 @@ fn project_build_warns_when_file_symbol_is_missing_from_index()
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "test_build_missing_index_entry",
         ],
@@ -248,11 +270,27 @@ fn project_build_warns_when_file_symbol_is_missing_from_index()
 #[test]
 fn project_build_path_usage() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir1, cwd1, out1) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_build1"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_build1",
+        ],
         None,
     )?;
     let (_temp_dir2, cwd2, out2) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_build2"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_build2",
+        ],
         None,
     )?;
 
@@ -354,6 +392,8 @@ fn workspace_build() -> Result<(), Box<dyn std::error::Error>> {
                 "init",
                 "--version",
                 "1.2.3",
+                "--publisher",
+                "a",
                 "--name",
                 project_cwd.file_name().unwrap(),
             ],
@@ -486,7 +526,15 @@ fn workspace_build_with_metamodel() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir(&project1_cwd)?;
     let out = run_sysand_in(
         &project1_cwd,
-        ["init", "--version", "1.0.0", "--name", "project1"],
+        [
+            "init",
+            "--version",
+            "1.0.0",
+            "--publisher",
+            "a",
+            "--name",
+            "project1",
+        ],
         None,
     )?;
     out.assert().success();
@@ -542,7 +590,15 @@ fn workspace_build_with_unknown_metamodel() -> Result<(), Box<dyn std::error::Er
     std::fs::create_dir(&project1_cwd)?;
     let out = run_sysand_in(
         &project1_cwd,
-        ["init", "--version", "1.0.0", "--name", "project1"],
+        [
+            "init",
+            "--version",
+            "1.0.0",
+            "--publisher",
+            "a",
+            "--name",
+            "project1",
+        ],
         None,
     )?;
     out.assert().success();
@@ -600,7 +656,15 @@ fn workspace_build_metamodel_conflict() -> Result<(), Box<dyn std::error::Error>
     std::fs::create_dir(&project1_cwd)?;
     let out = run_sysand_in(
         &project1_cwd,
-        ["init", "--version", "1.0.0", "--name", "project1"],
+        [
+            "init",
+            "--version",
+            "1.0.0",
+            "--publisher",
+            "a",
+            "--name",
+            "project1",
+        ],
         None,
     )?;
     out.assert().success();
@@ -650,7 +714,15 @@ fn workspace_build_metamodel_same_no_conflict() -> Result<(), Box<dyn std::error
     std::fs::create_dir(&project1_cwd)?;
     let out = run_sysand_in(
         &project1_cwd,
-        ["init", "--version", "1.0.0", "--name", "project1"],
+        [
+            "init",
+            "--version",
+            "1.0.0",
+            "--publisher",
+            "a",
+            "--name",
+            "project1",
+        ],
         None,
     )?;
     out.assert().success();
@@ -701,7 +773,15 @@ fn workspace_build_metamodel_idempotent() -> Result<(), Box<dyn std::error::Erro
     std::fs::create_dir(&project1_cwd)?;
     let out = run_sysand_in(
         &project1_cwd,
-        ["init", "--version", "1.0.0", "--name", "project1"],
+        [
+            "init",
+            "--version",
+            "1.0.0",
+            "--publisher",
+            "a",
+            "--name",
+            "project1",
+        ],
         None,
     )?;
     out.assert().success();
@@ -768,7 +848,15 @@ fn compression_methods() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn project_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_readme"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_readme",
+        ],
         None,
     )?;
 
@@ -798,7 +886,15 @@ fn project_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn project_build_without_readme() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_no_readme"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_no_readme",
+        ],
         None,
     )?;
 
@@ -840,7 +936,15 @@ fn workspace_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
         let project_name = project_cwd.file_name().unwrap();
         let out = run_sysand_in(
             project_cwd,
-            ["init", "--version", "1.2.3", "--name", project_name],
+            [
+                "init",
+                "--version",
+                "1.2.3",
+                "--publisher",
+                "a",
+                "--name",
+                project_name,
+            ],
             None,
         )?;
         out.assert().success();
@@ -881,7 +985,15 @@ fn workspace_build_with_readme() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn project_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_changelog"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_changelog",
+        ],
         None,
     )?;
 
@@ -914,7 +1026,15 @@ fn project_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn project_build_without_changelog() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_no_changelog"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_no_changelog",
+        ],
         None,
     )?;
 
@@ -956,7 +1076,15 @@ fn workspace_build_with_changelog() -> Result<(), Box<dyn std::error::Error>> {
         let project_name = project_cwd.file_name().unwrap();
         let out = run_sysand_in(
             project_cwd,
-            ["init", "--version", "1.2.3", "--name", project_name],
+            [
+                "init",
+                "--version",
+                "1.2.3",
+                "--publisher",
+                "a",
+                "--name",
+                project_name,
+            ],
             None,
         )?;
         out.assert().success();
@@ -1006,6 +1134,8 @@ fn project_build_with_single_license() -> Result<(), Box<dyn std::error::Error>>
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "test_license",
             "--license",
@@ -1046,6 +1176,8 @@ fn project_build_with_compound_license() -> Result<(), Box<dyn std::error::Error
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "test_compound_license",
             "--license",
@@ -1093,6 +1225,8 @@ fn project_build_with_license_exception() -> Result<(), Box<dyn std::error::Erro
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "test_license_with",
             "--license",
@@ -1140,6 +1274,8 @@ fn project_build_with_license_ref() -> Result<(), Box<dyn std::error::Error>> {
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "test_license_ref",
             "--license",
@@ -1181,6 +1317,8 @@ fn project_build_with_license_file_missing() -> Result<(), Box<dyn std::error::E
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "a",
             "--name",
             "test_missing_license",
             "--license",
@@ -1210,7 +1348,15 @@ fn project_build_with_license_file_missing() -> Result<(), Box<dyn std::error::E
 #[test]
 fn project_build_without_license() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "test_no_license"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_no_license",
+        ],
         None,
     )?;
 
@@ -1266,8 +1412,18 @@ fn assert_kpar_no_licenses_dir(kpar_path: &camino::Utf8Path) {
 }
 
 fn compression_method(compression: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) =
-        run_sysand(["init", "--version", "1.2.3", "--name", "test_build"], None)?;
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "--name",
+            "test_build",
+        ],
+        None,
+    )?;
 
     {
         let mut sysml_file = std::fs::File::create(cwd.join("test.sysml"))?;

--- a/sysand/tests/cli_clone.rs
+++ b/sysand/tests/cli_clone.rs
@@ -205,7 +205,15 @@ fn clone_not_found() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn clone_std_deps_note() -> Result<(), Box<dyn std::error::Error>> {
     let (_dep_temp_dir, cwd_dep, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "clone_std_note_dep"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "--name",
+            "clone_std_note_dep",
+        ],
         None,
     )?;
     out.assert().success();

--- a/sysand/tests/cli_clone.rs
+++ b/sysand/tests/cli_clone.rs
@@ -204,18 +204,7 @@ fn clone_not_found() -> Result<(), Box<dyn std::error::Error>> {
 // note if deps of cloned project include std libs
 #[test]
 fn clone_std_deps_note() -> Result<(), Box<dyn std::error::Error>> {
-    let (_dep_temp_dir, cwd_dep, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "clone_std_note_dep",
-        ],
-        None,
-    )?;
+    let (_dep_temp_dir, cwd_dep, out) = cli_init_project_basic("a", "clone_std_note_dep", "1.2.3")?;
     out.assert().success();
 
     std::fs::write(

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -282,18 +282,7 @@ fn env_install_from_local_dir_allow_overwrite() -> Result<(), Box<dyn std::error
 
 #[test]
 fn install_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "install_nonexistent",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "install_nonexistent", "1.2.3")?;
 
     out.assert().success();
 
@@ -317,18 +306,7 @@ fn env_install_allow_multiple() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, _) = run_sysand(["env"], None)?;
 
     // Build v1 with a .meta.json so checksum_canonical_variant succeeds.
-    let (_temp_v1, cwd_v1, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.0.0",
-            "--publisher",
-            "a",
-            "--name",
-            "allow_multiple_lib",
-        ],
-        None,
-    )?;
+    let (_temp_v1, cwd_v1, out) = cli_init_project_basic("a", "allow_multiple_lib", "1.0.0")?;
     out.assert().success();
     std::fs::write(cwd_v1.join("TestLib.sysml"), "package TestLib;")?;
     run_sysand_in(&cwd_v1, ["include", "TestLib.sysml"], None)?
@@ -336,18 +314,7 @@ fn env_install_allow_multiple() -> Result<(), Box<dyn std::error::Error>> {
         .success();
 
     // Build v2 with the same IRI but a different version.
-    let (_temp_v2, cwd_v2, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "2.0.0",
-            "--name",
-            "allow_multiple_lib",
-        ],
-        None,
-    )?;
+    let (_temp_v2, cwd_v2, out) = cli_init_project_basic("a", "allow_multiple_lib", "2.0.0")?;
     out.assert().success();
     std::fs::write(cwd_v2.join("TestLib.sysml"), "package TestLib;")?;
     run_sysand_in(&cwd_v2, ["include", "TestLib.sysml"], None)?
@@ -440,36 +407,14 @@ fn env_install_multiple_projects_env_toml() -> Result<(), Box<dyn std::error::Er
     let (_temp_dir, cwd, _) = run_sysand(["env"], None)?;
 
     // Build two projects with valid .meta.json so checksum_canonical_variant succeeds.
-    let (_tmp_a, cwd_a, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.0.0",
-            "--name",
-            "env_multi_proj_a",
-        ],
-        None,
-    )?;
+    let (_tmp_a, cwd_a, out) = cli_init_project_basic("a", "env_multi_proj_a", "1.0.0")?;
     out.assert().success();
     std::fs::write(cwd_a.join("A.sysml"), "package A;")?;
     run_sysand_in(&cwd_a, ["include", "A.sysml"], None)?
         .assert()
         .success();
 
-    let (_tmp_b, cwd_b, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "2.0.0",
-            "--name",
-            "env_multi_proj_b",
-        ],
-        None,
-    )?;
+    let (_tmp_b, cwd_b, out) = cli_init_project_basic("a", "env_multi_proj_b", "2.0.0")?;
     out.assert().success();
     std::fs::write(cwd_b.join("B.sysml"), "package B;")?;
     run_sysand_in(&cwd_b, ["include", "B.sysml"], None)?

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -285,6 +285,8 @@ fn install_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -316,7 +318,15 @@ fn env_install_allow_multiple() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build v1 with a .meta.json so checksum_canonical_variant succeeds.
     let (_temp_v1, cwd_v1, out) = run_sysand(
-        ["init", "--version", "1.0.0", "--name", "allow_multiple_lib"],
+        [
+            "init",
+            "--version",
+            "1.0.0",
+            "--publisher",
+            "a",
+            "--name",
+            "allow_multiple_lib",
+        ],
         None,
     )?;
     out.assert().success();
@@ -327,7 +337,15 @@ fn env_install_allow_multiple() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build v2 with the same IRI but a different version.
     let (_temp_v2, cwd_v2, out) = run_sysand(
-        ["init", "--version", "2.0.0", "--name", "allow_multiple_lib"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "2.0.0",
+            "--name",
+            "allow_multiple_lib",
+        ],
         None,
     )?;
     out.assert().success();
@@ -423,7 +441,15 @@ fn env_install_multiple_projects_env_toml() -> Result<(), Box<dyn std::error::Er
 
     // Build two projects with valid .meta.json so checksum_canonical_variant succeeds.
     let (_tmp_a, cwd_a, out) = run_sysand(
-        ["init", "--version", "1.0.0", "--name", "env_multi_proj_a"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.0.0",
+            "--name",
+            "env_multi_proj_a",
+        ],
         None,
     )?;
     out.assert().success();
@@ -433,7 +459,15 @@ fn env_install_multiple_projects_env_toml() -> Result<(), Box<dyn std::error::Er
         .success();
 
     let (_tmp_b, cwd_b, out) = run_sysand(
-        ["init", "--version", "2.0.0", "--name", "env_multi_proj_b"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "2.0.0",
+            "--name",
+            "env_multi_proj_b",
+        ],
         None,
     )?;
     out.assert().success();

--- a/sysand/tests/cli_include_exclude.rs
+++ b/sysand/tests/cli_include_exclude.rs
@@ -19,6 +19,8 @@ fn include_and_exclude_simple() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -75,6 +77,8 @@ fn include_no_checksum() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -118,6 +122,8 @@ fn include_no_index() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -168,6 +174,8 @@ fn include_empty_and_update() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -237,6 +245,8 @@ fn include_same_file_replaces_old_symbols() -> Result<(), Box<dyn std::error::Er
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -286,6 +296,8 @@ fn include_and_exclude_both_nested() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -368,6 +380,8 @@ fn include_and_exclude_single_nested() -> Result<(), Box<dyn std::error::Error>>
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -466,6 +480,8 @@ fn include_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -498,6 +514,8 @@ fn exclude_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",

--- a/sysand/tests/cli_include_exclude.rs
+++ b/sysand/tests/cli_include_exclude.rs
@@ -16,18 +16,7 @@ pub use common::*;
 
 #[test]
 fn include_and_exclude_simple() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_and_exclude",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "include_and_exclude", "1.2.3")?;
 
     fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -74,18 +63,7 @@ fn include_and_exclude_simple() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn include_no_checksum() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_no_checksum",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "include_no_checksum", "1.2.3")?;
 
     fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -119,18 +97,7 @@ fn include_no_checksum() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn include_no_index() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_and_exclude",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "include_and_exclude", "1.2.3")?;
 
     fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -171,18 +138,7 @@ fn include_no_index() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn include_empty_and_update() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_and_exclude",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "include_and_exclude", "1.2.3")?;
 
     let mut sysml_file = fs::File::create(cwd.join("test.sysml"))?;
     sysml_file.sync_all()?;
@@ -242,18 +198,8 @@ fn include_empty_and_update() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn include_same_file_replaces_old_symbols() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_same_file_replaces_old_symbols",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "include_same_file_replaces_old_symbols", "1.2.3")?;
 
     fs::write(cwd.join("test.sysml"), b"package A;\npackage B;\n")?;
 
@@ -293,18 +239,7 @@ fn include_same_file_replaces_old_symbols() -> Result<(), Box<dyn std::error::Er
 
 #[test]
 fn include_and_exclude_both_nested() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_and_exclude",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "include_and_exclude", "1.2.3")?;
 
     fs::write(cwd.join("test.sysml"), b"package P;\n")?;
     fs::create_dir(cwd.join("extra"))?;
@@ -377,18 +312,8 @@ fn include_and_exclude_both_nested() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn include_and_exclude_single_nested() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_and_exclude_single_nested",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "include_and_exclude_single_nested", "1.2.3")?;
 
     fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -477,18 +402,7 @@ fn include_and_exclude_single_nested() -> Result<(), Box<dyn std::error::Error>>
 
 #[test]
 fn include_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "include_nonexistent",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "include_nonexistent", "1.2.3")?;
 
     out.assert().success();
 
@@ -511,18 +425,7 @@ fn include_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn exclude_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "exclude_nonexistent",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exclude_nonexistent", "1.2.3")?;
 
     out.assert().success();
 

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -33,18 +33,7 @@ fn mock_index_config_absent(server: &mut mockito::Server, expected_count: usize)
 
 #[test]
 fn info_basic_in_cwd() -> Result<(), Box<dyn Error>> {
-    let (_temp_dir, cwd, out_init) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "info_basic",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out_init) = cli_init_project_basic("a", "info_basic", "1.2.3")?;
     out_init
         .assert()
         .success()
@@ -61,17 +50,8 @@ fn info_basic_in_cwd() -> Result<(), Box<dyn Error>> {
 }
 
 fn info_basic(use_iri: bool, use_auto: bool) -> Result<(), Box<dyn Error>> {
-    let (_temp_dir, cwd, out_init) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "info_basic",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out_init) =
+        cli_init_project(Some("info_basic"), "a", None, Some("1.2.3"), None)?;
     out_init
         .assert()
         .success()
@@ -1405,17 +1385,8 @@ fn info_multi_index_url_config() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn info_detailed_verbs() -> Result<(), Box<dyn Error>> {
-    let (_tmp, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "info_detailed_verbs",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_tmp, cwd, out) =
+        cli_init_project(Some("info_detailed_verbs"), "a", None, Some("1.2.3"), None)?;
     out.assert().success();
 
     let project_path = &cwd.join("info_detailed_verbs");
@@ -1625,15 +1596,11 @@ fn info_detailed_verbs() -> Result<(), Box<dyn Error>> {
 fn info_set_metamodel() -> Result<(), Box<dyn Error>> {
     let _ = env_logger::try_init();
 
-    let (_tmp, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "info_custom_metamodel",
-            "--version",
-            "1.2.3",
-        ],
+    let (_tmp, cwd, out) = cli_init_project(
+        Some("info_custom_metamodel"),
+        "a",
+        None,
+        Some("1.2.3"),
         None,
     )?;
     out.assert().success();

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -33,8 +33,18 @@ fn mock_index_config_absent(server: &mut mockito::Server, expected_count: usize)
 
 #[test]
 fn info_basic_in_cwd() -> Result<(), Box<dyn Error>> {
-    let (_temp_dir, cwd, out_init) =
-        run_sysand(["init", "--version", "1.2.3", "--name", "info_basic"], None)?;
+    let (_temp_dir, cwd, out_init) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "--name",
+            "info_basic",
+        ],
+        None,
+    )?;
     out_init
         .assert()
         .success()
@@ -51,8 +61,17 @@ fn info_basic_in_cwd() -> Result<(), Box<dyn Error>> {
 }
 
 fn info_basic(use_iri: bool, use_auto: bool) -> Result<(), Box<dyn Error>> {
-    let (_temp_dir, cwd, out_init) =
-        run_sysand(["init", "--version", "1.2.3", "info_basic"], None)?;
+    let (_temp_dir, cwd, out_init) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "info_basic",
+        ],
+        None,
+    )?;
     out_init
         .assert()
         .success()
@@ -1386,7 +1405,17 @@ fn info_multi_index_url_config() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn info_detailed_verbs() -> Result<(), Box<dyn Error>> {
-    let (_tmp, cwd, out) = run_sysand(["init", "info_detailed_verbs", "--version", "1.2.3"], None)?;
+    let (_tmp, cwd, out) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "info_detailed_verbs",
+            "--version",
+            "1.2.3",
+        ],
+        None,
+    )?;
     out.assert().success();
 
     let project_path = &cwd.join("info_detailed_verbs");
@@ -1492,6 +1521,11 @@ fn info_detailed_verbs() -> Result<(), Box<dyn Error>> {
     try_clear("name", false)?;
     try_add("name", "name_1", false)?;
     try_remove("name", "1", false)?;
+    get_field("publisher", Some("a\n".to_string()))?;
+    try_set("publisher", "a_alt", true, None)?;
+    try_clear("publisher", false)?;
+    try_add("publisher", "pub_1", false)?;
+    try_remove("publisher", "1", false)?;
     get_field("version", Some("1.2.3\n".to_string()))?;
     try_set("version", "3.2.1", true, None)?;
     try_clear("version", false)?;
@@ -1592,7 +1626,14 @@ fn info_set_metamodel() -> Result<(), Box<dyn Error>> {
     let _ = env_logger::try_init();
 
     let (_tmp, cwd, out) = run_sysand(
-        ["init", "info_custom_metamodel", "--version", "1.2.3"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "info_custom_metamodel",
+            "--version",
+            "1.2.3",
+        ],
         None,
     )?;
     out.assert().success();

--- a/sysand/tests/cli_init.rs
+++ b/sysand/tests/cli_init.rs
@@ -51,6 +51,31 @@ fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// `sysand init`, when not given a version, should default to `0.0.1`.
+#[test]
+fn init_default_version() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) =
+        cli_init_project(Some("init_default_version"), "a", None, None, None)?;
+
+    let proj_dir_path = cwd.join("init_default_version");
+
+    out.assert().success().stdout(predicate::str::is_empty());
+
+    let info = std::fs::read_to_string(proj_dir_path.join(".project.json"))?;
+
+    assert_eq!(
+        info,
+        r#"{
+  "name": "init_default_version",
+  "publisher": "a",
+  "version": "0.0.1"
+}
+"#
+    );
+
+    Ok(())
+}
+
 /// `sysand init`, when not given a directory, should create a
 /// project in cwd.
 #[test]

--- a/sysand/tests/cli_init.rs
+++ b/sysand/tests/cli_init.rs
@@ -13,7 +13,17 @@ pub use common::*;
 /// on directory name as name.
 #[test]
 fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(["init", "--version", "1.2.3", "init_basic"], None)?;
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "a",
+            "init_basic",
+        ],
+        None,
+    )?;
 
     let proj_dir_path = cwd.join("init_basic");
 
@@ -30,7 +40,7 @@ fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
         info,
         r#"{
   "name": "init_basic",
-  "publisher": "untitled",
+  "publisher": "a",
   "version": "1.2.3"
 }
 "#
@@ -46,7 +56,15 @@ fn init_basic() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn init_basic_cwd() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--name", "init_basic_cwd", "--version", "1.2.3"],
+        [
+            "init",
+            "--publisher",
+            "b",
+            "--name",
+            "init_basic_cwd",
+            "--version",
+            "1.2.3",
+        ],
         None,
     )?;
 
@@ -63,7 +81,7 @@ fn init_basic_cwd() -> Result<(), Box<dyn std::error::Error>> {
         info,
         r#"{
   "name": "init_basic_cwd",
-  "publisher": "untitled",
+  "publisher": "b",
   "version": "1.2.3"
 }
 "#
@@ -84,6 +102,8 @@ fn init_explicit_name() -> Result<(), Box<dyn std::error::Error>> {
             "init",
             "--version",
             "1.2.3",
+            "--publisher",
+            "c",
             "--name",
             "other_than_init_explicit_name",
             "init_explicit_name",
@@ -106,7 +126,7 @@ fn init_explicit_name() -> Result<(), Box<dyn std::error::Error>> {
         info,
         r#"{
   "name": "other_than_init_explicit_name",
-  "publisher": "untitled",
+  "publisher": "c",
   "version": "1.2.3"
 }
 "#
@@ -124,7 +144,14 @@ fn init_explicit_name() -> Result<(), Box<dyn std::error::Error>> {
 fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
     // Run 1
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "init_fail_on_double_init"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "init_fail_on_double_init",
+        ],
         None,
     )?;
     out.assert().success().stdout(predicate::str::is_empty());
@@ -139,7 +166,14 @@ fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
     // Run 2
     let out_again = run_sysand_in(
         &cwd,
-        ["init", "--version", "1.2.3", "init_fail_on_double_init"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "init_fail_on_double_init",
+        ],
         None,
     )?;
     out_again
@@ -168,6 +202,8 @@ fn init_fail_on_double_init_cwd() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--name",
             "init_fail_on_double_init_cwd",
             "--version",
@@ -185,6 +221,8 @@ fn init_fail_on_double_init_cwd() -> Result<(), Box<dyn std::error::Error>> {
         &cwd,
         [
             "init",
+            "--publisher",
+            "a",
             "--name",
             "init_fail_on_double_init_cwd_again",
             "--version",

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -26,7 +26,15 @@ use serde_json::json;
 #[test]
 fn lock_trivial() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--name", "lock_trivial", "--version", "1.2.3"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--name",
+            "lock_trivial",
+            "--version",
+            "1.2.3",
+        ],
         None,
     )?;
 
@@ -58,13 +66,32 @@ fn lock_trivial() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn lock_local_source() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--name", "lock_local_source", "--version", "1.2.3"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--name",
+            "lock_local_source",
+            "--version",
+            "1.2.3",
+        ],
         None,
     )?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
-    let out = run_sysand_in(&cwd, ["init", "--version", "1.0.0", "local_dep"], None)?;
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.0.0",
+            "local_dep",
+        ],
+        None,
+    )?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
@@ -101,7 +128,15 @@ fn lock_local_source() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn lock_std_lib() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--name", "lock_std_lib", "--version", "1.2.3"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--name",
+            "lock_std_lib",
+            "--version",
+            "1.2.3",
+        ],
         None,
     )?;
 
@@ -291,6 +326,8 @@ fn lock_basic_http_deps() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--name",
             "lock_basic_http_deps",
             "--version",
@@ -461,6 +498,8 @@ fn lock_and_sync_against_mock_index() -> Result<(), Box<dyn std::error::Error>> 
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--name",
             "lock_and_sync_against_mock_index",
             "--version",
@@ -582,7 +621,15 @@ fn sync_hard_fails_on_kpar_digest_drift_from_lockfile() -> Result<(), Box<dyn st
         .create();
 
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--name", "sync_tripwire", "--version", "1.2.3"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--name",
+            "sync_tripwire",
+            "--version",
+            "1.2.3",
+        ],
         None,
     )?;
     out.assert().success().stdout(predicate::str::is_empty());
@@ -664,6 +711,8 @@ fn lock_rejects_non_normalized_sysand_purl() -> Result<(), Box<dyn std::error::E
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--name",
             "lock_rejects_non_normalized_sysand_purl",
             "--version",
@@ -705,6 +754,8 @@ fn lock_fail_unsatisfiable() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--name",
             "lock_basic_http_deps",
             "--version",

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -25,18 +25,7 @@ use serde_json::json;
 /// and .meta.json files in the current working directory. (Non-interactive use)
 #[test]
 fn lock_trivial() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "lock_trivial",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "lock_trivial", "1.2.3")?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
@@ -65,33 +54,11 @@ fn lock_trivial() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn lock_local_source() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "lock_local_source",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "lock_local_source", "1.2.3")?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
-    let out = run_sysand_in(
-        &cwd,
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.0.0",
-            "local_dep",
-        ],
-        None,
-    )?;
+    let out = cli_init_project_in(&cwd, Some("local_dep"), "a", None, Some("1.0.0"), None)?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
@@ -127,18 +94,7 @@ fn lock_local_source() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn lock_std_lib() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "lock_std_lib",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "lock_std_lib", "1.2.3")?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
@@ -323,18 +279,7 @@ fn lock_basic_http_deps() -> Result<(), Box<dyn std::error::Error>> {
         [&c_url],
     );
 
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "lock_basic_http_deps",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "lock_basic_http_deps", "1.2.3")?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
@@ -495,18 +440,8 @@ fn lock_and_sync_against_mock_index() -> Result<(), Box<dyn std::error::Error>> 
         .expect(1)
         .create();
 
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "lock_and_sync_against_mock_index",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "lock_and_sync_against_mock_index", "1.2.3")?;
     out.assert().success().stdout(predicate::str::is_empty());
 
     inject_usages(
@@ -620,18 +555,7 @@ fn sync_hard_fails_on_kpar_digest_drift_from_lockfile() -> Result<(), Box<dyn st
         .expect(0)
         .create();
 
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "sync_tripwire",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "sync_tripwire", "1.2.3")?;
     out.assert().success().stdout(predicate::str::is_empty());
 
     inject_usages(
@@ -708,18 +632,8 @@ fn lock_rejects_non_normalized_sysand_purl() -> Result<(), Box<dyn std::error::E
     // offending IRI and shows the suggested normalized form, rather than
     // being silently rerouted to `_iri/<sha256>/` and surfacing only as
     // an opaque "not found" downstream.
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "lock_rejects_non_normalized_sysand_purl",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "lock_rejects_non_normalized_sysand_purl", "1.2.3")?;
     out.assert().success().stdout(predicate::str::is_empty());
 
     inject_usages(
@@ -751,18 +665,7 @@ fn lock_fail_unsatisfiable() -> Result<(), Box<dyn std::error::Error>> {
         NO_DEP,
     );
 
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "lock_basic_http_deps",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "lock_basic_http_deps", "1.2.3")?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -17,20 +17,8 @@ pub use common::*;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn init_project(name: &str) -> Result<(Utf8TempDir, Utf8PathBuf), Box<dyn std::error::Error>> {
-    let (temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "example-pub1",
-            "--version",
-            "1.0.0",
-            "--name",
-            name,
-            "--license",
-            "MIT",
-        ],
-        None,
-    )?;
+    let (temp_dir, cwd, out) =
+        cli_init_project(None, "example-pub1", Some(name), Some("1.0.0"), Some("MIT"))?;
     out.assert().success();
     let mut licenses = cwd.join("LICENSES");
     fs::create_dir(&licenses)?;

--- a/sysand/tests/cli_publish.rs
+++ b/sysand/tests/cli_publish.rs
@@ -20,6 +20,8 @@ fn init_project(name: &str) -> Result<(Utf8TempDir, Utf8PathBuf), Box<dyn std::e
     let (temp_dir, cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "example-pub1",
             "--version",
             "1.0.0",
             "--name",

--- a/sysand/tests/cli_source.rs
+++ b/sysand/tests/cli_source.rs
@@ -10,8 +10,17 @@ use sysand_core::project::utils::wrapfs;
 
 #[test]
 fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir1, cwd_dep, out) =
-        run_sysand(["init", "--version", "1.2.3", "list_sources_dep"], None)?;
+    let (_temp_dir1, cwd_dep, out) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "list_sources_dep",
+        ],
+        None,
+    )?;
     out.assert().success();
 
     let dep_path = cwd_dep.join("list_sources_dep");
@@ -21,7 +30,17 @@ fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
     let out = run_sysand_in(&dep_path, ["include", "dep_src.sysml"], None)?;
     out.assert().success();
 
-    let (_temp_dir2, cwd, out) = run_sysand(["init", "--version", "1.2.3", "list_sources"], None)?;
+    let (_temp_dir2, cwd, out) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "list_sources",
+        ],
+        None,
+    )?;
     out.assert().success();
 
     let path = cwd.join("list_sources");
@@ -124,7 +143,14 @@ fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn sources_without_std() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir1, cwd_dep, out) = run_sysand(
-        ["init", "--version", "1.2.3", "sources_without_std_dep"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "sources_without_std_dep",
+        ],
         None,
     )?;
     out.assert().success();
@@ -180,8 +206,17 @@ fn sources_without_std() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     out.assert().success();
 
-    let (_temp_dir2, cwd, out) =
-        run_sysand(["init", "--version", "1.2.3", "sources_without_std"], None)?;
+    let (_temp_dir2, cwd, out) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "sources_without_std",
+        ],
+        None,
+    )?;
     out.assert().success();
 
     let path = cwd.join("sources_without_std");

--- a/sysand/tests/cli_source.rs
+++ b/sysand/tests/cli_source.rs
@@ -10,17 +10,8 @@ use sysand_core::project::utils::wrapfs;
 
 #[test]
 fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir1, cwd_dep, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "list_sources_dep",
-        ],
-        None,
-    )?;
+    let (_temp_dir1, cwd_dep, out) =
+        cli_init_project(Some("list_sources_dep"), "a", None, Some("1.2.3"), None)?;
     out.assert().success();
 
     let dep_path = cwd_dep.join("list_sources_dep");
@@ -30,17 +21,8 @@ fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
     let out = run_sysand_in(&dep_path, ["include", "dep_src.sysml"], None)?;
     out.assert().success();
 
-    let (_temp_dir2, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "list_sources",
-        ],
-        None,
-    )?;
+    let (_temp_dir2, cwd, out) =
+        cli_init_project(Some("list_sources"), "a", None, Some("1.2.3"), None)?;
     out.assert().success();
 
     let path = cwd.join("list_sources");
@@ -142,15 +124,11 @@ fn list_sources() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn sources_without_std() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir1, cwd_dep, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "sources_without_std_dep",
-        ],
+    let (_temp_dir1, cwd_dep, out) = cli_init_project(
+        Some("sources_without_std_dep"),
+        "a",
+        None,
+        Some("1.2.3"),
         None,
     )?;
     out.assert().success();
@@ -206,17 +184,8 @@ fn sources_without_std() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     out.assert().success();
 
-    let (_temp_dir2, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "sources_without_std",
-        ],
-        None,
-    )?;
+    let (_temp_dir2, cwd, out) =
+        cli_init_project(Some("sources_without_std"), "a", None, Some("1.2.3"), None)?;
     out.assert().success();
 
     let path = cwd.join("sources_without_std");

--- a/sysand/tests/cli_std_notices.rs
+++ b/sysand/tests/cli_std_notices.rs
@@ -26,7 +26,15 @@ const FUNCTION_LIBRARY_IRI: &str = "https://www.omg.org/spec/KerML/20250201/Func
 #[test]
 fn add_std_lib_direct_note_still_locks_skips_sync() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "add_std_direct"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "u",
+            "--name",
+            "add_std_direct",
+        ],
         None,
     )?;
     out.assert().success();
@@ -46,7 +54,7 @@ fn add_std_lib_direct_note_still_locks_skips_sync() -> Result<(), Box<dyn std::e
         format!(
             r#"{{
   "name": "add_std_direct",
-  "publisher": "untitled",
+  "publisher": "u",
   "version": "1.2.3",
   "usage": [
     {{
@@ -140,6 +148,8 @@ fn env_install_transitive_std_deps_note() -> Result<(), Box<dyn std::error::Erro
     let (_dep_temp_dir, cwd_dep, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "1.2.3",
             "--name",
@@ -205,7 +215,15 @@ fn env_install_transitive_std_deps_note() -> Result<(), Box<dyn std::error::Erro
 #[test]
 fn info_all_usages_ignored_std_only() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "info_std_only"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "--name",
+            "info_std_only",
+        ],
         None,
     )?;
     out.assert().success();
@@ -239,8 +257,18 @@ fn info_all_usages_ignored_std_only() -> Result<(), Box<dyn std::error::Error>> 
 /// usage prints the normal usage plus the "Some usages are ignored" note.
 #[test]
 fn info_some_usages_ignored_mixed() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) =
-        run_sysand(["init", "--version", "1.2.3", "--name", "info_mixed"], None)?;
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "--name",
+            "info_mixed",
+        ],
+        None,
+    )?;
     out.assert().success();
 
     run_sysand_in(&cwd, ["add", "--no-lock", "urn:kpar:normal-dep"], None)?

--- a/sysand/tests/cli_std_notices.rs
+++ b/sysand/tests/cli_std_notices.rs
@@ -25,18 +25,7 @@ const FUNCTION_LIBRARY_IRI: &str = "https://www.omg.org/spec/KerML/20250201/Func
 /// provided (source-less) dependency
 #[test]
 fn add_std_lib_direct_note_still_locks_skips_sync() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "u",
-            "--name",
-            "add_std_direct",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("u", "add_std_direct", "1.2.3")?;
     out.assert().success();
 
     let out = run_sysand_in(&cwd, ["add", FUNCTION_LIBRARY_IRI], None)?;
@@ -145,18 +134,8 @@ fn env_install_std_lib_direct_no_path_warns_and_skips() -> Result<(), Box<dyn st
 #[test]
 fn env_install_transitive_std_deps_note() -> Result<(), Box<dyn std::error::Error>> {
     // A project that itself depends on a standard library.
-    let (_dep_temp_dir, cwd_dep, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "env_install_std_dep",
-        ],
-        None,
-    )?;
+    let (_dep_temp_dir, cwd_dep, out) =
+        cli_init_project_basic("a", "env_install_std_dep", "1.2.3")?;
     out.assert().success();
 
     std::fs::write(cwd_dep.join("EnvInstallStdDep.sysml"), "package Dep;")?;
@@ -214,18 +193,7 @@ fn env_install_transitive_std_deps_note() -> Result<(), Box<dyn std::error::Erro
 /// "All usages are ignored" note instead of an empty/misleading usage list.
 #[test]
 fn info_all_usages_ignored_std_only() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "info_std_only",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "info_std_only", "1.2.3")?;
     out.assert().success();
 
     run_sysand_in(
@@ -257,18 +225,7 @@ fn info_all_usages_ignored_std_only() -> Result<(), Box<dyn std::error::Error>> 
 /// usage prints the normal usage plus the "Some usages are ignored" note.
 #[test]
 fn info_some_usages_ignored_mixed() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "info_mixed",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "info_mixed", "1.2.3")?;
     out.assert().success();
 
     run_sysand_in(&cwd, ["add", "--no-lock", "urn:kpar:normal-dep"], None)?

--- a/sysand/tests/cli_sync.rs
+++ b/sysand/tests/cli_sync.rs
@@ -19,18 +19,7 @@ pub use common::*;
 
 #[test]
 fn sync_to_current() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--version",
-            "1.2.3",
-            "--publisher",
-            "d",
-            "--name",
-            "sync_to_current",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("d", "sync_to_current", "1.2.3")?;
 
     fs::write(cwd.join("test.sysml"), b"package P;\n")?;
 
@@ -84,32 +73,11 @@ editable = true
 
 #[test]
 fn repeated_sync_keeps_lockfile_and_env_toml_stable() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "--name",
-            "lock_sync_stable",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "lock_sync_stable", "1.2.3")?;
     out.assert().success().stdout(predicate::str::is_empty());
 
-    let (_dep_temp_dir, dep_cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "2.0.0",
-            "--name",
-            "lock_sync_stable_dep",
-        ],
-        None,
-    )?;
+    let (_dep_temp_dir, dep_cwd, out) =
+        cli_init_project_basic("a", "lock_sync_stable_dep", "2.0.0")?;
     out.assert().success().stdout(predicate::str::is_empty());
 
     let config_path = cwd.join("sysand.toml");
@@ -531,18 +499,7 @@ sources = [
 #[test]
 fn sync_env_toml_with_editable_and_non_editable() -> Result<(), Box<dyn std::error::Error>> {
     // Set up main project with .meta.json (required for sync to lock itself).
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.0.0",
-            "--name",
-            "sync_mixed",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "sync_mixed", "1.0.0")?;
     out.assert().success();
     fs::write(cwd.join("P.sysml"), "package P;")?;
     run_sysand_in(&cwd, ["include", "P.sysml"], None)?
@@ -550,18 +507,7 @@ fn sync_env_toml_with_editable_and_non_editable() -> Result<(), Box<dyn std::err
         .success();
 
     // Non-editable dep: needs .meta.json so sync can compute its checksum.
-    let (_tmp_src, cwd_src, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "2.0.0",
-            "--name",
-            "sync_mixed_src",
-        ],
-        None,
-    )?;
+    let (_tmp_src, cwd_src, out) = cli_init_project_basic("a", "sync_mixed_src", "2.0.0")?;
     out.assert().success();
     fs::write(cwd_src.join("Q.sysml"), "package Q;")?;
     run_sysand_in(&cwd_src, ["include", "Q.sysml"], None)?
@@ -569,18 +515,8 @@ fn sync_env_toml_with_editable_and_non_editable() -> Result<(), Box<dyn std::err
         .success();
 
     // Editable dep: only .project.json is needed (no install, just reference).
-    let (_tmp_editable, cwd_editable, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "3.0.0",
-            "--name",
-            "sync_mixed_editable",
-        ],
-        None,
-    )?;
+    let (_tmp_editable, cwd_editable, out) =
+        cli_init_project_basic("a", "sync_mixed_editable", "3.0.0")?;
     out.assert().success();
 
     let config_path = cwd.join("sysand.toml");

--- a/sysand/tests/cli_sync.rs
+++ b/sysand/tests/cli_sync.rs
@@ -20,7 +20,15 @@ pub use common::*;
 #[test]
 fn sync_to_current() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "sync_to_current"],
+        [
+            "init",
+            "--version",
+            "1.2.3",
+            "--publisher",
+            "d",
+            "--name",
+            "sync_to_current",
+        ],
         None,
     )?;
 
@@ -51,7 +59,7 @@ fn sync_to_current() -> Result<(), Box<dyn std::error::Error>> {
 version = "0.1"
 
 [[project]]
-publisher = "untitled"
+publisher = "d"
 name = "sync_to_current"
 version = "1.2.3"
 path = "."
@@ -77,7 +85,15 @@ editable = true
 #[test]
 fn repeated_sync_keeps_lockfile_and_env_toml_stable() -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, cwd, out) = run_sysand(
-        ["init", "--version", "1.2.3", "--name", "lock_sync_stable"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "--name",
+            "lock_sync_stable",
+        ],
         None,
     )?;
     out.assert().success().stdout(predicate::str::is_empty());
@@ -85,6 +101,8 @@ fn repeated_sync_keeps_lockfile_and_env_toml_stable() -> Result<(), Box<dyn std:
     let (_dep_temp_dir, dep_cwd, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "2.0.0",
             "--name",
@@ -513,8 +531,18 @@ sources = [
 #[test]
 fn sync_env_toml_with_editable_and_non_editable() -> Result<(), Box<dyn std::error::Error>> {
     // Set up main project with .meta.json (required for sync to lock itself).
-    let (_temp_dir, cwd, out) =
-        run_sysand(["init", "--version", "1.0.0", "--name", "sync_mixed"], None)?;
+    let (_temp_dir, cwd, out) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.0.0",
+            "--name",
+            "sync_mixed",
+        ],
+        None,
+    )?;
     out.assert().success();
     fs::write(cwd.join("P.sysml"), "package P;")?;
     run_sysand_in(&cwd, ["include", "P.sysml"], None)?
@@ -523,7 +551,15 @@ fn sync_env_toml_with_editable_and_non_editable() -> Result<(), Box<dyn std::err
 
     // Non-editable dep: needs .meta.json so sync can compute its checksum.
     let (_tmp_src, cwd_src, out) = run_sysand(
-        ["init", "--version", "2.0.0", "--name", "sync_mixed_src"],
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "2.0.0",
+            "--name",
+            "sync_mixed_src",
+        ],
         None,
     )?;
     out.assert().success();
@@ -536,6 +572,8 @@ fn sync_env_toml_with_editable_and_non_editable() -> Result<(), Box<dyn std::err
     let (_tmp_editable, cwd_editable, out) = run_sysand(
         [
             "init",
+            "--publisher",
+            "a",
             "--version",
             "3.0.0",
             "--name",

--- a/sysand/tests/common/mod.rs
+++ b/sysand/tests/common/mod.rs
@@ -105,6 +105,56 @@ pub fn sysand_cmd_in<'a, I: IntoIterator<Item = &'a str>>(
     sysand_cmd_in_with(cwd, args, cfg, &IndexMap::<&str, &str>::default())
 }
 
+/// Initialize a project in a temp directory
+pub fn cli_init_project_basic(
+    publisher: &str,
+    name: &str,
+    version: &str,
+) -> Result<(Utf8TempDir, Utf8PathBuf, Output), Box<dyn Error>> {
+    cli_init_project(None, publisher, Some(name), Some(version), None)
+}
+
+/// Initialize a project in a temp directory
+pub fn cli_init_project(
+    path: Option<&str>,
+    publisher: &str,
+    name: Option<&str>,
+    version: Option<&str>,
+    license: Option<&str>,
+) -> Result<(Utf8TempDir, Utf8PathBuf, Output), Box<dyn Error>> {
+    let (tempdir, cwd) = new_temp_cwd()?;
+    cli_init_project_in(&cwd, path, publisher, name, version, license).map(|o| (tempdir, cwd, o))
+}
+
+/// Like [`cli_init_project`], but initializes the project in an already
+/// existing `cwd`
+pub fn cli_init_project_in(
+    cwd: &Utf8Path,
+    path: Option<&str>,
+    publisher: &str,
+    name: Option<&str>,
+    version: Option<&str>,
+    license: Option<&str>,
+) -> Result<Output, Box<dyn Error>> {
+    let mut args = vec!["init", "--publisher", publisher];
+    if let Some(name) = name {
+        args.push("--name");
+        args.push(name);
+    }
+    if let Some(version) = version {
+        args.push("--version");
+        args.push(version);
+    }
+    if let Some(license) = license {
+        args.push("--license");
+        args.push(license);
+    }
+    if let Some(path) = path {
+        args.push(path);
+    }
+    run_sysand_in(cwd, args, None)
+}
+
 /// Creates a temporary directory and returns the tuple of the temporary
 /// directory handle and the canonicalised path to it. We need to canonicalise
 /// the path because tests check the output of CLI to see whether it operated on

--- a/sysand/tests/discover.rs
+++ b/sysand/tests/discover.rs
@@ -13,7 +13,17 @@ pub use common::*;
 /// on directory name as name.
 #[test]
 fn discover_basic() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, _) = run_sysand(["init", "--version", "1.2.3", "discover_basic"], None)?;
+    let (_temp_dir, cwd, _) = run_sysand(
+        [
+            "init",
+            "--publisher",
+            "a",
+            "--version",
+            "1.2.3",
+            "discover_basic",
+        ],
+        None,
+    )?;
 
     let project_path = cwd.join("discover_basic").join("path");
 

--- a/sysand/tests/discover.rs
+++ b/sysand/tests/discover.rs
@@ -13,17 +13,8 @@ pub use common::*;
 /// on directory name as name.
 #[test]
 fn discover_basic() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, _) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--version",
-            "1.2.3",
-            "discover_basic",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, _) =
+        cli_init_project(Some("discover_basic"), "a", None, Some("1.2.3"), None)?;
 
     let project_path = cwd.join("discover_basic").join("path");
 


### PR DESCRIPTION
Applies to CLI and bindings, so this is a breaking change.

Added a few helpers to reduce test init boilerplate.

Support for existing projects without a publisher remains unchanged.

Requested in https://github.com/sensmetry/sysand/pull/426#discussion_r3628499935.