### PR TITLE
feat(py): `env.projects`, `discover`, export `env.sources`

### DIFF
--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -12,11 +12,17 @@ from ._model import (
     Dependencies,
     CompressionMethod,
     UsageConstraintChange,
+    EnvProject,
+    EnvProjectChecksum,
+    EnvProjectChecksumKpar,
+    EnvProjectChecksumSrc,
+    Discovery,
 )
 
 from ._errors import (
     SysandError,
     ProjectError,
+    EnvError,
 )
 
 from ._info import info_path, info
@@ -59,6 +65,10 @@ from ._root import (
     root,
 )
 
+from ._discover import (
+    discover,
+)
+
 __all__ = [
     "InterchangeProjectUsageResource",
     "InterchangeProjectUsageDirectory",
@@ -70,9 +80,15 @@ __all__ = [
     "Dependencies",
     "CompressionMethod",
     "UsageConstraintChange",
+    "EnvProject",
+    "EnvProjectChecksum",
+    "EnvProjectChecksumKpar",
+    "EnvProjectChecksumSrc",
+    "Discovery",
     ## Errors
     "SysandError",
     "ProjectError",
+    "EnvError",
     ## Add
     "add",
     ## Usage
@@ -96,4 +112,6 @@ __all__ = [
     "sources",
     ## Root
     "root",
+    ## Discover
+    "discover",
 ]

--- a/bindings/py/python/sysand/_discover.py
+++ b/bindings/py/python/sysand/_discover.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sysand._sysand_core as sysand_rs  # type: ignore
+
+from ._model import Discovery
+
+
+def discover(path: str | Path = ".") -> Discovery:
+    """Find the project and the workspace enclosing ``path``.
+
+    This is the same lookup every CLI command performs first: walk up from
+    ``path`` to the nearest directory holding ``.project.json`` (or
+    ``.meta.json``), and separately to the nearest one holding
+    ``.workspace.json``. Paths are canonicalized, as :func:`sysand.root` does.
+    A tool that must not operate inside a workspace checks
+    ``workspace_root`` before doing anything else.
+
+    Raises:
+        ProjectError: a directory could not be read, or ``.workspace.json`` is
+            malformed.
+    """
+    project_root, workspace_root = sysand_rs.do_discover_py(str(path))
+    return Discovery(project_root=project_root, workspace_root=workspace_root)
+
+
+__all__ = ["discover"]

--- a/bindings/py/python/sysand/_errors.py
+++ b/bindings/py/python/sysand/_errors.py
@@ -26,7 +26,12 @@ class ProjectError(SysandError):
     missing, malformed, or does not contain what the call needs."""
 
 
+class EnvError(SysandError):
+    """The ``.sysand`` environment is missing, unreadable or malformed."""
+
+
 __all__ = [
     "SysandError",
     "ProjectError",
+    "EnvError",
 ]

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -44,6 +44,51 @@ class UsageConstraintChange(typing.TypedDict):
     new_constraint: typing.Optional[str]
 
 
+class EnvProjectChecksumKpar(typing.TypedDict):
+    kpar_cksum: str
+    """Checksum of the KPAR the project was installed from."""
+
+
+class EnvProjectChecksumSrc(typing.TypedDict):
+    src_cksum: str
+    """Checksum of the source directory the project was installed from."""
+
+
+EnvProjectChecksum = typing.Union[EnvProjectChecksumKpar, EnvProjectChecksumSrc]
+
+
+class EnvProject(typing.TypedDict):
+    """One entry of an environment's ``env.toml``, see
+    :func:`sysand.env.projects`."""
+
+    publisher: typing.Optional[str]
+    name: str
+    version: str
+    path: str
+    """Verbatim from ``env.toml``: relative to the environment directory, or
+    to the workspace/project root when ``editable``. Not joined."""
+    identifiers: typing.List[str]
+    """IRIs of the project; the first is canonical. Empty only for
+    ``editable`` entries."""
+    usages: typing.List[str]
+    editable: bool
+    workspace: bool
+    checksum: typing.Optional[EnvProjectChecksum]
+    """Checksum of what the project was installed from, or ``None`` when
+    ``env.toml`` records none (``editable`` entries)."""
+
+
+class Discovery(typing.TypedDict):
+    """Result of :func:`sysand.discover`."""
+
+    project_root: typing.Optional[str]
+    """Canonical path of the enclosing project (the directory holding
+    ``.project.json`` or ``.meta.json``), or ``None``."""
+    workspace_root: typing.Optional[str]
+    """Canonical path of the enclosing workspace (the directory holding
+    ``.workspace.json``), or ``None``."""
+
+
 class InterchangeProjectInfo(typing.TypedDict):
     publisher: typing.Optional[str]
     name: str

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -4,6 +4,9 @@
 from enum import Enum, auto
 import typing
 
+# IMPORTANT
+# Keep the types here in sync with Rust types from sysand-core.
+#
 # Use raw types for components, as these classes are converted
 # to/from Rust `*Raw` model type variants
 

--- a/bindings/py/python/sysand/env/__init__.py
+++ b/bindings/py/python/sysand/env/__init__.py
@@ -10,6 +10,14 @@ from ._install import (
     install_path,
 )
 
+from ._projects import (
+    projects,
+)
+
+from ._sources import (
+    sources,
+)
+
 from pathlib import Path
 
 
@@ -22,4 +30,8 @@ __all__ = [
     "DEFAULT_ENV_NAME",
     ## Install
     "install_path",
+    ## Projects
+    "projects",
+    ## Sources
+    "sources",
 ]

--- a/bindings/py/python/sysand/env/_projects.py
+++ b/bindings/py/python/sysand/env/_projects.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sysand._sysand_core as sysand_rs  # type: ignore
+
+from sysand._model import EnvProject
+
+
+def projects(env_path: str | Path) -> list[EnvProject]:
+    """List the projects recorded in the environment at ``env_path``.
+
+    This reads ``env.toml``; install paths are returned verbatim (see
+    :class:`~sysand.EnvProject`), so a caller re-reading the file set after a
+    ``sync`` joins ``path`` onto the environment directory itself (or onto the
+    workspace/project root for ``editable`` entries).
+
+    Raises:
+        EnvError: the environment is missing, unreadable or malformed.
+    """
+    return sysand_rs.do_env_projects_py(str(env_path))  # type: ignore
+
+
+__all__ = ["projects"]

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -19,10 +19,12 @@ use sysand_core::{
         env::{EnvError, do_env_local_dir},
         init::do_init_local_file,
     },
+    discover::{discover_project, discover_workspace},
     env::{
         DEFAULT_ENV_NAME, ReadEnvironment as _, WriteEnvironment as _,
         local_directory::{
-            LocalDirectoryEnvironment, LocalReadError, LocalWriteError, metadata::EnvMetadataError,
+            LocalDirectoryEnvironment, LocalReadError, LocalWriteError,
+            metadata::{EnvMetadataError, EnvProject, EnvProjectChecksum},
         },
         utils::clone_project,
     },
@@ -524,8 +526,10 @@ mod py_errors {
     // `PyTypeInfo` trait method of the same name.
     #![allow(clippy::same_name_method)]
     pyo3::import_exception!(sysand._errors, ProjectError);
+    pyo3::import_exception!(sysand._errors, EnvError);
 }
-use py_errors::ProjectError;
+// `sysand_core::commands::env::EnvError` is already in scope under that name.
+use py_errors::{EnvError as PyEnvError, ProjectError};
 
 /// Returns `(matched_resource, found, changed, old_constraint, new_constraint)`.
 ///
@@ -710,6 +714,8 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_include_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_exclude_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_env_install_path_py, m)?)?;
+    m.add_function(wrap_pyfunction!(do_env_projects_py, m)?)?;
+    m.add_function(wrap_pyfunction!(do_discover_py, m)?)?;
     // Currently this interop is done with strings instead
     // m.add_class::<KparCompressionMethod>()?;
 
@@ -718,9 +724,48 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 fn env_read_to_pyerr(err: EnvMetadataError) -> PyErr {
-    PyIOError::new_err(format!(
-        "failed to read environment metadata: {}",
-        format_err(err)
+    PyEnvError::new_err(format_err(err))
+}
+
+/// The entries of the environment's `env.toml`, each converted to a dict by
+/// `EnvProject`'s `IntoPyObject`. `path` is returned verbatim (relative to the
+/// environment directory, or to the workspace/project root for editable
+/// entries).
+#[pyfunction(name = "do_env_projects_py")]
+#[pyo3(
+    signature = (env_path),
+)]
+fn do_env_projects_py(env_path: String) -> PyResult<Vec<EnvProject>> {
+    common_init();
+
+    let env = LocalDirectoryEnvironment::read(env_path).map_err(env_read_to_pyerr)?;
+    Ok(env.projects().to_vec())
+}
+
+/// `(project_root, workspace_root)`, both canonicalized as `do_root_py` does,
+/// found by walking up from `path` exactly as the CLI does before every
+/// command.
+#[pyfunction(name = "do_discover_py")]
+#[pyo3(
+    signature = (path),
+)]
+fn do_discover_py(path: String) -> PyResult<(Option<String>, Option<String>)> {
+    common_init();
+
+    let path = Utf8PathBuf::from(path);
+    let project_root = discover_project(&path)
+        .map_err(|e| ProjectError::new_err(format_err(e)))?
+        .map(|project| wrapfs::canonicalize(project.root_path()))
+        .transpose()
+        .map_err(|e| ProjectError::new_err(format_err(e)))?;
+    let workspace_root = discover_workspace(&path)
+        .map_err(|e| ProjectError::new_err(format_err(e)))?
+        .map(|workspace| wrapfs::canonicalize(workspace.root_path()))
+        .transpose()
+        .map_err(|e| ProjectError::new_err(format_err(e)))?;
+    Ok((
+        project_root.map(Utf8PathBuf::into_string),
+        workspace_root.map(Utf8PathBuf::into_string),
     ))
 }
 
@@ -794,6 +839,29 @@ fn info_and_metadata_fields_guard(
                 let InterchangeProjectChecksumRaw { value, algorithm } = cksum;
             }
         }
+        None => (),
+    }
+}
+
+// Same purpose as `info_and_metadata_fields_guard`, for the `EnvProject`
+// typed dict in `_model.py`.
+#[expect(unused)]
+fn env_project_fields_guard(project: EnvProject) {
+    let EnvProject {
+        publisher,
+        name,
+        version,
+        path,
+        identifiers,
+        usages,
+        editable,
+        workspace,
+        checksum,
+    } = project;
+
+    match checksum {
+        Some(EnvProjectChecksum::Kpar { kpar_cksum }) => {}
+        Some(EnvProjectChecksum::Project { src_cksum }) => {}
         None => (),
     }
 }

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -1,18 +1,19 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
+import json
 import logging
 import tempfile
 from pathlib import Path
-import re
 import os
+import re
 from typing import List, Union
 
 import pytest
 from pytest_httpserver import HTTPServer
 
 import sysand
-from mockindex import MockIndex
+from mockindex import MockIndex, run_cli_in
 
 
 def test_basic_init(caplog: pytest.LogCaptureFixture) -> None:
@@ -257,6 +258,117 @@ def test_add_returns_whether_a_usage_was_added(tmp_path: Path) -> None:
     assert sysand.add(tmp_path, "acme-labs/my.project", ">=1.0.0") is True
     assert sysand.add(tmp_path, "acme-labs/my.project", ">=1.0.0") is False
     assert sysand.add(tmp_path, "acme-labs/other") is True
+
+
+def _project_with_dir_usage(tmp_path: Path) -> tuple[Path, Path]:
+    """A project using a sibling directory project, locked and synced offline
+    by the shipped CLI, plus a `urn:kpar:dep` project installed by path."""
+    root = tmp_path / "proj"
+    dep = tmp_path / "dir-dep"
+    kpar_dep = tmp_path / "kpar-dep"
+    for name, path in [("proj", root), ("dir-dep", dep), ("kpar-dep", kpar_dep)]:
+        path.mkdir()
+        sysand.init(name, "acme", "1.0.0", path)
+        (path / f"{name}.sysml").write_text(f"package P_{name.replace('-', '_')};")
+        sysand.include(path, f"{name}.sysml")
+    manifest = json.loads((root / ".project.json").read_text())
+    manifest["usage"] = [{"dir": "../dir-dep", "publisher": "acme", "name": "dir-dep"}]
+    (root / ".project.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    assert run_cli_in(root, "lock", "--no-config", "--no-index")
+    assert run_cli_in(root, "sync", "--no-config", "--no-index")
+    env_dir = root / sysand.env.DEFAULT_ENV_NAME
+    # After `sync`, which prunes anything not in the lockfile.
+    sysand.env.install_path(env_dir, "urn:kpar:dep", kpar_dep)
+    return root, env_dir
+
+
+def test_env_projects_lists_installed_and_editable(tmp_path: Path) -> None:
+    root, env_dir = _project_with_dir_usage(tmp_path)
+
+    projects = {p["name"]: p for p in sysand.env.projects(env_dir)}
+    assert set(projects) == {"proj", "dir-dep", "kpar-dep"}
+    for project in projects.values():
+        assert set(project) == set(sysand.EnvProject.__annotations__)
+
+    # The locked project itself is the environment's editable entry: `path`
+    # is relative to the project root and it has no identifiers.
+    own = projects["proj"]
+    assert own["editable"] is True
+    assert own["workspace"] is False
+    assert own["publisher"] == "acme"
+    assert own["version"] == "1.0.0"
+    assert own["identifiers"] == []
+    assert os.path.samefile(root / own["path"], root)
+    assert own["usages"] == ["pkg:sysand/acme/dir-dep"]
+    assert own["checksum"] is None
+
+    # A directory usage is installed as a copy, relative to the env dir.
+    dir_dep = projects["dir-dep"]
+    assert dir_dep["editable"] is False
+    assert dir_dep["identifiers"][0] == "pkg:sysand/acme/dir-dep"
+    assert (env_dir / dir_dep["path"] / "dir-dep.sysml").is_file()
+    assert dir_dep["usages"] == []
+    # Installed from a source directory, so `env.toml` records `src_cksum`.
+    assert set(dir_dep["checksum"]) == {"src_cksum"}
+    assert re.fullmatch(r"[0-9a-f]{64}", dir_dep["checksum"]["src_cksum"])
+
+    kpar_dep = projects["kpar-dep"]
+    assert kpar_dep["editable"] is False
+    assert kpar_dep["identifiers"] == ["urn:kpar:dep"]
+    assert (env_dir / kpar_dep["path"] / "kpar-dep.sysml").is_file()
+    assert kpar_dep["path"].startswith("lib/")
+
+
+def test_env_sources_is_exported(tmp_path: Path) -> None:
+    root, env_dir = _project_with_dir_usage(tmp_path)
+    [kpar_dep] = [p for p in sysand.env.projects(env_dir) if p["name"] == "kpar-dep"]
+
+    [source] = sysand.env.sources(env_dir, "urn:kpar:dep")
+
+    assert os.path.samefile(source, env_dir / kpar_dep["path"] / "kpar-dep.sysml")
+    assert "sources" in sysand.env.__all__
+
+
+def test_env_projects_missing_env(tmp_path: Path) -> None:
+    with pytest.raises(sysand.EnvError) as excinfo:
+        sysand.env.projects(tmp_path / "nope")
+    assert excinfo.value.wrote is False
+    assert isinstance(excinfo.value, RuntimeError)
+    assert isinstance(excinfo.value, sysand.SysandError)
+
+    # The same failure raises the same class from `install_path`.
+    with pytest.raises(sysand.EnvError):
+        sysand.env.install_path(tmp_path / "nope", "urn:kpar:x", tmp_path)
+
+
+def test_discover(tmp_path: Path) -> None:
+    assert sysand.discover(tmp_path) == {"project_root": None, "workspace_root": None}
+
+    root = tmp_path / "ws" / "proj"
+    root.mkdir(parents=True)
+    sysand.init("discover", "acme", "1.0.0", root)
+    nested = root / "src" / "deep"
+    nested.mkdir(parents=True)
+
+    for start in (root, nested):
+        found = sysand.discover(start)
+        assert found["project_root"] is not None
+        assert os.path.samefile(found["project_root"], root)
+        assert found["workspace_root"] is None
+    assert sysand.discover(root)["project_root"] == str(sysand.root(root))
+
+    (tmp_path / "ws" / ".workspace.json").write_text('{"projects": []}\n')
+    found = sysand.discover(nested)
+    assert found["workspace_root"] is not None
+    assert os.path.samefile(found["workspace_root"], tmp_path / "ws")
+    assert found["project_root"] is not None
+    assert os.path.samefile(found["project_root"], root)
+    assert sysand.discover(tmp_path / "ws")["project_root"] is None
+
+    (tmp_path / "ws" / ".workspace.json").write_text("not json")
+    with pytest.raises(sysand.ProjectError) as excinfo:
+        sysand.discover(root)
+    assert excinfo.value.wrote is False
 
 
 def test_basic_info(caplog: pytest.LogCaptureFixture) -> None:

--- a/bindings/py/tests/test_migration_scenarios.py
+++ b/bindings/py/tests/test_migration_scenarios.py
@@ -7,12 +7,15 @@ Each test starts from `baseline` / `make_baseline` (conftest.py): a real
 project whose manifest, lockfile and `.sysand` were produced by the shipped
 CLI against the mock index, with the library pinned to the 0.10 line. The
 tests then move that constraint to the 0.11 line with
-`sysand.set_usage_constraint` and check what happened to the manifest.
+`sysand.set_usage_constraint` and check what happened to the manifest, or
+check what the tool driving the migration can find out about the project
+before it starts.
 """
 
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -79,3 +82,25 @@ def test_add_when_missing(make_baseline: MakeBaseline) -> None:
     # A second add merges into the existing usage rather than adding one.
     assert sysand.add(baseline.root, LIBRARY, TARGET_CONSTRAINT) is False
     assert len(json.loads(baseline.manifest.read_text())["usage"]) == 1
+
+
+def test_workspace_detection(baseline: Baseline) -> None:
+    # A tool that must not edit a project inside a workspace checks
+    # `discover` first: the project root is found, the workspace root only
+    # once a `.workspace.json` appears above the project.
+    discovery = sysand.discover(baseline.root)
+    assert discovery["workspace_root"] is None
+    assert discovery["project_root"] is not None
+    assert os.path.samefile(discovery["project_root"], baseline.root)
+
+    workspace = baseline.root.parent
+    (workspace / ".workspace.json").write_text('{"projects": []}\n')
+    discovery = sysand.discover(baseline.root)
+    assert discovery["workspace_root"] is not None
+    assert os.path.samefile(discovery["workspace_root"], workspace)
+    assert os.path.samefile(discovery["project_root"], baseline.root)
+
+    nested = baseline.root / "src" / "deep"
+    nested.mkdir(parents=True)
+    assert os.path.samefile(sysand.discover(nested)["project_root"], baseline.root)
+    assert sysand.discover(workspace)["project_root"] is None

--- a/core/src/env/local_directory/metadata.rs
+++ b/core/src/env/local_directory/metadata.rs
@@ -4,6 +4,8 @@
 use std::{fmt::Display, str::FromStr};
 
 use camino::{Utf8Path, Utf8PathBuf};
+#[cfg(feature = "python")]
+use pyo3::IntoPyObject;
 use serde::Deserialize;
 use thiserror::Error;
 use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, Value, value};
@@ -239,6 +241,7 @@ impl EnvMetadata {
 
 /// Metadata describing a project belonging to an environment.
 #[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "python", derive(IntoPyObject))]
 pub struct EnvProject {
     /// Publisher of the project. Intended for display purposes.
     pub publisher: Option<String>,
@@ -251,6 +254,7 @@ pub struct EnvProject {
     /// to the env directory and otherwise it should be relative
     /// to the workspace root.
     #[serde(deserialize_with = "deserialize_unix_path")]
+    #[cfg_attr(feature = "python", pyo3(into_py_with = unix_path_to_py))]
     pub path: Utf8UnixPathBuf,
     /// List of identifiers (IRIs) used for the project.
     /// The first identifier is considered the canonical
@@ -280,10 +284,20 @@ pub struct EnvProject {
 // Serde by default will allow both variants to coexist in the file, this
 // is desirable to have forward compat.
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "python", derive(IntoPyObject))]
 #[serde(untagged)]
 pub enum EnvProjectChecksum {
     Kpar { kpar_cksum: String },
     Project { src_cksum: String },
+}
+
+#[cfg(feature = "python")]
+fn unix_path_to_py<'py>(
+    path: std::borrow::Cow<'_, Utf8UnixPathBuf>,
+    py: pyo3::Python<'py>,
+) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::PyAny>> {
+    use pyo3::IntoPyObjectExt as _;
+    path.as_str().into_bound_py_any(py)
 }
 
 impl From<ProjectChecksum> for EnvProjectChecksum {


### PR DESCRIPTION
# feat(py): `env.projects`, `discover`, export `env.sources`

This MR lets a Python caller inspect the state the CLI otherwise keeps to itself: what is installed in a `.sysand` environment, and which project and workspace enclose a given path.

- `sysand.env.projects(env_path)` returns the entries of the environment's `env.toml` as typed dicts.
- `sysand.discover(path)` returns the enclosing project root and workspace root, or `None` for each, using the same lookup every CLI command starts with.
- `sysand.env.sources` is exported. The module existed but was never added to `sysand.env.__all__`, so the environment-side listing of a project's sources was unreachable through the public API.
- A new `EnvError` (a `SysandError`, hence a `RuntimeError`) replaces the bare `IOError` that was raised when an environment could not be read.

## Why

A tool that drives sysand from Python needs to answer two questions after `sync` that the bindings could not answer:

- Which projects are installed now, where, and under which IRIs? `env.toml` is an internal format. Parsing it from Python would couple the caller to its layout and to the path conventions of editable versus copied entries, which are exactly what `LocalDirectoryEnvironment` already encapsulates.
- Am I inside a project, and is that project part of a workspace? `sysand.root` finds the project root but says nothing about workspaces, and the CLI's workspace detection lived only behind the CLI. A tool that must refuse to operate inside a workspace had no way to check.

Both are read-only lookups over code the CLI already runs, so exposing them is a matter of wiring rather than new behaviour.

## What changed

### `sysand.env.projects` (`env/_projects.py`, `lib.rs::do_env_projects_py`)

Reads the environment with `LocalDirectoryEnvironment::read` and maps each entry of `env.toml` to an `EnvProject` typed dict:

| field | meaning |
|---|---|
| `publisher`, `name`, `version` | as recorded in `env.toml` |
| `path` | verbatim from `env.toml`: relative to the environment directory, or to the workspace/project root for `editable` entries. Not joined. |
| `identifiers` | IRIs of the project, the first canonical. Empty only for `editable` entries. |
| `usages` | IRIs of the project's usages |
| `editable`, `workspace` | the two flags from `env.toml` |

`path` is deliberately left relative, because the base differs by entry kind. The docstring on `EnvProject` says which base to join it onto, and the test covers both cases (`os.path.samefile(root / own["path"], root)` for the editable entry, `env_dir / dep["path"]` for copied ones).

The Rust side returns plain tuples and the Python side builds the dicts, the same split the other bindings use.

### `sysand.discover` (`_discover.py`, `lib.rs::do_discover_py`)

Calls `discover_project` and `discover_workspace` from `sysand_core::discover`, so the result is the same the CLI computes before running a command: walk up from `path` to the nearest directory holding `.project.json` or `.meta.json`, and separately to the nearest one holding `.workspace.json`. Both paths are canonicalized as `sysand.root` does, and `Discovery` is a typed dict with `project_root` and `workspace_root`, each `Optional[str]`. A directory that cannot be read or a malformed `.workspace.json` raises `ProjectError` with `wrote == False`.

`sysand.root` is unchanged; `discover(...)["project_root"]` equals `str(root(...))` where both find a project, and the test checks that.

### `sysand.env.sources` export (`env/__init__.py`)

`sysand/env/_sources.py` has existed since the "only dependencies" mode was added to `sources`. It lists the sources of an installed project by IRI, whereas top-level `sysand.sources` lists them by project path. Only the top-level one was exported. This MR adds `sources` (and `projects`) to `sysand.env.__all__`; the function body is untouched.

### `EnvError` (`_errors.py`, `lib.rs::env_read_to_pyerr`)

`env_read_to_pyerr` used to wrap a failed environment read in `IOError("failed to read environment metadata: ...")`. It now raises `EnvError`, a `SysandError` subclass, with the error's own message and `wrote == False`. This affects the three existing entry points that read an environment (`env.install_path`, `env.sources`, and `sources` when `env_path` is given) as well as the new `env.projects`.

### Tests (`tests/test_basic.py`)

`_project_with_dir_usage` builds three projects with `sysand.init`: the project under test, a sibling used through a `dir` usage, and a third one installed by path under `urn:kpar:dep`. The first two are locked and synced by the shipped CLI with `--no-config --no-index`, so the environment is exactly what `sync` produces, with the extra project added afterwards because `sync` prunes anything not in the lockfile. On top of that:

- `test_env_projects_lists_installed_and_editable`: the three entries, the editable flag and relative `path` of the project's own entry, the IRIs and `lib/` path of the copied ones, and that `usages` lists the `dir` dependency's IRI.
- `test_env_sources_is_exported`: `sysand.env.sources` resolves the installed `urn:kpar:dep` project's source file and is in `__all__`.
- `test_env_projects_missing_env`: a missing environment raises `EnvError` with `wrote == False` from `projects` and from `install_path`, and the class is both a `RuntimeError` and a `SysandError`.
- `test_discover`: no project, a project found from its root and from a nested directory, agreement with `sysand.root`, a workspace found from a nested path while the workspace root itself has no project, and a malformed `.workspace.json` raising `ProjectError`.

