### PR TITLE
feat(windows): expand CLI globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,6 +4089,7 @@ dependencies = [
  "toml",
  "typed-path",
  "url",
+ "wild",
  "zip",
 ]
 
@@ -4190,6 +4191,7 @@ dependencies = [
  "camino",
  "camino-tempfile",
  "fluent-uri",
+ "glob",
  "log",
  "predicates",
  "pyo3",
@@ -4827,6 +4829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wild"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/bindings/py/Cargo.toml
+++ b/bindings/py/Cargo.toml
@@ -33,6 +33,9 @@ typed-path = { version = "0.12.3", default-features = false, features = ["std"] 
 url = { version = "2.5.8", default-features = false }
 tokio = { version = "1.50.0", default-features = false, features = ["rt"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+glob = "0.3.3"
+
 [dev-dependencies]
 predicates = "3.1.4"
 camino-tempfile = "1.4"

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -52,7 +52,44 @@ use typed_path::Utf8UnixPathBuf;
 
 #[pyfunction(name = "_run_cli")]
 fn run_cli(args: Vec<String>) -> bool {
-    let exit_code = sysand::lib_main(args);
+    let exit_code;
+    // Expand glob arguments
+    #[cfg(windows)]
+    {
+        use glob::{MatchOptions, glob_with};
+        let options = MatchOptions {
+            case_sensitive: false,
+            require_literal_separator: true,
+            require_literal_leading_dot: false,
+        };
+
+        let args = args.into_iter().flat_map(|arg| {
+            if !arg.contains(['*', '?']) {
+                return vec![arg.into()];
+            }
+
+            // Treat '[' and ']' as literal characters to match Windows behavior
+            let escaped = arg.replace('[', "[[]");
+
+            if let Ok(entries) = glob_with(&escaped, options) {
+                let matches: Vec<OsString> = entries
+                    .filter_map(Result::ok)
+                    .map(|p| p.to_owned())
+                    .collect();
+
+                if !matches.is_empty() {
+                    return matches;
+                }
+            }
+
+            vec![arg.into()]
+        });
+        exit_code = sysand::lib_main(args);
+    }
+    #[cfg(not(windows))]
+    {
+        exit_code = sysand::lib_main(args);
+    }
     exit_code == ExitCode::SUCCESS
 }
 

--- a/bindings/py/tests/windows_glob.rs
+++ b/bindings/py/tests/windows_glob.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! Unlike POSIX shells, `cmd.exe` and PowerShell do not expand glob patterns
+//! (`*`, `?`, ...) in arguments before invoking a program; `_run_cli` expands
+//! them itself (via the `glob` crate), but only on Windows.
+
+use std::fs;
+
+use pyo3::prelude::*;
+
+use camino_tempfile::Utf8TempDir;
+use sysand_py::sysand_py;
+
+#[test]
+fn run_cli_expands_glob_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let proj_dir = Utf8TempDir::new()?;
+    let proj_dir_path = proj_dir.path();
+
+    fs::write(proj_dir_path.join("p1.sysml"), b"package P1;\n")?;
+    fs::write(proj_dir_path.join("p2.sysml"), b"package P2;\n")?;
+    fs::write(proj_dir_path.join("p3.sysml"), b"package P3;\n")?;
+    // Should not be picked up by the `*.sysml` glob below.
+    fs::write(proj_dir_path.join("readme.txt"), b"not a model file\n")?;
+
+    // `_run_cli` glob-expands relative to CWD.
+    std::env::set_current_dir(proj_dir_path)?;
+
+    pyo3::append_to_inittab!(sysand_py);
+    Python::initialize();
+
+    let success: bool = Python::attach(|py| -> PyResult<bool> {
+        let core = py.import("_sysand_core")?;
+
+        core.getattr("do_init_py_local_file")?.call1((
+            "windows_glob",
+            "a",
+            "1.0.0",
+            proj_dir_path.as_str(),
+        ))?;
+
+        // Passed as a single, unexpanded argument, exactly as `cmd.exe` and
+        // PowerShell would hand it to us.
+        core.getattr("_run_cli")?
+            .call1((vec!["sysand", "include", "*.sysml"],))?
+            .extract()
+    })?;
+
+    let meta = std::fs::read_to_string(proj_dir_path.join(".meta.json"))?;
+
+    if cfg!(target_os = "windows") {
+        assert!(success);
+        assert!(meta.contains(r#""P1": "p1.sysml""#), "meta.json: {meta}");
+        assert!(meta.contains(r#""P2": "p2.sysml""#), "meta.json: {meta}");
+        assert!(meta.contains(r#""P3": "p3.sysml""#), "meta.json: {meta}");
+        assert!(!meta.contains("readme.txt"), "meta.json: {meta}");
+    } else {
+        // `_run_cli` only expands globs on Windows, so `include` sees a
+        // literal `*.sysml` path, which doesn't exist.
+        assert!(!success);
+        assert!(meta.contains(r#""index": {}"#), "meta.json: {meta}");
+    }
+
+    Ok(())
+}

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -43,9 +43,8 @@ impl Default for Config {
 static STYLE_CONFIG: OnceLock<Config> = OnceLock::new();
 
 pub fn set_style_config(config: Config) {
-    STYLE_CONFIG
-        .set(config)
-        .expect("BUG: attempting to set output style twice");
+    // Must not panic on double init, python bindings may trigger it more than once
+    let _unneeded = STYLE_CONFIG.set(config);
 }
 
 pub fn get_style_config() -> &'static Config {

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -54,6 +54,7 @@ tokio = { version = "1.50.0", default-features = false }
 reqwest-middleware = { version = "0.5.1", features = ["multipart"] }
 rpassword = "7.5.4"
 reqwest = { version = "0.13.2", features = ["rustls", "blocking"] }
+wild = "2.2.1"
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/sysand/src/main.rs
+++ b/sysand/src/main.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Sysand contributors <opensource@sensmetry.com>
 
-use std::{env, process::ExitCode};
+use std::process::ExitCode;
 
 use sysand::lib_main;
 
 fn main() -> ExitCode {
-    lib_main(env::args_os())
+    // `args_os()` does not panic on invalid Unicode, and clap gives a nice error
+    lib_main(wild::args_os())
 }

--- a/sysand/tests/cli_windows_glob.rs
+++ b/sysand/tests/cli_windows_glob.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! Unlike POSIX shells, `cmd.exe` and PowerShell do not expand glob patterns
+//! (`*`, `?`, ...) in arguments before invoking a program; expansion is left
+//! up to the program itself.
+
+#![cfg(target_os = "windows")]
+
+use std::fs;
+
+use assert_cmd::prelude::*;
+use indexmap::IndexMap;
+use sysand_core::model::InterchangeProjectMetadataRaw;
+
+// pub due to https://github.com/rust-lang/rust/issues/46379
+mod common;
+pub use common::*;
+
+#[test]
+fn include_expands_glob_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, cwd, out) = cli_init_project_basic("a", "windows_glob", "1.0.0")?;
+
+    out.assert().success();
+
+    fs::write(cwd.join("p1.sysml"), b"package P1;\n")?;
+    fs::write(cwd.join("p2.sysml"), b"package P2;\n")?;
+    fs::write(cwd.join("p3.sysml"), b"package P3;\n")?;
+    // Should not be picked up by the `*.sysml` glob below.
+    fs::write(cwd.join("readme.txt"), b"not a model file\n")?;
+
+    // Passed as a single, unexpanded argument, exactly as `cmd.exe` and
+    // PowerShell would hand it to us.
+    let out = run_sysand_in(&cwd, ["include", "*.sysml"], None)?;
+
+    out.assert().success();
+
+    let meta: InterchangeProjectMetadataRaw =
+        serde_json::from_reader(fs::File::open(cwd.join(".meta.json"))?)?;
+
+    assert_eq!(
+        meta.index,
+        IndexMap::from([
+            ("P1".to_owned(), "p1.sysml".to_owned()),
+            ("P2".to_owned(), "p2.sysml".to_owned()),
+            ("P3".to_owned(), "p3.sysml".to_owned()),
+        ])
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Windows shells (CMD and PowerShell) don't expand CLI glob patterns, it's left up to the application. Use [`wild`](https://docs.rs/wild/latest/wild/) crate to do that on Rust CLI. On Python, approximate this behavior via [`glob.glob`](https://docs.python.org/3/library/glob.html#glob.glob), since `wild` does not allow supplying args from elsewehere (another option is to use Rust `glob`).