### PR TITLE
fix: include error cause chains consistently, do not silently discard errors

### DIFF
--- a/bindings/java/src/conversion.rs
+++ b/bindings/java/src/conversion.rs
@@ -11,6 +11,7 @@ use sysand_core::model::{
     InterchangeProjectChecksum, InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw,
     InterchangeProjectMetadataRaw, InterchangeProjectUsageRaw,
 };
+use sysand_core::utils::format_err;
 
 fn get_string_field<'local>(
     env: &mut JNIEnv<'local>,
@@ -21,19 +22,28 @@ fn get_string_field<'local>(
         Ok(v) => match v.l() {
             Ok(o) => o,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to get field `{field_name}`: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         },
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get field `{field_name}`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
     match env.get_string(&JString::from(field_obj)) {
         Ok(s) => Some(s.into()),
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to read string field `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to read string field `{field_name}`: {}",
+                format_err(e)
+            ));
             None
         }
     }
@@ -49,12 +59,18 @@ fn get_nullable_string_field<'local>(
         Ok(v) => match v.l() {
             Ok(o) => o,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to get field `{field_name}`: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         },
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get field `{field_name}`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
@@ -64,7 +80,10 @@ fn get_nullable_string_field<'local>(
     match env.get_string(&JString::from(field_obj)) {
         Ok(s) => Some(Some(s.into())),
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to read string field `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to read string field `{field_name}`: {}",
+                format_err(e)
+            ));
             None
         }
     }
@@ -79,12 +98,18 @@ fn get_string_array_field<'local>(
         Ok(v) => match v.l() {
             Ok(o) => o,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to get field `{field_name}`: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         },
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get field `{field_name}`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
@@ -92,7 +117,10 @@ fn get_string_array_field<'local>(
     let len = match env.get_array_length(&arr) {
         Ok(l) => l as usize,
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get length of `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get length of `{field_name}`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
@@ -102,7 +130,8 @@ fn get_string_array_field<'local>(
             Ok(o) => o,
             Err(e) => {
                 env.throw_runtime_exception(format!(
-                    "Failed to get element of `{field_name}[{i}]`: {e}"
+                    "Failed to get element of `{field_name}[{i}]`: {}",
+                    format_err(e)
                 ));
                 return None;
             }
@@ -111,7 +140,8 @@ fn get_string_array_field<'local>(
             Ok(s) => s.into(),
             Err(e) => {
                 env.throw_runtime_exception(format!(
-                    "Failed to read string element of `{field_name}[{i}]`: {e}"
+                    "Failed to read string element of `{field_name}[{i}]`: {}",
+                    format_err(e)
                 ));
                 return None;
             }
@@ -131,12 +161,18 @@ fn get_nullable_boolean_field<'local>(
         Ok(v) => match v.l() {
             Ok(o) => o,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to get field `{field_name}`: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         },
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get field `{field_name}`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
@@ -147,13 +183,17 @@ fn get_nullable_boolean_field<'local>(
         Ok(v) => match v.z() {
             Ok(b) => Some(Some(b)),
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to unbox Boolean `{field_name}`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to unbox Boolean `{field_name}`: {}",
+                    format_err(e)
+                ));
                 None
             }
         },
         Err(e) => {
             env.throw_runtime_exception(format!(
-                "Failed to call booleanValue on `{field_name}`: {e}"
+                "Failed to call booleanValue on `{field_name}`: {}",
+                format_err(e)
             ));
             None
         }
@@ -170,12 +210,18 @@ fn get_usage_array_field<'local>(
         Ok(v) => match v.l() {
             Ok(o) => o,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to get field `{field_name}`: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         },
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get field `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get field `{field_name}`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
@@ -183,7 +229,10 @@ fn get_usage_array_field<'local>(
     let len = match env.get_array_length(&arr) {
         Ok(l) => l as usize,
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get length of `{field_name}`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get length of `{field_name}`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
@@ -193,7 +242,8 @@ fn get_usage_array_field<'local>(
             Ok(o) => o,
             Err(e) => {
                 env.throw_runtime_exception(format!(
-                    "Failed to get element of `{field_name}[{i}]`: {e}"
+                    "Failed to get element of `{field_name}[{i}]`: {}",
+                    format_err(e)
                 ));
                 return None;
             }
@@ -217,7 +267,8 @@ fn get_usage_array_field<'local>(
             Err(e) => {
                 env.throw_runtime_exception(format!(
                     "Failed to check whether `{field_name}[{i}]` is InterchangeProjectUsageResource:\n\
-                    {e}"
+                    {}",
+                    format_err(e)
                 ));
                 return None;
             }
@@ -260,12 +311,15 @@ pub(crate) fn java_metadata_to_raw<'local>(
         Ok(v) => match v.l() {
             Ok(o) => o,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to get field `index`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to get field `index`: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         },
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get field `index`: {e}"));
+            env.throw_runtime_exception(format!("Failed to get field `index`: {}", format_err(e)));
             return None;
         }
     };
