### PR TITLE
feat: relative local path projects

### DIFF
--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/ModelRoundtripTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/ModelRoundtripTest.java
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+package com.sensmetry.sysand;
+
+import org.junit.jupiter.api.Test;
+
+import com.sensmetry.sysand.model.InterchangeProject;
+import com.sensmetry.sysand.model.InterchangeProjectChecksum;
+import com.sensmetry.sysand.model.InterchangeProjectInfo;
+import com.sensmetry.sysand.model.InterchangeProjectMetadata;
+import com.sensmetry.sysand.model.InterchangeProjectUsage;
+import com.sensmetry.sysand.model.InterchangeProjectUsageDirectory;
+import com.sensmetry.sysand.model.InterchangeProjectUsageKparPath;
+import com.sensmetry.sysand.model.InterchangeProjectUsageResource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.LinkedHashMap;
+
+public class ModelRoundtripTest {
+
+    @Test
+    public void testModelTypesRoundtripThroughRust() {
+        InterchangeProjectInfo info = new InterchangeProjectInfo(
+                "roundtrip-project",
+                "acme",
+                "A project with every exposed info field",
+                "1.2.3",
+                "MIT",
+                new String[]{"Alice", "Bob"},
+                "https://example.com/roundtrip",
+                new String[]{"sysml", "bindings"},
+                new InterchangeProjectUsage[]{
+                    new InterchangeProjectUsageResource("pkg:sysand/acme/remote-lib", ">=1.0.0"),
+                    new InterchangeProjectUsageDirectory("../local-lib", "local-pub", "local-lib"),
+                    new InterchangeProjectUsageKparPath("deps/archive-lib.kpar", "archive-pub", "archive-lib"),
+                });
+
+        LinkedHashMap<String, String> index = new LinkedHashMap<>();
+        index.put("Alpha", "src/Alpha.sysml");
+        index.put("Beta", "src/nested/Beta.kerml");
+
+        LinkedHashMap<String, InterchangeProjectChecksum> checksum = new LinkedHashMap<>();
+        checksum.put("src/Alpha.sysml", new InterchangeProjectChecksum("0123456789abcdef", "MD5"));
+        checksum.put("src/nested/Beta.kerml", new InterchangeProjectChecksum("deadbeef", "ADLER32"));
+
+        InterchangeProjectMetadata metadata = new InterchangeProjectMetadata(
+                index,
+                "2026-01-02T03:04:05Z",
+                "https://www.omg.org/spec/SysML/20250201",
+                Boolean.TRUE,
+                Boolean.FALSE,
+                checksum);
+
+        InterchangeProject roundtripped = SysandTestHooks.modelRoundtrip(info, metadata);
+
+        assertInfoEquals(info, roundtripped.info);
+        assertMetadataEquals(metadata, roundtripped.metadata);
+    }
+
+    private static void assertInfoEquals(InterchangeProjectInfo expected, InterchangeProjectInfo actual) {
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getPublisher(), actual.getPublisher());
+        assertEquals(expected.getDescription(), actual.getDescription());
+        assertEquals(expected.getVersion(), actual.getVersion());
+        assertEquals(expected.getLicense(), actual.getLicense());
+        assertArrayEquals(expected.getMaintainer(), actual.getMaintainer());
+        assertEquals(expected.getWebsite(), actual.getWebsite());
+        assertArrayEquals(expected.getTopic(), actual.getTopic());
+
+        InterchangeProjectUsage[] expectedUsage = expected.getUsage();
+        InterchangeProjectUsage[] actualUsage = actual.getUsage();
+        assertEquals(expectedUsage.length, actualUsage.length);
+
+        InterchangeProjectUsageResource expectedResource = (InterchangeProjectUsageResource) expectedUsage[0];
+        assertInstanceOf(InterchangeProjectUsageResource.class, actualUsage[0]);
+        InterchangeProjectUsageResource actualResource = (InterchangeProjectUsageResource) actualUsage[0];
+        assertEquals(expectedResource.getResource(), actualResource.getResource());
+        assertEquals(expectedResource.getVersionConstraint(), actualResource.getVersionConstraint());
+
+        InterchangeProjectUsageDirectory expectedDirectory = (InterchangeProjectUsageDirectory) expectedUsage[1];
+        assertInstanceOf(InterchangeProjectUsageDirectory.class, actualUsage[1]);
+        InterchangeProjectUsageDirectory actualDirectory = (InterchangeProjectUsageDirectory) actualUsage[1];
+        assertEquals(expectedDirectory.getDirectory(), actualDirectory.getDirectory());
+        assertEquals(expectedDirectory.getPublisher(), actualDirectory.getPublisher());
+        assertEquals(expectedDirectory.getName(), actualDirectory.getName());
+
+        InterchangeProjectUsageKparPath expectedKparPath = (InterchangeProjectUsageKparPath) expectedUsage[2];
+        assertInstanceOf(InterchangeProjectUsageKparPath.class, actualUsage[2]);
+        InterchangeProjectUsageKparPath actualKparPath = (InterchangeProjectUsageKparPath) actualUsage[2];
+        assertEquals(expectedKparPath.getKparPath(), actualKparPath.getKparPath());
+        assertEquals(expectedKparPath.getPublisher(), actualKparPath.getPublisher());
+        assertEquals(expectedKparPath.getName(), actualKparPath.getName());
+    }
+
+    private static void assertMetadataEquals(
+            InterchangeProjectMetadata expected,
+            InterchangeProjectMetadata actual) {
+        assertEquals(expected.getIndex(), actual.getIndex());
+        assertEquals(expected.getCreated(), actual.getCreated());
+        assertEquals(expected.getMetamodel(), actual.getMetamodel());
+        assertEquals(expected.getIncludesDerived(), actual.getIncludesDerived());
+        assertEquals(expected.getIncludesImplied(), actual.getIncludesImplied());
+
+        LinkedHashMap<String, InterchangeProjectChecksum> expectedChecksum = expected.getChecksum();
+        LinkedHashMap<String, InterchangeProjectChecksum> actualChecksum = actual.getChecksum();
+        assertNotNull(actualChecksum);
+        assertEquals(expectedChecksum.keySet(), actualChecksum.keySet());
+        for (String key : expectedChecksum.keySet()) {
+            assertEquals(expectedChecksum.get(key).getValue(), actualChecksum.get(key).getValue());
+            assertEquals(expectedChecksum.get(key).getAlgorithm(), actualChecksum.get(key).getAlgorithm());
+        }
+    }
+}

--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SetProjectInfoTest.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SetProjectInfoTest.java
@@ -10,6 +10,7 @@ import com.sensmetry.sysand.model.InterchangeProjectInfo;
 import com.sensmetry.sysand.model.InterchangeProjectMetadata;
 import com.sensmetry.sysand.model.InterchangeProjectUsage;
 import com.sensmetry.sysand.model.InterchangeProjectUsageDirectory;
+import com.sensmetry.sysand.model.InterchangeProjectUsageKparPath;
 import com.sensmetry.sysand.model.InterchangeProjectUsageResource;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -181,6 +182,29 @@ public class SetProjectInfoTest {
         assertEquals("../some-dep", d.getDirectory());
         assertEquals("acme", d.getPublisher());
         assertEquals("lib", d.getName());
+    }
+
+    @Test
+    public void testSetProjectInfoWithKparPathUsage() throws Exception {
+        Path dir = initProject();
+
+        InterchangeProjectUsageKparPath usage = new InterchangeProjectUsageKparPath(
+                "deps/lib.kpar", "acme", "lib");
+        InterchangeProjectInfo updated = new InterchangeProjectInfo(
+                "original", "pub", null, "1.0.0", null,
+                new String[]{}, null, new String[]{},
+                new InterchangeProjectUsage[]{usage});
+
+        Sysand.setProjectInfo(dir, updated);
+
+        com.sensmetry.sysand.model.InterchangeProject project = Sysand.infoPath(dir);
+        assertEquals(1, project.info.getUsage().length);
+        assertInstanceOf(InterchangeProjectUsageKparPath.class, project.info.getUsage()[0]);
+        InterchangeProjectUsageKparPath k =
+                (InterchangeProjectUsageKparPath) project.info.getUsage()[0];
+        assertEquals("deps/lib.kpar", k.getKparPath());
+        assertEquals("acme", k.getPublisher());
+        assertEquals("lib", k.getName());
     }
 
     // --- setProjectMetadata ---

--- a/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SysandTestHooks.java
+++ b/bindings/java/java-test/src/test/java/com/sensmetry/sysand/SysandTestHooks.java
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+package com.sensmetry.sysand;
+
+/**
+ * Test-only native entry points. This class lives in the test sources, so
+ * these methods are not part of the published Java API, even though their
+ * implementations ship inside the native library. JNI resolves natives by
+ * the declaring class name, so the Rust side exports them under
+ * {@code Java_com_sensmetry_sysand_SysandTestHooks_*}.
+ */
+final class SysandTestHooks {
+
+    static {
+        // Trigger Sysand's static initializer, which loads the native
+        // library, instead of extracting a second copy via NativeLoader.
+        try {
+            Class.forName(Sysand.class.getName());
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private SysandTestHooks() {
+    }
+
+    /**
+     * Converts the given project to the Rust model types and back, without
+     * touching the filesystem. Exists purely so tests can verify that the
+     * Java model classes stay in sync with the Rust definitions in
+     * {@code core/src/model.rs}.
+     */
+    static native com.sensmetry.sysand.model.InterchangeProject modelRoundtrip(
+            com.sensmetry.sysand.model.InterchangeProjectInfo info,
+            com.sensmetry.sysand.model.InterchangeProjectMetadata metadata);
+}

--- a/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsageKparPath.java
+++ b/bindings/java/java/src/main/java/com/sensmetry/sysand/model/InterchangeProjectUsageKparPath.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+package com.sensmetry.sysand.model;
+
+public class InterchangeProjectUsageKparPath implements InterchangeProjectUsage {
+
+    private String kparPath;
+    private String publisher;
+    private String name;
+
+    public InterchangeProjectUsageKparPath(String kparPath, String publisher, String name) {
+        this.kparPath = kparPath;
+        this.publisher = publisher;
+        this.name = name;
+    }
+
+    public String getKparPath() {
+        return kparPath;
+    }
+
+    public void setKparPath(String kparPath) {
+        this.kparPath = kparPath;
+    }
+
+    public String getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(String publisher) {
+        this.publisher = publisher;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+

--- a/bindings/java/plugin/pom.xml
+++ b/bindings/java/plugin/pom.xml
@@ -112,7 +112,6 @@ SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <showVersion>true</showVersion>
           <streamLogs>true</streamLogs>
-          <filterPom>true</filterPom>
         </configuration>
         <executions>
           <execution>

--- a/bindings/java/plugin/src/main/java/org/sysand/maven/SysandBuildKParMojo.java
+++ b/bindings/java/plugin/src/main/java/org/sysand/maven/SysandBuildKParMojo.java
@@ -13,6 +13,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import com.sensmetry.sysand.model.CompressionMethod;
 
+/**
+ * Mojo that calls {@code Sysand.buildProject} or {@code Sysand.buildWorkspace}
+ * during the package phase.
+ */
 @Mojo(name = "build-kpar", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = false)
 public class SysandBuildKParMojo extends AbstractMojo {
 

--- a/bindings/java/scripts/run_tests.sh
+++ b/bindings/java/scripts/run_tests.sh
@@ -16,3 +16,4 @@ cd "$PACKAGE_DIR"
 cargo test
 python3 scripts/java-builder.py build
 python3 scripts/java-builder.py test
+python3 scripts/java-builder.py build-plugin

--- a/bindings/java/src/conversion.rs
+++ b/bindings/java/src/conversion.rs
@@ -18,6 +18,49 @@ use sysand_core::{
 };
 use sysand_core::{project::local_src::LocalSrcError, utils::format_err};
 
+pub(crate) const STRING: FieldSignature = jni_sig!(java.lang.String);
+pub(crate) const BOOLEAN: FieldSignature = jni_sig!(java.lang.Boolean);
+pub(crate) const LINKED_HASH_MAP: FieldSignature = jni_sig!(java.util.LinkedHashMap);
+pub(crate) const INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsageResource);
+pub(crate) const INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS_CONSTRUCTOR: MethodSignature =
+    jni_sig!((java.lang.String, java.lang.String));
+pub(crate) const INTERCHANGE_PROJECT_USAGE_DIRECTORY_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsageDirectory);
+pub(crate) const INTERCHANGE_PROJECT_USAGE_DIRECTORY_CLASS_CONSTRUCTOR: MethodSignature =
+    jni_sig!((java.lang.String, java.lang.String, java.lang.String));
+pub(crate) const INTERCHANGE_PROJECT_USAGE_KPAR_PATH_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsageKparPath);
+pub(crate) const INTERCHANGE_PROJECT_USAGE_KPAR_PATH_CLASS_CONSTRUCTOR: MethodSignature =
+    jni_sig!((java.lang.String, java.lang.String, java.lang.String));
+pub(crate) const INTERCHANGE_PROJECT_USAGE_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsage);
+pub(crate) const INTERCHANGE_PROJECT_USAGE_CLASS_ARRAY: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsage[]);
+pub(crate) const INTERCHANGE_PROJECT_INFO_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectInfo);
+pub(crate) const INTERCHANGE_PROJECT_INFO_CLASS_CONSTRUCTOR: MethodSignature = jni_sig!((java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String[], java.lang.String, java.lang.String[], com.sensmetry.sysand.model.InterchangeProjectUsage[]));
+pub(crate) const INTERCHANGE_PROJECT_METADATA_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectMetadata);
+pub(crate) const INTERCHANGE_PROJECT_METADATA_CLASS_CONSTRUCTOR: MethodSignature = jni_sig!((
+    java.util.LinkedHashMap,
+    java.lang.String,
+    java.lang.String,
+    java.lang.Boolean,
+    java.lang.Boolean,
+    java.util.LinkedHashMap
+));
+pub(crate) const INTERCHANGE_PROJECT_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProject);
+pub(crate) const INTERCHANGE_PROJECT_CLASS_CONSTRUCTOR: MethodSignature = jni_sig!((
+    com.sensmetry.sysand.model.InterchangeProjectInfo,
+    com.sensmetry.sysand.model.InterchangeProjectMetadata
+));
+pub(crate) const INTERCHANGE_PROJECT_CHECKSUM_CLASS: FieldSignature =
+    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectChecksum);
+pub(crate) const INTERCHANGE_PROJECT_CHECKSUM_CLASS_CONSTRUCTOR: MethodSignature =
+    jni_sig!((java.lang.String, java.lang.String));
+
 /// Unwrap or throw a `RuntimeException` with the given format string
 /// as a message
 macro_rules! unwrap_throw {
@@ -225,6 +268,20 @@ fn get_usage_array_field<'local>(
                 publisher,
                 name,
             });
