### PR TITLE
maint: migrate from `chrono` to `jiff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,15 +46,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,20 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,8 +539,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "unicase",
- "unicode-width",
 ]
 
 [[package]]
@@ -2247,30 +2222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_casemap"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,10 +2429,12 @@ dependencies = [
  "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -3184,8 +3137,8 @@ version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
- "chrono",
  "indexmap",
+ "jiff",
  "libc",
  "once_cell",
  "portable-atomic",
@@ -3741,10 +3694,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -4026,12 +3975,12 @@ dependencies = [
  "assert_cmd",
  "camino",
  "camino-tempfile",
- "chrono",
  "clap",
  "env_logger",
  "fluent-uri",
  "glob",
  "indexmap",
+ "jiff",
  "log",
  "mockito",
  "nix",
@@ -4062,7 +4011,6 @@ dependencies = [
  "bytes",
  "camino",
  "camino-tempfile",
- "chrono",
  "digest 0.11.3",
  "dirs",
  "dunce",
@@ -4076,6 +4024,7 @@ dependencies = [
  "icu_properties",
  "idna",
  "indexmap",
+ "jiff",
  "keyring",
  "log",
  "logos",
@@ -4503,12 +4452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4782,41 +4725,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "windows-link"
@@ -5172,7 +5080,6 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes 0.9.2",
  "bzip2",
- "chrono",
  "constant_time_eq",
  "crc32fast",
  "deflate64",
@@ -5180,6 +5087,7 @@ dependencies = [
  "getrandom 0.4.3",
  "hmac 0.13.0",
  "indexmap",
+ "jiff",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -27,7 +27,7 @@ camino.workspace = true
 fluent-uri.workspace = true
 env_logger.workspace = true
 jni = "0.22.4"
-indexmap = { version = "2.13.0", default-features = false, features = ["serde"] }
+indexmap = { version = "2.13.0", default-features = false }
 tokio = { version = "1.50.0", default-features = false, features = ["rt"] }
 
 [lints]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ std = [
 lenient_checks = []
 # Binding support (but not binding libraries themselves)
 python = ["dep:pyo3"]
-js = []  # ["dep:wasm-bindgen"]
+js = ["jiff/js"]  # ["dep:wasm-bindgen"]
 filesystem = ["dep:camino-tempfile", "dep:dirs", "dep:zip"]
 networking = ["dep:reqwest", "dep:gix"]  # "dep:reqwest-middleware", "dep:partialzip"
 # OS-keyring-backed credential store (not for wasm; the js binding must not
@@ -43,7 +43,7 @@ alltests = []
 camino.workspace = true
 camino-tempfile = { version = "1.4", optional = true }
 anstyle = { version = "1.0.13", default-features = false }
-chrono = { version = "0.4.44", features = ["now", "serde"] }
+jiff = { version = "0.2", default-features = false, features = ["std", "serde"] }
 digest = { version = "0.11", default-features = false }
 sha2.workspace = true
 hex.workspace = true
@@ -54,9 +54,9 @@ indexmap = { version = "2.13.0", default-features = false, features = ["serde"] 
 log.workspace = true
 pubgrub = { version = "0.4.0", default-features = false }
 # partialzip = { version = "5.0.0", default-features = false, optional = true }
-pyo3 = { version = "0.29.0", default-features = false, features = ["macros", "chrono", "indexmap"], optional = true }
+pyo3 = { version = "0.29.0", default-features = false, features = ["macros", "jiff-02", "indexmap"], optional = true }
 reqwest-middleware = { version = "0.5.1", features = ["multipart"] }
-semver = { version = "1.0.27", features = ["serde"] }
+semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", default-features = false, features = ["preserve_order"] }
 sysand-macros = { path = "../macros" }
@@ -68,7 +68,7 @@ typed-path = { version = "0.12.3", default-features = false }
 # wasm-bindgen = { version = "0.2.114", default-features = false, optional = true }
 zip = { version = "8.0.0", default-features = false, optional = true, features = [
   "deflate",
-  "chrono"
+  "jiff-02"
 ] }
 url = { version = "2.5.8", default-features = false }
 percent-encoding = { version = "2.3.2", default-features = false, features = ["alloc"] }

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -8,8 +8,8 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use chrono::{DateTime, Utc};
 use globset::{GlobBuilder, GlobSetBuilder};
+use jiff::Timestamp;
 use reqwest::{Response, StatusCode, header};
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
 
@@ -647,7 +647,7 @@ impl StandardHTTPAuthenticationBuilder {
 pub struct StoredBearerAuth {
     auth: ForceBearerAuth,
     key: String,
-    expires_at: Option<DateTime<Utc>>,
+    expires_at: Option<Timestamp>,
     /// Whether the reactive expiry hint has already been emitted for this
     /// record. `Arc`d so the flag is shared across the record's globs and
     /// across map clones: together with the once-per-process map cache
@@ -669,11 +669,7 @@ impl std::fmt::Debug for StoredBearerAuth {
 }
 
 impl StoredBearerAuth {
-    pub(crate) fn new(
-        auth: ForceBearerAuth,
-        key: String,
-        expires_at: Option<DateTime<Utc>>,
-    ) -> Self {
+    pub(crate) fn new(auth: ForceBearerAuth, key: String, expires_at: Option<Timestamp>) -> Self {
         Self {
             auth,
             key,
@@ -694,13 +690,13 @@ impl StoredBearerAuth {
     }
 
     /// Expiry, when a validating login learned it.
-    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+    pub fn expires_at(&self) -> Option<Timestamp> {
         self.expires_at
     }
 
     /// The reactive expiry hint, returned at most once per record: `Some` exactly when the record
     /// carries a past `expires_at` and no hint was emitted before.
-    fn take_expiry_warning(&self, now: DateTime<Utc>) -> Option<String> {
+    fn take_expiry_warning(&self, now: Timestamp) -> Option<String> {
         let expires_at = self.expires_at?;
         if expires_at >= now || self.expiry_warned.swap(true, Ordering::SeqCst) {
             return None;
@@ -716,7 +712,7 @@ impl StoredBearerAuth {
     /// ended in a 4xx. Any 4xx counts, not just 401: GitLab-style hosts
     /// answer 404 on bad auth.
     fn warn_if_expired(&self) {
-        if let Some(message) = self.take_expiry_warning(Utc::now()) {
+        if let Some(message) = self.take_expiry_warning(Timestamp::now()) {
             log::warn!("{message}");
         }
     }

--- a/core/src/auth_tests.rs
+++ b/core/src/auth_tests.rs
@@ -719,17 +719,17 @@ fn debug_never_renders_secrets() {
 
 // The reactive expiry hint.
 
-use chrono::{Duration, Utc};
+use jiff::{SignedDuration, Timestamp};
 
 use crate::auth::{ForceBearerAuth, StoredBearerAuth};
 
 #[test]
 fn stored_bearer_expiry_warning_fires_at_most_once() {
-    let now = Utc::now();
+    let now = Timestamp::now();
     let bearer = StoredBearerAuth::new(
         ForceBearerAuth::new("tok"),
         "https://example.com/".to_owned(),
-        Some(now - Duration::hours(1)),
+        Some(now - SignedDuration::from_hours(1)),
     );
 
     let message = bearer
@@ -751,11 +751,11 @@ fn stored_bearer_expiry_warning_fires_at_most_once() {
 
 #[test]
 fn stored_bearer_expiry_warning_skips_unexpired_and_unknown_expiry() {
-    let now = Utc::now();
+    let now = Timestamp::now();
     let unexpired = StoredBearerAuth::new(
         ForceBearerAuth::new("tok"),
         "https://example.com/".to_owned(),
-        Some(now + Duration::hours(1)),
+        Some(now + SignedDuration::from_hours(1)),
     );
     assert_eq!(unexpired.take_expiry_warning(now), None);
     assert!(!unexpired.expiry_warning_emitted());
@@ -798,7 +798,7 @@ fn lazy_layer_warns_once_for_an_expired_record_that_keeps_failing() {
     let forced_mock = versions_mock(&mut server, Some("stored-token"), 404, 2);
 
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
-    record.expires_at = Some(Utc::now() - Duration::days(1));
+    record.expires_at = Some(Timestamp::now() - SignedDuration::from_hours(24));
     let (store, _lists) = counting_store(vec![record]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
@@ -825,7 +825,7 @@ fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
     let _unauth = versions_mock(&mut server, None, 401, 1);
     let _forced = versions_mock(&mut server, Some("stored-token"), 404, 1);
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
-    record.expires_at = Some(Utc::now() + Duration::days(1));
+    record.expires_at = Some(Timestamp::now() + SignedDuration::from_hours(24));
     let (store, _lists) = counting_store(vec![record]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let runtime = runtime();
@@ -839,7 +839,7 @@ fn lazy_layer_does_not_warn_for_an_unexpired_record_or_a_successful_retry() {
     let _unauth = versions_mock(&mut server, None, 401, 1);
     let _forced = versions_mock(&mut server, Some("stored-token"), 200, 1);
     let mut record = bearer_record(&[format!("{}/**", server.url())], "stored-token");
-    record.expires_at = Some(Utc::now() - Duration::days(1));
+    record.expires_at = Some(Timestamp::now() - SignedDuration::from_hours(24));
     let (store, _lists) = counting_store(vec![record]);
     let policy = CredentialStoreAuthentication::new(empty_env_policy(), store);
     let url = format!("{}/pkg/versions.json", server.url());

--- a/core/src/commands/add_tests.rs
+++ b/core/src/commands/add_tests.rs
@@ -95,5 +95,5 @@ fn add_rejects_non_normalized_sysand_shorthand() {
     let err = format_err(err);
     assert!(err.contains("`Acme Labs/My.Project`"), "{err}");
     assert!(err.contains("`pkg:sysand/acme-labs/my.project`"), "{err}");
-    assert!(project.info.unwrap().usage.is_empty());
+    assert_eq!(project.info.unwrap().usage, []);
 }

--- a/core/src/commands/auth.rs
+++ b/core/src/commands/auth.rs
@@ -14,8 +14,8 @@
 
 use std::fmt::Write as _;
 
-use chrono::{DateTime, Utc};
 use globset::GlobBuilder;
+use jiff::Timestamp;
 use thiserror::Error;
 use url::Url;
 
@@ -261,7 +261,7 @@ pub struct StoredCredentialStatus {
     /// The URL glob patterns the credential applies to.
     pub globs: Vec<String>,
     /// Expiry, when a validating login learned it.
-    pub expires_at: Option<DateTime<Utc>>,
+    pub expires_at: Option<Timestamp>,
     /// Whether `expires_at` is known and in the past.
     pub expired: bool,
     /// Whole days until `expires_at`, against the assembly clock. Present
@@ -521,7 +521,7 @@ pub struct WhoamiIdentity {
     pub subject: CredentialSubject,
     pub token_name: Option<String>,
     pub token_prefix: Option<String>,
-    pub expires_at: Option<DateTime<Utc>>,
+    pub expires_at: Option<Timestamp>,
 }
 
 /// Wire shape of a `v1/whoami` 200 body (design/index-api-protocol.md,
@@ -546,9 +546,9 @@ struct WhoamiToken {
     name: Option<String>,
     #[serde(default)]
     prefix: Option<String>,
-    // chrono's serde impl parses the protocol's RFC 3339 timestamp.
+    // jiff's serde impl parses the protocol's RFC 3339 timestamp.
     #[serde(default)]
-    expires_at: Option<DateTime<Utc>>,
+    expires_at: Option<Timestamp>,
 }
 
 /// Read and parse a `v1/whoami` `200` body into the identity fields.
@@ -1390,7 +1390,7 @@ fn lenient_glob_matches(pattern: &str, target: &str) -> bool {
 pub fn assemble_auth_status(
     records: Vec<CredentialRecord>,
     mut env: Vec<EnvCredentialEntry>,
-    now: DateTime<Utc>,
+    now: Timestamp,
     default_key: Option<&str>,
 ) -> AuthStatus {
     let default_glob_root = default_key.and_then(index_key_glob_root);
@@ -1425,7 +1425,9 @@ pub fn assemble_auth_status(
                 .collect();
             StoredCredentialStatus {
                 expired: record.expires_at.is_some_and(|expiry| expiry < now),
-                expires_in_days: record.expires_at.map(|expiry| (expiry - now).num_days()),
+                expires_in_days: record
+                    .expires_at
+                    .map(|expiry| expiry.duration_since(now).as_secs() / 86400),
                 applies_to_default: default_key == Some(record.key.as_str())
                     || default_applies(&record.globs),
                 key: record.key,
@@ -1456,7 +1458,12 @@ pub fn do_auth_status<B: BlobBackend>(
     default_key: Option<&str>,
 ) -> Result<AuthStatus, AuthCommandError> {
     match store.list() {
-        Ok(records) => Ok(assemble_auth_status(records, env, Utc::now(), default_key)),
+        Ok(records) => Ok(assemble_auth_status(
+            records,
+            env,
+            Timestamp::now(),
+            default_key,
+        )),
         Err(CredentialStoreError::BackendAbsent { source }) => Ok(AuthStatus {
             stored: StoredCredentialsStatus::BackendUnavailable {
                 reason: source.to_string(),

--- a/core/src/commands/auth_tests.rs
+++ b/core/src/commands/auth_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use chrono::{TimeZone as _, Utc};
+use jiff::Timestamp;
 
 use std::assert_matches;
 
@@ -77,7 +77,7 @@ fn logout_normalizes_url_spellings_to_the_stored_key() {
     let key = logout(&mut store, "HTTPS://Example.COM:443/idx").unwrap();
 
     assert_eq!(key, "https://example.com/idx/");
-    assert!(store.list().unwrap().is_empty());
+    assert_eq!(store.list().unwrap(), []);
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn logout_of_non_http_url_errors_without_touching_the_store() {
 #[test]
 fn status_lists_stored_records_and_env_entries() {
     let mut expiring = record("https://example.com/idx/", "tok-1");
-    let expiry = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
+    let expiry: Timestamp = "2026-09-01T00:00:00Z".parse().unwrap();
     expiring.expires_at = Some(expiry);
     expiring.validated = vec![ValidatedSurface::Read];
     expiring.globs = vec![
@@ -140,25 +140,25 @@ fn status_lists_stored_records_and_env_entries() {
     assert_eq!(stored[1].key, "https://other.example/");
     assert_eq!(stored[1].expires_at, None);
     assert!(!stored[1].expired);
-    assert!(stored[1].validated.is_empty());
+    assert_eq!(stored[1].validated, []);
 }
 
 #[test]
 fn status_marks_expiry_against_the_given_clock() {
     let mut record = record("https://example.com/idx/", "tok");
-    let expiry = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
+    let expiry: Timestamp = "2026-09-01T00:00:00Z".parse().unwrap();
     record.expires_at = Some(expiry);
 
     let before = assemble_auth_status(
         vec![record.clone()],
         vec![],
-        Utc.with_ymd_and_hms(2026, 8, 31, 0, 0, 0).unwrap(),
+        "2026-08-31T00:00:00Z".parse().unwrap(),
         None,
     );
     let after = assemble_auth_status(
         vec![record],
         vec![],
-        Utc.with_ymd_and_hms(2026, 9, 2, 0, 0, 0).unwrap(),
+        "2026-09-02T00:00:00Z".parse().unwrap(),
         None,
     );
 
@@ -185,13 +185,13 @@ fn status_reports_env_entries_shadowing_a_stored_key() {
         env_entry("SYSAND_CRED_BROKEN", "https://example.com/[invalid"),
     ];
 
-    let status = assemble_auth_status(records, env, Utc::now(), None);
+    let status = assemble_auth_status(records, env, Timestamp::now(), None);
 
     let StoredCredentialsStatus::Available(stored) = status.stored else {
         panic!("expected stored credentials");
     };
     assert_eq!(stored[0].shadowed_by, vec!["SYSAND_CRED_TEAM".to_owned()]);
-    assert!(stored[1].shadowed_by.is_empty());
+    assert_eq!(stored[1].shadowed_by, [] as [String; 0]);
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn status_marks_entries_applying_to_the_default_index() {
         env_entry("SYSAND_CRED_MISS", "https://elsewhere.example/**"),
     ];
 
-    let status = assemble_auth_status(records, env, Utc::now(), Some("https://sysand.com/"));
+    let status = assemble_auth_status(records, env, Timestamp::now(), Some("https://sysand.com/"));
 
     let StoredCredentialsStatus::Available(stored) = status.stored else {
         panic!("expected stored credentials");
@@ -243,7 +243,7 @@ fn status_marks_entries_for_a_template_default_index() {
     let status = assemble_auth_status(
         vec![template_entry, host_entry],
         env,
-        Utc::now(),
+        Timestamp::now(),
         Some(template_key),
     );
 
@@ -444,7 +444,7 @@ mod login {
         let record = &store.list().unwrap()[0];
         assert_eq!(record.secret, "tok");
         // Nothing exercised the token: the record carries no claim.
-        assert!(record.validated.is_empty());
+        assert_eq!(record.validated, []);
     }
 
     #[test]
@@ -461,7 +461,7 @@ mod login {
 
         let (_, globs) = stored(outcome);
         assert_eq!(globs.len(), 1, "Case A must not add a glob: {globs:?}");
-        assert!(notices.is_empty());
+        assert_eq!(notices, []);
         assert_surface_coverage(&globs, &root, &root, &api_root);
     }
 
@@ -781,7 +781,7 @@ mod login {
         // A differently-spelled scheme normalizes to the same key.
         let removed = logout(&mut store, "HTTP://127.0.0.1:1/files/{path}/raw?ref=main").unwrap();
         assert_eq!(removed, template);
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -876,7 +876,7 @@ mod login {
         );
         // `logout` accepts the normalized key `status` would print.
         assert_eq!(logout(&mut store, &key).unwrap(), key);
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -1053,7 +1053,7 @@ mod login {
         let (outcome, _) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, []);
         whoami.assert();
     }
 
@@ -1181,7 +1181,7 @@ mod login {
         assert_eq!(record.token_prefix.as_deref(), Some("sysand_u_1a2b3c4d"));
         assert_eq!(
             record.expires_at,
-            Some(Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap())
+            Some("2026-09-01T00:00:00Z".parse().unwrap())
         );
     }
 
@@ -1210,7 +1210,7 @@ mod login {
             message.contains("`v1/whoami` answered HTTP 401"),
             "was: {message}"
         );
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -1242,7 +1242,7 @@ mod login {
             message.contains("or no index exists at this URL"),
             "was: {message}"
         );
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -1270,7 +1270,7 @@ mod login {
             !message.contains("no index exists"),
             "a 403 must not be hedged: {message}"
         );
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -1376,7 +1376,7 @@ mod login {
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, []);
         assert!(
             notices.iter().any(|n| matches!(
                 n,
@@ -1407,7 +1407,7 @@ mod login {
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, []);
         assert!(
             notices.iter().any(|n| matches!(
                 n,
@@ -1452,7 +1452,7 @@ mod login {
             !message.contains("does not support"),
             "Basic is routed, not reported as unsupported: {message}"
         );
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -1516,7 +1516,7 @@ mod login {
             !message.contains("BASIC_USER"),
             "no basic routing without a Basic challenge: {message}"
         );
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -1551,7 +1551,7 @@ mod login {
             message.contains("the authentication scheme `Negotiate`"),
             "was: {message}"
         );
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     #[test]
@@ -1760,7 +1760,7 @@ mod login {
         assert!(message.contains("`index.json`, HTTP 404"), "was: {message}");
         assert!(message.contains("`v1/whoami`, HTTP 401"), "was: {message}");
         assert!(!message.contains("no index exists"), "was: {message}");
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
     }
 
     // Authenticated discovery: the login discovery fetch is an
@@ -1873,7 +1873,7 @@ mod login {
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, globs, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, []);
         assert!(notices.is_empty(), "unexpected notices: {notices:?}");
         assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
         config.assert();
@@ -1910,7 +1910,7 @@ mod login {
             )),
             "expected a discovery notice naming the 401, got {notices:?}"
         );
-        assert!(store.list().unwrap().is_empty());
+        assert_eq!(store.list().unwrap(), []);
         config.assert();
         index.assert();
     }
@@ -1931,7 +1931,7 @@ mod login {
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, globs, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, []);
         assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
         assert!(
             notices.iter().any(|n| matches!(
@@ -1989,7 +1989,7 @@ mod login {
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, _, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, []);
         assert!(
             notices
                 .iter()
@@ -2020,7 +2020,7 @@ mod login {
         let (outcome, notices) = run_login(&mut store, &server.url(), "tok");
 
         let (_, globs, validated) = stored_validated(outcome);
-        assert!(validated.is_empty());
+        assert_eq!(validated, []);
         assert_eq!(globs, vec![format!("{}**", globset::escape(&root))]);
         assert!(
             notices.iter().any(|n| matches!(

--- a/core/src/commands/build.rs
+++ b/core/src/commands/build.rs
@@ -4,6 +4,7 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use fluent_uri::Iri;
 use indexmap::IndexMap;
+use jiff::tz::TimeZone;
 use thiserror::Error;
 
 use std::{collections::HashSet, io::Write as _};
@@ -348,7 +349,7 @@ fn do_build_kpar_inner<P: AsRef<Utf8Path>, Pr: ProjectRead>(
     let archive_file = wrapfs::File::create(&path)?;
     let mut zip = zip::ZipWriter::new(archive_file);
 
-    let time = chrono::Utc::now().naive_utc();
+    let time = jiff::Timestamp::now().to_zoned(TimeZone::UTC).datetime();
     let options = zip::write::SimpleFileOptions::default()
         .compression_method(compression.into())
         .system(zip::System::Unix)

--- a/core/src/commands/init.rs
+++ b/core/src/commands/init.rs
@@ -67,7 +67,7 @@ pub fn do_init_ext<P: ProjectMut>(
         },
         &InterchangeProjectMetadata {
             index: indexmap::IndexMap::new(),
-            created: chrono::Utc::now(),
+            created: jiff::Timestamp::now(),
             metamodel: None,
             includes_derived: None,
             includes_implied: None,

--- a/core/src/commands/lock.rs
+++ b/core/src/commands/lock.rs
@@ -179,7 +179,7 @@ pub fn do_lock_projects<
         let sources = project
             .sources(ctx)
             .map_err(LockProjectError::InputProjectError)?;
-        debug_assert!(!sources.is_empty());
+        debug_assert_ne!(sources, []);
 
         lock.projects.push(Project {
             name: info.name,
@@ -279,7 +279,7 @@ pub fn do_lock_extend<
             Vec::new()
         } else {
             let sources = project.sources(ctx).map_err(LockError::DependencyProject)?;
-            debug_assert!(!sources.is_empty());
+            debug_assert_ne!(sources, []);
             sources
         };
 

--- a/core/src/commands/publish.rs
+++ b/core/src/commands/publish.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use url::Url;
 use zip::result::ZipError;
 
-use chrono::{DateTime, TimeDelta, Utc};
+use jiff::{SignedDuration, Timestamp};
 
 use crate::{
     auth::{
@@ -225,7 +225,7 @@ pub fn do_publish(
         key,
         expires_at: Some(expires_at),
     } = &bearer.provenance
-        && stored_bearer_clearly_expired(*expires_at, Utc::now())
+        && stored_bearer_clearly_expired(*expires_at, Timestamp::now())
     {
         return Err(PublishError::StoredCredentialExpired {
             key: key.clone(),
@@ -291,8 +291,8 @@ pub fn do_publish(
 /// generous clock-skew margin, so a skewed client clock cannot false-trip
 /// the pre-upload stop. The stop is only an optimization; the server's 401
 /// is the real authority, so the margin errs toward attempting.
-fn stored_bearer_clearly_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-    now.signed_duration_since(expires_at) > TimeDelta::hours(1)
+fn stored_bearer_clearly_expired(expires_at: Timestamp, now: Timestamp) -> bool {
+    now.duration_since(expires_at) > SignedDuration::from_hours(1)
 }
 
 /// Validate the shape of the resolved `api_root` that comes back from
@@ -406,7 +406,7 @@ pub enum PublishBearerProvenance {
     /// A stored credential (`sysand auth login`) for the given index key.
     Stored {
         key: String,
-        expires_at: Option<DateTime<Utc>>,
+        expires_at: Option<Timestamp>,
     },
     /// A short-lived token acquired via CI trusted publishing.
     TrustedPublishing,
@@ -1022,10 +1022,7 @@ pub enum PublishError {
          precedence instead)",
         crate::utils::format_expiry_utc(.expires_at)
     )]
-    StoredCredentialExpired {
-        key: String,
-        expires_at: DateTime<Utc>,
-    },
+    StoredCredentialExpired { key: String, expires_at: Timestamp },
 
     #[error("conflict: package version already exists: {0}")]
     Conflict(String),

--- a/core/src/commands/publish_tests.rs
+++ b/core/src/commands/publish_tests.rs
@@ -15,7 +15,7 @@ use crate::{
     resolve::net_utils::create_reqwest_client,
 };
 use bytes::Bytes;
-use chrono::{DateTime, Duration, Utc};
+use jiff::{SignedDuration, Timestamp};
 use mockito::Matcher;
 use std::assert_matches;
 use std::sync::Arc;
@@ -66,7 +66,7 @@ fn stored_sources(entries: &[(&str, &str)]) -> GlobMap<StoredBearerAuth> {
 
 fn stored_sources_expiring(
     entries: &[(&str, &str)],
-    expires_at: Option<DateTime<Utc>>,
+    expires_at: Option<Timestamp>,
 ) -> GlobMap<StoredBearerAuth> {
     let mut builder = GlobMapBuilder::new();
     for (pattern, token) in entries {
@@ -866,7 +866,7 @@ fn env_bearer(label: &str) -> SelectedPublishBearer {
     }
 }
 
-fn stored_bearer(expires_at: Option<DateTime<Utc>>) -> SelectedPublishBearer {
+fn stored_bearer(expires_at: Option<Timestamp>) -> SelectedPublishBearer {
     SelectedPublishBearer {
         auth: ForceBearerAuth::new("stored-token"),
         provenance: PublishBearerProvenance::Stored {
@@ -965,7 +965,7 @@ fn publish_stops_before_upload_when_the_stored_bearer_is_expired() {
     let mut server = mockito::Server::new();
     let mock = server.mock("POST", "/api/v1/upload").expect(0).create();
 
-    let expires_at = Utc::now() - Duration::days(1);
+    let expires_at = Timestamp::now() - SignedDuration::from_hours(24);
     let err = publish_to(&server, stored_bearer(Some(expires_at))).unwrap_err();
 
     assert_matches!(
@@ -995,30 +995,33 @@ fn publish_uploads_normally_without_a_known_expiry() {
 
 #[test]
 fn stored_bearer_clearly_expired_allows_a_skew_margin() {
-    let now = Utc::now();
+    let now = Timestamp::now();
     // Within the one-hour margin: a skewed client clock must not false-trip
     // and refuse a token the server would accept; the server's 401 stays the
     // authority.
     assert!(!stored_bearer_clearly_expired(
-        now - Duration::minutes(30),
+        now - SignedDuration::from_mins(30),
         now
     ));
     // Well past the margin: skip uploading with a known-dead token.
-    assert!(stored_bearer_clearly_expired(now - Duration::hours(2), now));
+    assert!(stored_bearer_clearly_expired(
+        now - SignedDuration::from_hours(2),
+        now
+    ));
     // Not yet expired.
     assert!(!stored_bearer_clearly_expired(
-        now + Duration::hours(1),
+        now + SignedDuration::from_hours(1),
         now
     ));
     // Exactly at the one-hour boundary: the comparison is strict (`>`), so
     // this is still within the margin; one second past it flips to expired.
     // Pins the boundary against an accidental `>=`.
     assert!(!stored_bearer_clearly_expired(
-        now - Duration::hours(1),
+        now - SignedDuration::from_hours(1),
         now
     ));
     assert!(stored_bearer_clearly_expired(
-        now - Duration::hours(1) - Duration::seconds(1),
+        now - SignedDuration::from_hours(1) - SignedDuration::from_secs(1),
         now
     ));
 }

--- a/core/src/commands/remove_tests.rs
+++ b/core/src/commands/remove_tests.rs
@@ -46,7 +46,7 @@ fn remove_accepts_normalized_sysand_shorthand() {
             version_constraint: None
         }
     );
-    assert!(project.info.unwrap().usage.is_empty());
+    assert_eq!(project.info.unwrap().usage, []);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn remove_keeps_iri_resource() {
             version_constraint: None
         }
     );
-    assert!(project.info.unwrap().usage.is_empty());
+    assert_eq!(project.info.unwrap().usage, []);
 }
 
 #[test]

--- a/core/src/commands/sync_tests.rs
+++ b/core/src/commands/sync_tests.rs
@@ -3,7 +3,6 @@
 
 use std::convert::Infallible;
 
-use chrono::DateTime;
 use indexmap::IndexMap;
 use semver::Version;
 
@@ -40,7 +39,7 @@ fn storage_example() -> InMemoryProject {
             .into(),
             &InterchangeProjectMetadata {
                 index: IndexMap::new(),
-                created: DateTime::from_timestamp(1, 2).unwrap(),
+                created: jiff::Timestamp::new(1, 2).unwrap(),
                 metamodel: None,
                 includes_derived: None,
                 includes_implied: None,

--- a/core/src/credential_store/keyring_store_tests.rs
+++ b/core/src/credential_store/keyring_store_tests.rs
@@ -41,7 +41,7 @@ fn read_modify_write_persists_records() {
     let backend = InMemoryBlobBackend::default();
     let mut store = store_at(backend.clone(), &dir);
 
-    assert!(store.list().unwrap().is_empty());
+    assert_eq!(store.list().unwrap(), []);
     store.upsert(record("https://a.example/", "tok-a")).unwrap();
     store.upsert(record("https://b.example/", "tok-b")).unwrap();
     store
@@ -198,7 +198,7 @@ fn exclusive_lock_blocks_reads() {
     let err = store.list().unwrap_err();
     assert_matches!(err, CredentialStoreError::LockTimeout { .. });
     file.unlock().unwrap();
-    assert!(store.list().unwrap().is_empty());
+    assert_eq!(store.list().unwrap(), []);
 }
 
 #[cfg(all(

--- a/core/src/credential_store/mod.rs
+++ b/core/src/credential_store/mod.rs
@@ -10,7 +10,7 @@
 //! the [`keyring_store::BlobBackend`] storage seam; the OS-keyring backend
 //! lives behind the `keyring` cargo feature.
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -208,7 +208,7 @@ pub struct CredentialRecord {
     pub scheme: CredentialScheme,
     pub secret: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<DateTime<Utc>>,
+    pub expires_at: Option<Timestamp>,
     /// Who the credential authenticates as, from `v1/whoami`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subject: Option<CredentialSubject>,

--- a/core/src/credential_store/mod_tests.rs
+++ b/core/src/credential_store/mod_tests.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
-use chrono::{TimeZone as _, Utc};
-
 use std::assert_matches;
 
 use super::{
@@ -28,7 +26,7 @@ fn record(key: &str, secret: &str) -> CredentialRecord {
 #[test]
 fn blob_round_trip_and_version_field() {
     let mut with_expiry = record("https://example.com/idx/", "tok-1");
-    with_expiry.expires_at = Some(Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap());
+    with_expiry.expires_at = Some("2026-09-01T00:00:00Z".parse().unwrap());
     let blob = CredentialBlob::new(vec![with_expiry, record("https://other.example/", "tok-2")]);
     let raw = serialize_blob(&blob);
     let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -84,7 +82,7 @@ fn parse_accepts_a_blob_written_before_the_newer_fields() {
     assert_eq!(record.subject, None);
     assert_eq!(record.token_name, None);
     assert_eq!(record.token_prefix, None);
-    assert!(record.validated.is_empty());
+    assert_eq!(record.validated, []);
     assert!(record.expires_at.is_some());
     assert!(record.extra.is_empty());
 }

--- a/core/src/env/index_tests.rs
+++ b/core/src/env/index_tests.rs
@@ -508,7 +508,7 @@ mod uris {
             .create();
 
         let uris: Result<Vec<_>, _> = env.uris()?.collect();
-        assert!(uris?.is_empty());
+        assert_eq!(uris?, [] as [String; 0]);
         index_mock.assert();
 
         Ok(())
@@ -1248,7 +1248,7 @@ mod get_project {
         assert_eq!(info.name, "proj0");
         assert_eq!(info.publisher.as_deref(), Some("admin"));
         assert_eq!(info.version, "0.3.0");
-        assert!(info.usage.is_empty());
+        assert_eq!(info.usage, []);
         assert!(meta.is_some());
 
         versions_mock.assert();

--- a/core/src/lock_tests.rs
+++ b/core/src/lock_tests.rs
@@ -1406,7 +1406,7 @@ fn remove_usage_prunes_unreachable_dependency() {
         .expect("root project should be found");
 
     assert_eq!(project_names(&lock), vec!["root".to_owned()]);
-    assert!(lock.projects[0].usages.is_empty());
+    assert_eq!(lock.projects[0].usages, []);
     assert_eq!(removed.len(), 1);
     assert_eq!(removed[0].name, "dep");
 }

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -643,7 +643,7 @@ pub type InterchangeProjectMetadataRaw =
 pub type InterchangeProjectMetadata = InterchangeProjectMetadataG<
     fluent_uri::Iri<String>,
     Utf8UnixPathBuf,
-    chrono::DateTime<chrono::Utc>,
+    jiff::Timestamp,
     InterchangeProjectChecksum,
 >;
 
@@ -652,14 +652,14 @@ pub type InterchangeProjectMetadata = InterchangeProjectMetadataG<
 /// helper so the format stays consistent across producers (default
 /// constructors, conversions, test fixtures) — two documents with the
 /// same instant serialize byte-for-byte the same.
-pub fn format_created(value: &chrono::DateTime<chrono::Utc>) -> String {
-    value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+pub fn format_created(value: &jiff::Timestamp) -> String {
+    format!("{value:.0}")
 }
 
-/// Shorthand for `format_created(&chrono::Utc::now())`, the most common
+/// Shorthand for `format_created(&jiff::Timestamp::now())`, the most common
 /// call site (default constructors and test fixtures all want "now").
 pub fn format_created_now() -> String {
-    format_created(&chrono::Utc::now())
+    format_created(&jiff::Timestamp::now())
 }
 
 impl From<InterchangeProjectMetadata> for InterchangeProjectMetadataRaw {
@@ -721,7 +721,7 @@ pub enum InterchangeProjectValidationError {
         source: RelativeUnixPathError,
     },
     #[error("failed to parse `{0}` as RFC3339 datetime: {1}")]
-    InvalidCreatedTime(Box<str>, chrono::ParseError),
+    InvalidCreatedTime(Box<str>, jiff::Error),
     #[error(
         "invalid file checksum algorithm `{0}`, expected one of:\n\
         SHA1, SHA224, SHA256, SHA-384, SHA3-256, SHA3-384, SHA3-512\n\
@@ -829,14 +829,12 @@ impl InterchangeProjectMetadataRaw {
         Ok(InterchangeProjectMetadata {
             index,
             // TODO: this is not strictly correct, as RFC3339 only partially overlaps with ISO8601
-            created: chrono::DateTime::parse_from_rfc3339(&self.created)
-                .map_err(|e| {
-                    InterchangeProjectValidationError::InvalidCreatedTime(
-                        self.created.as_str().into(),
-                        e,
-                    )
-                })?
-                .into(),
+            created: self.created.parse::<jiff::Timestamp>().map_err(|e| {
+                InterchangeProjectValidationError::InvalidCreatedTime(
+                    self.created.as_str().into(),
+                    e,
+                )
+            })?,
             metamodel,
             includes_derived: self.includes_derived,
             includes_implied: self.includes_implied,

--- a/core/src/project/memory.rs
+++ b/core/src/project/memory.rs
@@ -160,7 +160,7 @@ impl ProjectRead for InMemoryProject {
     }
 
     fn sources(&self, _ctx: &ProjectContext) -> Result<Vec<Source>, Self::Error> {
-        debug_assert!(!self.nominal_sources.is_empty());
+        debug_assert_ne!(self.nominal_sources, []);
         Ok(self.nominal_sources.clone())
     }
 

--- a/core/src/project/utils.rs
+++ b/core/src/project/utils.rs
@@ -627,8 +627,8 @@ impl Identifier {
     fn make_identifier_iri(publisher: impl AsRef<str>, name: impl AsRef<str>) -> Self {
         let publisher = publisher.as_ref();
         let name = name.as_ref();
-        debug_assert!(!publisher.is_empty());
-        debug_assert!(!name.is_empty());
+        debug_assert_ne!(publisher, "");
+        debug_assert_ne!(name, "");
 
         let normalized_pub = normalize_field(publisher);
         let normalized_name = normalize_field(name);

--- a/core/src/resolve/remote.rs
+++ b/core/src/resolve/remote.rs
@@ -226,8 +226,6 @@ impl<HTTPResolver: ResolveRead, GitResolver: ResolveRead> Iterator
                         self.resolved_http = None;
                     }
                 }
-
-                None
             }
             RemotePriority::PreferHTTP => {
                 if let Some(primary_resolver) = &mut self.resolved_http {
@@ -255,10 +253,9 @@ impl<HTTPResolver: ResolveRead, GitResolver: ResolveRead> Iterator
                         self.resolved_git = None;
                     }
                 }
-
-                None
             }
         }
+        None
     }
 }
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -259,8 +259,8 @@ pub fn to_pretty_json_string<T: Serialize>(value: &T) -> String {
 
 pub const SP: char = ' ';
 
-/// Render an expiry timestamp for display, without chrono's sub-second
+/// Render an expiry timestamp for display, without sub-second
 /// noise (`11:39:28.149443` reads as `11:39:28`).
-pub fn format_expiry_utc(expires_at: &chrono::DateTime<chrono::Utc>) -> String {
-    expires_at.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+pub fn format_expiry_utc(expires_at: &jiff::Timestamp) -> String {
+    expires_at.strftime("%Y-%m-%d %H:%M:%S UTC").to_string()
 }

--- a/core/tests/filesystem_env.rs
+++ b/core/tests/filesystem_env.rs
@@ -170,7 +170,7 @@ version = \"0.1\"
 
         // v2 project dir still has its files
         let v2_dir = cwd.path().join(".sysand/lib/sysand_test.multi_2.0.0");
-        assert!(!ls_dir(&v2_dir).is_empty());
+        assert_ne!(ls_dir(&v2_dir), [] as [String; 0]);
 
         // Persisted to disk: re-reading gives same result
         let env2 = LocalDirectoryEnvironment::read(cwd.path().join(".sysand"))?;
@@ -227,7 +227,7 @@ version = \"0.1\"
 
         // No versions for the deleted URI
         let versions: Vec<String> = env.versions(uri)?.into_iter().collect::<Result<_, _>>()?;
-        assert!(versions.is_empty());
+        assert_eq!(versions, [] as [String; 0]);
 
         // URI is gone from the listing
         let uris: Vec<String> = env.uris()?.into_iter().collect::<Result<_, _>>()?;
@@ -246,7 +246,7 @@ version = \"0.1\"
         // Persisted to disk: re-reading gives same result
         let env2 = LocalDirectoryEnvironment::read(cwd.path().join(".sysand"))?;
         let versions: Vec<String> = env2.versions(uri)?.into_iter().collect::<Result<_, _>>()?;
-        assert!(versions.is_empty());
+        assert_eq!(versions, [] as [String; 0]);
 
         Ok(())
     }

--- a/core/tests/memory_env.rs
+++ b/core/tests/memory_env.rs
@@ -6,7 +6,6 @@ use std::{
     io::{Cursor, Read as _},
 };
 
-use chrono::DateTime;
 use fluent_uri::Iri;
 use indexmap::IndexMap;
 use semver::Version;
@@ -62,7 +61,7 @@ fn env_manual_install() -> Result<(), Box<dyn std::error::Error>> {
 
     let meta = InterchangeProjectMetadata {
         index,
-        created: DateTime::from_timestamp(1, 2).unwrap(),
+        created: jiff::Timestamp::new(1, 2).unwrap(),
         metamodel: None,
         includes_derived: None,
         includes_implied: None,

--- a/sysand/Cargo.toml
+++ b/sysand/Cargo.toml
@@ -27,10 +27,9 @@ camino.workspace = true
 camino-tempfile = "1.4"
 anstream = "1.0.0"
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", default-features = false, features = ["now"] }
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 clap = { version = "4.5.60", default-features = false, features = [
   "derive",
-  "unicode",
   "help",
   "cargo",
   "color",
@@ -51,9 +50,9 @@ typed-path = { version = "0.12.3", default-features = false }
 url = { version = "2.5.8", default-features = false }
 indexmap = "2.13.0"
 tokio = { version = "1.50.0", default-features = false }
-reqwest-middleware = { version = "0.5.1", features = ["multipart"] }
+reqwest-middleware = "0.5.1"
 rpassword = "7.5.4"
-reqwest = { version = "0.13.2", features = ["rustls", "blocking"] }
+reqwest = { version = "0.13.2", features = ["rustls"] }
 wild = "2.2.1"
 
 [dev-dependencies]

--- a/sysand/src/commands/auth.rs
+++ b/sysand/src/commands/auth.rs
@@ -22,7 +22,7 @@ use sysand_core::{
     credential_store::CredentialStoreError,
 };
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 
 use crate::{CliAuthPolicy, DEFAULT_INDEX_URL, credential_store::open_cli_credential_store};
 
@@ -236,11 +236,11 @@ pub fn command_auth_login(
             // The core store reports only the condition (it must not name
             // CLI commands); the CLI owns the `sysand auth` remediation.
             let stored = store.list().unwrap_or_default();
-            let entries: Vec<(&str, Option<DateTime<Utc>>)> = stored
+            let entries: Vec<(&str, Option<Timestamp>)> = stored
                 .iter()
                 .map(|record| (record.key.as_str(), record.expires_at))
                 .collect();
-            bail!("{}", blob_full_message(&entries, Utc::now()))
+            bail!("{}", blob_full_message(&entries, Timestamp::now()))
         }
         Err(err) => Err(err.into()),
     }
@@ -250,7 +250,7 @@ pub fn command_auth_login(
 /// `auth login` (Windows ~2.5 KB). Naming the `sysand auth` commands
 /// belongs in the CLI, not core. Lists already-expired logins as drop
 /// candidates; with no stored credentials there is nothing to remove.
-fn blob_full_message(stored: &[(&str, Option<DateTime<Utc>>)], now: DateTime<Utc>) -> String {
+fn blob_full_message(stored: &[(&str, Option<Timestamp>)], now: Timestamp) -> String {
     let expired: Vec<&str> = stored
         .iter()
         .filter(|(_, at)| at.is_some_and(|at| at < now))
@@ -417,7 +417,7 @@ pub fn command_auth_status(config: &Config) -> Result<()> {
         // Could not open the store: degrade to the env-only view like an
         // absent backend, keeping the env entries' default-index marking.
         Err(err) => {
-            let mut status = assemble_auth_status(Vec::new(), env, chrono::Utc::now(), default_key);
+            let mut status = assemble_auth_status(Vec::new(), env, Timestamp::now(), default_key);
             status.stored = StoredCredentialsStatus::BackendUnavailable {
                 reason: err.to_string(),
             };
@@ -718,12 +718,15 @@ pub fn command_auth_whoami(
                         println!("{header}{:>12}{header:#} {prefix}", "Token prefix");
                     }
                     if let Some(expires_at) = identity.expires_at {
-                        let now = chrono::Utc::now();
+                        let now = Timestamp::now();
                         println!(
                             "{header}{:>12}{header:#} {}{}",
                             "Expires",
                             sysand_core::utils::format_expiry_utc(&expires_at),
-                            expiry_qualifier(expires_at < now, Some((expires_at - now).num_days()))
+                            expiry_qualifier(
+                                expires_at < now,
+                                Some(expires_at.duration_since(now).as_secs() / 86400),
+                            )
                         );
                     }
                 }

--- a/sysand/src/commands/auth_tests.rs
+++ b/sysand/src/commands/auth_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use super::{blob_full_message, cred_env_var_stem};
-use chrono::{Duration, Utc};
+use jiff::{SignedDuration, Timestamp};
 
 #[test]
 fn cred_env_var_stem_uses_the_uppercased_host() {
@@ -58,14 +58,14 @@ fn cred_env_var_stem_escapes_reserved_and_labelless_spellings() {
 
 #[test]
 fn blob_full_first_login_does_not_suggest_removing_a_login() {
-    let message = blob_full_message(&[], Utc::now());
+    let message = blob_full_message(&[], Timestamp::now());
     assert!(message.contains("use a smaller token"), "{message}");
     assert!(!message.contains("logout"), "{message}");
 }
 
 #[test]
 fn blob_full_names_the_status_and_logout_commands() {
-    let now = Utc::now();
+    let now = Timestamp::now();
     let stored = [("https://a.example/", None), ("https://b.example/", None)];
     let message = blob_full_message(&stored, now);
     assert!(message.contains("sysand auth status"), "{message}");
@@ -74,10 +74,16 @@ fn blob_full_names_the_status_and_logout_commands() {
 
 #[test]
 fn blob_full_lists_expired_logins_as_drop_candidates() {
-    let now = Utc::now();
+    let now = Timestamp::now();
     let stored = [
-        ("https://live.example/", Some(now + Duration::days(30))),
-        ("https://dead.example/", Some(now - Duration::days(1))),
+        (
+            "https://live.example/",
+            Some(now + SignedDuration::from_hours(30 * 24)),
+        ),
+        (
+            "https://dead.example/",
+            Some(now - SignedDuration::from_hours(24)),
+        ),
         ("https://unknown.example/", None),
     ];
     let message = blob_full_message(&stored, now);

--- a/sysand/src/commands/remove.rs
+++ b/sysand/src/commands/remove.rs
@@ -47,7 +47,7 @@ pub fn command_remove<Policy: HTTPAuthentication>(
     runtime: Arc<tokio::runtime::Runtime>,
     auth_policy: Arc<Policy>,
 ) -> Result<()> {
-    let mut current_project = ctx
+    let current_project = ctx
         .current_project
         .as_mut()
         .ok_or(CliError::MissingProjectCurrentDir)?;
@@ -62,7 +62,7 @@ pub fn command_remove<Policy: HTTPAuthentication>(
     // (unlike `add`), the failure must be pre-existing or transient
     // (i.e. lock/sync would have also failed even without the `remove`).
     // Therefore lock/sync failures should not revert the removal
-    let usages = do_remove(&mut current_project, iri.into_string())?;
+    let usages = do_remove(current_project, iri.into_string())?;
     print_removed(&usages);
 
     if !no_lock {
@@ -105,14 +105,14 @@ pub fn exp_command_remove<Policy: HTTPAuthentication>(
 ) -> Result<()> {
     let publisher = publisher.as_ref();
     let name = name.as_ref();
-    let mut current_project = ctx
+    let current_project = ctx
         .current_project
         .as_mut()
         .ok_or(CliError::MissingProjectCurrentDir)?;
 
     let project_root = current_project.root_path().to_owned();
 
-    let usages = exp_do_remove(&mut current_project, publisher, name)?;
+    let usages = exp_do_remove(current_project, publisher, name)?;
     print_removed(&usages);
 
     let usage_identifier = Identifier::from_pub_name(publisher, name);


### PR DESCRIPTION
We were transitively depending on `jiff` anyway, and all deps can be configured to use it.

Also drop some unused dependency features.