@@ -273,7 +327,7 @@ pub(crate) fn java_metadata_to_raw<'local>(
         Ok(m) => m,
         Err(jni::errors::Error::JavaException) => return None,
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to convert index map: {e}"));
+            env.throw_runtime_exception(format!("Failed to convert index map: {}", format_err(e)));
             return None;
         }
     };
@@ -285,12 +339,18 @@ pub(crate) fn java_metadata_to_raw<'local>(
         Ok(v) => match v.l() {
             Ok(o) => o,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to get field `checksum`: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to get field `checksum`: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         },
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to get field `checksum`: {e}"));
+            env.throw_runtime_exception(format!(
+                "Failed to get field `checksum`: {}",
+                format_err(e)
+            ));
             return None;
         }
     };
@@ -300,14 +360,20 @@ pub(crate) fn java_metadata_to_raw<'local>(
         let jmap = match JMap::from_env(env, &checksum_obj) {
             Ok(m) => m,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to wrap checksum map: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to wrap checksum map: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         };
         let mut iter = match jmap.iter(env) {
             Ok(i) => i,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to iterate checksum map: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to iterate checksum map: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         };
@@ -318,7 +384,8 @@ pub(crate) fn java_metadata_to_raw<'local>(
                 Ok(None) => break,
                 Err(e) => {
                     env.throw_runtime_exception(format!(
-                        "Failed to iterate checksum map entry: {e}"
+                        "Failed to iterate checksum map entry: {}",
+                        format_err(e)
                     ));
                     return None;
                 }
@@ -327,7 +394,10 @@ pub(crate) fn java_metadata_to_raw<'local>(
             let key_str: String = match env.get_string(&JString::from(key)) {
                 Ok(s) => s.into(),
                 Err(e) => {
-                    env.throw_runtime_exception(format!("Failed to read checksum key: {e}"));
+                    env.throw_runtime_exception(format!(
+                        "Failed to read checksum key: {}",
+                        format_err(e)
+                    ));
                     return None;
                 }
             };
@@ -401,7 +471,7 @@ impl ToJObject for str {
         match env.new_string(self) {
             Ok(s) => Some(s.into()),
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create String: {e}"));
+                env.throw_runtime_exception(format!("Failed to create String: {}", format_err(e)));
                 None
             }
         }
@@ -431,7 +501,10 @@ impl ToJObjectArray for [String] {
         ) {
             Ok(a) => a,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create String[]: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to create String[]: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         };
@@ -441,7 +514,10 @@ impl ToJObjectArray for [String] {
             match env.set_object_array_element(&mut array, index, value_object) {
                 Ok(_) => (),
                 Err(e) => {
-                    env.throw_runtime_exception(format!("Failed to set String[] element: {e}"));
+                    env.throw_runtime_exception(format!(
+                        "Failed to set String[] element: {}",
+                        format_err(e)
+                    ));
                     return None;
                 }
             };
@@ -462,7 +538,7 @@ impl ToJObject for bool {
         match env.new_object("java/lang/Boolean", "(Z)V", &[JValue::from(boolean_value)]) {
             Ok(b) => Some(b),
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create Boolean: {e}"));
+                env.throw_runtime_exception(format!("Failed to create Boolean: {}", format_err(e)));
                 None
             }
         }
@@ -474,7 +550,10 @@ impl<K: ToJObject, V: ToJObject> ToJObject for IndexMap<K, V> {
         let mut map = match env.new_object("java/util/LinkedHashMap", "()V", &[]) {
             Ok(l) => l,
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create LinkedHashMap: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to create LinkedHashMap: {}",
+                    format_err(e)
+                ));
                 return None;
             }
         };
