### PR TITLE
fix: set zip date to 1980-01-02, fix CI and test feature gating

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,20 +76,30 @@ jobs:
 
       # cargo clippy is run with variants of features enabled, where
       # --all-features is done by prek so we don't do it here
+      # To avoid feature unification (which enables the superset of features
+      # required by all crates, which will include all features required by the CLI),
+      # check core and CLI separately
+      - name: cargo clippy (CLI + macros + bindings)
+        run: cargo clippy -p sysand -p sysand-macros -p sysand-js -p sysand-java -p sysand-py --locked --all-targets --features sysand/alltests -- --deny warnings
 
       - name: cargo clippy ... (no features)
-        run: cargo clippy --workspace --locked --all-targets -- --deny warnings
+        run: cargo clippy -p sysand-core --locked --all-targets -- --deny warnings
 
       - name: cargo clippy --features std,filesystem,alltests ...  (specific feature set 1)
-        run: cargo clippy --workspace --locked --all-targets --no-default-features --features std,filesystem,alltests -- --deny warnings
+        run: cargo clippy -p sysand-core --locked --all-targets --no-default-features --features std,filesystem,alltests -- --deny warnings
 
       - name: cargo clippy --features std,networking,alltests ... (specific feature set 2)
-        run: cargo clippy --workspace --locked --all-targets --no-default-features --features std,networking,alltests -- --deny warnings
+        run: cargo clippy -p sysand-core --locked --all-targets --no-default-features --features std,networking,alltests -- --deny warnings
+
+      - name: cargo clippy --features std,keyring,alltests ... (specific feature set 3)
+        run: cargo clippy -p sysand-core --locked --all-targets --no-default-features --features std,keyring,alltests -- --deny warnings
 
       # since we use --no-dev-deps below (as recommended), we don't do
       # --all-targets to include tests with required development dependencies
       - name: cargo hack clippy --each-feature ... (individual features)
-        run: cargo hack clippy --each-feature --no-dev-deps --features std --ignore-unknown-features -- --deny warnings
+        run: |
+          cargo hack clippy -p sysand-core --each-feature --no-dev-deps --features std --ignore-unknown-features -- --deny warnings
+          cargo hack clippy -p sysand --each-feature --no-dev-deps --features std --ignore-unknown-features -- --deny warnings
 
   test:
     needs: [plan]
@@ -157,7 +167,7 @@ jobs:
           cargo test --locked
           --package sysand-core
           --package sysand
-          --features sysand-core/filesystem,sysand-core/networking,alltests,kpar-bzip2,kpar-zstd,kpar-xz,kpar-ppmd
+          --features sysand-core/filesystem,sysand-core/networking,sysand-core/keyring,alltests,kpar-bzip2,kpar-zstd,kpar-xz,kpar-ppmd
 
   build:
     needs: [test]

--- a/core/scripts/run_tests.sh
+++ b/core/scripts/run_tests.sh
@@ -11,7 +11,7 @@ PACKAGE_DIR=$(dirname "$SCRIPT_DIR")
 
 cd "$PACKAGE_DIR"
 
-cargo test --features filesystem,networking,alltests $@
+cargo test --features filesystem,networking,keyring,alltests $@
 # Currently these features don't enable any tests
 # cargo test --features js $@
 # cargo test --features python $@

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -343,10 +343,16 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     let archive_file = wrapfs::File::create(&path)?;
     let mut zip = zip::ZipWriter::new(archive_file);
 
+    // Keep ZIPs reproducible
     let options = zip::write::SimpleFileOptions::default()
         .compression_method(compression.into())
         .system(zip::System::Unix)
-        .last_modified_time(zip::DateTime::DEFAULT);
+        // Previously used `zip::DateTime::DEFAULT` (earliest allowed
+        // zip date: 1980-01-01), but some extractors try to convert that time
+        // to local (somehow) when extracting, which can result in time earlier
+        // than that, which results in the tool (incorrectly) complaining about
+        // date being too old for zip
+        .last_modified_time(zip::DateTime::from_date_and_time(1980, 1, 2, 0, 0, 0).unwrap());
 
     let source_paths = meta.source_paths(true);
     let mut checksums = if let Some(mut checksum) = meta.checksum.take() {

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -205,7 +205,10 @@ fn exclusive_lock_blocks_reads() {
     assert!(store.list().unwrap().is_empty());
 }
 
-#[cfg(not(all(target_os = "linux", target_env = "musl")))]
+#[cfg(all(
+    feature = "keyring",
+    not(all(target_os = "linux", target_env = "musl"))
+))]
 #[test]
 fn map_keyring_error_covers_the_taxonomy() {
     use super::map_keyring_error;

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -287,13 +287,14 @@ pub fn serialize_blob(blob: &CredentialBlob) -> String {
 /// file. Test-only so they never reach the library's public API.
 #[cfg(test)]
 pub(crate) mod test_support {
-    use std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
-    };
+    #[cfg(feature = "networking")]
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use super::CredentialStoreError;
-    use super::keyring_store::{BlobBackend, LockedBlobStore};
+    use super::keyring_store::BlobBackend;
+    #[cfg(all(feature = "networking", feature = "filesystem"))]
+    use super::keyring_store::LockedBlobStore;
 
     /// In-memory [`BlobBackend`] sharing its contents across clones,
     /// standing in for the single OS keyring entry.
@@ -332,6 +333,7 @@ pub(crate) mod test_support {
 
     /// A lock-file path no other store in this test process shares, so
     /// parallel tests never contend on the cross-process lock.
+    #[cfg(feature = "networking")]
     pub(crate) fn unique_lock_path() -> camino::Utf8PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         camino::Utf8PathBuf::from_path_buf(std::env::temp_dir())
@@ -344,6 +346,7 @@ pub(crate) mod test_support {
     }
 
     /// An empty in-memory store, the test stand-in for the keyring store.
+    #[cfg(all(feature = "networking", feature = "filesystem"))]
     pub(crate) fn in_memory_store() -> LockedBlobStore<InMemoryBlobBackend> {
         LockedBlobStore::new(InMemoryBlobBackend::default(), unique_lock_path())
     }


### PR DESCRIPTION
`cargo test -p sysand-core` did not work due to references to `keyring` crate. CI was not actually `cargo check`ing all feature combinations, since due to feature unification (with CLI crate) most features of core were always enabled.