+        } else if try_instance_of(
+            env,
+            &elem,
+            INTERCHANGE_PROJECT_USAGE_KPAR_PATH_CLASS,
+            &label,
+        )? {
+            let kpar_path = get_string_field(env, &elem, jni_str!("kparPath"))?;
+            let publisher = get_string_field(env, &elem, jni_str!("publisher"))?;
+            let name = get_string_field(env, &elem, jni_str!("name"))?;
+            result.push(InterchangeProjectUsageRaw::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            });
         } else {
             env.throw_runtime_exception(format!("Unknown usage type for `{label}`"));
             return None;
@@ -333,45 +390,6 @@ pub(crate) fn java_metadata_to_raw<'local>(
         checksum,
     })
 }
-
-pub(crate) const STRING: FieldSignature = jni_sig!(java.lang.String);
-pub(crate) const BOOLEAN: FieldSignature = jni_sig!(java.lang.Boolean);
-pub(crate) const LINKED_HASH_MAP: FieldSignature = jni_sig!(java.util.LinkedHashMap);
-pub(crate) const INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsageResource);
-pub(crate) const INTERCHANGE_PROJECT_USAGE_RESOURCE_CLASS_CONSTRUCTOR: MethodSignature =
-    jni_sig!((java.lang.String, java.lang.String));
-pub(crate) const INTERCHANGE_PROJECT_USAGE_DIRECTORY_CLASS: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsageDirectory);
-pub(crate) const INTERCHANGE_PROJECT_USAGE_DIRECTORY_CLASS_CONSTRUCTOR: MethodSignature =
-    jni_sig!((java.lang.String, java.lang.String, java.lang.String));
-pub(crate) const INTERCHANGE_PROJECT_USAGE_CLASS: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsage);
-pub(crate) const INTERCHANGE_PROJECT_USAGE_CLASS_ARRAY: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectUsage[]);
-pub(crate) const INTERCHANGE_PROJECT_INFO_CLASS: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectInfo);
-pub(crate) const INTERCHANGE_PROJECT_INFO_CLASS_CONSTRUCTOR: MethodSignature = jni_sig!((java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String[], java.lang.String, java.lang.String[], com.sensmetry.sysand.model.InterchangeProjectUsage[]));
-pub(crate) const INTERCHANGE_PROJECT_METADATA_CLASS: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectMetadata);
-pub(crate) const INTERCHANGE_PROJECT_METADATA_CLASS_CONSTRUCTOR: MethodSignature = jni_sig!((
-    java.util.LinkedHashMap,
-    java.lang.String,
-    java.lang.String,
-    java.lang.Boolean,
-    java.lang.Boolean,
-    java.util.LinkedHashMap
-));
-pub(crate) const INTERCHANGE_PROJECT_CLASS: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProject);
-pub(crate) const INTERCHANGE_PROJECT_CLASS_CONSTRUCTOR: MethodSignature = jni_sig!((
-    com.sensmetry.sysand.model.InterchangeProjectInfo,
-    com.sensmetry.sysand.model.InterchangeProjectMetadata
-));
-pub(crate) const INTERCHANGE_PROJECT_CHECKSUM_CLASS: FieldSignature =
-    jni_sig!(com.sensmetry.sysand.model.InterchangeProjectChecksum);
-pub(crate) const INTERCHANGE_PROJECT_CHECKSUM_CLASS_CONSTRUCTOR: MethodSignature =
-    jni_sig!((java.lang.String, java.lang.String));
 
 pub(crate) trait ToJObject {
     /// `None` return = exception thrown. Parent must return
@@ -594,6 +612,28 @@ impl ToJObject for InterchangeProjectUsageRaw {
                         ],
                     ),
                     "Failed to create InterchangeProjectUsageDirectory"
+                )
+            }
+            InterchangeProjectUsageRaw::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            } => {
+                let kpar_path = kpar_path.to_jobject(env)?;
+                let publisher = publisher.to_jobject(env)?;
+                let name = name.to_jobject(env)?;
+                unwrap_throw!(
+                    env,
+                    env.new_object(
+                        INTERCHANGE_PROJECT_USAGE_KPAR_PATH_CLASS.sig(),
+                        INTERCHANGE_PROJECT_USAGE_KPAR_PATH_CLASS_CONSTRUCTOR,
+                        &[
+                            JValue::from(&kpar_path),
+                            JValue::from(&publisher),
+                            JValue::from(&name),
+                        ],
+                    ),
+                    "Failed to create InterchangeProjectUsageKparPath"
                 )
             }
         };

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -516,6 +516,31 @@ fn build_workspace<'local>(
     Ok(())
 }
 
+// Test-only hook: the declaring Java class `SysandTestHooks` lives in the
+// java-test sources, not in the published jar, so this entry point is not
+// reachable through the public Java API. For the same reason, it can't be
+// registered in JNI_OnLoad, since the test classes are not included in
+// the release; instead specifying `extern` exports the correctly mangled
+// function name for the JVM to find
+const _: NativeMethod = native_method!(
+    java_type = com.sensmetry.sysand.SysandTestHooks,
+    static extern fn model_roundtrip(info: com.sensmetry.sysand.model.InterchangeProjectInfo, metadata: com.sensmetry.sysand.model.InterchangeProjectMetadata) -> com.sensmetry.sysand.model.InterchangeProject
+);
+fn model_roundtrip<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    info: JObject<'local>,
+    metadata: JObject<'local>,
+) -> JniResult<JObject<'local>> {
+    let Some(info) = java_info_to_raw(env, &info) else {
+        ret_null!()
+    };
+    let Some(metadata) = java_metadata_to_raw(env, &metadata) else {
+        ret_null!()
+    };
+    Ok((info, metadata).to_jobject(env).unwrap_or_default())
+}
+
 /// `JNI_OnLoad` is automatically called by the JVM when the library
 /// is loaded. Do not call this manually.
 ///
