### PR TITLE
maint: more linting: add cargo-dylint and ast-grep patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ unseparated_literal_suffix = "allow"
 unwrap_in_result = "allow"
 unwrap_used = "allow"
 verbose_file_reads = "allow"
+# may want to enable this
 wildcard_enum_match_arm = "allow"
 
 # Style
@@ -179,8 +180,29 @@ redundant_pub_crate = "allow"
 future_not_send = "allow"
 too_long_first_doc_paragraph = "allow"
 missing_const_for_fn = "allow"
+# false positives (e.g. suggests pointless drop immediately before return)
+# and can't be disabled in integration tests
 significant_drop_tightening = "allow"
-fallible_impl_from = "allow"
-single_option_map = "allow"
+# false positives
 uninhabited_references = "allow"
 option_if_let_else = "allow"
+
+[workspace.metadata.dylint]
+# cargo-dylint (https://github.com/trailofbits/dylint)
+# is for additional lints. Lint providers are configured with
+# `libraries` array. Run all configured lints with:
+# cargo dylint --all -- --all-targets
+#
+# Advisory only: includes lots of opinionated lints. For this
+# reason this is not checked in pre-commit or CI, and is
+# provided here as a reference
+
+libraries = [
+  { git = "https://github.com/trailofbits/dylint", pattern = [
+    "examples/general",
+    "examples/supplementary",
+    "examples/restriction/*",  # * is needed here, but not for others
+  ] },
+  { git = "https://github.com/scarletindustries/mordant" },
+  { git = "https://github.com/KSXGitHub/perfectionist" }
+]

--- a/core/src/config/local_fs.rs
+++ b/core/src/config/local_fs.rs
@@ -58,7 +58,10 @@ pub(crate) fn load_configs_from<P: AsRef<Utf8Path>>(
     user_config: Option<&Utf8Path>,
     working_dir: P,
 ) -> Result<Config, ConfigReadError> {
-    let mut config = user_config.map_or_else(|| Ok(Config::default()), get_config)?;
+    let mut config = match user_config {
+        Some(path) => get_config(path)?,
+        None => Config::default(),
+    };
     config.merge(get_config(working_dir.as_ref().join(CONFIG_FILE))?);
 
     Ok(config)

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -667,13 +667,6 @@ impl From<Iri<String>> for Identifier {
     }
 }
 
-impl From<Identifier> for Iri<String> {
-    fn from(value: Identifier) -> Self {
-        // Identifier is always valid IRI
-        Self::parse(value.0).unwrap()
-    }
-}
-
 impl Display for Identifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)

--- a/rules/dot_ok.yml
+++ b/rules/dot_ok.yml
@@ -1,0 +1,9 @@
+id: dot-ok
+severity: warning
+language: rust
+rule:
+  pattern: $EXPR.ok()
+message: "`.ok()` silently discards the error"
+ignores:
+  - "**/tests/**"
+  - "**/*_tests.rs"

--- a/rules/empty_err_arm.yml
+++ b/rules/empty_err_arm.yml
@@ -1,0 +1,13 @@
+id: empty-err-arm
+severity: warning
+language: rust
+rule:
+  any:
+    - pattern:
+        context: "match x { Err(_) => $EXPR }"
+        selector: match_arm
+    - pattern: if let Err(_) = $EXPR {}
+message: "empty `Err` arm silently discards the error"
+ignores:
+  - "**/tests/**"
+  - "**/*_tests.rs"

--- a/rules/if_let_ok.yml
+++ b/rules/if_let_ok.yml
@@ -1,0 +1,11 @@
+id: if-let-ok
+severity: warning
+language: rust
+rule:
+  any:
+    - pattern: if let Ok($PAT) = $EXPR { $$$THEN }
+    - pattern: let Ok($PAT) = $EXPR else { $$$ELSE };
+message: "`(if) let Ok()` silently discards the error"
+ignores:
+  - "**/tests/**"
+  - "**/*_tests.rs"

--- a/rules/let_underscore_result.yml
+++ b/rules/let_underscore_result.yml
@@ -1,0 +1,14 @@
+# This is likely to produce false positives, as nothing
+# binds it to Result-related identifiers (e.g. Ok/Err/.ok())
+id: let-underscore-result
+severity: warning
+language: rust
+rule:
+  all:
+    - pattern: let _ = $EXPR;
+    - not:
+        pattern: let _ = $A?;
+message: "`let _ = ...` silently discards a potential error"
+ignores:
+  - "**/tests/**"
+  - "**/*_tests.rs"

--- a/rules/map_map_err.yml
+++ b/rules/map_map_err.yml
@@ -1,0 +1,15 @@
+# Remove once clippy adds this, see
+# https://github.com/rust-lang/rust-clippy/issues/17469
+id: map-then-map-err
+severity: warning
+language: rust
+rule:
+  any:
+    - pattern: $EXPR.map($F).map_err($G)
+    - pattern: $EXPR.map_err($G).map($F)
+fix: |
+  match $EXPR {
+      Ok(v) => Ok($F(v)),
+      Err(e) => Err($G(e)),
+  }
+message: "`match` makes the intent clearer"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,13 @@
+# ast-grep (https://ast-grep.github.io/) is used essentially as a linter
+# for patterns not covered by clippy or dylint.
+#
+# Config reference: https://ast-grep.github.io/reference/sgconfig
+#
+# Advisory only, not run in pre-commit or CI
+#
+# Run all the checks:
+# ast-grep scan
+# Run a specific check:
+# ast-grep scan --rule rules/<rule>.yml
+ruleDirs:
+  - rules

--- a/sysand/src/cli.rs
+++ b/sysand/src/cli.rs
@@ -1133,6 +1133,7 @@ impl InfoCommand {
             )
         }
 
+        #[expect(clippy::single_option_map)]
         fn impossible<T>(impossible: Option<Infallible>) -> Option<T> {
             impossible.map(|x| match x {})
         }


### PR DESCRIPTION
Neither is enforced with pre-commit or in CI for now.