### PR TITLE
feat: preserve datetime of building the KPAR in the zip metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5529,6 +5529,7 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes 0.9.1",
  "bzip2",
+ "chrono",
  "constant_time_eq",
  "crc32fast",
  "deflate64",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,7 +62,7 @@ typed-path = { version = "0.12.3", default-features = false }
 walkdir = "2.5.0"
 # unicode-normalization = { version = "0.1.24", default-features = false }
 wasm-bindgen = { version = "0.2.114", default-features = false, optional = true }
-zip = { version = "8.0.0", default-features = false, optional = true, features = ["deflate"] }
+zip = { version = "8.0.0", default-features = false, optional = true, features = ["deflate", "chrono"] }
 url = { version = "2.5.8", default-features = false }
 percent-encoding = { version = "2.3.2", default-features = false, features = ["alloc"] }
 gix = { version = "0.86.0", default-features = false, optional = true, features = ["blocking-http-transport-reqwest", "blocking-network-client", "worktree-mutation", "sha1"] }

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -343,16 +343,11 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     let archive_file = wrapfs::File::create(&path)?;
     let mut zip = zip::ZipWriter::new(archive_file);
 
-    // Keep ZIPs reproducible
+    let time = chrono::Utc::now().naive_utc();
     let options = zip::write::SimpleFileOptions::default()
         .compression_method(compression.into())
         .system(zip::System::Unix)
-        // Previously used `zip::DateTime::DEFAULT` (earliest allowed
-        // zip date: 1980-01-01), but some extractors try to convert that time
-        // to local (somehow) when extracting, which can result in time earlier
-        // than that, which results in the tool (incorrectly) complaining about
-        // date being too old for zip
-        .last_modified_time(zip::DateTime::from_date_and_time(1980, 1, 2, 0, 0, 0).unwrap());
+        .last_modified_time(zip::DateTime::try_from(time).unwrap());
 
     let source_paths = meta.source_paths(true);
     let mut checksums = if let Some(mut checksum) = meta.checksum.take() {


### PR DESCRIPTION
We initialy wanted to make kpars reproducible, so set datetime to earliest possible (#372). To prevent confusion of users who download and unzip a kpar manually (and then see that the files date back to 1980), set the datetime to the build datetime (same for all files). If we find a good reason to have reproducible kpars, this can be changed in the future.

What do you think @consideRatio? We don't currently have good reasons to do either way, but having the correct time is less confusing to users.