@@ -531,14 +556,14 @@ pub unsafe extern "system" fn JNI_OnLoad(
     let vm = unsafe { JavaVM::from_raw(vm_ptr) };
 
     let registration_result = vm.attach_current_thread(|env| {
-        let class = env.load_class(jni_str!("com.sensmetry.sysand.Sysand"))?;
+        let sysand = env.load_class(jni_str!("com.sensmetry.sysand.Sysand"))?;
         // SAFETY: `native_method!()` checks signatures to match intended on the Rust side,
         //         and also checks that `class`/`this` arguments are correct.
         //         Function names/args might not match those in Java, these will be checked
         //         and error out on mismatch.
         unsafe {
             env.register_native_methods(
-                class,
+                sysand,
                 &[
                     SYSAND_INIT,
                     SYSAND_BUILD_PROJECT,
@@ -564,7 +589,7 @@ pub unsafe extern "system" fn JNI_OnLoad(
         }
         Err(e) => {
             eprintln!(
-                "failed to attach to Java VM or register native methods: {}",
+                "error: failed to attach to Java VM or register native methods:\n{}",
                 format_err(e)
             );
             // Registration failed, return JNI_ERR to abort library loading

--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: © 2025-2026 Sysand contributors <opensource@sensmetry.com>
 
 from ._model import (
+    InterchangeProjectUsageResource,
+    InterchangeProjectUsageDirectory,
+    InterchangeProjectUsageKparPath,
     InterchangeProjectUsage,
     InterchangeProjectInfo,
     InterchangeProjectChecksum,
@@ -47,6 +50,9 @@ from ._root import (
 )
 
 __all__ = [
+    "InterchangeProjectUsageResource",
+    "InterchangeProjectUsageDirectory",
+    "InterchangeProjectUsageKparPath",
     "InterchangeProjectUsage",
     "InterchangeProjectInfo",
     "InterchangeProjectChecksum",

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -3,15 +3,37 @@
 
 from enum import Enum, auto
 import typing
-import datetime
+
+# Use raw types for components, as these classes are converted
+# to/from Rust `*Raw` model type variants
 
 
-class InterchangeProjectUsage(typing.TypedDict):
+class InterchangeProjectUsageResource(typing.TypedDict):
     resource: str
     version_constraint: typing.Optional[str]
 
 
+class InterchangeProjectUsageDirectory(typing.TypedDict):
+    dir: str
+    publisher: str
+    name: str
+
+
+class InterchangeProjectUsageKparPath(typing.TypedDict):
+    kpar_path: str
+    publisher: str
+    name: str
+
+
+InterchangeProjectUsage = typing.Union[
+    InterchangeProjectUsageResource,
+    InterchangeProjectUsageDirectory,
+    InterchangeProjectUsageKparPath,
+]
+
+
 class InterchangeProjectInfo(typing.TypedDict):
+    publisher: typing.Optional[str]
     name: str
     description: typing.Optional[str]
     version: str
@@ -29,11 +51,11 @@ class InterchangeProjectChecksum(typing.TypedDict):
 
 class InterchangeProjectMetadata(typing.TypedDict):
     index: typing.Dict[str, str]
-    created: datetime.datetime
+    created: str
     metamodel: typing.Optional[str]
     includes_derived: typing.Optional[bool]
     includes_implied: typing.Optional[bool]
-    checksum: typing.Optional[typing.List[InterchangeProjectChecksum]]
+    checksum: typing.Optional[typing.Dict[str, InterchangeProjectChecksum]]
 
 
 class Dependencies(Enum):
@@ -63,6 +85,9 @@ class CompressionMethod(Enum):
 
 
 __all__ = [
+    "InterchangeProjectUsageResource",
+    "InterchangeProjectUsageDirectory",
+    "InterchangeProjectUsageKparPath",
     "InterchangeProjectUsage",
     "InterchangeProjectInfo",
     "InterchangeProjectChecksum",

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -8,6 +8,7 @@ use fluent_uri::Iri;
 use pyo3::{
     exceptions::{PyFileExistsError, PyFileNotFoundError, PyIOError, PyRuntimeError, PyValueError},
     prelude::*,
+    types::PyAny,
 };
 use semver::{Version, VersionReq};
 use sysand_core::{
@@ -30,7 +31,10 @@ use sysand_core::{
     index_location::IndexLocation,
     info::{InfoProjectError, do_info, do_info_project},
     init::InitError,
-    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw, InterchangeProjectUsage},
+    model::{
+        InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw,
+        InterchangeProjectUsage, InterchangeProjectUsageRaw,
+    },
     project::{
         ProjectRead as _,
         local_kpar::{KparInnerPath, LocalKParProject},
@@ -541,7 +545,7 @@ fn do_env_install_path_py(env_path: String, iri: String, location: String) -> Py
     let metadata =
         wrapfs::metadata(&location).map_err(|e| PyErr::new::<PyIOError, _>(format_err(e)))?;
     if metadata.is_file() {
-        let project = LocalKParProject::new(&location, KparInnerPath::Guess, None, None);
+        let project = LocalKParProject::new_access(&location, KparInnerPath::Guess, None);
 
         let Some(version) = project
             .version()
@@ -595,6 +599,7 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_init_py_local_file, m)?)?;
     m.add_function(wrap_pyfunction!(do_env_py_local_dir, m)?)?;
     m.add_function(wrap_pyfunction!(do_info_py_path, m)?)?;
+    m.add_function(wrap_pyfunction!(do_model_roundtrip_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_info_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_root_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_build_py, m)?)?;
@@ -617,4 +622,78 @@ fn env_read_to_pyerr(err: EnvMetadataError) -> PyErr {
         "failed to read environment metadata: {}",
         format_err(err)
     ))
+}
+
+// Test-only helper: converts the python dicts to the Rust model types and
+// back, so tests can verify that the typed dicts in `_model.py` stay in sync
+// with `core/src/model.rs`. It cannot be compiled out of
+// release wheels because CI runs pytest against the wheels it ships.
+#[pyfunction(name = "_do_model_roundtrip_py")]
+#[pyo3(
+    signature = (info, metadata),
+)]
+fn do_model_roundtrip_py(
+    info: &Bound<'_, PyAny>,
+    metadata: &Bound<'_, PyAny>,
+) -> PyResult<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
+    Ok((info.extract()?, metadata.extract()?))
+}
+
+// Break the build when core types gain, lose, or rename a field/variant,
+// since the typed dicts in `_model.py` cannot catch that on their own and
+// must be updated together with this match.
+// If this breaks, look if types in other bindings also need to be updated.
+#[expect(unused)]
+fn info_and_metadata_fields_guard(
+    info: InterchangeProjectInfoRaw,
+    meta: InterchangeProjectMetadataRaw,
+) {
+    let InterchangeProjectInfoRaw {
+        name,
+        publisher,
+        description,
+        version,
+        license,
+        maintainer,
+        website,
+        topic,
+        usage,
+    } = info;
+
+    for usage in usage {
+        match usage {
+            InterchangeProjectUsageRaw::Resource {
+                resource,
+                version_constraint,
+            } => {}
+            InterchangeProjectUsageRaw::Directory {
+                dir,
+                publisher,
+                name,
+            } => {}
+            InterchangeProjectUsageRaw::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            } => {}
+        }
+    }
+
+    let InterchangeProjectMetadataRaw {
+        index,
+        created,
+        metamodel,
+        includes_derived,
+        includes_implied,
+        checksum,
+    } = meta;
+
+    match checksum {
+        Some(c) => {
+            for (path, cksum) in c {
+                let InterchangeProjectChecksumRaw { value, algorithm } = cksum;
+            }
+        }
+        None => todo!(),
+    }
 }

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -199,6 +199,57 @@ def test_index_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) ->
     assert meta["checksum"] is None
 
 
+def test_model_roundtrip() -> None:
+    # Round-trips the typed dicts through the Rust model types
+    from sysand._sysand_core import _do_model_roundtrip_py  # type: ignore
+
+    info: sysand.InterchangeProjectInfo = {
+        "name": "roundtrip-project",
+        "publisher": "acme",
+        "description": "A project with every exposed info field",
+        "version": "1.2.3",
+        "license": "MIT",
+        "maintainer": ["Alice", "Bob"],
+        "website": "https://example.com/roundtrip",
+        "topic": ["sysml", "bindings"],
+        "usage": [
+            sysand.InterchangeProjectUsageResource(
+                resource="pkg:sysand/acme/remote-lib",
+                version_constraint=">=1.0.0",
+            ),
+            sysand.InterchangeProjectUsageDirectory(
+                dir="../local-lib", publisher="local-pub", name="local-lib"
+            ),
+            sysand.InterchangeProjectUsageKparPath(
+                kpar_path="deps/archive-lib.kpar",
+                publisher="archive-pub",
+                name="archive-lib",
+            ),
+        ],
+    }
+
+    metadata: sysand.InterchangeProjectMetadata = {
+        "index": {"Alpha": "src/Alpha.sysml", "Beta": "src/nested/Beta.kerml"},
+        "created": "2026-01-02T03:04:05Z",
+        "metamodel": "https://www.omg.org/spec/SysML/20250201",
+        "includes_derived": True,
+        "includes_implied": False,
+        "checksum": {
+            "src/Alpha.sysml": sysand.InterchangeProjectChecksum(
+                value="0123456789abcdef", algorithm="MD5"
+            ),
+            "src/nested/Beta.kerml": sysand.InterchangeProjectChecksum(
+                value="deadbeef", algorithm="ADLER32"
+            ),
+        },
+    }
+
+    roundtripped_info, roundtripped_metadata = _do_model_roundtrip_py(info, metadata)
+
+    assert roundtripped_info == info
+    assert roundtripped_metadata == metadata
+
+
 def compare_sources(
     sources: Union[List[Path], List[str]],
     expected_sources: Union[List[Path], List[str]],

--- a/core/src/commands/add.rs
+++ b/core/src/commands/add.rs
@@ -69,6 +69,40 @@ pub fn do_add_guess<P: ProjectMut>(
     do_add(project, &usage_raw)
 }
 
+/// Common merge logic for path-like usages (`Directory`, `KparPath`): if an
+/// existing usage matches `new_publisher`/`new_name`, update its path; if it
+/// matches `new_path` instead, overwrite its publisher/name. Returns `true`
+/// if a match was found and merged (and thus the new usage should not be
+/// added separately), or `false` if there was no match.
+fn try_merge_path_usage(
+    noun: &str,
+    path: &mut String,
+    publisher: &mut String,
+    name: &mut String,
+    new_path: &str,
+    new_publisher: &str,
+    new_name: &str,
+) -> bool {
+    if publisher == new_publisher && name == new_name {
+        log::warn!(
+            "usage `{publisher}`/`{name}` is already present;\n\
+            {SP:>8} it will be updated to point to `{new_path}`"
+        );
+        *path = new_path.to_owned();
+        true
+    } else if path == new_path {
+        log::warn!(
+            "existing usage `{publisher}`/`{name}` already points to {noun}
+            {SP:>8} `{path}`; existing usage will be overwritten"
+        );
+        *publisher = new_publisher.to_owned();
+        *name = new_name.to_owned();
+        true
+    } else {
+        false
+    }
+}
+
 /// Ok(true) => usage added to project info
 /// Ok(false) => usage already present in project info
 pub fn do_add<P: ProjectMut>(
@@ -150,31 +184,54 @@ pub fn do_add<P: ProjectMut>(
                 publisher: new_publisher,
                 name: new_name,
             } => {
+                // It might be desirable to merge different path-like usages
+                // (`file:`, dir, kpar_path) or alternatively error out if
+                // a path-like usage of that path already exists, but it is not
+                // currently done.
                 for u in info.usage.iter_mut() {
                     if let InterchangeProjectUsageRaw::Directory {
                         dir,
                         publisher,
                         name,
                     } = u
+                        && try_merge_path_usage(
+                            "path",
+                            dir,
+                            publisher,
+                            name,
+                            new_dir,
+                            new_publisher,
+                            new_name,
+                        )
                     {
-                        if publisher == new_publisher && name == new_name {
-                            log::warn!(
-                                "usage `{publisher}`/`{name}` is already present;\n\
-                                {SP:>8} it will be updated to point to `{new_dir}`"
-                            );
-                            *dir = new_dir.to_owned();
-                            dont_add = true;
-                            break;
-                        } else if dir == new_dir {
-                            log::warn!(
-                                "existing usage `{publisher}`/`{name}` already points to path
-                                {SP:>8} `{dir}`; existing usage will be overwritten"
-                            );
-                            *publisher = new_publisher.to_owned();
-                            *name = new_name.to_owned();
-                            dont_add = true;
-                            break;
-                        }
+                        dont_add = true;
+                        break;
+                    }
+                }
+            }
+            InterchangeProjectUsageRaw::KparPath {
+                kpar_path: new_kpar_path,
+                publisher: new_publisher,
+                name: new_name,
+            } => {
+                for u in info.usage.iter_mut() {
+                    if let InterchangeProjectUsageRaw::KparPath {
+                        kpar_path,
+                        publisher,
+                        name,
+                    } = u
+                        && try_merge_path_usage(
+                            "file",
+                            kpar_path,
+                            publisher,
+                            name,
+                            new_kpar_path,
+                            new_publisher,
+                            new_name,
+                        )
+                    {
+                        dont_add = true;
+                        break;
                     }
                 }
             }

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -314,6 +314,11 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
                 publisher: _,
                 name: _,
             } => Some(dir),
+            InterchangeProjectUsageRaw::KparPath {
+                kpar_path,
+                publisher: _,
+                name: _,
+            } => Some(kpar_path),
         }
     }) {
         if allow_path_usage {

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -28,8 +28,8 @@ use crate::{
     include::{IncludeError, extract_symbols},
     index_location::IndexLocation,
     model::{
-        InterchangeProjectUsageRaw, InterchangeProjectValidationError, KERML_METAMODEL_PREFIX,
-        KerMlChecksumAlg, SYSML_METAMODEL_PREFIX,
+        InterchangeProjectUsageRaw, InterchangeProjectValidationError, KERML_SPEC_PREFIX,
+        KerMlChecksumAlg, SYSML_SPEC_PREFIX,
     },
     project::{
         ProjectRead,
@@ -1386,8 +1386,8 @@ pub fn prepare_publish_payload(path: &Utf8Path) -> Result<PublishPreparation, Pu
 /// `Err` - invalid SysML/KerML or other
 fn check_metamodel(metamodel: &str) -> Result<AllowedMetamodelKind, PublishError> {
     for (prefix, kind) in [
-        (SYSML_METAMODEL_PREFIX, AllowedMetamodelKind::SysML),
-        (KERML_METAMODEL_PREFIX, AllowedMetamodelKind::KerML),
+        (SYSML_SPEC_PREFIX, AllowedMetamodelKind::SysML),
+        (KERML_SPEC_PREFIX, AllowedMetamodelKind::KerML),
     ] {
         if let Some(metamodel_version) = metamodel.strip_prefix(prefix) {
             if is_valid_metamodel_version(metamodel_version) {
@@ -1533,15 +1533,9 @@ const SYSML_STD_LIB_SUFFIXES: [&str; 7] = [
 /// A resource usage can be either `pkg:sysand/` or an std lib
 // TODO: be case insensitive
 fn check_usage(usage: &InterchangeProjectUsageRaw) -> Result<(), PublishError> {
-    if check_std_libs(
-        usage,
-        &SYSML_STD_LIB_SUFFIXES,
-        "https://www.omg.org/spec/SysML/",
-    )? || check_std_libs(
-        usage,
-        &KERML_STD_LIB_SUFFIXES,
-        "https://www.omg.org/spec/KerML/",
-    )? {
+    if check_std_libs(usage, &SYSML_STD_LIB_SUFFIXES, SYSML_SPEC_PREFIX)?
+        || check_std_libs(usage, &KERML_STD_LIB_SUFFIXES, KERML_SPEC_PREFIX)?
+    {
         return Ok(());
     }
 
@@ -1560,6 +1554,9 @@ fn check_usage(usage: &InterchangeProjectUsageRaw) -> Result<(), PublishError> {
         }
         InterchangeProjectUsageRaw::Directory { dir, .. } => Err(PublishError::PathUsage {
             path: dir.as_str().into(),
+        }),
+        InterchangeProjectUsageRaw::KparPath { kpar_path, .. } => Err(PublishError::PathUsage {
+            path: kpar_path.as_str().into(),
         }),
     }
 }
@@ -1602,7 +1599,8 @@ fn check_std_libs(
             }
             Ok(false)
         }
-        InterchangeProjectUsageRaw::Directory { .. } => Ok(false),
+        InterchangeProjectUsageRaw::Directory { .. }
+        | InterchangeProjectUsageRaw::KparPath { .. } => Ok(false),
     }
 }
 

--- a/core/src/commands/sync.rs
+++ b/core/src/commands/sync.rs
@@ -123,7 +123,8 @@ where
     SrcPathStorage: ProjectRead,
     CreateRemoteSrcStorage: Fn(String, String) -> Result<RemoteSrcStorage, UrlParseError>,
     RemoteSrcStorage: ProjectRead,
-    CreateKParPathStorage: Fn(String, NonZeroU64, String) -> KParPathStorage,
+    CreateKParPathStorage:
+        Fn(Utf8UnixPathBuf, NonZeroU64, String, Option<String>, String) -> KParPathStorage,
     KParPathStorage: ProjectRead,
     CreateRemoteKParStorage:
         Fn(String, NonZeroU64, String) -> Result<RemoteKParStorage, UrlParseError>,
@@ -257,9 +258,11 @@ where
                         SyncError::MissingLocalKparStorage(kpar_path.as_str().into())
                     })?;
                     let storage = kpar_path_storage(
-                        kpar_path.as_str().to_owned(),
+                        kpar_path.clone(),
                         *kpar_size,
                         kpar_digest.to_owned(),
+                        project.publisher.clone(),
+                        project.name.clone(),
                     );
                     log::debug!("trying to install `{uri}` from kpar_path: {kpar_path}");
                     try_install(

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
+//! Core types for interchange projects. Originally matched KerML 1.0 spec,
+//! but now includes various changes.
+//!
+//! IMPORTANT: when updating any of these types, update the corresponding
+//! bindings' types (in `_model.py` for Python and various Java classes)
+
 use std::{clone::Clone, collections::HashSet, fmt::Display, hash::Hash};
 
 use digest::array::{Array, typenum};
@@ -24,8 +30,10 @@ pub const KNOWN_METAMODELS: [&str; 2] = [
     "https://www.omg.org/spec/KerML/20250201",
 ];
 
-pub const SYSML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/SysML/";
-pub const KERML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/KerML/";
+/// Prefix shared between SysML v2 metamodel and standard libs
+pub const SYSML_SPEC_PREFIX: &str = "https://www.omg.org/spec/SysML/";
+/// Prefix shared between KerML metamodel and standard libs
+pub const KERML_SPEC_PREFIX: &str = "https://www.omg.org/spec/KerML/";
 
 /// A dependency on another interchange project. In the dependency solver,
 /// usages are treated as referring to the same project iff they derive the
@@ -33,7 +41,11 @@ pub const KERML_METAMODEL_PREFIX: &str = "https://www.omg.org/spec/KerML/";
 /// all usages of that identifier accept (in particular, it satisfies
 /// all version constraints)
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Hash, Debug)]
-#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+#[cfg_attr(
+    feature = "python",
+    derive(FromPyObject, IntoPyObject),
+    pyo3(from_item_all)
+)]
 #[serde(untagged)]
 pub enum InterchangeProjectUsageG<Iri, VersionReq, Path> {
     /// Untyped usage, the only shape KerML 1.0 specifies. Kept for
@@ -48,6 +60,7 @@ pub enum InterchangeProjectUsageG<Iri, VersionReq, Path> {
     // `rename_all` does not apply to enum variant fields if applied on
     // the whole enum
     #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "python", pyo3(from_item_all))]
     Resource {
         resource: Iri, // TODO: We should have a fallback for invalid IRIs
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,8 +71,18 @@ pub enum InterchangeProjectUsageG<Iri, VersionReq, Path> {
     /// actual values found at `dir`, without any normalization.
     /// No version constraint, as the directory contains a single version
     // TODO: should absolute paths also be supported (like Cargo)?
+    #[cfg_attr(feature = "python", pyo3(from_item_all))]
     Directory {
         dir: Path,
+        publisher: String,
+        name: String,
+    },
+    /// The project KPAR at `kpar_path`, relative to the root of
+    /// the project declaring the usage.
+    /// Project must be at the archive root
+    #[cfg_attr(feature = "python", pyo3(from_item_all))]
+    KparPath {
+        kpar_path: Path,
         publisher: String,
         name: String,
     },
@@ -73,7 +96,7 @@ impl InterchangeProjectUsageRaw {
     /// Caller is responsible for identifying the project when reporting the error
     pub fn validate(&self) -> Result<InterchangeProjectUsage, InterchangeProjectValidationError> {
         match self {
-            InterchangeProjectUsageG::Resource {
+            InterchangeProjectUsageRaw::Resource {
                 resource,
                 version_constraint,
             } => {
@@ -109,13 +132,29 @@ impl InterchangeProjectUsageRaw {
                         .transpose()?,
                 })
             }
-            InterchangeProjectUsageG::Directory {
+            InterchangeProjectUsageRaw::Directory {
                 dir: path,
                 publisher,
                 name,
             } => match parse_relative_unix_path(path, RelativePathKind::Directory) {
-                Ok(p) => Ok(InterchangeProjectUsageG::Directory {
+                Ok(p) => Ok(InterchangeProjectUsage::Directory {
                     dir: p.to_owned(),
+                    publisher: publisher.clone(),
+                    name: name.clone(),
+                }),
+                Err(e) => Err(InterchangeProjectValidationError::InvalidUsagePath {
+                    publisher: publisher.clone(),
+                    name: name.clone(),
+                    source: e,
+                }),
+            },
+            InterchangeProjectUsageRaw::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            } => match parse_relative_unix_path(kpar_path, RelativePathKind::File) {
+                Ok(p) => Ok(InterchangeProjectUsage::KparPath {
+                    kpar_path: p.to_owned(),
                     publisher: publisher.clone(),
                     name: name.clone(),
                 }),
@@ -133,10 +172,7 @@ impl<Iri, VersionReq, Path> InterchangeProjectUsageG<Iri, VersionReq, Path> {
     /// Typed usages (all non-`Resource`) are treated specially in some places,
     /// as e.g. if they resolve to invalid projects, it can't be ignored
     pub fn is_typed(&self) -> bool {
-        match self {
-            InterchangeProjectUsageG::Resource { .. } => false,
-            InterchangeProjectUsageG::Directory { .. } => true,
-        }
+        !matches!(self, InterchangeProjectUsageG::Resource { .. })
     }
 }
 
@@ -156,6 +192,15 @@ impl From<InterchangeProjectUsage> for InterchangeProjectUsageRaw {
                 name,
             } => InterchangeProjectUsageRaw::Directory {
                 dir: dir.into_string(),
+                publisher,
+                name,
+            },
+            InterchangeProjectUsage::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            } => InterchangeProjectUsageRaw::KparPath {
+                kpar_path: kpar_path.into_string(),
                 publisher,
                 name,
             },
@@ -190,6 +235,15 @@ impl From<InterchangeProjectUsageG<fluent_uri::Iri<String>, semver::VersionReq, 
                 publisher,
                 name,
             },
+            InterchangeProjectUsageG::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            } => InterchangeProjectUsageG::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            },
         }
     }
 }
@@ -215,13 +269,24 @@ impl<Iri: Display, VersionReq: Display, Path: Display> Display
             } => {
                 write!(f, "`{publisher}/{name}` from `{dir}`")?;
             }
+            InterchangeProjectUsageG::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            } => {
+                write!(f, "`{publisher}/{name}` in `{kpar_path}`")?;
+            }
         }
         Ok(())
     }
 }
 
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+#[cfg_attr(
+    feature = "python",
+    derive(FromPyObject, IntoPyObject),
+    pyo3(from_item_all)
+)]
 #[serde(rename_all = "camelCase")]
 pub struct InterchangeProjectInfoG<Iri, Version, VersionReq, Path> {
     pub name: String,
@@ -324,6 +389,11 @@ impl<Iri: PartialEq + Clone, Version, VersionReq: Clone, Path>
                 InterchangeProjectUsageG::Resource { .. } => false,
                 InterchangeProjectUsageG::Directory {
                     dir: _,
+                    publisher: p,
+                    name: n,
+                }
+                | InterchangeProjectUsageG::KparPath {
+                    kpar_path: _,
                     publisher: p,
                     name: n,
                 } => p == publisher && n == name,
@@ -515,7 +585,11 @@ impl KerMlChecksumAlg {
 }
 
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+#[cfg_attr(
+    feature = "python",
+    derive(FromPyObject, IntoPyObject),
+    pyo3(from_item_all)
+)]
 #[serde(rename_all = "camelCase")]
 pub struct InterchangeProjectChecksum {
     // TODO: use Vec<u8> or Box<[u8]> and store raw hash bytes
@@ -524,7 +598,11 @@ pub struct InterchangeProjectChecksum {
 }
 
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+#[cfg_attr(
+    feature = "python",
+    derive(FromPyObject, IntoPyObject),
+    pyo3(from_item_all)
+)]
 #[serde(rename_all = "camelCase")]
 pub struct InterchangeProjectChecksumRaw {
     pub value: String,
@@ -532,7 +610,11 @@ pub struct InterchangeProjectChecksumRaw {
 }
 
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "python", derive(FromPyObject, IntoPyObject))]
+#[cfg_attr(
+    feature = "python",
+    derive(FromPyObject, IntoPyObject),
+    pyo3(from_item_all)
+)]
 #[serde(rename_all = "camelCase")]
 pub struct InterchangeProjectMetadataG<Iri, Path: Eq + Hash, DateTime, IPC> {
     pub index: IndexMap<String, Path>,

--- a/core/src/project/any.rs
+++ b/core/src/project/any.rs
@@ -81,11 +81,10 @@ impl<Policy: HTTPAuthentication> AnyProject<Policy> {
                 ))
             }
             OverrideSource::LocalKpar { kpar_path } => {
-                Ok(AnyProject::LocalKpar(LocalKParProject::new(
+                Ok(AnyProject::LocalKpar(LocalKParProject::new_access(
                     project_root.as_ref().join(kpar_path.as_str()),
                     KparInnerPath::Guess,
                     Some(kpar_path),
-                    None,
                 )))
             }
             OverrideSource::LocalSrc { src_path } => {

--- a/core/src/project/local_kpar.rs
+++ b/core/src/project/local_kpar.rs
@@ -62,15 +62,18 @@ pub struct LocalKParProject {
     /// to the lockfile.
     // TODO: Consider removing this and replacing it with some way of
     // relativizing `archive_path` at the call site of .sources().
-    pub nominal_path: Option<Utf8UnixPathBuf>,
+    nominal_path: Option<Utf8UnixPathBuf>,
     /// Path used when locating the project archive internally.
     /// Should be absolute.
     archive_path: Utf8PathBuf,
     expected: Option<KparMeta>,
+    // Separate from `expected`, since usages know publisher+name,
+    // but not size/checksum
+    expected_pub_name: Option<(Option<String>, String)>,
     /// Optionally specify name of project directory inside archive.
     /// If none, currently always tries to guess before reading
     /// any project files.
-    pub root: KparInnerPath,
+    root: KparInnerPath,
     init: OnceCell<(LocalKParProjectRaw, KparMeta)>,
 }
 
@@ -117,6 +120,19 @@ pub enum LocalKParError {
     },
     #[error("kpar at `{path}` is an empty file")]
     EmptyKpar { path: Box<str> },
+    #[error(
+        "project publisher `{}` does not match expected `{}`",
+        if let Some(a) = actual { a.as_str() } else { "<none>" },
+        if let Some(p) = expected { p.as_str() } else { "<none>" }
+    )]
+    PublisherMismatch {
+        expected: Option<String>,
+        actual: Option<String>,
+    },
+    #[error("project name `{actual}` does not match expected `{expected}`")]
+    NameMismatch { expected: String, actual: String },
+    #[error("project is missing project information file `.project.json`")]
+    MissingInfo,
 }
 
 impl From<FsIoError> for LocalKParError {
@@ -148,18 +164,56 @@ impl<ReadError> From<FsIoError> for IntoKparError<ReadError> {
 }
 
 impl LocalKParProject {
-    pub fn new<P: AsRef<Utf8Path>>(
-        path: P,
+    /// Access the project. No invariants will be checked. If `nominal_path` is provided,
+    /// `sources()` will work.
+    pub fn new_access(
+        path: impl Into<Utf8PathBuf>,
         root: KparInnerPath,
-        nominal: Option<Utf8UnixPathBuf>,
-        expected: Option<KparMeta>,
-    ) -> Self {
+        nominal_path: Option<Utf8UnixPathBuf>,
+    ) -> LocalKParProject {
         LocalKParProject {
-            nominal_path: nominal,
+            nominal_path,
             root,
             init: OnceCell::new(),
-            archive_path: path.to_path_buf(),
+            archive_path: path.into(),
+            expected: None,
+            expected_pub_name: None,
+        }
+    }
+
+    /// Assumes the project is at archive root
+    pub fn new_for_solve(
+        path: impl Into<Utf8PathBuf>,
+        nominal_path: Option<Utf8UnixPathBuf>,
+        publisher: Option<String>,
+        name: String,
+    ) -> LocalKParProject {
+        LocalKParProject {
+            nominal_path,
+            root: KparInnerPath::Root,
+            init: OnceCell::new(),
+            archive_path: path.into(),
+            expected: None,
+            expected_pub_name: Some((publisher, name)),
+        }
+    }
+
+    /// Construct from lockfile information, where everything is known
+    pub fn new_for_sync(
+        path: impl Into<Utf8PathBuf>,
+        root: KparInnerPath,
+        nominal_path: Option<Utf8UnixPathBuf>,
+        publisher: Option<String>,
+        name: String,
+        expected: Option<KparMeta>,
+    ) -> LocalKParProject {
+        LocalKParProject {
+            nominal_path,
+            root,
+            init: OnceCell::new(),
+            archive_path: path.into(),
             expected,
+            expected_pub_name: Some((publisher, name)),
         }
     }
 
@@ -176,6 +230,7 @@ impl LocalKParProject {
             None => {
                 let (inner, meta) =
                     LocalKParProjectRaw::new_hash(&self.archive_path, self.root.to_owned())?;
+                // TODO: move these sorts of checks out of this type
                 if let Some(expected) = &self.expected {
                     if meta.size_bytes != expected.size_bytes {
                         return Err(LocalKParError::SizeMismatch {
@@ -188,6 +243,24 @@ impl LocalKParProject {
                             path: self.archive_path.as_str().into(),
                             expected: expected.sha256_hex.to_owned(),
                             computed: meta.sha256_hex,
+                        });
+                    }
+                }
+                // No need to check publisher/name if checksum is already verified,
+                // but this will ensure that e.g. lockfile is accurate
+                if let Some((expected_publisher, expected_name)) = &self.expected_pub_name {
+                    let Some(info) = inner.get_info()? else {
+                        return Err(LocalKParError::MissingInfo);
+                    };
+                    if expected_publisher != &info.publisher {
+                        return Err(LocalKParError::PublisherMismatch {
+                            expected: expected_publisher.to_owned(),
+                            actual: info.publisher,
+                        });
+                    } else if expected_name != &info.name {
+                        return Err(LocalKParError::NameMismatch {
+                            expected: expected_name.to_owned(),
+                            actual: info.name,
                         });
                     }
                 }
@@ -286,7 +359,7 @@ impl ProjectRead for LocalKParProject {
     fn project_root(&self) -> Option<&Utf8Path> {
         // TODO: is this appropriate? KPAR is not really meant
         // to be tied to a specific folder
-        Some(&self.archive_path)
+        None
     }
 }
 

--- a/core/src/project/local_kpar_tests.rs
+++ b/core/src/project/local_kpar_tests.rs
@@ -33,7 +33,7 @@ fn basic_kpar_archive() -> Result<(), Box<dyn std::error::Error>> {
         zip.finish().unwrap();
     }
 
-    let project = super::LocalKParProject::new(zip_path, KparInnerPath::Guess, None, None);
+    let project = super::LocalKParProject::new_access(zip_path, KparInnerPath::Guess, None);
 
     let (Some(info), Some(meta)) = project.get_project()? else {
         panic!();
@@ -76,7 +76,7 @@ fn nested_kpar_archive() -> Result<(), Box<dyn std::error::Error>> {
         zip.finish().unwrap();
     }
 
-    let project = super::LocalKParProject::new(zip_path, KparInnerPath::Guess, None, None);
+    let project = super::LocalKParProject::new_access(zip_path, KparInnerPath::Guess, None);
 
     let (Some(info), Some(meta)) = project.get_project()? else {
         panic!();
@@ -92,6 +92,55 @@ fn nested_kpar_archive() -> Result<(), Box<dyn std::error::Error>> {
         .read_to_string(&mut src)?;
 
     assert_eq!(src, "package Test;");
+
+    Ok(())
+}
+
+#[test]
+fn expected_pub_name_check() -> Result<(), Box<dyn std::error::Error>> {
+    let cwd = tempdir()?;
+    let zip_path = cwd.path().join("test.kpar");
+
+    {
+        let file = std::fs::File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+
+        let options = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .unix_permissions(0o755);
+
+        zip.start_file(".project.json", options)?;
+        zip.write_all(
+            br#"{"publisher":"acme","name":"expected_pub_name_check","version":"1.2.3"}"#,
+        )?;
+        zip.start_file(".meta.json", options)?;
+        zip.write_all(br#"{"index":{},"created":"123"}"#)?;
+
+        zip.finish().unwrap();
+    }
+
+    let project = super::LocalKParProject::new_for_solve(
+        &zip_path,
+        None,
+        Some("acme".to_owned()),
+        "expected_pub_name_check".to_owned(),
+    );
+
+    let (Some(info), Some(_meta)) = project.get_project()? else {
+        panic!();
+    };
+    assert_eq!(info.name, "expected_pub_name_check");
+
+    let mismatched = super::LocalKParProject::new_for_solve(
+        &zip_path,
+        None,
+        Some("acme".to_owned()),
+        "wrong-name".to_owned(),
+    );
+    assert!(matches!(
+        mismatched.get_info(),
+        Err(super::LocalKParError::NameMismatch { .. })
+    ));
 
     Ok(())
 }

--- a/core/src/project/local_src.rs
+++ b/core/src/project/local_src.rs
@@ -82,7 +82,7 @@ impl LocalSrcProject {
         }
     }
 
-    /// Construct lockfile information, where everything is known
+    /// Construct from lockfile information, where everything is known
     pub fn new_for_sync(
         path: impl Into<Utf8PathBuf>,
         nominal_path: Option<Utf8UnixPathBuf>,

--- a/core/src/project/reference_tests.rs
+++ b/core/src/project/reference_tests.rs
@@ -7,10 +7,9 @@ use crate::project::{
 };
 #[test]
 fn project_reference_is_cloneable() {
-    let kpar = ProjectReference::new(LocalKParProject::new(
+    let kpar = ProjectReference::new(LocalKParProject::new_access(
         "path",
         KparInnerPath::Known("root".into()),
-        None,
         None,
     ));
     let _clone = kpar.clone();

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -553,6 +553,9 @@ impl From<&InterchangeProjectUsage> for Identifier {
             }
             InterchangeProjectUsage::Directory {
                 publisher, name, ..
+            }
+            | InterchangeProjectUsage::KparPath {
+                publisher, name, ..
             } => (publisher, name),
         };
         Self::make_identifier_iri(publisher, name)
@@ -566,6 +569,9 @@ impl From<InterchangeProjectUsage> for Identifier {
                 return Self(resource.into_string());
             }
             InterchangeProjectUsage::Directory {
+                publisher, name, ..
+            }
+            | InterchangeProjectUsage::KparPath {
                 publisher, name, ..
             } => (publisher, name),
         };
@@ -584,6 +590,9 @@ impl Identifier {
                 return Self(resource.to_string());
             }
             InterchangeProjectUsageRaw::Directory {
+                publisher, name, ..
+            }
+            | InterchangeProjectUsageRaw::KparPath {
                 publisher, name, ..
             } => (publisher, name),
         };

--- a/core/src/project/utils_tests.rs
+++ b/core/src/project/utils_tests.rs
@@ -234,6 +234,19 @@ fn identifier_from_directory_usage_arbitrary_publisher_gives_urn() {
 }
 
 #[test]
+fn identifier_from_kpar_path_usage_purl_safe() {
+    let usage = InterchangeProjectUsage::KparPath {
+        kpar_path: Utf8UnixPathBuf::from("dep.kpar"),
+        publisher: "acme-corp".to_owned(),
+        name: "my-lib".to_owned(),
+    };
+    assert_eq!(
+        Identifier::from(usage).as_str(),
+        "pkg:sysand/acme-corp/my-lib"
+    );
+}
+
+#[test]
 fn identifier_from_interchange_usage_unchecked_resource() {
     let usage = InterchangeProjectUsageRaw::Resource {
         resource: "urn:kpar:test".to_owned(),

--- a/core/src/resolve/combined.rs
+++ b/core/src/resolve/combined.rs
@@ -21,7 +21,7 @@ use crate::{
 /// The logic is as follows:
 /// 1. Do not resolve any further if file_resolver is successful, or rejected the usage
 ///    (i.e. it is a path). NotFound allows fallthrough to other resolvers mainly to
-///    accomodate environment resolver, which may resolve the usage by its identifier only
+///    accommodate environment resolver, which may resolve the usage by its identifier only
 ///    (no other resolvers should resolve such a usage, environment is special here).
 ///    Otherwise go to step 2.
 /// 2. If remote_resolver produces any results, discard any that do not point to a valid

--- a/core/src/resolve/file.rs
+++ b/core/src/resolve/file.rs
@@ -104,6 +104,30 @@ impl FileResolver {
         }
         Ok(ResolutionOutcome::Resolved(path))
     }
+
+    /// Resolve `relative` against `base`, canonicalize it, and check it
+    /// against the sandbox roots.
+    fn resolve_relative_path(
+        &self,
+        base: &Utf8Path,
+        relative: &str,
+    ) -> Result<ResolutionOutcome<Utf8PathBuf>, FileResolverError> {
+        let abs_path = base.join(relative);
+        let canonical = match wrapfs::canonicalize_raw(&abs_path) {
+            Ok(p) => p,
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                return Ok(ResolutionOutcome::NotFound {
+                    reason: format!("path `{abs_path}` does not exist"),
+                });
+            }
+            Err(e) => {
+                return Err(FileResolverError::Io(
+                    FsIoError::Canonicalize(abs_path, e).into(),
+                ));
+            }
+        };
+        self.check_sandbox(canonical)
+    }
 }
 
 #[derive(Debug)]
@@ -146,6 +170,19 @@ pub enum FileResolverProjectError {
     },
     #[error("kpar at `{path}` is an empty file")]
     EmptyKpar { path: Box<str> },
+    #[error(
+        "project publisher `{}` does not match expected `{}`",
+        if let Some(a) = actual { a.as_str() } else { "<none>" },
+        if let Some(p) = expected { p.as_str() } else { "<none>" }
+    )]
+    PublisherMismatch {
+        expected: Option<String>,
+        actual: Option<String>,
+    },
+    #[error("project name `{actual}` does not match expected `{expected}`")]
+    NameMismatch { expected: String, actual: String },
+    #[error("project is missing project information file `.project.json`")]
+    MissingInfo,
     #[error("{0}")]
     Other(String),
 }
@@ -197,6 +234,13 @@ impl From<LocalKParError> for FileResolverProjectError {
                 actual,
             },
             LocalKParError::EmptyKpar { path } => Self::EmptyKpar { path },
+            LocalKParError::PublisherMismatch { expected, actual } => {
+                Self::PublisherMismatch { expected, actual }
+            }
+            LocalKParError::NameMismatch { expected, actual } => {
+                Self::NameMismatch { expected, actual }
+            }
+            LocalKParError::MissingInfo => Self::MissingInfo,
         }
     }
 }
@@ -313,7 +357,7 @@ impl ResolveRead for FileResolver {
                                 LocalSrcProject::new_access(path.clone(), None),
                             )),
                             Ok(FileResolverProject::LocalKParProject(
-                                LocalKParProject::new(path, KparInnerPath::Guess, None, None),
+                                LocalKParProject::new_access(path, KparInnerPath::Guess, None),
                             )),
                         ]
                     }))
