### PR TITLE
test(py): add `mock_index` fixture and a red end-to-end scenario suite

### DIFF
--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -51,7 +51,14 @@ use sysand_core::{
 use typed_path::Utf8UnixPathBuf;
 
 #[pyfunction(name = "_run_cli")]
-fn run_cli(args: Vec<String>) -> bool {
+fn run_cli(py: Python<'_>, args: Vec<String>) -> bool {
+    // The CLI can run for seconds and talk to the network; holding the GIL
+    // would block every other Python thread meanwhile — including an HTTP
+    // server the CLI is talking to (the Python test suite's mock index).
+    py.detach(|| run_cli_blocking(args))
+}
+
+fn run_cli_blocking(args: Vec<String>) -> bool {
     let exit_code;
     // Expand glob arguments, CMD/PowerShell don't do it
     #[cfg(windows)]

--- a/bindings/py/tests/conftest.py
+++ b/bindings/py/tests/conftest.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import typing
+from pathlib import Path
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+import sysand
+from mockindex import (
+    LEGACY_CONSTRAINT,
+    LIBRARY,
+    MockIndex,
+    run_cli_in,
+    usage,
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _claim_logger(tmp_path_factory: pytest.TempPathFactory) -> None:
+    # Whoever installs the global `log` logger first owns it for the process:
+    # binding functions install `pyo3_log` (records reach `caplog`), while
+    # `_run_cli` tries `env_logger`. Make one cheap binding call before any
+    # test so `_run_cli` can never steal the logger from the tests that
+    # assert on log records; `run_cli` then only prints a "failed to set up
+    # logger" warning and continues.
+    sysand.env.env(tmp_path_factory.mktemp("logger") / sysand.env.DEFAULT_ENV_NAME)
+
+
+def isolate_sysand_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors `sysand/tests/common/mod.rs`.
+
+    Drop every ambient `SYSAND_*` override (index, config, credentials, and
+    whatever is added later) so tests see only what they set themselves, then
+    point the credential store at the debug-only seam in
+    `sysand/src/credential_store.rs` so the developer's real OS keyring is
+    never touched.
+    """
+    for var in [v for v in os.environ if v.startswith("SYSAND_")]:
+        monkeypatch.delenv(var)
+    monkeypatch.setenv("SYSAND_TEST_CREDENTIAL_STORE", ":absent:")
+    monkeypatch.setenv("NO_COLOR", "1")
+
+
+@pytest.fixture(autouse=True)
+def _sysand_isolation(monkeypatch: pytest.MonkeyPatch) -> None:
+    isolate_sysand_env(monkeypatch)
+
+
+@pytest.fixture
+def mock_index(httpserver: HTTPServer) -> typing.Iterator[MockIndex]:
+    index = MockIndex(httpserver)
+    yield index
+    assert httpserver.handler_errors == [], (
+        f"mock index handler raised: {httpserver.handler_errors}"
+    )
+    assert index.requests("/index.json") == [], (
+        "`/index.json` must never be fetched: lookups go through the "
+        "per-project `versions.json` (see `sysand/tests/cli_lock.rs`)"
+    )
+
+
+@dataclasses.dataclass
+class Baseline:
+    """A project whose manifest, lockfile and `.sysand` are at library 0.10.3."""
+
+    root: Path
+    index: MockIndex
+
+    @property
+    def manifest(self) -> Path:
+        return self.root / ".project.json"
+
+    @property
+    def lockfile(self) -> Path:
+        return self.root / "sysand-lock.toml"
+
+    @property
+    def env_dir(self) -> Path:
+        return self.root / sysand.env.DEFAULT_ENV_NAME
+
+    def installed(self) -> list[str]:
+        """Names of the version-stamped install directories."""
+        lib = self.env_dir / "lib"
+        return sorted(p.name for p in lib.iterdir()) if lib.is_dir() else []
+
+    def snapshot(self) -> dict[str, object]:
+        """Everything a migration may touch, for "unchanged" assertions."""
+        return {
+            "manifest": self.manifest.read_bytes(),
+            "lockfile": self.lockfile.read_bytes(),
+            "env.toml": (self.env_dir / "env.toml").read_bytes(),
+            "installed": self.installed(),
+        }
+
+    def cli(self, *args: str) -> bool:
+        return run_cli_in(
+            self.root, *args, "--no-config", "--default-index", self.index.url
+        )
+
+
+MakeBaseline = typing.Callable[..., Baseline]
+
+
+@pytest.fixture
+def make_baseline(tmp_path: Path, mock_index: MockIndex) -> MakeBaseline:
+    """Factory for the project's real starting state.
+
+    The manifest is hand-written on purpose: it carries an unknown top-level
+    key, an unknown key inside the usage, and non-canonical key order and
+    whitespace (the input the manifest-fidelity scenario needs), which the
+    typed `add` path would not preserve. The lockfile and environment are then
+    produced by the shipped CLI, in-process, so the 0.10.3 state is real rather
+    than hand-written and depends on none of the APIs the scenarios exercise.
+    """
+
+    def make(
+        *,
+        include_library: bool = True,
+        extra_usages: typing.Sequence[dict] = (),
+        library_files: typing.Mapping[str, bytes] = {
+            "library.sysml": b"package Library;\n"
+        },
+    ) -> Baseline:
+        mock_index.publish(LIBRARY, "0.10.3", files=library_files)
+
+        root = tmp_path / "migrating"
+        root.mkdir()
+        sysand.init("migrating", "acme", "1.0.0", root)
+
+        usages: list[dict] = []
+        if include_library:
+            legacy = usage(LIBRARY, LEGACY_CONSTRAINT)
+            legacy["x-consumer-note"] = "pre-0.11"
+            usages.append(legacy)
+        usages.extend(extra_usages)
+        manifest = {
+            "version": "1.0.0",
+            "name": "migrating",
+            "publisher": "acme",
+            "x-consumer-extension": {"migrated": False},
+            "usage": usages,
+        }
+        (root / ".project.json").write_text(json.dumps(manifest, indent=4) + "\n")
+
+        baseline = Baseline(root=root, index=mock_index)
+        assert baseline.cli("lock"), "baseline `sysand lock` failed"
+        assert baseline.cli("sync"), "baseline `sysand sync` failed"
+        return baseline
+
+    return make
+
+
+@pytest.fixture
+def baseline(make_baseline: MakeBaseline) -> Baseline:
+    return make_baseline()

--- a/bindings/py/tests/mockindex.py
+++ b/bindings/py/tests/mockindex.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+"""A local sysand index served by ``pytest_httpserver``.
+
+The layout is the real index protocol's (see ``core/src/env/discovery.rs``):
+
+- ``pkg:sysand/<publisher>/<name>`` lives at ``/<publisher>/<name>/``;
+- any other IRI lives at ``/_iri/<sha256hex(canonical iri)>/``;
+- each project directory holds ``versions.json`` and, per version,
+  ``.project.json``, ``.meta.json`` and ``project.kpar``;
+- ``/sysand-index-config.json`` answers 404, so the index root defaults to
+  the discovery root;
+- ``/index.json`` is served, but the ``mock_index`` fixture fails a test that
+  fetches it (``lock`` must target ``versions.json``, never enumerate).
+
+Nothing on the sysand side is stubbed: the CLI and the bindings talk to this
+server over HTTP exactly as they talk to a live index.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import typing
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import quote
+
+from pytest_httpserver import HTTPServer
+from werkzeug.wrappers import Request, Response
+
+from sysand._sysand_core import _run_cli  # type: ignore
+
+# The library under test and the constraints the scenarios move between.
+LIBRARY = "pkg:sysand/mock/library"
+DEPENDENT = "pkg:sysand/mock/dependent"
+LEGACY_CONSTRAINT = ">=0.10.0, <0.11.0"
+TARGET_CONSTRAINT = ">=0.11.0, <0.12.0"
+
+# Fixed so archive digests are reproducible across runs.
+CREATED = "2026-01-01T00:00:00Z"
+_ZIP_DATE_TIME = (2026, 1, 1, 0, 0, 0)
+
+DISCOVERY_PATH = "/sysand-index-config.json"
+INDEX_PATH = "/index.json"
+
+_PURL_PREFIX = "pkg:sysand/"
+_SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def usage(resource: str, version_constraint: str | None = None) -> dict:
+    """A usage entry in the manifest's wire shape (camelCase)."""
+    entry: dict = {"resource": resource}
+    if version_constraint is not None:
+        entry["versionConstraint"] = version_constraint
+    return entry
+
+
+def _semver_key(version: str) -> tuple[int, int, int]:
+    m = _SEMVER.match(version)
+    if m is None:
+        # The index protocol rejects non-semver (and pre-release/build)
+        # entries at ingest (`core/src/env/index.rs::validate_versions`),
+        # so the fixture refuses them rather than serving an invalid index.
+        raise ValueError(
+            f"mock index only publishes plain X.Y.Z versions, got {version!r}"
+        )
+    return tuple(int(g) for g in m.groups())  # type: ignore[return-value]
+
+
+def _segments(iri: str) -> list[str]:
+    """The project directory's path segments, as `project_rel_segments` builds them."""
+    if iri.startswith(_PURL_PREFIX):
+        publisher, name = iri[len(_PURL_PREFIX) :].split("/", 1)
+        return [publisher, name]
+    # Core hashes `canonicalize_iri(iri)`. The fixture hashes the IRI as
+    # given, which is identical for IRIs that are already canonical
+    # (`urn:...`, PURLs); pass canonical IRIs.
+    return ["_iri", hashlib.sha256(iri.encode()).hexdigest()]
+
+
+@dataclasses.dataclass
+class _Version:
+    version: str
+    usage: list[dict]
+    kpar: bytes
+    project_json: bytes
+    meta_json: bytes
+
+    @property
+    def digest(self) -> str:
+        return "sha256:" + hashlib.sha256(self.kpar).hexdigest()
+
+    def versions_entry(self) -> dict:
+        return {
+            "version": self.version,
+            "usage": self.usage,
+            "kpar_size": len(self.kpar),
+            "kpar_digest": self.digest,
+        }
+
+
+@dataclasses.dataclass
+class _Project:
+    iri: str
+    name: str
+    publisher: str | None
+    versions: dict[str, _Version] = dataclasses.field(default_factory=dict)
+
+
+class MockIndex:
+    def __init__(self, httpserver: HTTPServer) -> None:
+        self._server = httpserver
+        self._projects: dict[str, _Project] = {}
+        self._files: dict[str, tuple[bytes, str]] = {}
+        self._bearer: str | None = None
+        self._fail_next: dict[str, int] = {}
+        httpserver.expect_request(re.compile(r"^/.*$")).respond_with_handler(
+            self._handle
+        )
+
+    # -- addressing ---------------------------------------------------------
+
+    @property
+    def url(self) -> str:
+        return self._server.url_for("")
+
+    @staticmethod
+    def project_dir(iri: str) -> str:
+        return "/" + "/".join(quote(seg, safe="") for seg in _segments(iri))
+
+    @classmethod
+    def versions_path(cls, iri: str) -> str:
+        return f"{cls.project_dir(iri)}/versions.json"
+
+    @classmethod
+    def kpar_path(cls, iri: str, version: str) -> str:
+        return f"{cls.project_dir(iri)}/{quote(version, safe='')}/project.kpar"
+
+    # -- publishing ---------------------------------------------------------
+
+    def publish(
+        self,
+        iri: str,
+        version: str,
+        *,
+        usage: typing.Sequence[dict] = (),
+        files: typing.Mapping[str, bytes] = {},
+        index: typing.Mapping[str, str] | None = None,
+        name: str | None = None,
+        publisher: str | None = None,
+    ) -> None:
+        """Publish ``iri`` at ``version``; may be called mid-test.
+
+        ``usage`` entries are the manifest wire shape, see :func:`usage`; they
+        are written to the ``versions.json`` entry (which is what the solver
+        reads) and mirrored into the archive's ``.project.json``.
+
+        ``files`` go into the archive and, unless ``index`` is given, are
+        listed in ``.meta.json``'s symbol index under their stem — ``sync``
+        installs only indexed source files.
+        """
+        if index is None:
+            index = {Path(path).stem: path for path in files}
+        _semver_key(version)
+        if iri.startswith(_PURL_PREFIX):
+            default_publisher, default_name = _segments(iri)
+        else:
+            default_publisher, default_name = None, re.split(r"[:/]", iri)[-1]
+        project = self._projects.setdefault(
+            iri,
+            _Project(
+                iri=iri,
+                name=name or default_name,
+                publisher=publisher or default_publisher,
+            ),
+        )
+        if version in project.versions:
+            raise ValueError(f"{iri} {version} is already published")
+
+        info: dict = {"name": project.name, "version": version}
+        if project.publisher is not None:
+            info["publisher"] = project.publisher
+        if usage:
+            info["usage"] = list(usage)
+        meta = {"index": dict(index), "created": CREATED}
+        project_json = (json.dumps(info, indent=2) + "\n").encode()
+        meta_json = (json.dumps(meta, indent=2) + "\n").encode()
+
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+            for arcname, data in [
+                (".project.json", project_json),
+                (".meta.json", meta_json),
+                *files.items(),
+            ]:
+                zi = zipfile.ZipInfo(arcname, date_time=_ZIP_DATE_TIME)
+                zi.compress_type = zipfile.ZIP_STORED
+                zi.external_attr = 0o644 << 16
+                zf.writestr(zi, data)
+
+        entry = _Version(
+            version=version,
+            usage=list(usage),
+            kpar=buf.getvalue(),
+            project_json=project_json,
+            meta_json=meta_json,
+        )
+        project.versions[version] = entry
+
+        base = f"{self.project_dir(iri)}/{quote(version, safe='')}"
+        self._files[f"{base}/.project.json"] = (project_json, "application/json")
+        self._files[f"{base}/.meta.json"] = (meta_json, "application/json")
+        self._files[f"{base}/project.kpar"] = (entry.kpar, "application/zip")
+        self._refresh_versions_json(project)
+
+    def _refresh_versions_json(self, project: _Project) -> None:
+        # Ingest validation requires strictly descending semver order.
+        ordered = sorted(
+            project.versions.values(),
+            key=lambda v: _semver_key(v.version),
+            reverse=True,
+        )
+        body = json.dumps({"versions": [v.versions_entry() for v in ordered]})
+        self._files[self.versions_path(project.iri)] = (
+            body.encode(),
+            "application/json",
+        )
+
+    def kpar_digest(self, iri: str, version: str) -> str:
+        return self._projects[iri].versions[version].digest
+
+    def kpar_size(self, iri: str, version: str) -> int:
+        return len(self._projects[iri].versions[version].kpar)
+
+    # -- fault injection ----------------------------------------------------
+
+    def require_bearer(self, token: str) -> None:
+        """Answer 401 to every request without ``Authorization: Bearer <token>``."""
+        self._bearer = token
+
+    def fail_next(self, path: str, status: int) -> None:
+        """Make the next request for ``path`` fail with ``status``."""
+        self._fail_next[path] = status
+
+    # -- observation --------------------------------------------------------
+
+    def requests(self, path_glob: str = "*") -> list[str]:
+        """Paths requested so far, in order, filtered by an fnmatch glob."""
+        return [
+            req.path
+            for req, _resp in self._server.log
+            if fnmatch.fnmatchcase(req.path, path_glob)
+        ]
+
+    # -- dispatch -----------------------------------------------------------
+
+    def _handle(self, request: Request) -> Response:
+        path = request.path
+        if self._bearer is not None:
+            if request.headers.get("Authorization") != f"Bearer {self._bearer}":
+                return Response(
+                    "unauthorized",
+                    status=401,
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+        status = self._fail_next.pop(path, None)
+        if status is not None:
+            return Response(f"injected failure {status}", status=status)
+        if path == DISCOVERY_PATH:
+            return Response("", status=404)
+        if path == INDEX_PATH:
+            body = json.dumps({"projects": [{"iri": iri} for iri in self._projects]})
+            return Response(body, status=200, content_type="application/json")
+        entry = self._files.get(path)
+        if entry is None:
+            return Response("not found", status=404)
+        body, content_type = entry
+        return Response(body, status=200, content_type=content_type)
+
+
+def run_cli_in(root: str | Path, *args: str) -> bool:
+    """Run the in-process CLI with ``root`` as its working directory.
+
+    ``run_cli`` discovers the project from the process cwd, so the cwd is
+    switched for the duration of the call (process-global, visible to Rust).
+    """
+    previous = os.getcwd()
+    os.chdir(root)
+    try:
+        return bool(_run_cli(["sysand", *args]))
+    finally:
+        os.chdir(previous)

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -12,6 +12,7 @@ import pytest
 from pytest_httpserver import HTTPServer
 
 import sysand
+from mockindex import MockIndex
 
 
 def test_basic_init(caplog: pytest.LogCaptureFixture) -> None:
@@ -151,39 +152,17 @@ def test_http_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) -> 
     assert meta["checksum"] is None
 
 
-def test_index_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) -> None:
+def test_index_info(caplog: pytest.LogCaptureFixture, mock_index: MockIndex) -> None:
     level = logging.DEBUG
     logging.basicConfig(level=level)
     caplog.set_level(level)
 
-    filler_digest = "sha256:" + ("a" * 64)
-    # No discovery document: index_root defaults to the discovery root.
-    httpserver.expect_request("/sysand-index-config.json").respond_with_data(
-        "", status=404
-    )
-    iri_dir = "/_iri/19148b59a7f258e6eab15189ebcc5b6f884e02690a3b27f3f43e4c6e15dd9536"
-    httpserver.expect_request(f"{iri_dir}/versions.json").respond_with_json(
-        {
-            "versions": [
-                {
-                    "version": "1.2.3",
-                    "usage": [],
-                    "kpar_size": 42,
-                    "kpar_digest": filler_digest,
-                }
-            ]
-        }
-    )
-    httpserver.expect_request(f"{iri_dir}/1.2.3/.project.json").respond_with_json(
-        {"name": "test_index_info", "version": "1.2.3"}
-    )
-    httpserver.expect_request(f"{iri_dir}/1.2.3/.meta.json").respond_with_json(
-        {"index": {}, "created": "2026-01-01T00:00:00Z"}
-    )
+    # Non-PURL IRIs live under `/_iri/<sha256hex>/`; the fixture serves the
+    # real index layout, with no discovery document (index_root defaults to
+    # the discovery root).
+    mock_index.publish("urn:kpar:test_index_info", "1.2.3")
 
-    info, meta = sysand.info(
-        "urn:kpar:test_index_info", index_urls=httpserver.url_for("")
-    )
+    info, meta = sysand.info("urn:kpar:test_index_info", index_urls=mock_index.url)
 
     assert info["name"] == "test_index_info"
     assert info["version"] == "1.2.3"
@@ -197,6 +176,10 @@ def test_index_info(caplog: pytest.LogCaptureFixture, httpserver: HTTPServer) ->
     assert meta["includes_derived"] is None
     assert meta["includes_implied"] is None
     assert meta["checksum"] is None
+
+    iri_dir = "/_iri/19148b59a7f258e6eab15189ebcc5b6f884e02690a3b27f3f43e4c6e15dd9536"
+    assert mock_index.requests("*/versions.json") == [f"{iri_dir}/versions.json"]
+    assert mock_index.requests("/index.json") == []
 
 
 def test_model_roundtrip() -> None:

--- a/bindings/py/tests/test_mock_index.py
+++ b/bindings/py/tests/test_mock_index.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+"""The `mock_index` fixture's own tests: the index layout it serves, and the
+shipped CLI driving `lock` + `sync` against it (the Python twin of
+`sysand/tests/cli_lock.rs::lock_and_sync_against_mock_index`)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+from conftest import Baseline, MakeBaseline, isolate_sysand_env
+from mockindex import DEPENDENT, LIBRARY, MockIndex, run_cli_in, usage
+
+
+def _get(url: str, headers: dict[str, str] = {}) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as error:
+        return error.code, error.read()
+
+
+def test_isolation_env() -> None:
+    assert [v for v in os.environ if v.startswith("SYSAND_")] == [
+        "SYSAND_TEST_CREDENTIAL_STORE"
+    ]
+    assert os.environ["SYSAND_TEST_CREDENTIAL_STORE"] == ":absent:"
+
+
+def test_isolation_sweeps_ambient_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Any `SYSAND_*` variable, including ones sysand does not know yet, is
+    # removed rather than only a fixed list of today's names.
+    monkeypatch.setenv("SYSAND_FUTURE_KNOB", "1")
+    monkeypatch.setenv("SYSAND_CRED_AMBIENT", "https://example.invalid/*")
+    with pytest.MonkeyPatch.context() as inner:
+        isolate_sysand_env(inner)
+        assert [v for v in os.environ if v.startswith("SYSAND_")] == [
+            "SYSAND_TEST_CREDENTIAL_STORE"
+        ]
+    assert os.environ["SYSAND_FUTURE_KNOB"] == "1"
+
+
+def test_layout_paths(mock_index: MockIndex) -> None:
+    mock_index.publish(LIBRARY, "0.10.3", files={"library.sysml": b"package Library;"})
+    mock_index.publish(LIBRARY, "0.11.0", usage=[usage(DEPENDENT, ">=1.0.0")])
+    mock_index.publish("urn:kpar:other", "1.2.3")
+
+    base = mock_index.url.rstrip("/")
+
+    status, _ = _get(base + "/sysand-index-config.json")
+    assert status == 404
+
+    status, body = _get(base + "/mock/library/versions.json")
+    assert status == 200
+    versions = json.loads(body)["versions"]
+    assert [v["version"] for v in versions] == ["0.11.0", "0.10.3"], (
+        "ingest validation requires descending semver order"
+    )
+    assert versions[0]["usage"] == [
+        {"resource": DEPENDENT, "versionConstraint": ">=1.0.0"}
+    ]
+    assert versions[1]["usage"] == []
+
+    status, kpar = _get(base + "/mock/library/0.10.3/project.kpar")
+    assert status == 200
+    assert versions[1]["kpar_size"] == len(kpar)
+    assert versions[1]["kpar_digest"] == "sha256:" + hashlib.sha256(kpar).hexdigest()
+    assert versions[1]["kpar_digest"] == mock_index.kpar_digest(LIBRARY, "0.10.3")
+
+    status, body = _get(base + "/mock/library/0.10.3/.project.json")
+    assert json.loads(body) == {
+        "name": "library",
+        "version": "0.10.3",
+        "publisher": "mock",
+    }
+    status, body = _get(base + "/mock/library/0.11.0/.project.json")
+    assert json.loads(body)["usage"] == versions[0]["usage"]
+
+    digest = hashlib.sha256(b"urn:kpar:other").hexdigest()
+    status, body = _get(f"{base}/_iri/{digest}/versions.json")
+    assert status == 200
+    assert [v["version"] for v in json.loads(body)["versions"]] == ["1.2.3"]
+    status, body = _get(f"{base}/_iri/{digest}/1.2.3/.project.json")
+    assert json.loads(body) == {"name": "other", "version": "1.2.3"}
+
+    status, _ = _get(base + "/mock/library/9.9.9/project.kpar")
+    assert status == 404
+
+    assert mock_index.requests("*/versions.json") == [
+        "/mock/library/versions.json",
+        f"/_iri/{digest}/versions.json",
+    ]
+
+
+def test_publish_rejects_duplicate_and_non_semver(mock_index: MockIndex) -> None:
+    mock_index.publish(LIBRARY, "0.10.3")
+    with pytest.raises(ValueError):
+        mock_index.publish(LIBRARY, "0.10.3")
+    with pytest.raises(ValueError):
+        mock_index.publish(LIBRARY, "not-a-version")
+
+
+def test_cli_lock_and_sync_against_mock_index(baseline: Baseline) -> None:
+    lockfile = baseline.lockfile.read_text()
+    assert 'name = "library"' in lockfile
+    assert 'version = "0.10.3"' in lockfile
+    assert (
+        baseline.index.kpar_digest(LIBRARY, "0.10.3").removeprefix("sha256:")
+        in lockfile
+    ), "lockfile must retain the advertised digest"
+
+    env_toml = (baseline.env_dir / "env.toml").read_text()
+    assert LIBRARY in env_toml
+
+    [installed] = baseline.installed()
+    assert installed.endswith("_0.10.3")
+    assert (baseline.env_dir / "lib" / installed / "library.sysml").read_bytes() == (
+        b"package Library;\n"
+    )
+
+    # The whole 0.10.3 state came from the index, not from anywhere else.
+    assert baseline.index.requests("*/project.kpar") == [
+        "/mock/library/0.10.3/project.kpar"
+    ]
+    assert baseline.index.requests("/index.json") == []
+
+
+def test_baseline_with_dependent(
+    make_baseline: MakeBaseline, mock_index: MockIndex
+) -> None:
+    # A bare version constraint is caret in sysand: "0.10.1" is
+    # `>=0.10.1, <0.11.0`, satisfied by 0.10.3.
+    mock_index.publish(DEPENDENT, "1.0.0", usage=[usage(LIBRARY, "0.10.1")])
+    baseline = make_baseline(extra_usages=[usage(DEPENDENT, "1.0.0")])
+    installed = baseline.installed()
+    assert len(installed) == 2
+    assert any(n.endswith("_1.0.0") for n in installed)
+    assert any(n.endswith("_0.10.3") for n in installed)
+
+
+def test_require_bearer(mock_index: MockIndex, baseline: Baseline) -> None:
+    mock_index.require_bearer("s3cret")
+    versions_url = mock_index.url.rstrip("/") + MockIndex.versions_path(LIBRARY)
+
+    status, _ = _get(versions_url)
+    assert status == 401
+    status, _ = _get(versions_url, {"Authorization": "Bearer wrong"})
+    assert status == 401
+    status, _ = _get(versions_url, {"Authorization": "Bearer s3cret"})
+    assert status == 200
+
+    # With the credential store simulated absent and no SYSAND_CRED_* set,
+    # the CLI has nothing to authenticate with and must fail.
+    (baseline.root / "sysand-lock.toml").unlink()
+    assert baseline.cli("lock") is False
+    assert not baseline.lockfile.exists()
+
+
+def test_fail_next(mock_index: MockIndex) -> None:
+    mock_index.publish(LIBRARY, "0.10.3")
+    path = MockIndex.kpar_path(LIBRARY, "0.10.3")
+    mock_index.fail_next(path, 500)
+    url = mock_index.url.rstrip("/") + path
+    assert _get(url)[0] == 500
+    assert _get(url)[0] == 200
+    assert mock_index.requests(path) == [path, path]
+
+
+def test_run_cli_in_restores_cwd(tmp_path) -> None:
+    before = os.getcwd()
+    assert run_cli_in(tmp_path, "--version") is True
+    assert os.getcwd() == before

--- a/sysand/tests/common/mod.rs
+++ b/sysand/tests/common/mod.rs
@@ -88,10 +88,16 @@ pub fn sysand_cmd_in_with<'a, I: IntoIterator<Item = &'a str>>(
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("sysand"));
 
     cmd.env("NO_COLOR", "1");
-    // A developer's ambient default-index override must not leak into
-    // tests (it would inject markers or ambiguity notes into asserted
-    // output); tests that need it set it explicitly via `env`.
-    cmd.env_remove("SYSAND_DEFAULT_INDEX");
+    // A developer's ambient `SYSAND_*` overrides (default index, config,
+    // credentials, and whatever is added later) must not leak into tests:
+    // they would inject markers or ambiguity notes into asserted output or
+    // authenticate against the wrong index. Tests that need one set it
+    // explicitly via `env`, which is applied after this sweep.
+    for (name, _) in std::env::vars_os() {
+        if name.to_string_lossy().starts_with("SYSAND_") {
+            cmd.env_remove(name);
+        }
+    }
     // Default the debug-only credential store seam
     // (sysand/src/credential_store.rs) to a simulated-absent keyring so
     // no test ever reads the developer's real OS keyring (which could


### PR DESCRIPTION
This pull request adds test infrastructure for the Python bindings: an
in-process sysand index served by `pytest-httpserver` and a factory that builds
a real project against it.

The only change to shipped code is that `_run_cli` now releases the GIL
while the CLI runs.

## Why

We need to extend the Python bindings to cover full Sysand functionality, which
requires us to be able to test it against a live index from Python. Until now
the only index-facing Python test hand-wrote `httpserver` expectations for a
single lookup. Testing the new functions that way would mean duplicating the
index layout in every test and would leave the interesting cases (a version
published mid-test, a 401, a 500 on one archive) untested.

As a motivating example for the testing infrastructure and new Python API is
using Python API to update a Sysand package.

## What changed

### `tests/mockindex.py` — `MockIndex`

Serves the real index protocol layout over HTTP, mirroring
`core/src/env/discovery.rs`:

- `pkg:sysand/<publisher>/<name>` at `/<publisher>/<name>/`, any other IRI
  at `/_iri/<sha256hex>/`;
- per project `versions.json` (kept in strictly descending semver order, as
  ingest validation requires) and per version `.project.json`, `.meta.json`
  and `project.kpar` with a reproducible archive digest;
- `/sysand-index-config.json` answers 404, so the index root defaults to the
  discovery root.

Nothing on the sysand side is stubbed: the CLI and the bindings talk to the
server exactly as to a live index.

Test controls: `publish()` may be called mid-test; `require_bearer(token)`
turns every unauthenticated request into a 401; `fail_next(path, status)`
injects one failure; `requests(glob)` returns the request log.
`run_cli_in(root, *args)` runs the in-process CLI with `root` as the
working directory and restores the previous one afterwards.

### `tests/conftest.py` — fixtures

- `mock_index`: wraps `MockIndex` and, on teardown, fails the test if a
  handler raised or if `/index.json` was fetched. Lookups must go through
  the per-project `versions.json`, never enumerate the index; this is the
  same invariant `sysand/tests/cli_lock.rs` checks.
- `make_baseline` / `baseline`: publishes `pkg:sysand/mock/library` 0.10.3, runs
  `sysand.init`, writes a manifest by hand and then runs `lock` and `sync`
  through the shipped CLI.
- `_sysand_isolation` (autouse): points the credential store at the
  debug-only `:absent:` seam and clears every `SYSAND_*` variable,
  so tests never touch the developer's keyring or configuration. This
  mirrors `sysand/tests/common/mod.rs`, which is also updated to clear all
  `SYSAND_` env vars.
- `_claim_logger` (session, autouse): makes one binding call before any
  test so `pyo3_log` owns the global logger. Otherwise the first `_run_cli`
  call could install `env_logger` instead and the tests that assert on
  `caplog` records would see nothing.

### `tests/test_mock_index.py`

The fixture's own tests: layout paths for PURL and non-PURL IRIs, duplicate
and non-semver publish rejection, bearer enforcement, fault injection, cwd
restoration, and `lock` + `sync` through the CLI against the mock index.
The last one is the Python twin of
`sysand/tests/cli_lock.rs::lock_and_sync_against_mock_index`.

### `test_basic.py::test_index_info`

Rewritten on top of `mock_index` instead of hand-written `httpserver`
expectations. The assertions are unchanged; it additionally checks that
only the project's `versions.json` was requested.

### `src/lib.rs` — `_run_cli` releases the GIL

`_run_cli` now runs the CLI inside `py.detach(...)`. The CLI can run for
seconds and talk to the network. Holding the GIL for that long blocked
every other Python thread, including `pytest-httpserver`'s thread, so a
CLI call against the in-process index deadlocked. Independently of tests,
a long-running CLI call should not freeze the interpreter.