@@ -490,7 +569,8 @@ impl<K: ToJObject, V: ToJObject> ToJObject for IndexMap<K, V> {
                 Ok(_) => (),
                 Err(e) => {
                     env.throw_runtime_exception(format!(
-                        "Failed to call LinkedHashMap::put(): {e}"
+                        "Failed to call LinkedHashMap::put(): {}",
+                        format_err(e)
                     ));
                     return None;
                 }
@@ -514,7 +594,10 @@ impl ToJObject for InterchangeProjectChecksum {
         ) {
             Ok(o) => Some(o),
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create LinkedHashMap: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to create LinkedHashMap: {}",
+                    format_err(e)
+                ));
                 None
             }
         }
@@ -533,7 +616,8 @@ impl ToJObject for InterchangeProjectChecksumRaw {
             Ok(o) => Some(o),
             Err(e) => {
                 env.throw_runtime_exception(format!(
-                    "Failed to create InterchangeProjectChecksum: {e}"
+                    "Failed to create InterchangeProjectChecksum: {}",
+                    format_err(e)
                 ));
                 None
             }
@@ -557,7 +641,10 @@ impl ToJObject for InterchangeProjectUsageRaw {
                 ) {
                     Ok(o) => Some(o),
                     Err(e) => {
-                        env.throw_runtime_exception(format!("Failed to create LinkedHashMap: {e}"));
+                        env.throw_runtime_exception(format!(
+                            "Failed to create InterchangeProjectUsageResource: {}",
+                            format_err(e)
+                        ));
                         None
                     }
                 }
@@ -578,7 +665,8 @@ impl ToJObjectArray for Vec<InterchangeProjectUsageRaw> {
             Ok(o) => o,
             Err(e) => {
                 env.throw_runtime_exception(format!(
-                    "Failed to create InterchangeProjectUsage[]: {e}"
+                    "Failed to create InterchangeProjectUsage[]: {}",
+                    format_err(e)
                 ));
                 return None;
             }
@@ -590,7 +678,8 @@ impl ToJObjectArray for Vec<InterchangeProjectUsageRaw> {
                 Ok(o) => o,
                 Err(e) => {
                     env.throw_runtime_exception(format!(
-                        "Failed to set InterchangeProjectUsage[] element: {e}"
+                        "Failed to set InterchangeProjectUsage[] element: {}",
+                        format_err(e)
                     ));
                     return None;
                 }
@@ -635,7 +724,8 @@ impl ToJObject for InterchangeProjectInfoRaw {
             Ok(o) => Some(o),
             Err(e) => {
                 env.throw_runtime_exception(format!(
-                    "Failed to create InterchangeProjectInfo: {e}"
+                    "Failed to create InterchangeProjectInfo: {}",
+                    format_err(e)
                 ));
                 None
             }
@@ -666,7 +756,8 @@ impl ToJObject for InterchangeProjectMetadataRaw {
             Ok(o) => Some(o),
             Err(e) => {
                 env.throw_runtime_exception(format!(
-                    "Failed to create InterchangeProjectMetadata: {e}"
+                    "Failed to create InterchangeProjectMetadata: {}",
+                    format_err(e)
                 ));
                 None
             }
@@ -705,7 +796,10 @@ impl ToJObject for (InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw) {
         ) {
             Ok(o) => Some(o),
             Err(e) => {
-                env.throw_runtime_exception(format!("Failed to create InterchangeProject: {e}"));
+                env.throw_runtime_exception(format!(
+                    "Failed to create InterchangeProject: {}",
+                    format_err(e)
+                ));
                 None
             }
         }

--- a/bindings/java/src/exceptions.rs
+++ b/bindings/java/src/exceptions.rs
@@ -4,6 +4,7 @@
 use std::fmt;
 
 use jni::{JNIEnv, objects::JString};
+use sysand_core::utils::format_err;
 
 pub(crate) trait JniExt {
     fn throw_exception(&mut self, exception_kind: ExceptionKind, message: impl AsRef<str>);
@@ -133,7 +134,10 @@ impl JniExt for JNIEnv<'_> {
                     None
                 }
                 jni::errors::Error::ThrowFailed(_) => {
-                    self.throw_runtime_exception(format!("`{variable_name}`: {error}"));
+                    self.throw_runtime_exception(format!(
+                        "`{variable_name}`: {}",
+                        format_err(error)
+                    ));
                     None
                 }
                 jni::errors::Error::ParseFailed(string_stream_error, _) => {
@@ -146,7 +150,8 @@ impl JniExt for JNIEnv<'_> {
                 jni::errors::Error::JniCall(jni_error) => {
                     self.throw_runtime_exception(format!(
                         "`{}`: JNI call failed: {}",
-                        variable_name, jni_error
+                        variable_name,
+                        format_err(jni_error)
                     ));
                     None
                 }

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -65,7 +65,10 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_init<'local>(
         Err(e) => match e {
             Error::NullPtr(_) => None,
             _ => {
-                env.throw_runtime_exception(format!("failed to get argument `license`: {}", e));
+                env.throw_runtime_exception(format!(
+                    "failed to get argument `license`: {}",
+                    format_err(e)
+                ));
                 return;
             }
         },
@@ -120,7 +123,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_defaultEnvName<'local>(
     match env.new_string(DEFAULT_ENV_NAME) {
         Ok(s) => s,
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to create String: {e}"));
+            env.throw_runtime_exception(format!("Failed to create String: {}", format_err(e)));
             JString::default()
         }
     }
@@ -326,7 +329,7 @@ pub extern "system" fn Java_com_sensmetry_sysand_Sysand_setProjectIndex<'local>(
             return;
         }
         Err(e) => {
-            env.throw_runtime_exception(format!("Failed to convert index map: {e}"));
+            env.throw_runtime_exception(format!("Failed to convert index map: {}", format_err(e)));
             return;
         }
     };

--- a/core/src/commands/env/list.rs
+++ b/core/src/commands/env/list.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use crate::env::ReadEnvironment;
+use crate::{env::ReadEnvironment, utils::format_err};
 
 pub fn do_env_list<E: ReadEnvironment>(
     env: E,
@@ -9,12 +9,13 @@ pub fn do_env_list<E: ReadEnvironment>(
     let uris: Vec<String> = env
         .uris()?
         .into_iter()
-        .inspect(|res| {
-            if let Err(e) = res {
-                log::warn!("failed to read uri: {e}");
+        .filter_map(|res| match res {
+            Ok(u) => Some(u),
+            Err(e) => {
+                log::warn!("failed to read uri: {}", format_err(e));
+                None
             }
         })
-        .filter_map(Result::ok)
         .collect();
 
     #[allow(clippy::type_complexity)]
@@ -24,7 +25,13 @@ pub fn do_env_list<E: ReadEnvironment>(
             let versions: Vec<String> = env
                 .versions(&uri)?
                 .into_iter()
-                .filter_map(Result::ok)
+                .filter_map(|res| match res {
+                    Ok(u) => Some(u),
+                    Err(e) => {
+                        log::warn!("failed to read one version of `{uri}`: {}", format_err(e));
+                        None
+                    }
+                })
                 .collect();
 
             if versions.is_empty() {

--- a/core/src/commands/info.rs
+++ b/core/src/commands/info.rs
@@ -71,7 +71,7 @@ pub fn do_info<S: AsRef<str>, R: ResolveRead>(
                         // These errors may be ugly, as `resolved` includes all
                         // possible candidates, with expectation that only some
                         // of them will work. So we don't show these by default
-                        log::debug!("skipping candidate project: {e}");
+                        log::debug!("skipping candidate project: {}", format_err(e));
                         continue;
                     }
                 };

--- a/core/src/project/reqwest_kpar_download.rs
+++ b/core/src/project/reqwest_kpar_download.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
 use std::{
-    error::Error,
     io::{self, Write as _},
     num::NonZeroU64,
     pin::Pin,
@@ -24,7 +23,7 @@ use crate::{
         local_kpar::{LocalKParError, LocalKParProject, LocalKParProjectRaw},
     },
     resolve::net_utils::kpar_get_request,
-    utils::lowercase_hex,
+    utils::{format_err, lowercase_hex},
 };
 
 use super::{
@@ -375,14 +374,7 @@ impl<Policy: HTTPAuthentication> ProjectReadAsync for ReqwestRemoteKparDownloade
         match self.ensure_downloaded_verified().await {
             Ok((inner, _)) => inner.is_definitely_invalid(),
             Err(e) => {
-                // TODO: generalize `format_sources()` to logging
-                log::debug!("error downloading/reading a kpar: {e}");
-                let mut error: &dyn Error = &e;
-                while let Some(source) = error.source() {
-                    log::debug!("  caused by: {source}");
-                    error = source;
-                }
-
+                log::debug!("error downloading/reading a kpar: {}", format_err(&e));
                 false
             }
         }
@@ -593,18 +585,11 @@ impl<Policy: HTTPAuthentication> ProjectReadAsync for ReqwestIndexKparDownloaded
 
     async fn is_definitely_invalid_async(&self) -> bool {
         // FIXME: error should be returned; does it make sense to download the project
-        // here, as this is supposed to be a quick check
+        // here (this is supposed to be a quick check)?
         match self.ensure_downloaded_verified().await {
             Ok(inner) => inner.is_definitely_invalid(),
             Err(e) => {
-                // TODO: generalize `format_sources()` to logging
-                log::debug!("error downloading/reading a kpar: {e}");
-                let mut error: &dyn Error = &e;
-                while let Some(source) = error.source() {
-                    log::debug!("  caused by: {source}");
-                    error = source;
-                }
-
+                log::debug!("error downloading/reading a kpar: {}", format_err(&e));
                 false
             }
         }

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -25,6 +25,7 @@ use sysand_core::{
         standard::{StandardResolver, standard_resolver},
     },
     utils::SP,
+    utils::format_err,
 };
 
 use crate::{
@@ -371,14 +372,17 @@ pub fn get_project_version<R: ResolveRead>(
                         // These errors may be ugly, as `candidates` includes all
                         // possible candidates, with expectation that only some
                         // of them will work. So we don't show these by default
-                        log::debug!("skipping candidate project: {e}");
+                        log::debug!("skipping candidate project: {}", format_err(e));
                         continue;
                     }
                 };
                 let maybe_info = match candidate_project.get_info() {
                     Ok(mi) => mi,
                     Err(e) => {
-                        log::debug!("skipping candidate project, failed to get info: {e}");
+                        log::debug!(
+                            "skipping candidate project, failed to get info: {}",
+                            format_err(e)
+                        );
                         continue;
                     }
                 };

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -23,6 +23,7 @@ use sysand_core::{
         standard::standard_resolver,
     },
     style,
+    utils::format_err,
 };
 
 use anstream::{print, println};
@@ -279,7 +280,7 @@ fn get_info_or_bail<Project: ProjectRead>(project: &Project) -> Result<Interchan
         Ok(Some(info)) => Ok(info),
         Ok(None) => bail!("project does not appear to have a valid `.project.json`"),
         Err(err) => {
-            bail!("failed to read `.project.json`: {}", err)
+            bail!("failed to read `.project.json`: {}", format_err(err))
         }
     }
 }
@@ -291,7 +292,7 @@ fn get_meta_or_bail<Project: ProjectRead>(
         Ok(Some(meta)) => Ok(meta),
         Ok(None) => bail!("project does not appear to have a valid `.meta.json`"),
         Err(err) => {
-            bail!("failed to read `.meta.json`: {}", err)
+            bail!("failed to read `.meta.json`: {}", format_err(err))
         }
     }
 }
@@ -301,7 +302,7 @@ fn set_info_or_bail<Project: ProjectMut>(
     info: &InterchangeProjectInfoRaw,
 ) -> Result<()> {
     if let Err(err) = project.put_info(info, true) {
-        bail!("failed to write `.project.json`: {}", err);
+        bail!("failed to write `.project.json`: {}", format_err(err));
     }
 
     Ok(())
@@ -312,7 +313,7 @@ fn set_meta_or_bail<Project: ProjectMut>(
     meta: &InterchangeProjectMetadataRaw,
 ) -> Result<()> {
     if let Err(err) = project.put_meta(meta, true) {
-        bail!("failed to write `.meta.json`: {}", err);
+        bail!("failed to write `.meta.json`: {}", format_err(err));
     }
 
     Ok(())

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -42,6 +42,7 @@ use sysand_core::{
     },
     resolve::net_utils::create_reqwest_client,
     stdlib::known_std_libs,
+    utils::format_err,
     workspace::Workspace,
 };
 use url::Url;
@@ -420,7 +421,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 Ok(l) => match Lock::from_str(&l) {
                     Ok(l) => l,
                     // Include file path in errors
-                    Err(e) => bail!("invalid lockfile `{lockfile}`:\n{e}"),
+                    Err(e) => bail!("invalid lockfile `{lockfile}`:\n{}", format_err(e)),
                 },
                 Err(e) => {
                     if e.kind() == ErrorKind::NotFound {
@@ -435,7 +436,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                             &ctx,
                         )?
                     } else {
-                        bail!("failed to read lockfile `{lockfile}`: {e}")
+                        bail!("failed to read lockfile `{lockfile}`: {}", format_err(e))
                     }
                 }
             };


### PR DESCRIPTION
Remaining after #418.

A few errors were silently discarded, now they use `log::debug`. 