@@ -329,28 +373,43 @@ impl ResolveRead for FileResolver {
             } => {
                 // TODO: should absolute paths be supported here? Cargo does.
                 if let Some(base) = resolve.base_path() {
-                    let abs_path = base.join(dir.as_str());
-                    let canonical = match wrapfs::canonicalize_raw(&abs_path) {
-                        Ok(p) => p,
-                        Err(e) if e.kind() == ErrorKind::NotFound => {
-                            return Ok(ResolutionOutcome::NotFound {
-                                reason: format!("path `{abs_path}` does not exist"),
-                            });
-                        }
-                        Err(e) => {
-                            return Err(FileResolverError::Io(
-                                FsIoError::Canonicalize(abs_path, e).into(),
-                            ));
-                        }
-                    };
-                    let res = self.check_sandbox(canonical)?;
+                    let res = self.resolve_relative_path(base, dir.as_str())?;
                     Ok(res.map(|path| {
                         vec![Ok(FileResolverProject::LocalSrcProject(
                             LocalSrcProject::new_for_solve(
                                 path,
+                                // Can't use `dir` here, since `FileResolver` is used for env projects,
+                                // and in that case using `dir` would resolve relative to the project
+                                // inside `.sysand`, and the dependency would not be found
                                 None,
                                 Some(publisher.clone()),
                                 name.clone(),
+                            ),
+                        ))]
+                    }))
+                } else {
+                    // TODO: return Err?
+                    Ok(ResolutionOutcome::Unresolvable {
+                        reason: String::from(
+                            "cannot resolve relative path usage without a base path",
+                        ),
+                    })
+                }
+            }
+            InterchangeProjectUsage::KparPath {
+                kpar_path,
+                publisher,
+                name,
+            } => {
+                if let Some(base) = resolve.base_path() {
+                    let res = self.resolve_relative_path(base, kpar_path.as_str())?;
+                    Ok(res.map(|path| {
+                        vec![Ok(FileResolverProject::LocalKParProject(
+                            LocalKParProject::new_for_solve(
+                                path,
+                                None,
+                                Some(publisher.to_owned()),
+                                name.to_owned(),
                             ),
                         ))]
                     }))

--- a/core/src/resolve/gix_git.rs
+++ b/core/src/resolve/gix_git.rs
@@ -70,7 +70,8 @@ impl ResolveRead for GitResolver {
                     .map_err(|e| e.into()),
                 )))
             }
