### PR TITLE
feat(py): lossless `set_usage_constraint`, `add` returns its bool

### DIFF
--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -11,6 +11,12 @@ from ._model import (
     InterchangeProjectMetadata,
     Dependencies,
     CompressionMethod,
+    UsageConstraintChange,
+)
+
+from ._errors import (
+    SysandError,
+    ProjectError,
 )
 
 from ._info import info_path, info
@@ -23,6 +29,10 @@ from ._init import (
 
 from ._add import (
     add,
+)
+
+from ._usage import (
+    set_usage_constraint,
 )
 
 
@@ -59,8 +69,14 @@ __all__ = [
     "InterchangeProjectMetadata",
     "Dependencies",
     "CompressionMethod",
+    "UsageConstraintChange",
+    ## Errors
+    "SysandError",
+    "ProjectError",
     ## Add
     "add",
+    ## Usage
+    "set_usage_constraint",
     ## Remove
     "remove",
     ## Env

--- a/bindings/py/python/sysand/_add.py
+++ b/bindings/py/python/sysand/_add.py
@@ -8,8 +8,16 @@ import sysand._sysand_core as sysand_rs  # type: ignore
 from pathlib import Path
 
 
-def add(path: Path | str, iri: str, version: str | None = None) -> None:
-    sysand_rs.do_add_py(str(path), iri, version)
+def add(path: Path | str, iri: str, version: str | None = None) -> bool:
+    """Add a usage of ``iri`` (an IRI or ``publisher/name`` shorthand) to the
+    project at ``path``.
+
+    Returns:
+        ``True`` when a new usage was added, ``False`` when ``iri`` was
+        already declared and the call merged into (or ignored for) the
+        existing usage.
+    """
+    return sysand_rs.do_add_py(str(path), iri, version)  # type: ignore
 
 
 __all__ = ["add"]

--- a/bindings/py/python/sysand/_errors.py
+++ b/bindings/py/python/sysand/_errors.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+
+class SysandError(RuntimeError):
+    """Base class of every error raised by the ``sysand`` package.
+
+    Subclasses ``RuntimeError`` so callers catching that keep working.
+
+    Attributes:
+        wrote: whether the failed call modified anything on disk before it
+            failed. ``False`` means a clean refusal: nothing to roll back.
+    """
+
+    wrote: bool
+
+    def __init__(self, message: str, *, wrote: bool = False) -> None:
+        super().__init__(message)
+        self.wrote = wrote
+
+
+class ProjectError(SysandError):
+    """The project (its ``.project.json``, ``.meta.json`` or location) is
+    missing, malformed, or does not contain what the call needs."""
+
+
+__all__ = [
+    "SysandError",
+    "ProjectError",
+]

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -32,6 +32,18 @@ InterchangeProjectUsage = typing.Union[
 ]
 
 
+class UsageConstraintChange(typing.TypedDict):
+    """Result of :func:`sysand.set_usage_constraint`."""
+
+    resource: str
+    """The resource actually matched, with the ``publisher/name`` shorthand
+    expanded to its ``pkg:sysand/`` IRI."""
+    found: bool
+    changed: bool
+    old_constraint: typing.Optional[str]
+    new_constraint: typing.Optional[str]
+
+
 class InterchangeProjectInfo(typing.TypedDict):
     publisher: typing.Optional[str]
     name: str

--- a/bindings/py/python/sysand/_usage.py
+++ b/bindings/py/python/sysand/_usage.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sysand._sysand_core as sysand_rs  # type: ignore
+
+from ._errors import ProjectError
+from ._model import UsageConstraintChange
+
+
+def set_usage_constraint(
+    path: str | Path,
+    resource: str,
+    constraint: str | None,
+    *,
+    must_exist: bool = True,
+) -> UsageConstraintChange:
+    """Set (or, with ``None``, clear) the version constraint of the usage
+    naming ``resource`` in the project at ``path``.
+
+    Only that one ``versionConstraint`` value is touched: every other key,
+    including keys sysand does not know, and the document's key order are
+    preserved. Whitespace is sysand's own pretty format, so a manifest last
+    written by sysand changes in exactly one line. An unchanged constraint
+    does not touch the file at all.
+
+    ``resource`` may be an IRI or the ``publisher/name`` shorthand, matched
+    the way ``add`` matches.
+
+    Args:
+        path: The project directory.
+        resource: The usage's resource IRI or shorthand.
+        constraint: A semver requirement such as ``">=0.11.0, <0.12.0"``, or
+            ``None`` to remove the constraint.
+        must_exist: Raise :class:`ProjectError` when no usage matches. With
+            ``False`` a missing usage is reported as ``found=False`` instead;
+            a missing or unreadable ``.project.json`` still raises.
+
+    Raises:
+        ValueError: ``constraint`` is not a valid semver requirement, or
+            ``resource`` is a malformed shorthand.
+        ProjectError: the manifest is missing or malformed, ``resource`` is
+            declared more than once, or (with ``must_exist``) not at all.
+            ``wrote`` is always ``False``.
+    """
+    matched, found, changed, old, new = sysand_rs.do_set_usage_constraint_py(
+        str(path), resource, constraint
+    )
+    change = UsageConstraintChange(
+        resource=matched,
+        found=found,
+        changed=changed,
+        old_constraint=old,
+        new_constraint=new,
+    )
+    if must_exist and not found:
+        raise ProjectError(
+            f"usage `{matched}` is not declared in `{Path(path) / '.project.json'}`",
+            wrote=False,
+        )
+    return change
+
+
+__all__ = ["set_usage_constraint"]

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -38,7 +38,7 @@ use sysand_core::{
     project::{
         ProjectRead as _,
         local_kpar::{KparInnerPath, LocalKParProject},
-        local_src::{LocalSrcError, LocalSrcProject},
+        local_src::{EditInfoError, LocalSrcError, LocalSrcProject},
         utils::wrapfs,
     },
     remove::do_remove_guess,
@@ -46,6 +46,7 @@ use sysand_core::{
     root::do_root,
     sources::{Dependencies, do_sources_local_src_project_no_deps, resolve_dependencies},
     symbols::Language,
+    usage::{ConstraintChange, SetConstraintError, do_set_usage_constraint_local},
     utils::format_err,
 };
 use typed_path::Utf8UnixPathBuf;
@@ -505,15 +506,59 @@ pub fn do_sources_project_py(
 #[pyo3(
     signature = (path, iri, version),
 )]
-fn do_add_py(path: String, iri: String, version: Option<String>) -> PyResult<()> {
+fn do_add_py(path: String, iri: String, version: Option<String>) -> PyResult<bool> {
     common_init();
 
     let mut project = LocalSrcProject::new_access(path, None);
 
     // TODO: do dependency resolution and locking?
-    match do_add_guess(&mut project, iri, version) {
-        Ok(_added) => Ok(()),
-        Err(e) => Err(PyRuntimeError::new_err(format_err(e))),
+    // `true` when a new usage was added, `false` when it was merged into an
+    // existing one.
+    do_add_guess(&mut project, iri, version).map_err(|e| PyRuntimeError::new_err(format_err(e)))
+}
+
+/// The exception classes live in Python (`sysand/_errors.py`) so that `mypy`
+/// sees their attributes; the Rust side only needs to raise them.
+mod py_errors {
+    // `import_exception!` generates an inherent `new_err` next to the
+    // `PyTypeInfo` trait method of the same name.
+    #![allow(clippy::same_name_method)]
+    pyo3::import_exception!(sysand._errors, ProjectError);
+}
+use py_errors::ProjectError;
+
+/// Returns `(matched_resource, found, changed, old_constraint, new_constraint)`.
+///
+/// Invalid input (a malformed shorthand or an invalid version requirement)
+/// raises `ValueError`; a missing, unreadable or malformed manifest and an
+/// ambiguous declaration raise `sysand.ProjectError` (`wrote` stays `False`:
+/// nothing is written unless the edit succeeds). A missing usage is *not* an
+/// error here — `found` is `False` and the Python side decides.
+#[pyfunction(name = "do_set_usage_constraint_py")]
+#[pyo3(
+    signature = (path, resource, constraint),
+)]
+fn do_set_usage_constraint_py(
+    path: String,
+    resource: String,
+    constraint: Option<String>,
+) -> PyResult<(String, bool, bool, Option<String>, Option<String>)> {
+    common_init();
+
+    let mut project = LocalSrcProject::new_access(path, None);
+
+    match do_set_usage_constraint_local(&mut project, &resource, constraint.as_deref()) {
+        Ok((resource, ConstraintChange::Replaced { old, new })) => {
+            Ok((resource, true, true, old, new))
+        }
+        Ok((resource, ConstraintChange::Unchanged { constraint })) => {
+            Ok((resource, true, false, constraint.clone(), constraint))
+        }
+        Ok((resource, ConstraintChange::NotFound)) => Ok((resource, false, false, None, None)),
+        Err(EditInfoError::Edit(
+            e @ (SetConstraintError::InvalidConstraint(..) | SetConstraintError::MalformedUsage(_)),
+        )) => Err(PyValueError::new_err(format_err(e))),
+        Err(e) => Err(ProjectError::new_err(format_err(e))),
     }
 }
 
@@ -660,6 +705,7 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_sources_env_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_sources_project_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_add_py, m)?)?;
+    m.add_function(wrap_pyfunction!(do_set_usage_constraint_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_remove_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_include_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_exclude_py, m)?)?;

