### PR TITLE
chore: don't log the failure to check for old sysand_env if it does not exist

### DIFF
--- a/core/src/env/local_directory/mod.rs
+++ b/core/src/env/local_directory/mod.rs
@@ -246,7 +246,11 @@ impl LocalDirectoryEnvironment {
                     );
                 }
             }
-            Err(e) => log::debug!("failed to get metadata of old env at `{path}`: {e}"),
+            Err(e) => {
+                if e.kind() != ErrorKind::NotFound {
+                    log::debug!("failed to get metadata of old env at `{path}`: {e}")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
It spams logs, and confuses users.