-            InterchangeProjectUsage::Directory { .. } => {
+            InterchangeProjectUsage::Directory { .. }
+            | InterchangeProjectUsage::KparPath { .. } => {
                 Ok(ResolutionOutcome::UnsupportedUsageType {
                     reason: String::from("not a git usage"),
                 })

--- a/core/src/resolve/memory.rs
+++ b/core/src/resolve/memory.rs
@@ -69,7 +69,8 @@ impl IRIPredicate for AcceptScheme<'_> {
                 resource,
                 version_constraint: _,
             } => resource.scheme() == self.scheme,
-            InterchangeProjectUsage::Directory { .. } => false,
+            InterchangeProjectUsage::Directory { .. }
+            | InterchangeProjectUsage::KparPath { .. } => false,
         }
     }
 }

--- a/core/src/resolve/mod.rs
+++ b/core/src/resolve/mod.rs
@@ -188,16 +188,21 @@ impl Display for ResolutionInfo {
                 }
             }
             InterchangeProjectUsage::Directory {
-                dir,
+                dir: path,
+                publisher,
+                name,
+            }
+            | InterchangeProjectUsage::KparPath {
+                kpar_path: path,
                 publisher,
                 name,
             } => {
                 if let Some(bp) = &self.base_path {
-                    let abs_path = bp.join(dir.as_str());
+                    let abs_path = bp.join(path.as_str());
                     let abs_path = wrapfs::absolute(&abs_path).unwrap_or(abs_path);
                     write!(f, "`{publisher}/{name}` from `{abs_path}`")?;
                 } else {
-                    write!(f, "`{publisher}/{name}` from `{dir}` (full path unknown)")?;
+                    write!(f, "`{publisher}/{name}` from `{path}` (base path unknown)")?;
                 }
             }
         }

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -457,12 +457,9 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
                     ));
                 }
             }