--- a/bindings/py/tests/conftest.py
+++ b/bindings/py/tests/conftest.py
@@ -113,11 +113,11 @@ def make_baseline(tmp_path: Path, mock_index: MockIndex) -> MakeBaseline:
     """Factory for the project's real starting state.
 
     The manifest is hand-written on purpose: it carries an unknown top-level
-    key, an unknown key inside the usage, and non-canonical key order and
-    whitespace (the input the manifest-fidelity scenario needs), which the
-    typed `add` path would not preserve. The lockfile and environment are then
-    produced by the shipped CLI, in-process, so the 0.10.3 state is real rather
-    than hand-written and depends on none of the APIs the scenarios exercise.
+    key, an unknown key inside the usage, and non-canonical key order (the
+    input the manifest-fidelity scenario needs), which the typed `add` path
+    would not preserve. The lockfile and environment are then produced by the
+    shipped CLI, in-process, so the 0.10.3 state is real rather than
+    hand-written and depends on none of the APIs the scenarios exercise.
     """
 
     def make(
@@ -147,7 +147,10 @@ def make_baseline(tmp_path: Path, mock_index: MockIndex) -> MakeBaseline:
             "x-consumer-extension": {"migrated": False},
             "usage": usages,
         }
-        (root / ".project.json").write_text(json.dumps(manifest, indent=4) + "\n")
+        # sysand's own pretty format (2-space indent, trailing newline):
+        # `set_usage_constraint` only guarantees a one-line diff for manifests
+        # last written by sysand.
+        (root / ".project.json").write_text(json.dumps(manifest, indent=2) + "\n")
 
         baseline = Baseline(root=root, index=mock_index)
         assert baseline.cli("lock"), "baseline `sysand lock` failed"

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -79,6 +79,186 @@ def test_remove_accepts_sysand_shorthand() -> None:
         )
 
 