-            InterchangeProjectUsage::Directory {
-                dir: _,
-                publisher: _,
-                name: _,
-            } => {
-                // Usually `candidates` will contain a single candidate for this type,
+            InterchangeProjectUsage::Directory { .. }
+            | InterchangeProjectUsage::KparPath { .. } => {
+                // Usually `candidates` will contain a single candidate for these types,
                 // but e.g. environment may have multiple project versions, and will
                 // return all of them based on the identifier
                 deps.push((

--- a/core/src/solve/pubgrub_tests.rs
+++ b/core/src/solve/pubgrub_tests.rs
@@ -557,6 +557,69 @@ impl ProjectRead for StubProject {
     }
 }
 
+/// Multiple versions of the same dependency are not allowed.
+/// Pubgrub does not allow multiple versions of the same project in
+/// the dependency graph, unless we implement it ourselves (e.g.
+/// make package identifier include a major version, so different
+/// major versions will be treated as different packages by pubgrub).
+/// SysMLv2 spec seemingly disallows having multiple versions of the
+/// same project in the dependency graph, but we may want to support
+/// it anyway
+#[test]
+fn usages_multiple_versions_of_same_project() {
+    let widget_v1 = trivial_memory_project("widget", "1.0.0", vec![]);
+    let widget_v2 = trivial_memory_project("widget", "2.0.0", vec![]);
+
+    let resolver = simple_resolver_environment(&[("urn:kpar:widget", &[widget_v1, widget_v2])]);
+
+    super::solve(
+        vec![
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("urn:kpar:widget").unwrap().into(),
+                version_constraint: Some(semver::VersionReq::parse("=1.0.0").unwrap()),
+            },
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("urn:kpar:widget").unwrap().into(),
+                version_constraint: Some(semver::VersionReq::parse("=2.0.0").unwrap()),
+            },
+        ],
+        None,
+        resolver,
+    )
+    .unwrap_err();
+}
+
+/// Transitive dependencies must not contain two different versions of the same project
+#[test]
+fn transitive_usages_different_versions_of_same_project() {
+    let app_a = trivial_memory_project("app_a", "1.0.0", [("urn:kpar:widget", Some("=1.0.0"))]);
+    let app_b = trivial_memory_project("app_b", "1.0.0", [("urn:kpar:widget", Some("=2.0.0"))]);
+    let widget_v1 = trivial_memory_project("widget", "1.0.0", []);
+    let widget_v2 = trivial_memory_project("widget", "2.0.0", []);
+
+    let resolver = simple_resolver_environment(&[
+        ("urn:kpar:app_a", &[app_a]),
+        ("urn:kpar:app_b", &[app_b]),
+        ("urn:kpar:widget", &[widget_v1, widget_v2]),
+    ]);
+
+    super::solve(
+        vec![
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("urn:kpar:app_a").unwrap().into(),
+                version_constraint: None,
+            },
+            InterchangeProjectUsage::Resource {
+                resource: Iri::parse("urn:kpar:app_b").unwrap().into(),
+                version_constraint: None,
+            },
+        ],
+        None,
+        resolver,
+    )
+    .unwrap_err();
+}
+
 /// A resolver whose only candidate for any usage is an error
 #[derive(Debug)]
 struct ErrorCandidateResolver;

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -21,7 +21,6 @@ pub type ProvidedIdentifiers = HashSet<Identifier>;
 
 #[cfg(feature = "filesystem")]
 pub(crate) mod scheme {
-    #[cfg(feature = "filesystem")]
     use fluent_uri::component::Scheme;
     pub const SCHEME_FILE: &Scheme = Scheme::new_or_panic("file");
     #[cfg(feature = "networking")]

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -15,7 +15,7 @@ use sysand_core::{
     add::expand_sysand_purl_shorthand,
     build::KparCompressionMethod,
     index_location::IndexLocation,
-    model::{KERML_METAMODEL_PREFIX, SYSML_METAMODEL_PREFIX},
+    model::{KERML_SPEC_PREFIX, SYSML_SPEC_PREFIX},
     sources::Dependencies,
 };
 
@@ -328,12 +328,16 @@ pub enum ExpCommand {
 }
 
 #[derive(clap::Args, Debug, Clone)]
+#[group(required = true, multiple = false)]
 pub struct ExpAddProjectLocatorArgs {
-    /// Add a project from a local directory path
-    /// Path to the project. Can be relative or absolute, and point
-    /// to a project directory
+    /// Add a project from a given directory path. Path can be relative
+    /// or absolute
     #[arg(long, verbatim_doc_comment)]
-    pub dir: Utf8PathBuf,
+    pub dir: Option<Utf8PathBuf>,
+    /// Add a project from a KPAR at a given path. Path can be relative
+    /// or absolute
+    #[arg(long, verbatim_doc_comment)]
+    pub kpar_path: Option<Utf8PathBuf>,
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -1812,8 +1816,8 @@ pub enum MetamodelKind {
 impl From<&MetamodelKind> for &'static str {
     fn from(value: &MetamodelKind) -> Self {
         match value {
-            MetamodelKind::SysML => SYSML_METAMODEL_PREFIX,
-            MetamodelKind::KerML => KERML_METAMODEL_PREFIX,
+            MetamodelKind::SysML => SYSML_SPEC_PREFIX,
+            MetamodelKind::KerML => KERML_SPEC_PREFIX,
         }
     }
 }

--- a/sysand/src/commands/add.rs
+++ b/sysand/src/commands/add.rs
@@ -19,6 +19,7 @@ use sysand_core::{
     model::{InterchangeProjectUsage, InterchangeProjectUsageRaw},
     project::{
         ProjectRead,
+        local_kpar::{KparInnerPath, LocalKParProject},
         local_src::LocalSrcProject,
         utils::{relativize_path, wrapfs},
     },
@@ -255,6 +256,7 @@ pub fn command_add<Policy: HTTPAuthentication>(
 
 pub enum ExpAddArgs {
     Dir { dir: Utf8PathBuf },
+    KparPath { kpar_path: Utf8PathBuf },
 }
 
 // TODO: Collect common arguments
@@ -275,7 +277,7 @@ pub fn exp_command_add<Policy: HTTPAuthentication>(
         .clone()
         .ok_or(CliError::MissingProjectCurrentDir)?;
 
-    match add {
+    let usage = match add {
         ExpAddArgs::Dir { dir } => {
             let abs_path = wrapfs::canonicalize(dir)?;
             let relative = relativize_path(&abs_path, current_project.root_path())?;
@@ -286,60 +288,76 @@ pub fn exp_command_add<Policy: HTTPAuthentication>(
             let publisher = info.publisher.ok_or_else(|| {
                 CliError::MissingPublisherForUsage(project.root_path().to_string())
             })?;
-            let usage = InterchangeProjectUsage::Directory {
+            InterchangeProjectUsage::Directory {
                 dir: relative,
                 publisher,
                 name: info.name,
-            };
-
-            if !no_lock {
-                let info_path = current_project.info_path();
-                let info_backup = wrapfs::read_to_string(&info_path)?;
-                let added = do_add(&mut current_project, &usage.into())?;
-                if !added {
-                    return Ok(());
-                }
-
-                let alias_iris = if let Some(w) = &ctx.current_workspace {
-                    w.projects()
-                        .iter()
-                        .find(|p| Path::new(&p.path) == current_project.root_path())
-                        .map(|p| p.iris.to_owned())
-                } else {
-                    None
-                };
-
-                let provided_iris = if !resolution_opts.include_std {
-                    // Don't warn; std libs are all `https://`, so they can't match this usage
-                    crate::known_std_libs()
-                } else {
-                    HashMap::default()
-                };
-
-                match resolve_deps(
-                    no_sync,
-                    resolution_opts,
-                    &config,
-                    client,
-                    runtime,
-                    auth_policy,
-                    current_project.root_path(),
-                    alias_iris,
-                    provided_iris,
-                    ctx,
-                ) {
-                    Ok(_) => Ok(()),
-                    Err(e) => {
-                        // Restore old info
-                        wrapfs::write(&info_path, info_backup)?;
-                        Err(e)
-                    }
-                }
-            } else {
-                do_add(&mut current_project, &usage.into())?;
-                Ok(())
             }
         }
+        ExpAddArgs::KparPath { kpar_path } => {
+            let abs_path = wrapfs::canonicalize(kpar_path)?;
+            let relative = relativize_path(&abs_path, current_project.root_path())?;
+            let project = LocalKParProject::new_access(abs_path.clone(), KparInnerPath::Root, None);
+            let info = project
+                .get_info()?
+                .ok_or_else(|| CliError::MissingProject(abs_path.to_string()))?;
+            let publisher = info
+                .publisher
+                .ok_or_else(|| CliError::MissingPublisherForUsage(abs_path.to_string()))?;
+            InterchangeProjectUsage::KparPath {
+                kpar_path: relative,
+                publisher,
+                name: info.name,
+            }
+        }
+    };
+
+    if !no_lock {
+        let info_path = current_project.info_path();
+        let info_backup = wrapfs::read_to_string(&info_path)?;
+        let added = do_add(&mut current_project, &usage.into())?;
+        if !added {
+            return Ok(());
+        }
+
+        let alias_iris = if let Some(w) = &ctx.current_workspace {
+            w.projects()
+                .iter()
+                .find(|p| Path::new(&p.path) == current_project.root_path())
+                .map(|p| p.iris.to_owned())
+        } else {
+            None
+        };
+
+        let provided_iris = if !resolution_opts.include_std {
+            // Don't warn; std libs are all `https://`, so they can't match this usage
+            crate::known_std_libs()
+        } else {
+            HashMap::default()
+        };
+
+        match resolve_deps(
+            no_sync,
+            resolution_opts,
+            &config,
+            client,
+            runtime,
+            auth_policy,
+            current_project.root_path(),
+            alias_iris,
+            provided_iris,
+            ctx,
+        ) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                // Restore old info
+                wrapfs::write(&info_path, info_backup)?;
+                Err(e)
+            }
+        }
+    } else {
+        do_add(&mut current_project, &usage.into())?;
+        Ok(())
     }
 }
 

--- a/sysand/src/commands/clone.rs
+++ b/sysand/src/commands/clone.rs
@@ -24,8 +24,7 @@ use sysand_core::{
         priority::PriorityResolver,
         standard::{StandardResolver, standard_resolver},
     },
-    utils::SP,
-    utils::format_err,
+    utils::{SP, format_err},
 };
 
 use crate::{

--- a/sysand/src/commands/env.rs
+++ b/sysand/src/commands/env.rs
@@ -235,11 +235,10 @@ pub fn command_env_install_path<Policy: HTTPAuthentication>(
             Some(Utf8UnixPathBuf::new()),
         ))
     } else if metadata.is_file() {
-        FileResolverProject::LocalKParProject(LocalKParProject::new(
+        FileResolverProject::LocalKParProject(LocalKParProject::new_access(
             &path,
             KparInnerPath::Guess,
             Some(path.as_str().into()),
-            None,
         ))
     } else {
         bail!("path `{path}` is neither a directory nor a file");

--- a/sysand/src/commands/info.rs
+++ b/sysand/src/commands/info.rs
@@ -76,7 +76,8 @@ pub fn pprint_interchange_project(
                 InterchangeProjectUsageRaw::Resource { resource, .. } => {
                     !excluded_iris.contains(resource)
                 }
-                InterchangeProjectUsageRaw::Directory { .. } => true,
+                InterchangeProjectUsageRaw::Directory { .. }
+                | InterchangeProjectUsageRaw::KparPath { .. } => true,
             })
             .collect();
         let has_ignored_usages = info.usage.len() > usages_to_print.len();
@@ -105,19 +106,19 @@ pub fn pprint_interchange_project(
 }
 
 fn interpret_project_path<P: AsRef<Utf8Path>>(path: P) -> Result<FileResolverProject> {
-    let metadata = wrapfs::metadata(&path)?;
+    let path = path.as_ref();
+    let metadata = wrapfs::metadata(path)?;
     Ok(if metadata.is_file() {
-        FileResolverProject::LocalKParProject(LocalKParProject::new(
+        FileResolverProject::LocalKParProject(LocalKParProject::new_access(
             path,
             KparInnerPath::Guess,
             None,
-            None,
         ))
     } else if metadata.is_dir() {
-        FileResolverProject::LocalSrcProject(LocalSrcProject::new_access(path.as_ref(), None))
+        FileResolverProject::LocalSrcProject(LocalSrcProject::new_access(path, None))
     } else {
         // TODO: NoResolve is for IRIs, this is a path
-        bail!(CliError::NoResolve(path.as_ref().to_string()));
+        bail!(CliError::NoResolve(path.to_string()));
     })
 }
 

--- a/sysand/src/commands/remove.rs
+++ b/sysand/src/commands/remove.rs
@@ -75,11 +75,16 @@ fn print_removed(usages: &[InterchangeProjectUsageRaw]) {
                 }
             },
             InterchangeProjectUsageRaw::Directory {
-                dir,
+                dir: path,
+                publisher,
+                name,
+            }
+            | InterchangeProjectUsageRaw::KparPath {
+                kpar_path: path,
                 publisher,
                 name,
             } => {
-                log::info!("{header}{removed:>12}{header:#} `{publisher}/{name}` (path `{dir}`)");
+                log::info!("{header}{removed:>12}{header:#} `{publisher}/{name}` (path `{path}`)");
             }
         }
     }

--- a/sysand/src/commands/sync.rs
+++ b/sysand/src/commands/sync.rs
@@ -37,6 +37,7 @@ pub fn command_sync<P: AsRef<Utf8Path>, Policy: HTTPAuthentication>(
     auth_policy: Arc<Policy>,
     ws: Option<&Workspace>,
 ) -> Result<()> {
+    let relative_root = ws.map_or(project_root.as_ref(), Workspace::root_path);
     sysand_core::commands::sync::do_sync(
         lock,
         env,
@@ -47,7 +48,7 @@ pub fn command_sync<P: AsRef<Utf8Path>, Policy: HTTPAuthentication>(
              checksum: String|
              -> LocalSrcProject {
                 LocalSrcProject::new_for_sync(
-                    project_root.as_ref().join(src_path.as_str()),
+                    relative_root.join(src_path.as_str()),
                     Some(src_path),
                     publisher,
                     name,
@@ -69,11 +70,18 @@ pub fn command_sync<P: AsRef<Utf8Path>, Policy: HTTPAuthentication>(
             },
         ),
         Some(
-            |kpar_path: String, kpar_size: NonZeroU64, kpar_digest: String| -> LocalKParProject {
-                LocalKParProject::new(
-                    project_root.as_ref().join(&kpar_path),
+            |kpar_path: Utf8UnixPathBuf,
+             kpar_size: NonZeroU64,
+             kpar_digest: String,
+             publisher: Option<String>,
+             name: String|
+             -> LocalKParProject {
+                LocalKParProject::new_for_sync(
+                    relative_root.join(kpar_path.as_str()),
                     KparInnerPath::Guess,
-                    Some(kpar_path.into()),
+                    Some(kpar_path),
+                    publisher,
+                    name,
                     Some(KparMeta {
                         size_bytes: kpar_size,
                         sha256_hex: kpar_digest,

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -729,7 +729,13 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
                 no_lock,
                 no_sync,
             } => {
-                let add = ExpAddArgs::Dir { dir: locator.dir };
+                let add = if let Some(dir) = locator.dir {
+                    ExpAddArgs::Dir { dir }
+                } else if let Some(kpar_path) = locator.kpar_path {
+                    ExpAddArgs::KparPath { kpar_path }
+                } else {
+                    unreachable!("clap group requires exactly one of `dir`/`kpar_path`")
+                };
                 exp_command_add(
                     add,
                     no_lock,

--- a/sysand/tests/cli_exp_add_remove.rs
+++ b/sysand/tests/cli_exp_add_remove.rs
@@ -1,12 +1,41 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
+use std::io::Write;
+
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 
 // pub due to https://github.com/rust-lang/rust/issues/46379
 mod common;
 pub use common::*;
+
+/// Write a KPAR containing `.project.json`/`.meta.json` at the archive root,
+/// as required by the `KparPath` usage type.
+fn write_dep_kpar(
+    kpar_path: &camino::Utf8Path,
+    publisher: &str,
+    name: &str,
+    version: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let file = std::fs::File::create(kpar_path)?;
+    let mut zip = zip::ZipWriter::new(file);
+
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored)
+        .unix_permissions(0o644);
+
+    zip.start_file(".project.json", options)?;
+    zip.write_all(
+        format!(r#"{{"name":"{name}","publisher":"{publisher}","version":"{version}"}}"#)
+            .as_bytes(),
+    )?;
+    zip.start_file(".meta.json", options)?;
+    zip.write_all(br#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)?;
+
+    zip.finish()?;
+    Ok(())
+}
 
 #[test]
 fn exp_add_and_remove_without_lock() -> Result<(), Box<dyn std::error::Error>> {
@@ -230,6 +259,257 @@ fn exp_remove_nonexistent() -> Result<(), Box<dyn std::error::Error>> {
     out.assert().failure().stderr(predicate::str::contains(
         "could not find usage for `a/nonexistent`",
     ));
+
+    Ok(())
+}
+
+#[test]
+fn exp_add_and_remove_kpar_path_without_lock() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "exp_add_and_remove_kpar_path", "1.2.3")?;
+    out.assert().success();
+
+    let dep_kpar = cwd.join("dep.kpar");
+    write_dep_kpar(&dep_kpar, "b", "my-dep", "1.0.0")?;
+
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "experimental",
+            "add",
+            "--no-lock",
+            "--kpar-path",
+            "dep.kpar",
+        ],
+        None,
+    )?;
+
+    out.assert().success().stderr(predicate::str::contains(
+        "Adding usage: `b/my-dep` in `dep.kpar`",
+    ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_and_remove_kpar_path",
+  "publisher": "a",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "kpar_path": "dep.kpar",
+      "publisher": "b",
+      "name": "my-dep"
+    }
+  ]
+}
+"#
+    );
+
+    let out = run_sysand_in(&cwd, ["experimental", "remove", "b", "my-dep"], None)?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Removing `b/my-dep` from usages"))
+        .stderr(predicate::str::contains(
+            "Removed `b/my-dep` (path `dep.kpar`)",
+        ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_and_remove_kpar_path",
+  "publisher": "a",
+  "version": "1.2.3"
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exp_add_kpar_path_missing_publisher_fails() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "exp_add_kpar_path_no_publisher", "1.2.3")?;
+    out.assert().success();
+
+    let dep_kpar = cwd.join("dep.kpar");
+    {
+        let file = std::fs::File::create(&dep_kpar)?;
+        let mut zip = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .unix_permissions(0o644);
+        zip.start_file(".project.json", options)?;
+        zip.write_all(br#"{"name":"no-publisher-dep","version":"1.0.0"}"#)?;
+        zip.finish()?;
+    }
+
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "experimental",
+            "add",
+            "--no-lock",
+            "--kpar-path",
+            "dep.kpar",
+        ],
+        None,
+    )?;
+
+    out.assert()
+        .failure()
+        .stderr(predicate::str::contains("does not have a publisher"));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_kpar_path_no_publisher",
+  "publisher": "a",
+  "version": "1.2.3"
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exp_add_kpar_path_nonexistent_project_fails() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "exp_add_kpar_path_nonexistent", "1.2.3")?;
+    out.assert().success();
+
+    let dep_kpar = cwd.join("dep.kpar");
+    // dep.kpar exists as a valid, but empty, archive: no `.project.json`
+    {
+        let file = std::fs::File::create(&dep_kpar)?;
+        zip::ZipWriter::new(file).finish()?;
+    }
+
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "experimental",
+            "add",
+            "--no-lock",
+            "--kpar-path",
+            "dep.kpar",
+        ],
+        None,
+    )?;
+
+    out.assert().failure().stderr(predicate::str::contains(
+        "unable to find interchange project",
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn exp_add_kpar_path_already_present_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "exp_add_kpar_path_already_present", "1.2.3")?;
+    out.assert().success();
+
+    let dep_kpar = cwd.join("dep.kpar");
+    write_dep_kpar(&dep_kpar, "b", "my-dep", "1.0.0")?;
+
+    run_sysand_in(
+        &cwd,
+        [
+            "experimental",
+            "add",
+            "--no-lock",
+            "--kpar-path",
+            "dep.kpar",
+        ],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(
+        &cwd,
+        [
+            "experimental",
+            "add",
+            "--no-lock",
+            "--kpar-path",
+            "dep.kpar",
+        ],
+        None,
+    )?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("is already present"));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_add_kpar_path_already_present",
+  "publisher": "a",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "kpar_path": "dep.kpar",
+      "publisher": "b",
+      "name": "my-dep"
+    }
+  ]
+}
+"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exp_remove_kpar_path() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "exp_remove_kpar_path", "1.2.3")?;
+    out.assert().success();
+
+    let dep_kpar = cwd.join("dep.kpar");
+    write_dep_kpar(&dep_kpar, "b", "my-dep", "1.0.0")?;
+
+    run_sysand_in(
+        &cwd,
+        [
+            "experimental",
+            "add",
+            "--no-lock",
+            "--kpar-path",
+            "dep.kpar",
+        ],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(&cwd, ["experimental", "remove", "b", "my-dep"], None)?;
+
+    out.assert()
+        .success()
+        .stderr(predicate::str::contains("Removing `b/my-dep` from usages"))
+        .stderr(predicate::str::contains(
+            "Removed `b/my-dep` (path `dep.kpar`)",
+        ));
+
+    let info_json = std::fs::read_to_string(cwd.join(".project.json"))?;
+    assert_eq!(
+        info_json,
+        r#"{
+  "name": "exp_remove_kpar_path",
+  "publisher": "a",
+  "version": "1.2.3"
+}
+"#
+    );
 
     Ok(())
 }

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -50,6 +50,61 @@ fn info_basic_in_cwd() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+fn info_prints_all_usage_types() -> Result<(), Box<dyn Error>> {
+    let (_temp_dir, cwd, out_init) =
+        cli_init_project_basic("pub1", "info_all_usage_types", "1.2.3")?;
+    out_init.assert().success();
+
+    // One usage of each shape: legacy `resource` (with and without a version
+    // constraint), `dir`, and `kpar_path`.
+    std::fs::write(
+        cwd.join(".project.json"),
+        r#"{
+  "name": "info_all_usage_types",
+  "version": "1.2.3",
+  "usage": [
+    {
+      "resource": "urn:kpar:constrained_dep",
+      "versionConstraint": "^1.0.0"
+    },
+    {
+      "resource": "urn:kpar:unconstrained_dep"
+    },
+    {
+      "dir": "deps/dir_dep",
+      "publisher": "acme",
+      "name": "dir_dep"
+    },
+    {
+      "kpar_path": "deps/kpar_dep.kpar",
+      "publisher": "acme",
+      "name": "kpar_dep"
+    }
+  ]
+}
+"#,
+    )?;
+
+    let out = run_sysand_in(&cwd, ["info"], None)?;
+
+    out.assert()
+        .success()
+        .stdout(predicate::str::contains("Usages:"))
+        .stdout(predicate::str::contains(
+            "IRI `urn:kpar:constrained_dep` (^1.0.0)",
+        ))
+        .stdout(predicate::str::contains("IRI `urn:kpar:unconstrained_dep`"))
+        .stdout(predicate::str::contains(
+            "`acme/dir_dep` from `deps/dir_dep`",
+        ))
+        .stdout(predicate::str::contains(
+            "`acme/kpar_dep` in `deps/kpar_dep.kpar`",
+        ));
+
+    Ok(())
+}
+
 fn info_basic(use_iri: bool, use_auto: bool) -> Result<(), Box<dyn Error>> {
     let (_temp_dir, cwd, out_init) =
         cli_init_project(Some("info_basic"), "a", None, Some("1.2.3"), None)?;

--- a/sysand/tests/cli_init.rs
+++ b/sysand/tests/cli_init.rs
@@ -80,18 +80,7 @@ fn init_default_version() -> Result<(), Box<dyn std::error::Error>> {
 /// project in cwd.
 #[test]
 fn init_basic_cwd() -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "b",
-            "--name",
-            "init_basic_cwd",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) = cli_init_project_basic("b", "init_basic_cwd", "1.2.3")?;
 
     out.assert().success().stdout(predicate::str::is_empty());
 
@@ -224,18 +213,8 @@ fn init_fail_on_double_init() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn init_fail_on_double_init_cwd() -> Result<(), Box<dyn std::error::Error>> {
     // Run 1
-    let (_temp_dir, cwd, out) = run_sysand(
-        [
-            "init",
-            "--publisher",
-            "a",
-            "--name",
-            "init_fail_on_double_init_cwd",
-            "--version",
-            "1.2.3",
-        ],
-        None,
-    )?;
+    let (_temp_dir, cwd, out) =
+        cli_init_project_basic("a", "init_fail_on_double_init_cwd", "1.2.3")?;
     out.assert().success().stdout(predicate::str::is_empty());
 
     let original_info = std::fs::read_to_string(cwd.join(".project.json"))?;

--- a/sysand/tests/cli_sync.rs
+++ b/sysand/tests/cli_sync.rs
@@ -10,7 +10,11 @@ use predicates::prelude::*;
 use reqwest::header;
 use sysand_core::{
     commands::lock::DEFAULT_LOCKFILE_NAME,
-    env::{DEFAULT_ENV_NAME, local_directory::METADATA_PATH},
+    env::{
+        DEFAULT_ENV_NAME,
+        local_directory::{LocalDirectoryEnvironment, METADATA_PATH},
+    },
+    lock::{Lock, Source},
 };
 
 // pub due to https://github.com/rust-lang/rust/issues/46379
@@ -606,6 +610,110 @@ fn sync_env_toml_with_editable_and_non_editable() -> Result<(), Box<dyn std::err
     out.assert()
         .success()
         .stderr(predicate::str::contains("env is already up to date"));
+
+    Ok(())
+}
+
+/// A transitive `kpar_path` usage must resolve relative to the directory of
+/// the project that declares it, not relative to the top-level project being
+/// synced
+#[test]
+fn sync_kpar_path_usage_transitive() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "app", "1.2.3")?;
+    out.assert().success().stdout(predicate::str::is_empty());
+
+    let deps_dir = cwd.join("deps");
+    std::fs::create_dir_all(&deps_dir)?;
+
+    // `gadget`: a leaf KPAR, built elsewhere and placed at `deps/gadget.kpar`.
+    let gadget_src = cwd.join("gadget_src");
+    std::fs::create_dir_all(&gadget_src)?;
+    cli_init_project_in(&gadget_src, None, "c", Some("gadget"), Some("2.0.0"), None)?
+        .assert()
+        .success();
+    run_sysand_in(&gadget_src, ["build", "../deps/gadget.kpar"], None)?
+        .assert()
+        .success();
+
+    // `widget`: a source directory declaring `../gadget.kpar`, resolved (and
+    // stored) relative to `widget`'s own directory.
+    let widget_dir = deps_dir.join("widget");
+    std::fs::create_dir_all(&widget_dir)?;
+    cli_init_project_in(&widget_dir, None, "b", Some("widget"), Some("1.0.0"), None)?
+        .assert()
+        .success();
+    run_sysand_in(
+        &widget_dir,
+        [
+            "experimental",
+            "add",
+            "--no-lock",
+            "--kpar-path",
+            "../gadget.kpar",
+        ],
+        None,
+    )?
+    .assert()
+    .success();
+
+    run_sysand_in(
+        &cwd,
+        ["experimental", "add", "--no-lock", "--dir", "deps/widget"],
+        None,
+    )?
+    .assert()
+    .success();
+
+    let out = run_sysand_in(&cwd, ["lock"], None)?;
+    out.assert().success();
+
+    let lock_file: Lock =
+        toml::from_str(&std::fs::read_to_string(cwd.join(DEFAULT_LOCKFILE_NAME))?)?;
+    let projects = lock_file.projects;
+
+    assert_eq!(
+        projects.len(),
+        3,
+        "expected app, widget and gadget in the lockfile, got: {projects:#?}"
+    );
+
+    // Resolved paths are relativized back against the top-level project
+    // root when recorded in the lockfile.
+    let widget = projects
+        .iter()
+        .find(|p| p.name == "widget")
+        .unwrap_or_else(|| panic!("`widget` missing from lockfile: {projects:#?}"));
+    assert_eq!(widget.version, "1.0.0");
+    let [Source::LocalSrc { src_path, .. }] = widget.sources.as_slice() else {
+        panic!("expected a single local src source for `widget`, got: {widget:#?}");
+    };
+    assert_eq!(src_path.as_str(), "deps/widget");
+
+    let gadget = projects
+        .iter()
+        .find(|p| p.name == "gadget")
+        .unwrap_or_else(|| panic!("`gadget` missing from lockfile: {projects:#?}"));
+    assert_eq!(gadget.version, "2.0.0");
+    let [Source::LocalKpar { kpar_path, .. }] = gadget.sources.as_slice() else {
+        panic!("expected a single local kpar source for `gadget`, got: {gadget:#?}");
+    };
+    assert_eq!(kpar_path.as_str(), "deps/gadget.kpar");
+
+    let out = run_sysand_in(&cwd, ["sync"], None)?;
+    out.assert().success();
+
+    let env_projects = LocalDirectoryEnvironment::read(cwd.join(DEFAULT_ENV_NAME))?
+        .projects()
+        .to_vec();
+
+    for (name, version) in [("widget", "1.0.0"), ("gadget", "2.0.0")] {
+        assert!(
+            env_projects
+                .iter()
+                .any(|p| p.name == name && p.version == version),
+            "`{name}` {version} missing from synced env: {env_projects:#?}"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Adds `KparPath` usage type, which is very similar to `Directory` usage type, but references a KPAR archive instead of the project directory.

Add tests to ensure that model type changes are reflected in the bindings, since bindings types were missed in #426. They also caught a few other issues.