+SYSAND_FORMATTED_MANIFEST = """{
+  "version": "1.2.3",
+  "name": "fidelity",
+  "x-unknown-top-level": {
+    "kept": true
+  },
+  "publisher": "acme",
+  "usage": [
+    {
+      "dir": "../local-lib",
+      "publisher": "local-pub",
+      "name": "local-lib"
+    },
+    {
+      "x-unknown-in-usage": null,
+      "resource": "pkg:sysand/mock/library",
+      "versionConstraint": ">=0.10.0, <0.11.0"
+    }
+  ]
+}
+"""
+
+
+def _one_line_diff(before: str, after: str) -> tuple[str, str]:
+    old_lines = before.splitlines(keepends=True)
+    new_lines = after.splitlines(keepends=True)
+    assert len(old_lines) == len(new_lines)
+    differing = [(o, n) for o, n in zip(old_lines, new_lines) if o != n]
+    assert len(differing) == 1, differing
+    return differing[0]
+
+
+def test_set_usage_constraint_preserves_document(tmp_path: Path) -> None:
+    manifest = tmp_path / ".project.json"
+    manifest.write_text(SYSAND_FORMATTED_MANIFEST)
+
+    change = sysand.set_usage_constraint(tmp_path, "mock/library", ">=0.11.0, <0.12.0")
+
+    assert change == {
+        "resource": "pkg:sysand/mock/library",
+        "found": True,
+        "changed": True,
+        "old_constraint": ">=0.10.0, <0.11.0",
+        "new_constraint": ">=0.11.0, <0.12.0",
+    }
+    old_line, new_line = _one_line_diff(SYSAND_FORMATTED_MANIFEST, manifest.read_text())
+    assert old_line == '      "versionConstraint": ">=0.10.0, <0.11.0"\n'
+    assert new_line == '      "versionConstraint": ">=0.11.0, <0.12.0"\n'
+
+
+def test_set_usage_constraint_purl_matches_shorthand_declaration(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".project.json").write_text(SYSAND_FORMATTED_MANIFEST)
+    change = sysand.set_usage_constraint(tmp_path, "pkg:sysand/mock/library", "0.11.0")
+    assert change["found"] and change["changed"]
+    assert change["new_constraint"] == "0.11.0"
+
+
+def test_set_usage_constraint_clear(tmp_path: Path) -> None:
+    manifest = tmp_path / ".project.json"
+    manifest.write_text(SYSAND_FORMATTED_MANIFEST)
+
+    change = sysand.set_usage_constraint(tmp_path, "mock/library", None)
+
+    assert change["changed"] is True
+    assert change["old_constraint"] == ">=0.10.0, <0.11.0"
+    assert change["new_constraint"] is None
+    expected = SYSAND_FORMATTED_MANIFEST.replace(
+        ',\n      "versionConstraint": ">=0.10.0, <0.11.0"', ""
+    )
+    assert manifest.read_text() == expected
+
+    # Setting a constraint on a usage without one appends it as the last key.
+    sysand.set_usage_constraint(tmp_path, "mock/library", "^0.11")
+    assert manifest.read_text() == SYSAND_FORMATTED_MANIFEST.replace(
+        ">=0.10.0, <0.11.0", "^0.11"
+    )
+
+
+def test_set_usage_constraint_unchanged_does_not_touch_file(tmp_path: Path) -> None:
+    manifest = tmp_path / ".project.json"
+    manifest.write_text(SYSAND_FORMATTED_MANIFEST)
+    os.utime(manifest, ns=(1_000_000_000_000_000_000, 1_000_000_000_000_000_000))
+    before = manifest.stat()
+
+    change = sysand.set_usage_constraint(tmp_path, "mock/library", ">=0.10.0, <0.11.0")
+
+    assert change["found"] is True
+    assert change["changed"] is False
+    assert change["old_constraint"] == change["new_constraint"] == ">=0.10.0, <0.11.0"
+    after = manifest.stat()
+    assert after.st_mtime_ns == before.st_mtime_ns
+    assert manifest.read_text() == SYSAND_FORMATTED_MANIFEST
+
+
+def test_set_usage_constraint_not_found(tmp_path: Path) -> None:
+    manifest = tmp_path / ".project.json"
+    manifest.write_text(SYSAND_FORMATTED_MANIFEST)
+
+    with pytest.raises(sysand.ProjectError) as excinfo:
+        sysand.set_usage_constraint(tmp_path, "acme/absent", "1.0.0")
+    assert excinfo.value.wrote is False
+    assert isinstance(excinfo.value, RuntimeError)
+    assert "pkg:sysand/acme/absent" in str(excinfo.value)
+
+    change = sysand.set_usage_constraint(
+        tmp_path, "acme/absent", "1.0.0", must_exist=False
+    )
+    assert change == {
+        "resource": "pkg:sysand/acme/absent",
+        "found": False,
+        "changed": False,
+        "old_constraint": None,
+        "new_constraint": None,
+    }
+    assert manifest.read_text() == SYSAND_FORMATTED_MANIFEST
+
+    # A missing manifest is an error even with must_exist=False.
+    with pytest.raises(sysand.ProjectError):
+        sysand.set_usage_constraint(
+            tmp_path / "nowhere", "acme/absent", "1.0.0", must_exist=False
+        )
+
+
+def test_set_usage_constraint_rejects_bad_input(tmp_path: Path) -> None:
+    manifest = tmp_path / ".project.json"
+    manifest.write_text(SYSAND_FORMATTED_MANIFEST)
+
+    with pytest.raises(ValueError):
+        sysand.set_usage_constraint(tmp_path, "mock/library", "nonsense")
+    with pytest.raises(ValueError):
+        sysand.set_usage_constraint(tmp_path, "ab/proj0", "1.0.0")
+    assert manifest.read_text() == SYSAND_FORMATTED_MANIFEST
+
+    manifest.write_text(
+        SYSAND_FORMATTED_MANIFEST.replace(
+            '"dir": "../local-lib"', '"resource": "pkg:sysand/mock/library"'
+        )
+    )
+    with pytest.raises(sysand.ProjectError) as excinfo:
+        sysand.set_usage_constraint(tmp_path, "mock/library", "1.0.0")
+    assert "2 times" in str(excinfo.value)
+    assert excinfo.value.wrote is False
+
+
+def test_set_usage_constraint_normalizes_hand_formatted_whitespace(
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / ".project.json"
+    manifest.write_text(
+        '{"name":"hand","version":"1.0.0","usage":[{"resource":"a:b","versionConstraint":"1.0.0"}],"z":1}'
+    )
+    sysand.set_usage_constraint(tmp_path, "a:b", "2.0.0")
+    # Same keys, same order, sysand's whitespace.
+    assert (
+        manifest.read_text()
+        == """{
+  "name": "hand",
+  "version": "1.0.0",
+  "usage": [
+    {
+      "resource": "a:b",
+      "versionConstraint": "2.0.0"
+    }
+  ],
+  "z": 1
+}
+"""
+    )
+
+
+def test_add_returns_whether_a_usage_was_added(tmp_path: Path) -> None:
+    sysand.init("test_add_returns", "a", "1.2.3", tmp_path)
+
+    assert sysand.add(tmp_path, "acme-labs/my.project", ">=1.0.0") is True
+    assert sysand.add(tmp_path, "acme-labs/my.project", ">=1.0.0") is False
+    assert sysand.add(tmp_path, "acme-labs/other") is True
+
+
 def test_basic_info(caplog: pytest.LogCaptureFixture) -> None:
     level = logging.DEBUG
     logging.basicConfig(level=level)

--- a/bindings/py/tests/test_migration_scenarios.py
+++ b/bindings/py/tests/test_migration_scenarios.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+"""End-to-end checks for editing a usage constraint through the Python API.
+
+Each test starts from `baseline` / `make_baseline` (conftest.py): a real
+project whose manifest, lockfile and `.sysand` were produced by the shipped
+CLI against the mock index, with the library pinned to the 0.10 line. The
+tests then move that constraint to the 0.11 line with
+`sysand.set_usage_constraint` and check what happened to the manifest.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import sysand
+from conftest import Baseline, MakeBaseline
+from mockindex import LEGACY_CONSTRAINT, LIBRARY, TARGET_CONSTRAINT, usage
+
+
+def migrate_constraint(baseline: Baseline) -> None:
+    change = sysand.set_usage_constraint(baseline.root, LIBRARY, TARGET_CONSTRAINT)
+    assert change["found"] is True
+    assert change["changed"] is True
+    assert change["old_constraint"] == LEGACY_CONSTRAINT
+    assert change["new_constraint"] == TARGET_CONSTRAINT
+
+
+def test_manifest_fidelity(baseline: Baseline) -> None:
+    # A manifest last written by sysand changes in exactly one line; unknown
+    # keys and the key order survive.
+    before = baseline.manifest.read_text().splitlines(keepends=True)
+    migrate_constraint(baseline)
+    after = baseline.manifest.read_text().splitlines(keepends=True)
+
+    assert len(before) == len(after)
+    differing = [(b, a) for b, a in zip(before, after) if b != a]
+    assert len(differing) == 1, differing
+    [(old_line, new_line)] = differing
+    assert LEGACY_CONSTRAINT in old_line
+    assert new_line == old_line.replace(LEGACY_CONSTRAINT, TARGET_CONSTRAINT)
+
+    manifest = json.loads("".join(after))
+    assert manifest["x-consumer-extension"] == {"migrated": False}
+    assert list(manifest) == [
+        "version",
+        "name",
+        "publisher",
+        "x-consumer-extension",
+        "usage",
+    ]
+    [library_usage] = manifest["usage"]
+    assert library_usage["x-consumer-note"] == "pre-0.11"
+
+
+def test_add_when_missing(make_baseline: MakeBaseline) -> None:
+    # The project does not declare the library at all: `set_usage_constraint`
+    # reports or refuses without writing, and `add` is the way to declare it.
+    baseline = make_baseline(include_library=False)
+    before = baseline.manifest.read_bytes()
+
+    change = sysand.set_usage_constraint(
+        baseline.root, LIBRARY, TARGET_CONSTRAINT, must_exist=False
+    )
+    assert change["found"] is False
+    assert change["changed"] is False
+    assert baseline.manifest.read_bytes() == before
+
+    with pytest.raises(sysand.ProjectError) as excinfo:
+        sysand.set_usage_constraint(baseline.root, LIBRARY, TARGET_CONSTRAINT)
+    assert excinfo.value.wrote is False
+
+    assert sysand.add(baseline.root, LIBRARY, TARGET_CONSTRAINT) is True
+    manifest = json.loads(baseline.manifest.read_text())
+    assert manifest["usage"] == [usage(LIBRARY, TARGET_CONSTRAINT)]
+    # A second add merges into the existing usage rather than adding one.
+    assert sysand.add(baseline.root, LIBRARY, TARGET_CONSTRAINT) is False
+    assert len(json.loads(baseline.manifest.read_text())["usage"]) == 1

--- a/core/src/commands/mod.rs
+++ b/core/src/commands/mod.rs
@@ -21,3 +21,4 @@ pub mod remove;
 pub mod root;
 pub mod sources;
 pub mod sync;
+pub mod usage;

--- a/core/src/commands/usage.rs
+++ b/core/src/commands/usage.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! Document-level edits of a project's `usage` entries.
+//!
+//! Unlike `add`/`remove`, which round-trip `.project.json` through the typed
+//! model (dropping keys the model does not know and re-ordering the rest),
+//! the operations here edit the JSON document itself, so every other key and
+//! the key order survive verbatim. `serde_json` is built with
+//! `preserve_order`, which is what makes this possible.
+
+use thiserror::Error;
+
+use crate::{add::expand_sysand_purl_shorthand, model::InterchangeProjectValidationError};
+
+/// Outcome of a constraint edit, so callers can report precisely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConstraintChange {
+    /// The usage was present and its constraint now differs.
+    Replaced {
+        old: Option<String>,
+        new: Option<String>,
+    },
+    /// The usage was present and already carried exactly this constraint.
+    /// The document was not modified.
+    Unchanged { constraint: Option<String> },
+    /// No usage matched the resource. The document was not modified.
+    NotFound,
+}
+
+#[derive(Debug, Error)]
+pub enum SetConstraintError {
+    #[error("`{0}` is not a valid version requirement")]
+    InvalidConstraint(String, #[source] semver::Error),
+    #[error(transparent)]
+    MalformedUsage(#[from] InterchangeProjectValidationError),
+    #[error("`.project.json` is not a JSON object")]
+    NotAnObject,
+    #[error("`usage` is present in `.project.json` but is not an array")]
+    UsageNotAnArray,
+    #[error("`{resource}` is declared {count} times in `.project.json`; refusing to guess")]
+    Ambiguous { resource: String, count: usize },
+}
+
+const USAGE_KEY: &str = "usage";
+const RESOURCE_KEY: &str = "resource";
+const VERSION_CONSTRAINT_KEY: &str = "versionConstraint";
+
+/// Expand `resource` the way `add` does: `publisher/name` becomes the
+/// `pkg:sysand/` PURL, anything else is used as given.
+fn expand_resource(resource: &str) -> Result<String, SetConstraintError> {
+    match expand_sysand_purl_shorthand(resource) {
+        Ok(Some(purl)) => Ok(purl),
+        Ok(None) => Ok(resource.to_owned()),
+        Err(source) => Err(
+            InterchangeProjectValidationError::MalformedUsageSysandPurl {
+                iri: resource.to_owned(),
+                source,
+            }
+            .into(),
+        ),
+    }
+}
+
+/// Set (or clear, with `None`) the `versionConstraint` of the `resource`
+/// usage naming `resource`, editing `doc` in place.
+///
+/// Only the one `versionConstraint` value is touched: every other key, every
+/// unknown key, and the document's key order are preserved verbatim. When a
+/// constraint is added to a usage that had none, the key is appended after
+/// the usage's existing keys.
+///
+/// `resource` is matched as `add` matches it: the `publisher/name` shorthand
+/// is expanded and then compared as a plain string. Returns the expanded
+/// resource alongside the change so callers can report what was matched.
+///
+/// The constraint is validated as a semver requirement, and a resource
+/// declared more than once is refused, before anything is modified.
+pub fn do_set_usage_constraint(
+    doc: &mut serde_json::Value,
+    resource: &str,
+    constraint: Option<&str>,
+) -> Result<(String, ConstraintChange), SetConstraintError> {
+    let resource = expand_resource(resource)?;
+    if let Some(constraint) = constraint {
+        semver::VersionReq::parse(constraint)
+            .map_err(|e| SetConstraintError::InvalidConstraint(constraint.to_owned(), e))?;
+    }
+
+    let serde_json::Value::Object(root) = doc else {
+        return Err(SetConstraintError::NotAnObject);
+    };
+    let usages = match root.get_mut(USAGE_KEY) {
+        None => return Ok((resource, ConstraintChange::NotFound)),
+        Some(serde_json::Value::Array(usages)) => usages,
+        Some(_) => return Err(SetConstraintError::UsageNotAnArray),
+    };
+
+    // Only `Resource` usages carry a `resource` key, so directory and kpar
+    // path usages never match.
+    let mut matches = usages.iter_mut().filter_map(|usage| match usage {
+        serde_json::Value::Object(usage)
+            if usage.get(RESOURCE_KEY).and_then(serde_json::Value::as_str) == Some(&resource) =>
+        {
+            Some(usage)
+        }
+        _ => None,
+    });
+    let Some(usage) = matches.next() else {
+        return Ok((resource, ConstraintChange::NotFound));
+    };
+    let count = 1 + matches.count();
+    if count > 1 {
+        return Err(SetConstraintError::Ambiguous { resource, count });
+    }
+
+    let old = match usage.get(VERSION_CONSTRAINT_KEY) {
+        None | Some(serde_json::Value::Null) => None,
+        Some(value) => value.as_str().map(str::to_owned),
+    };
+    if old.as_deref() == constraint {
+        return Ok((resource, ConstraintChange::Unchanged { constraint: old }));
+    }
+
+    match constraint {
+        Some(constraint) => {
+            // Assigning through the existing entry keeps its position;
+            // inserting a new key appends it.
+            usage.insert(
+                VERSION_CONSTRAINT_KEY.to_owned(),
+                serde_json::Value::String(constraint.to_owned()),
+            );
+        }
+        None => {
+            // `remove` is `swap_remove` under `preserve_order`; keep the order
+            // of the remaining keys.
+            usage.shift_remove(VERSION_CONSTRAINT_KEY);
+        }
+    }
+
+    Ok((
+        resource,
+        ConstraintChange::Replaced {
+            old,
+            new: constraint.map(str::to_owned),
+        },
+    ))
+}
+
+/// [`do_set_usage_constraint`] on the `.project.json` of a local project,
+/// written back in sysand's pretty format only when the document changed.
+#[cfg(feature = "filesystem")]
+pub fn do_set_usage_constraint_local(
+    project: &mut crate::project::local_src::LocalSrcProject,
+    resource: &str,
+    constraint: Option<&str>,
+) -> Result<(String, ConstraintChange), crate::project::local_src::EditInfoError<SetConstraintError>>
+{
+    project.edit_info_document(|doc| do_set_usage_constraint(doc, resource, constraint))
+}
+
+#[cfg(test)]
+#[path = "./usage_tests.rs"]
+mod tests;

--- a/core/src/commands/usage_tests.rs
+++ b/core/src/commands/usage_tests.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use std::assert_matches;
+
+use super::{ConstraintChange, SetConstraintError, do_set_usage_constraint};
+
+const LIBRARY: &str = "pkg:sysand/mock/library";
+const LEGACY: &str = ">=0.10.0, <0.11.0";
+const TARGET: &str = ">=0.11.0, <0.12.0";
+
+/// A manifest as sysand writes it, carrying an unknown top-level key, an
+/// unknown key inside the target usage, non-canonical key order, and a
+/// directory usage that must never match a resource lookup.
+const MANIFEST: &str = r#"{
+  "version": "1.2.3",
+  "name": "fidelity",
+  "x-unknown-top-level": {
+    "kept": true
+  },
+  "publisher": "acme",
+  "usage": [
+    {
+      "dir": "../local-lib",
+      "publisher": "local-pub",
+      "name": "local-lib"
+    },
+    {
+      "x-unknown-in-usage": null,
+      "resource": "pkg:sysand/mock/library",
+      "versionConstraint": ">=0.10.0, <0.11.0"
+    }
+  ]
+}
+"#;
+
+fn doc(text: &str) -> serde_json::Value {
+    serde_json::from_str(text).expect("test manifest must parse")
+}
+
+fn render(doc: &serde_json::Value) -> String {
+    let mut text = serde_json::to_string_pretty(doc).expect("render");
+    text.push('\n');
+    text
+}
+
+fn one_line_diff<'a>(before: &'a str, after: &'a str) -> (&'a str, &'a str) {
+    let before: Vec<_> = before.lines().collect();
+    let after: Vec<_> = after.lines().collect();
+    assert_eq!(before.len(), after.len(), "line count must not change");
+    let differing: Vec<_> = before
+        .iter()
+        .zip(&after)
+        .filter(|(b, a)| b != a)
+        .map(|(b, a)| (*b, *a))
+        .collect();
+    assert_eq!(
+        differing.len(),
+        1,
+        "exactly one line must differ: {differing:?}"
+    );
+    differing[0]
+}
+
+#[test]
+fn replace_touches_exactly_one_line() {
+    let mut d = doc(MANIFEST);
+
+    let (resource, change) = do_set_usage_constraint(&mut d, LIBRARY, Some(TARGET)).unwrap();
+
+    assert_eq!(resource, LIBRARY);
+    assert_eq!(
+        change,
+        ConstraintChange::Replaced {
+            old: Some(LEGACY.to_owned()),
+            new: Some(TARGET.to_owned()),
+        }
+    );
+    let after = render(&d);
+    let (old_line, new_line) = one_line_diff(MANIFEST, &after);
+    assert_eq!(
+        old_line,
+        r#"      "versionConstraint": ">=0.10.0, <0.11.0""#
+    );
+    assert_eq!(
+        new_line,
+        r#"      "versionConstraint": ">=0.11.0, <0.12.0""#
+    );
+}
+
+#[test]
+fn shorthand_matches_purl_declaration() {
+    let mut d = doc(MANIFEST);
+
+    let (resource, change) = do_set_usage_constraint(&mut d, "mock/library", Some(TARGET)).unwrap();
+
+    assert_eq!(resource, LIBRARY);
+    assert_matches!(change, ConstraintChange::Replaced { .. });
+    assert_eq!(render(&d), MANIFEST.replace(LEGACY, TARGET));
+}
+
+#[test]
+fn clear_removes_the_key_and_keeps_order() {
+    let mut d = doc(MANIFEST);
+
+    let (_, change) = do_set_usage_constraint(&mut d, LIBRARY, None).unwrap();
+
+    assert_eq!(
+        change,
+        ConstraintChange::Replaced {
+            old: Some(LEGACY.to_owned()),
+            new: None,
+        }
+    );
+    let expected = MANIFEST.replace(",\n      \"versionConstraint\": \">=0.10.0, <0.11.0\"", "");
+    assert_eq!(render(&d), expected);
+}
+
+#[test]
+fn set_when_absent_appends_the_key() {
+    let mut d = doc(&MANIFEST.replace(",\n      \"versionConstraint\": \">=0.10.0, <0.11.0\"", ""));
+
+    let (_, change) = do_set_usage_constraint(&mut d, LIBRARY, Some("^0.11")).unwrap();
+
+    assert_eq!(
+        change,
+        ConstraintChange::Replaced {
+            old: None,
+            new: Some("^0.11".to_owned()),
+        }
+    );
+    assert_eq!(render(&d), MANIFEST.replace(LEGACY, "^0.11"));
+}
+
+#[test]
+fn null_constraint_counts_as_absent() {
+    let mut d = doc(&MANIFEST.replace(&format!("\"{LEGACY}\""), "null"));
+
+    let (_, change) = do_set_usage_constraint(&mut d, LIBRARY, None).unwrap();
+
+    assert_eq!(change, ConstraintChange::Unchanged { constraint: None });
+}
+
+#[test]
+fn unchanged_leaves_the_document_alone() {
+    let mut d = doc(MANIFEST);
+
+    let (_, change) = do_set_usage_constraint(&mut d, LIBRARY, Some(LEGACY)).unwrap();
+
+    assert_eq!(
+        change,
+        ConstraintChange::Unchanged {
+            constraint: Some(LEGACY.to_owned()),
+        }
+    );
+    assert_eq!(render(&d), MANIFEST);
+}
+
+#[test]
+fn not_found_without_usage_key_and_without_match() {
+    let mut d = doc(r#"{"name": "n", "version": "1.0.0"}"#);
+    let (resource, change) = do_set_usage_constraint(&mut d, "acme/absent", Some("1")).unwrap();
+    assert_eq!(resource, "pkg:sysand/acme/absent");
+    assert_eq!(change, ConstraintChange::NotFound);
+    assert_eq!(d, doc(r#"{"name": "n", "version": "1.0.0"}"#));
+
+    let mut d = doc(MANIFEST);
+    let (_, change) = do_set_usage_constraint(&mut d, "acme/absent", Some("1")).unwrap();
+    assert_eq!(change, ConstraintChange::NotFound);
+    assert_eq!(render(&d), MANIFEST);
+}
+
+#[test]
+fn directory_usage_never_matches() {
+    // A directory usage whose `name` equals the looked-up shorthand's name
+    // is not a resource usage.
+    let mut d = doc(MANIFEST);
+    let (_, change) = do_set_usage_constraint(&mut d, "local-pub/local-lib", Some("1")).unwrap();
+    assert_eq!(change, ConstraintChange::NotFound);
+}
+
+#[test]
+fn ambiguous_is_refused_before_editing() {
+    // Turn the directory usage into a second resource usage of the library.
+    let mut d = doc(MANIFEST);
+    d["usage"][0] = serde_json::json!({ "resource": LIBRARY });
+    let before = d.clone();
+
+    let err = do_set_usage_constraint(&mut d, LIBRARY, Some(TARGET)).unwrap_err();
+
+    assert_matches!(
+        err,
+        SetConstraintError::Ambiguous { resource, count: 2 } if resource == LIBRARY
+    );
+    assert_eq!(d, before);
+}
+
+#[test]
+fn invalid_constraint_is_rejected_before_editing() {
+    let mut d = doc(MANIFEST);
+
+    let err = do_set_usage_constraint(&mut d, LIBRARY, Some("nonsense")).unwrap_err();
+
+    assert_matches!(err, SetConstraintError::InvalidConstraint(c, _) if c == "nonsense");
+    assert_eq!(render(&d), MANIFEST);
+}
+
+#[test]
+fn malformed_shorthand_is_rejected_like_add() {
+    let mut d = doc(MANIFEST);
+
+    let err = do_set_usage_constraint(&mut d, "ab/proj0", Some("1")).unwrap_err();
+
+    assert_matches!(
+        err,
+        SetConstraintError::MalformedUsage(
+            crate::model::InterchangeProjectValidationError::MalformedUsageSysandPurl { .. }
+        )
+    );
+    assert_eq!(render(&d), MANIFEST);
+}
+
+#[test]
+fn malformed_documents_are_rejected() {
+    let mut d = doc("[]");
+    assert_matches!(
+        do_set_usage_constraint(&mut d, LIBRARY, None).unwrap_err(),
+        SetConstraintError::NotAnObject
+    );
+
+    let mut d = doc(r#"{"usage": {"resource": "x"}}"#);
+    assert_matches!(
+        do_set_usage_constraint(&mut d, LIBRARY, None).unwrap_err(),
+        SetConstraintError::UsageNotAnArray
+    );
+}
+
+#[cfg(feature = "filesystem")]
+mod filesystem {
+    use camino_tempfile::tempdir;
+
+    use super::{LEGACY, LIBRARY, MANIFEST, TARGET, one_line_diff};
+    use crate::{
+        project::local_src::{EditInfoError, LocalSrcProject},
+        usage::{ConstraintChange, SetConstraintError, do_set_usage_constraint_local},
+    };
+
+    #[test]
+    fn sysand_formatted_file_changes_in_one_line() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".project.json");
+        std::fs::write(&path, MANIFEST).unwrap();
+        let mut project = LocalSrcProject::new_access(dir.path(), None);
+
+        let (_, change) =
+            do_set_usage_constraint_local(&mut project, LIBRARY, Some(TARGET)).unwrap();
+
+        assert_eq!(
+            change,
+            ConstraintChange::Replaced {
+                old: Some(LEGACY.to_owned()),
+                new: Some(TARGET.to_owned()),
+            }
+        );
+        let after = std::fs::read_to_string(&path).unwrap();
+        one_line_diff(MANIFEST, &after);
+    }
+
+    #[test]
+    fn unchanged_does_not_touch_the_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".project.json");
+        std::fs::write(&path, MANIFEST).unwrap();
+        let old_mtime = filetime_of(&path);
+        let mut project = LocalSrcProject::new_access(dir.path(), None);
+
+        let (_, change) =
+            do_set_usage_constraint_local(&mut project, LIBRARY, Some(LEGACY)).unwrap();
+
+        assert!(matches!(change, ConstraintChange::Unchanged { .. }));
+        assert_eq!(filetime_of(&path), old_mtime);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), MANIFEST);
+    }
+
+    #[test]
+    fn hand_formatted_file_gets_sysand_whitespace_but_keeps_keys_and_order() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".project.json");
+        std::fs::write(
+            &path,
+            r#"{"name":"hand","version":"1.0.0","usage":[{"resource":"a:b","versionConstraint":"1.0.0"}],"z":1}"#,
+        )
+        .unwrap();
+        let mut project = LocalSrcProject::new_access(dir.path(), None);
+
+        do_set_usage_constraint_local(&mut project, "a:b", Some("2.0.0")).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"{
+  "name": "hand",
+  "version": "1.0.0",
+  "usage": [
+    {
+      "resource": "a:b",
+      "versionConstraint": "2.0.0"
+    }
+  ],
+  "z": 1
+}
+"#
+        );
+    }
+
+    #[test]
+    fn edit_errors_leave_the_file_untouched() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".project.json");
+        std::fs::write(&path, MANIFEST).unwrap();
+        let mut project = LocalSrcProject::new_access(dir.path(), None);
+
+        let err =
+            do_set_usage_constraint_local(&mut project, LIBRARY, Some("nonsense")).unwrap_err();
+
+        assert!(matches!(
+            err,
+            EditInfoError::Edit(SetConstraintError::InvalidConstraint(..))
+        ));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), MANIFEST);
+    }
+
+    #[test]
+    fn missing_manifest_is_a_project_error() {
+        let dir = tempdir().unwrap();
+        let mut project = LocalSrcProject::new_access(dir.path(), None);
+
+        let err = do_set_usage_constraint_local(&mut project, LIBRARY, None).unwrap_err();
+
+        assert!(matches!(err, EditInfoError::Project(_)));
+    }
+
+    fn filetime_of(path: &camino::Utf8Path) -> std::time::SystemTime {
+        std::fs::metadata(path).unwrap().modified().unwrap()
+    }
+}

--- a/core/src/project/local_src.rs
+++ b/core/src/project/local_src.rs
@@ -222,6 +222,58 @@ impl LocalSrcProject {
     }
 }
 
+/// Error of [`LocalSrcProject::edit_info_document`]: either the project
+/// could not be read or written, or the edit itself failed.
+#[derive(Debug, Error)]
+pub enum EditInfoError<E> {
+    #[error(transparent)]
+    Project(#[from] LocalSrcError),
+    #[error(transparent)]
+    Edit(E),
+}
+
+impl LocalSrcProject {
+    /// Read `.project.json` as a JSON document, apply `edit`, and write the
+    /// document back in the byte shape `put_info` produces (pretty-printed,
+    /// trailing newline) — but only if `edit` changed it. An unchanged
+    /// document does not touch the file at all.
+    ///
+    /// Editing the document rather than the typed model keeps every key the
+    /// model does not know and the document's key order intact
+    /// (`serde_json` is built with `preserve_order`). The whole file is
+    /// serialized to memory before anything is written, so a failing edit or
+    /// serialization leaves the file untouched.
+    pub fn edit_info_document<F, T, E>(&mut self, edit: F) -> Result<T, EditInfoError<E>>
+    where
+        F: FnOnce(&mut serde_json::Value) -> Result<T, E>,
+    {
+        let project_json_path = self.info_path();
+
+        let text = wrapfs::read_to_string(&project_json_path).map_err(LocalSrcError::from)?;
+        let mut doc: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+            LocalSrcError::from(ProjectDeserializationError::new(&project_json_path, e))
+        })?;
+        let before = doc.clone();
+
+        let result = edit(&mut doc).map_err(EditInfoError::Edit)?;
+        if doc == before {
+            return Ok(result);
+        }
+
+        let mut buf = Vec::new();
+        serde_json::to_writer_pretty(&mut buf, &doc).map_err(|e| {
+            LocalSrcError::from(ProjectSerializationError::new(
+                format!("failed to serialize and write project info to `{project_json_path}`"),
+                e,
+            ))
+        })?;
+        buf.push(b'\n');
+        wrapfs::write(&project_json_path, buf).map_err(LocalSrcError::from)?;
+
+        Ok(result)
+    }
+}
+
 impl ProjectMut for LocalSrcProject {
     fn put_info(
         &mut self,


### PR DESCRIPTION
This MR adds `sysand.set_usage_constraint(path, resource, constraint, *, must_exist=True)`, which replaces (or clears) the version constraint of one usage in `.project.json` without disturbing anything else in the file, and makes `sysand.add` return whether it actually added a usage. It also introduces `sysand.SysandError` and `sysand.ProjectError`, the first two classes of a typed exception hierarchy for the bindings.

## Why

A tool that upgrades a dependency on the user's behalf needs to move one usage from, say, `>=0.10.0, <0.11.0` to `>=0.11.0, <0.12.0` and show the user what it did. The bindings offered no way to do that well:

- `add` on an already declared usage does not replace the constraint. It merges the new requirement into the existing one, so the two ranges above become an unsatisfiable conjunction.
- Every typed read-modify-write of `.project.json` (`add`, `remove`) goes through the Rust model, which drops keys it does not know and rewrites the remaining keys in its own order. A tool that edits a manifest owned by a user, possibly carrying extension keys, cannot afford that.
- `add` already computed whether a usage was added, but both the Rust binding and the Python wrapper discarded the value, so a caller could not tell "declared it" from "merged into an existing declaration".
- Failures surfaced as a bare `RuntimeError`, giving a caller no way to distinguish bad input from a broken project, or to know whether anything had been written before the failure.

## What changed

### `core/src/commands/usage.rs` — `do_set_usage_constraint`

Edits the parsed JSON document rather than the typed model. `serde_json` is already built with `preserve_order`, so every other key, unknown keys included, and the key order survive verbatim. Only the matched usage's `versionConstraint` value is touched: it is replaced in place, appended when the usage had none, or removed (order-preserving) when clearing.

Validation happens before any modification: the constraint must parse as a semver requirement, and a resource declared more than once is refused as `Ambiguous` instead of guessing. The resource is matched the way `add` matches it: the `publisher/name` shorthand is expanded to its `pkg:sysand/` PURL, then compared as a plain string. Directory and kpar-path usages carry no `resource` key and never match.

The result is `(matched_resource, ConstraintChange)`, where the change is `Replaced { old, new }`, `Unchanged { constraint }` or `NotFound`, so callers can report precisely what happened. `do_set_usage_constraint_local` applies it to a `LocalSrcProject`.

### `core/src/project/local_src.rs` — `edit_info_document`

A new method on `LocalSrcProject` that reads `.project.json` as a document, applies a caller-supplied edit, and writes the result back in the same byte shape `put_info` produces (pretty-printed, trailing newline), but only if the document changed. The whole file is serialized to memory first, so a failing edit or serialization never truncates the manifest. Errors are `EditInfoError<E>`: either the project could not be read or written, or the edit itself failed with `E`.

### Python: `set_usage_constraint`, `UsageConstraintChange`

`sysand.set_usage_constraint` returns a `UsageConstraintChange` TypedDict with `resource` (the expanded IRI actually matched), `found`, `changed`, `old_constraint` and `new_constraint`. With `must_exist=True` (the default) a missing usage raises `ProjectError`; with `False` it is reported as `found=False` and nothing is written. Bad input (an invalid requirement or a malformed shorthand) raises `ValueError`; a missing, malformed or ambiguous manifest raises `ProjectError`.

Because whitespace is normalised to sysand's own format, a manifest last written by sysand changes in exactly one line. A hand-formatted manifest gets sysand's whitespace on first edit but keeps all of its keys and their order.

### Python: `SysandError`, `ProjectError`

Defined in `sysand/_errors.py` and raised from Rust via `pyo3::import_exception!`, so `mypy` sees their attributes. `SysandError` subclasses `RuntimeError`, so existing `except RuntimeError` handlers keep working, and carries `wrote: bool`, which tells a caller whether the failed call modified anything on disk. Every error raised in this MR has `wrote=False`: nothing is written unless the edit succeeds.

### Python: `add` returns `bool`

`do_add_py` now passes through the value `do_add_guess` already produced, and `sysand.add` returns it: `True` when a new usage was added, `False` when the call merged into an existing declaration.

### Tests

- `core/src/commands/usage_tests.rs`: document-level tests, including a one-line-diff check on a manifest with unknown keys and non-canonical order, shorthand matching, clear keeps order, append when absent, `null` counts as absent, unchanged leaves the document alone, not-found cases, directory usages never match, and every refusal (ambiguous, invalid constraint, malformed shorthand, malformed document) happens before any edit.
- `bindings/py/tests/test_basic.py`: pytest equivalents on real files, plus "unchanged does not touch the file" (mtime and bytes), hand-formatted whitespace normalisation, and the `add` return value.
- `bindings/py/tests/test_migration_scenarios.py`: two end-to-end tests against the `baseline` fixture from the mock index. One moves the library's constraint and asserts the manifest differs in exactly one line with extension keys and order intact; the other covers a project that does not declare the library at all (`must_exist=False`, the refusal with `wrote=False`, then `add` declaring it and a second `add` merging).
- `bindings/py/tests/conftest.py`: the baseline manifest is now written in sysand's own two-space format, which is the documented scope of the one-line guarantee.

