### PR TITLE
feat(py): `AuthPolicy`, `Resolution`, typed exceptions

### DIFF
--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -22,7 +22,18 @@ from ._model import (
 from ._errors import (
     SysandError,
     ProjectError,
+    ResolutionError,
+    NotFoundError,
+    SolveError,
+    AuthError,
+    IndexProtocolError,
+    SyncError,
     EnvError,
+)
+
+from ._auth import (
+    AuthPolicy,
+    Resolution,
 )
 
 from ._info import info_path, info
@@ -88,7 +99,16 @@ __all__ = [
     ## Errors
     "SysandError",
     "ProjectError",
+    "ResolutionError",
+    "NotFoundError",
+    "SolveError",
+    "AuthError",
+    "IndexProtocolError",
+    "SyncError",
     "EnvError",
+    ## Auth and index configuration
+    "AuthPolicy",
+    "Resolution",
     ## Add
     "add",
     ## Usage

--- a/bindings/py/python/sysand/_auth.py
+++ b/bindings/py/python/sysand/_auth.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+"""Credentials and index configuration for calls that reach an index.
+
+Both classes are pure configuration: they hold strings and flags, and the
+Rust side builds the actual policy, resolver and HTTP client per call. That
+keeps a secret out of every ``repr`` and lets one object be reused across
+calls.
+"""
+
+from __future__ import annotations
+
+import typing
+
+_REDACTED = "<redacted>"
+
+
+class AuthPolicy:
+    """How to authenticate against indexes. Build one with the static
+    constructors; the default for every call is :meth:`none`.
+
+    Opening the OS credential store can raise a keychain prompt on some
+    platforms, so a library call never does it unasked: only
+    :meth:`from_env` with the default ``keyring=True`` opts in.
+    """
+
+    __slots__ = ("_kind", "_keyring", "_url_glob", "_secret", "_username", "_label")
+
+    def __init__(
+        self,
+        kind: str,
+        *,
+        keyring: bool = False,
+        url_glob: str | None = None,
+        secret: str | None = None,
+        username: str | None = None,
+        label: str | None = None,
+    ) -> None:
+        self._kind = kind
+        self._keyring = keyring
+        self._url_glob = url_glob
+        self._secret = secret
+        self._username = username
+        self._label = label
+
+    @staticmethod
+    def none() -> AuthPolicy:
+        """No credentials at all; a 401/403 raises :class:`AuthError`."""
+        return AuthPolicy("none")
+
+    @staticmethod
+    def from_env(*, keyring: bool = True) -> AuthPolicy:
+        """The CLI's own resolution: validated ``SYSAND_CRED_<LABEL>`` groups
+        (``SYSAND_CRED_<LABEL>`` holds the URL glob, ``..._BEARER_TOKEN`` or
+        ``..._BASIC_USER``/``..._BASIC_PASSWORD`` the credential), composed
+        with the OS credential store ``sysand auth login`` writes unless
+        ``keyring=False``. Environment variables alone can never prompt.
+        The variables are read when a call is made, not here."""
+        return AuthPolicy("env", keyring=keyring)
+
+    @staticmethod
+    def bearer(url_glob: str, token: str, *, label: str = "python") -> AuthPolicy:
+        """A bearer token for every URL matching ``url_glob``. Globs do not
+        cross ``/``: use ``https://index.example/**`` for a whole host.
+        ``label`` is the name error messages use for this credential."""
+        return AuthPolicy("bearer", url_glob=url_glob, secret=token, label=label)
+
+    @staticmethod
+    def basic(url_glob: str, username: str, password: str) -> AuthPolicy:
+        """HTTP basic credentials for every URL matching ``url_glob``."""
+        return AuthPolicy(
+            "basic", url_glob=url_glob, username=username, secret=password
+        )
+
+    @property
+    def kind(self) -> str:
+        return self._kind
+
+    def _spec(self) -> dict[str, typing.Any]:
+        return {
+            "kind": self._kind,
+            "keyring": self._keyring,
+            "url_glob": self._url_glob,
+            "secret": self._secret,
+            "username": self._username,
+            "label": self._label,
+        }
+
+    def __repr__(self) -> str:
+        if self._kind == "none":
+            return "AuthPolicy.none()"
+        if self._kind == "env":
+            return f"AuthPolicy.from_env(keyring={self._keyring!r})"
+        if self._kind == "bearer":
+            return (
+                f"AuthPolicy.bearer({self._url_glob!r}, {_REDACTED}, "
+                f"label={self._label!r})"
+            )
+        return f"AuthPolicy.basic({self._url_glob!r}, {self._username!r}, {_REDACTED})"
+
+
+class Resolution:
+    """Which indexes a call resolves against, mirroring the CLI's
+    ``--index`` / ``--default-index`` / ``--no-index`` / ``--include-std``.
+
+    With ``use_config`` (the default) sysand's configuration files are
+    loaded and merged as the CLI does. Only the files: the CLI's environment
+    overrides (``SYSAND_INDEX``, ``SYSAND_DEFAULT_INDEX``,
+    ``SYSAND_CONFIG_FILE``, ``SYSAND_NO_CONFIG``) are not read.
+    ``default_index`` replaces the built-in default (``https://sysand.com``)
+    and any default marked in the configuration; ``index`` adds indexes that
+    are tried before the defaults.
+    """
+
+    __slots__ = ("index", "default_index", "no_index", "include_std", "use_config")
+
+    def __init__(
+        self,
+        *,
+        index: typing.Sequence[str] = (),
+        default_index: typing.Sequence[str] = (),
+        no_index: bool = False,
+        include_std: bool = False,
+        use_config: bool = True,
+    ) -> None:
+        if no_index and (index or default_index):
+            raise ValueError("no_index cannot be combined with index or default_index")
+        self.index = list(index)
+        self.default_index = list(default_index)
+        self.no_index = no_index
+        self.include_std = include_std
+        self.use_config = use_config
+
+    def _spec(self) -> dict[str, typing.Any]:
+        return {
+            "index": self.index,
+            "default_index": self.default_index,
+            "no_index": self.no_index,
+            "include_std": self.include_std,
+            "use_config": self.use_config,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"Resolution(index={self.index!r}, default_index={self.default_index!r}, "
+            f"no_index={self.no_index!r}, include_std={self.include_std!r}, "
+            f"use_config={self.use_config!r})"
+        )
+
+
+__all__ = ["AuthPolicy", "Resolution"]

--- a/bindings/py/python/sysand/_errors.py
+++ b/bindings/py/python/sysand/_errors.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import typing
+
 
 class SysandError(RuntimeError):
     """Base class of every error raised by the ``sysand`` package.
@@ -26,6 +28,78 @@ class ProjectError(SysandError):
     missing, malformed, or does not contain what the call needs."""
 
 
+class ResolutionError(SysandError):
+    """A project could not be resolved from the configured sources."""
+
+
+class NotFoundError(ResolutionError):
+    """No configured source knows the project."""
+
+
+class SolveError(SysandError):
+    """Dependency resolution found no solution.
+
+    Attributes:
+        conflicts: machine-readable participants in the failure, one dict per
+            conflict with a ``"kind"`` key (``"Constraint"``, ``"NoVersions"``,
+            ``"NotFound"``) and the variant's fields.
+        report: the human-readable report, identical to the CLI's output.
+        kind: ``"no_solution"`` or ``"retrieval"``.
+    """
+
+    conflicts: typing.List[typing.Dict[str, typing.Any]]
+    report: str
+    kind: str
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        wrote: bool = False,
+        conflicts: typing.Sequence[typing.Dict[str, typing.Any]] = (),
+        report: str = "",
+        kind: str = "no_solution",
+    ) -> None:
+        super().__init__(message, wrote=wrote)
+        self.conflicts = list(conflicts)
+        self.report = report or message
+        self.kind = kind
+
+
+class AuthError(SysandError):
+    """An index refused the request for lack of (accepted) credentials.
+
+    The message names the URL and, when it can, the credential to fix: the
+    glob that was tried, or the ``SYSAND_CRED_<LABEL>`` variable it came
+    from. It never contains a secret."""
+
+
+class IndexProtocolError(SysandError):
+    """An index answered, but not with what the protocol requires
+    (discovery document, ``versions.json``, digests, JSON shape)."""
+
+
+class SyncError(SysandError):
+    """``sync`` failed part-way.
+
+    Attributes:
+        partial: what was installed and pruned before the failure — a
+            ``SyncOutcome`` dict — or ``None`` when nothing was.
+    """
+
+    partial: typing.Optional[typing.Dict[str, typing.Any]]
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        wrote: bool = False,
+        partial: typing.Optional[typing.Dict[str, typing.Any]] = None,
+    ) -> None:
+        super().__init__(message, wrote=wrote)
+        self.partial = partial
+
+
 class EnvError(SysandError):
     """The ``.sysand`` environment is missing, unreadable or malformed."""
 
@@ -33,5 +107,11 @@ class EnvError(SysandError):
 __all__ = [
     "SysandError",
     "ProjectError",
+    "ResolutionError",
+    "NotFoundError",
+    "SolveError",
+    "AuthError",
+    "IndexProtocolError",
+    "SyncError",
     "EnvError",
 ]

--- a/bindings/py/python/sysand/_info.py
+++ b/bindings/py/python/sysand/_info.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from ._auth import AuthPolicy, Resolution
 from ._model import InterchangeProjectInfo, InterchangeProjectMetadata
 
 import sysand._sysand_core as sysand_rs  # type: ignore
@@ -21,11 +22,36 @@ def info(
     uri: str,
     *,
     index_urls: str | typing.List[str] | None = None,
+    resolution: Resolution | None = None,
+    auth: AuthPolicy | None = None,
 ) -> typing.Tuple[InterchangeProjectInfo, InterchangeProjectMetadata]:
+    """Fetch the best-matching version's ``.project.json`` and ``.meta.json``
+    for ``uri``.
+
+    Without ``resolution`` and ``index_urls`` no index is consulted at all
+    (only local files and URLs). ``index_urls`` is the older way to name
+    exactly the indexes to use; ``resolution`` is the general one, shared
+    with every other call that reaches an index. Passing both is an error.
+    ``auth`` defaults to :meth:`AuthPolicy.none`.
+
+    Raises:
+        NotFoundError: no source knows ``uri``.
+        AuthError: an index refused the request (HTTP 401/403).
+        IndexProtocolError: an index answered with something malformed.
+        ResolutionError: any other resolution failure.
+    """
     if isinstance(index_urls, str):
         index_urls = [index_urls]
+    if index_urls is not None:
+        if resolution is not None:
+            raise ValueError("pass either index_urls or resolution, not both")
+        resolution = Resolution(default_index=index_urls, use_config=False)
 
-    return sysand_rs.do_info_py(uri, index_urls)  # type: ignore
+    return sysand_rs.do_info_py(  # type: ignore
+        uri,
+        resolution._spec() if resolution is not None else None,
+        auth._spec() if auth is not None else None,
+    )
 
 
 __all__ = [

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -353,7 +353,8 @@ fn auth_hint(auth: &AuthSpec, policy: &CliAuthPolicy, url: &str) -> String {
         "bearer" | "basic" => {
             let glob = auth.url_glob.as_deref().unwrap_or("");
             format!(
-                "the {} credential for URL glob `{glob}` was rejected by, or does not match, `{url}`",
+                "the {} credential for URL glob `{glob}`\n\
+                was rejected by, or does not match, `{url}`",
                 auth.kind
             )
         }

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -11,17 +11,21 @@ use pyo3::{
     types::PyAny,
 };
 use semver::{Version, VersionReq};
+use sysand::{CliAuthPolicy, DEFAULT_INDEX_URL, standard_auth_policy};
 use sysand_core::{
     add::do_add_guess,
-    auth::Unauthenticated,
+    auth::{GlobMapResult, StandardHTTPAuthenticationBuilder},
     build::{KParBuildError, KparCompressionMethod, do_build_kpar},
     commands::{
         env::{EnvError, do_env_local_dir},
         init::do_init_local_file,
     },
+    config::{Config, local_fs::load_configs},
     discover::{discover_project, discover_workspace},
     env::{
         DEFAULT_ENV_NAME, ReadEnvironment as _, WriteEnvironment as _,
+        discovery::DiscoveryError,
+        index::{HttpFetchError, IndexEnvironmentError},
         local_directory::{
             LocalDirectoryEnvironment, LocalReadError, LocalWriteError,
             metadata::{EnvMetadataError, EnvProject, EnvProjectChecksum},
@@ -31,7 +35,7 @@ use sysand_core::{
     exclude::do_exclude,
     include::do_include,
     index_location::IndexLocation,
-    info::{InfoProjectError, do_info, do_info_project},
+    info::{InfoError, InfoProjectError, do_info, do_info_project},
     init::InitError,
     model::{
         InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw,
@@ -44,7 +48,12 @@ use sysand_core::{
         utils::wrapfs,
     },
     remove::do_remove_guess,
-    resolve::{net_utils::create_reqwest_client, standard::standard_resolver},
+    resolve::{
+        ResolveRead,
+        combined::CombinedResolverError,
+        net_utils::create_reqwest_client,
+        standard::{StandardResolver, standard_resolver},
+    },
     root::do_root,
     sources::{Dependencies, do_sources_local_src_project_no_deps, resolve_dependencies},
     symbols::Language,
@@ -213,18 +222,210 @@ fn do_info_py_path(
     }
 }
 
+/// Pure configuration of an authentication policy, as `AuthPolicy._spec()`
+/// emits it. The Rust policy is built per call, inside `py.detach`.
+#[derive(FromPyObject, Debug)]
+#[pyo3(from_item_all)]
+struct AuthSpec {
+    kind: String,
+    #[pyo3(default)]
+    keyring: bool,
+    #[pyo3(default)]
+    url_glob: Option<String>,
+    #[pyo3(default)]
+    secret: Option<String>,
+    #[pyo3(default)]
+    username: Option<String>,
+    #[pyo3(default)]
+    label: Option<String>,
+}
+
+impl Default for AuthSpec {
+    fn default() -> Self {
+        Self {
+            kind: "none".to_owned(),
+            keyring: false,
+            url_glob: None,
+            secret: None,
+            username: None,
+            label: None,
+        }
+    }
+}
+
+/// Pure configuration of index resolution, as `Resolution._spec()` emits
+/// it; mirrors the CLI's `ResolutionOptions`.
+#[derive(FromPyObject, Debug)]
+#[pyo3(from_item_all)]
+struct ResolutionSpec {
+    #[pyo3(default)]
+    index: Vec<String>,
+    #[pyo3(default)]
+    default_index: Vec<String>,
+    #[pyo3(default)]
+    no_index: bool,
+    /// Read by `lock`/`sync`, which build the provided-projects set.
+    #[expect(dead_code, reason = "read only by lock and sync, not exposed yet")]
+    #[pyo3(default)]
+    include_std: bool,
+    use_config: bool,
+}
+
+/// Every `AuthPolicy` variant becomes the same concrete policy type as the
+/// CLI's, so the resolver stack is monomorphised once. `none()` is an
+/// empty credential map, which behaves as unauthenticated.
+fn build_auth_policy(spec: &AuthSpec) -> PyResult<Arc<CliAuthPolicy>> {
+    let policy = match spec.kind.as_str() {
+        "none" => CliAuthPolicy::without_store(
+            StandardHTTPAuthenticationBuilder::new()
+                .build()
+                .map_err(|e| PyAuthError::new_err(format_err(e)))?,
+        ),
+        "env" => standard_auth_policy(spec.keyring)
+            .map_err(|e| PyAuthError::new_err(format!("{e:#}")))?,
+        "bearer" | "basic" => {
+            let missing = || PyValueError::new_err("incomplete AuthPolicy specification");
+            let url_glob = spec.url_glob.as_deref().ok_or_else(missing)?;
+            let secret = spec.secret.as_deref().ok_or_else(missing)?;
+            let mut builder = StandardHTTPAuthenticationBuilder::new();
+            if spec.kind == "bearer" {
+                builder.add_bearer_auth(
+                    url_glob,
+                    secret,
+                    spec.label.as_deref().unwrap_or("python"),
+                );
+            } else {
+                let username = spec.username.as_deref().ok_or_else(missing)?;
+                builder.add_basic_auth(url_glob, username, secret);
+            }
+            CliAuthPolicy::without_store(builder.build().map_err(|e| {
+                PyValueError::new_err(format!("invalid URL glob `{url_glob}`: {e}"))
+            })?)
+        }
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "unknown AuthPolicy kind `{other}`"
+            )));
+        }
+    };
+    Ok(Arc::new(policy))
+}
+
+/// The index URLs a call resolves against: `None` means "no index" (the
+/// `no_index` flag, or no `Resolution` at all), otherwise the CLI's merge of
+/// explicit indexes, configuration files, and the default index.
+fn index_locations(
+    spec: Option<&ResolutionSpec>,
+    project_root: Option<&Utf8Path>,
+) -> PyResult<Option<Vec<IndexLocation>>> {
+    let Some(spec) = spec else {
+        return Ok(None);
+    };
+    if spec.no_index {
+        return Ok(None);
+    }
+    let config = if spec.use_config {
+        load_configs(project_root.unwrap_or_else(|| Utf8Path::new(".")))
+            .map_err(|e| ProjectError::new_err(format_err(e)))?
+    } else {
+        Config::default()
+    };
+    let locations = config
+        .index_urls(
+            spec.index.clone(),
+            vec![DEFAULT_INDEX_URL.to_owned()],
+            spec.default_index.clone(),
+        )
+        .map_err(|e| PyValueError::new_err(format_err(e)))?;
+    Ok(Some(locations))
+}
+
+type StandardResolverError = <StandardResolver<CliAuthPolicy> as ResolveRead>::Error;
+
+/// What to tell the user about an HTTP 401/403 from `url`, given the
+/// policy that was in force. Never includes a secret.
+fn auth_hint(auth: &AuthSpec, policy: &CliAuthPolicy, url: &str) -> String {
+    match auth.kind.as_str() {
+        "none" => format!(
+            "no credentials were configured for `{url}`; pass `auth=AuthPolicy.bearer(...)`, \
+             `AuthPolicy.basic(...)` or `AuthPolicy.from_env()`"
+        ),
+        "bearer" | "basic" => {
+            let glob = auth.url_glob.as_deref().unwrap_or("");
+            format!(
+                "the {} credential for URL glob `{glob}` was rejected by, or does not match, `{url}`",
+                auth.kind
+            )
+        }
+        _ => match policy.env_policy().publish_bearer_auth_map() {
+            Ok(map) => match map.lookup(url) {
+                GlobMapResult::Found(entry) => format!(
+                    "the bearer token in `SYSAND_CRED_{label}_BEARER_TOKEN` (URL glob \
+                     `SYSAND_CRED_{label}`) was rejected by `{url}`",
+                    label = entry.label
+                ),
+                GlobMapResult::NotFound => {
+                    format!("no `SYSAND_CRED_*` bearer token matches `{url}`")
+                }
+                GlobMapResult::Ambiguous(entries) => format!(
+                    "several `SYSAND_CRED_*` URL globs match `{url}`: {}",
+                    entries
+                        .iter()
+                        .map(|(_, e)| format!("`SYSAND_CRED_{}`", e.label))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            },
+            Err(_) => format!("credentials from `SYSAND_CRED_*` were rejected by `{url}`"),
+        },
+    }
+}
+
+/// Typed exception for a failed `info`. The resolver's error type is known
+/// statically, so this matches variants rather than walking `source()`
+/// (the `transparent` wrappers in between would collapse that chain).
+fn info_error_to_pyerr(
+    err: InfoError<StandardResolverError>,
+    auth: &AuthSpec,
+    policy: &CliAuthPolicy,
+) -> PyErr {
+    let message = format_err(&err);
+    match &err {
+        InfoError::NotFound { .. } => PyNotFoundError::new_err(message),
+        InfoError::Resolution(CombinedResolverError::Index(
+            IndexEnvironmentError::Discovery(DiscoveryError::Fetch(fetch))
+            | IndexEnvironmentError::Fetch(fetch),
+        )) => match fetch {
+            HttpFetchError::BadHttpStatus { url, status }
+                if matches!(status.as_u16(), 401 | 403) =>
+            {
+                PyAuthError::new_err(format!("{message}\n  {}", auth_hint(auth, policy, url)))
+            }
+            // Connection-level failures are not the index's fault.
+            HttpFetchError::Request { .. } => PyResolutionError::new_err(message),
+            _ => PyIndexProtocolError::new_err(message),
+        },
+        InfoError::Resolution(CombinedResolverError::Index(_)) => {
+            PyIndexProtocolError::new_err(message)
+        }
+        _ => PyResolutionError::new_err(message),
+    }
+}
+
 #[pyfunction(name = "do_info_py")]
 #[pyo3(
-    signature = (uri, index_urls),
+    signature = (uri, resolution, auth),
 )]
 fn do_info_py(
     py: Python,
     uri: String,
-    index_urls: Option<Vec<String>>,
+    resolution: Option<ResolutionSpec>,
+    auth: Option<AuthSpec>,
 ) -> PyResult<(InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw)> {
     common_init();
 
     py.detach(|| {
+        let auth = auth.unwrap_or_default();
         let client = create_reqwest_client().map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
 
         let runtime = Arc::new(
@@ -233,32 +434,17 @@ fn do_info_py(
                 .build()?,
         );
 
-        let index_url = index_urls
-            .map(|url_strs| {
-                url_strs
-                    .iter()
-                    .map(|url_str| IndexLocation::parse(url_str))
-                    .collect()
-            })
-            .transpose()
-            .map_err(|err| PyValueError::new_err(format_err(err)))?;
+        // Without a `Resolution` no index is consulted, as before.
+        let index_urls = index_locations(resolution.as_ref(), None)?;
+        let auth_policy = build_auth_policy(&auth)?;
 
-        let combined_resolver = standard_resolver(
-            None,
-            Some(client),
-            index_url,
-            runtime,
-            // FIXME: Add Python support for authentication
-            Arc::new(Unauthenticated {}),
-        )
-        .map_err(|err| PyValueError::new_err(format_err(err)))?;
+        let combined_resolver =
+            standard_resolver(None, Some(client), index_urls, runtime, auth_policy.clone())
+                .map_err(|err| PyValueError::new_err(format_err(err)))?;
 
         let uri = Iri::parse(uri)
             .map_err(|(e, input)| PyValueError::new_err(format!("invalid IRI `{input}`: {e}")))?;
-        match do_info(&uri, &combined_resolver) {
-            Ok(info_meta) => Ok(info_meta),
-            Err(e) => Err(PyRuntimeError::new_err(format_err(e))),
-        }
+        do_info(&uri, &combined_resolver).map_err(|e| info_error_to_pyerr(e, &auth, &auth_policy))
     })
 }
 
@@ -527,9 +713,16 @@ mod py_errors {
     #![allow(clippy::same_name_method)]
     pyo3::import_exception!(sysand._errors, ProjectError);
     pyo3::import_exception!(sysand._errors, EnvError);
+    pyo3::import_exception!(sysand._errors, ResolutionError);
+    pyo3::import_exception!(sysand._errors, NotFoundError);
+    pyo3::import_exception!(sysand._errors, AuthError);
+    pyo3::import_exception!(sysand._errors, IndexProtocolError);
 }
 // `sysand_core::commands::env::EnvError` is already in scope under that name.
-use py_errors::{EnvError as PyEnvError, ProjectError};
+use py_errors::{
+    AuthError as PyAuthError, EnvError as PyEnvError, IndexProtocolError as PyIndexProtocolError,
+    NotFoundError as PyNotFoundError, ProjectError, ResolutionError as PyResolutionError,
+};
 
 /// Returns `(matched_resource, found, changed, old_constraint, new_constraint)`.
 ///

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -347,8 +347,8 @@ type StandardResolverError = <StandardResolver<CliAuthPolicy> as ResolveRead>::E
 fn auth_hint(auth: &AuthSpec, policy: &CliAuthPolicy, url: &str) -> String {
     match auth.kind.as_str() {
         "none" => format!(
-            "no credentials were configured for `{url}`; pass `auth=AuthPolicy.bearer(...)`, \
-             `AuthPolicy.basic(...)` or `AuthPolicy.from_env()`"
+            "no credentials were configured for `{url}`;\n\
+            pass `auth=AuthPolicy.bearer(...)`, `AuthPolicy.basic(...)` or `AuthPolicy.from_env()`"
         ),
         "bearer" | "basic" => {
             let glob = auth.url_glob.as_deref().unwrap_or("");

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -434,7 +434,7 @@ fn do_info_py(
                 .build()?,
         );
 
-        // Without a `Resolution` no index is consulted, as before.
+        // Without a `Resolution` no index is consulted
         let index_urls = index_locations(resolution.as_ref(), None)?;
         let auth_policy = build_auth_policy(&auth)?;
 

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -369,7 +369,7 @@ fn auth_hint(auth: &AuthSpec, policy: &CliAuthPolicy, url: &str) -> String {
                     format!("no `SYSAND_CRED_*` bearer token matches `{url}`")
                 }
                 GlobMapResult::Ambiguous(entries) => format!(
-                    "several `SYSAND_CRED_*` URL globs match `{url}`: {}",
+                    "several `SYSAND_CRED_*` URL globs match `{url}`:\n{}",
                     entries
                         .iter()
                         .map(|(_, e)| format!("`SYSAND_CRED_{}`", e.label))

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -361,7 +361,7 @@ fn auth_hint(auth: &AuthSpec, policy: &CliAuthPolicy, url: &str) -> String {
         _ => match policy.env_policy().publish_bearer_auth_map() {
             Ok(map) => match map.lookup(url) {
                 GlobMapResult::Found(entry) => format!(
-                    "the bearer token in `SYSAND_CRED_{label}_BEARER_TOKEN` (URL glob \
+                    "the bearer token in `SYSAND_CRED_{label}_BEARER_TOKEN` (URL glob\n\
                      `SYSAND_CRED_{label}`) was rejected by `{url}`",
                     label = entry.label
                 ),

--- a/bindings/py/tests/test_auth.py
+++ b/bindings/py/tests/test_auth.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+"""`AuthPolicy`, `Resolution` and the typed exceptions, exercised through
+`sysand.info()` against the mock index."""
+
+from __future__ import annotations
+
+import pytest
+
+import sysand
+from mockindex import MockIndex
+
+IRI = "urn:kpar:auth_probe"
+
+
+def resolution(index: MockIndex) -> sysand.Resolution:
+    return sysand.Resolution(default_index=[index.url], use_config=False)
+
+
+def test_auth_policy_repr_hides_secrets() -> None:
+    policies = [
+        sysand.AuthPolicy.none(),
+        sysand.AuthPolicy.from_env(),
+        sysand.AuthPolicy.from_env(keyring=False),
+        sysand.AuthPolicy.bearer("https://example.org/**", "s3cret"),
+        sysand.AuthPolicy.bearer("https://example.org/**", "s3cret", label="ci"),
+        sysand.AuthPolicy.basic("https://example.org/**", "alice", "s3cret"),
+    ]
+    for policy in policies:
+        assert "s3cret" not in repr(policy)
+        assert "s3cret" not in str(policy)
+    assert repr(policies[0]) == "AuthPolicy.none()"
+    assert repr(policies[1]) == "AuthPolicy.from_env(keyring=True)"
+    assert repr(policies[2]) == "AuthPolicy.from_env(keyring=False)"
+    assert "https://example.org/**" in repr(policies[3])
+    assert "label='ci'" in repr(policies[4])
+    assert "alice" in repr(policies[5])
+    assert sysand.AuthPolicy.bearer("g", "t").kind == "bearer"
+
+
+def test_resolution_defaults_and_validation() -> None:
+    default = sysand.Resolution()
+    assert default.index == []
+    assert default.default_index == []
+    assert default.no_index is False
+    assert default.include_std is False
+    assert default.use_config is True
+    assert "use_config=True" in repr(default)
+
+    with pytest.raises(ValueError):
+        sysand.Resolution(no_index=True, index=["https://example.org"])
+    with pytest.raises(TypeError):
+        sysand.Resolution(["https://example.org"])  # type: ignore[misc]
+
+
+def test_exception_hierarchy() -> None:
+    for cls in (
+        sysand.ProjectError,
+        sysand.ResolutionError,
+        sysand.NotFoundError,
+        sysand.SolveError,
+        sysand.AuthError,
+        sysand.IndexProtocolError,
+        sysand.SyncError,
+        sysand.EnvError,
+    ):
+        assert issubclass(cls, sysand.SysandError)
+        assert issubclass(cls, RuntimeError)
+        error = cls("message")
+        assert error.wrote is False
+        assert str(error) == "message"
+    assert issubclass(sysand.NotFoundError, sysand.ResolutionError)
+
+    solve = sysand.SolveError("no solution")
+    assert solve.conflicts == []
+    assert solve.report == "no solution"
+    assert solve.kind == "no_solution"
+    sync = sysand.SyncError("half", wrote=True, partial={"installed": [], "pruned": []})
+    assert sync.wrote is True
+    assert sync.partial == {"installed": [], "pruned": []}
+
+
+def test_info_through_resolution(mock_index: MockIndex) -> None:
+    mock_index.publish(IRI, "1.0.0")
+    mock_index.publish(IRI, "1.1.0")
+
+    info, _meta = sysand.info(IRI, resolution=resolution(mock_index))
+    assert info["name"] == "auth_probe"
+    assert info["version"] == "1.1.0"
+
+    # The older spelling still works and means the same thing.
+    info, _meta = sysand.info(IRI, index_urls=mock_index.url)
+    assert info["version"] == "1.1.0"
+
+    with pytest.raises(ValueError):
+        sysand.info(IRI, index_urls=mock_index.url, resolution=resolution(mock_index))
+
+
+def test_info_not_found(mock_index: MockIndex) -> None:
+    with pytest.raises(sysand.NotFoundError) as excinfo:
+        sysand.info("urn:kpar:absent", resolution=resolution(mock_index))
+    assert isinstance(excinfo.value, sysand.ResolutionError)
+    assert excinfo.value.wrote is False
+    assert "urn:kpar:absent" in str(excinfo.value)
+
+
+def test_info_auth_matrix(
+    mock_index: MockIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_index.publish(IRI, "1.0.0")
+    mock_index.require_bearer("s3cret")
+    res = resolution(mock_index)
+    glob = mock_index.url + "**"
+
+    # No credentials: the very first request (the discovery document) is
+    # refused, and the error says so without naming any secret.
+    with pytest.raises(sysand.AuthError) as excinfo:
+        sysand.info(IRI, resolution=res)
+    assert excinfo.value.wrote is False
+    assert "401" in str(excinfo.value)
+    assert mock_index.url in str(excinfo.value)
+    assert "AuthPolicy" in str(excinfo.value)
+
+    with pytest.raises(sysand.AuthError):
+        sysand.info(IRI, resolution=res, auth=sysand.AuthPolicy.none())
+
+    with pytest.raises(sysand.AuthError) as excinfo:
+        sysand.info(IRI, resolution=res, auth=sysand.AuthPolicy.bearer(glob, "wrong"))
+    assert glob in str(excinfo.value)
+    assert "wrong" not in str(excinfo.value)
+
+    with pytest.raises(sysand.AuthError):
+        sysand.info(
+            IRI, resolution=res, auth=sysand.AuthPolicy.basic(glob, "alice", "s3cret")
+        )
+
+    info, _meta = sysand.info(
+        IRI, resolution=res, auth=sysand.AuthPolicy.bearer(glob, "s3cret")
+    )
+    assert info["version"] == "1.0.0"
+    # An unauthenticated first attempt followed by the bearer retry.
+    assert "/sysand-index-config.json" in mock_index.requests()
+
+    # The CLI's own resolution from `SYSAND_CRED_*`, with and without the
+    # (simulated absent) credential store.
+    monkeypatch.setenv("SYSAND_CRED_TEST", glob)
+    monkeypatch.setenv("SYSAND_CRED_TEST_BEARER_TOKEN", "s3cret")
+    for policy in (
+        sysand.AuthPolicy.from_env(keyring=False),
+        sysand.AuthPolicy.from_env(),
+    ):
+        info, _meta = sysand.info(IRI, resolution=res, auth=policy)
+        assert info["version"] == "1.0.0"
+
+    # A wrong env token: the error names the variable, never the token.
+    monkeypatch.setenv("SYSAND_CRED_TEST_BEARER_TOKEN", "wrong")
+    with pytest.raises(sysand.AuthError) as excinfo:
+        sysand.info(IRI, resolution=res, auth=sysand.AuthPolicy.from_env(keyring=False))
+    assert "SYSAND_CRED_TEST" in str(excinfo.value)
+    assert "wrong" not in str(excinfo.value)
+
+
+def test_from_env_rejects_malformed_groups(
+    mock_index: MockIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_index.publish(IRI, "1.0.0")
+    # A glob with no credential: the CLI refuses this too. `from_env()` is
+    # pure configuration, so the error comes from the call that uses it.
+    monkeypatch.setenv("SYSAND_CRED_TEST", mock_index.url + "**")
+    policy = sysand.AuthPolicy.from_env(keyring=False)
+
+    with pytest.raises(sysand.AuthError) as excinfo:
+        sysand.info(IRI, resolution=resolution(mock_index), auth=policy)
+    assert "SYSAND_CRED_TEST" in str(excinfo.value)
+    assert excinfo.value.wrote is False
+    assert mock_index.requests() == [], "a malformed credential set makes no request"

--- a/sysand/src/lib.rs
+++ b/sysand/src/lib.rs
@@ -21,7 +21,10 @@ use fluent_uri::Iri;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser as _;
 use sysand_core::{
-    auth::{HTTPAuthentication, StandardHTTPAuthenticationBuilder, StandardLazyHTTPAuthentication},
+    auth::{
+        HTTPAuthentication, StandardHTTPAuthentication, StandardHTTPAuthenticationBuilder,
+        StandardLazyHTTPAuthentication,
+    },
     commands::lock::DEFAULT_LOCKFILE_NAME,
     config::{
         Config,
@@ -150,6 +153,58 @@ fn set_panic_hook() {
     }));
 }
 
+/// The eager part of the CLI's credential resolution: every validated
+/// `SYSAND_CRED_*` group composed into one policy. Malformed groups are an
+/// error naming the variable to fix.
+pub fn env_auth_policy() -> Result<StandardHTTPAuthentication> {
+    // Validation guarantees every group has a pattern and at least one
+    // complete scheme, so iterating the patterns covers every group.
+    let groups = cred_env::validated_env_groups()?;
+    let mut auths_builder = StandardHTTPAuthenticationBuilder::new();
+    for (k, pattern) in &groups.patterns {
+        if let (Some(username), Some(password)) =
+            (groups.basic_users.get(k), groups.basic_passwords.get(k))
+        {
+            log::debug!("auth: env vars specify HTTP basic for URL glob `{pattern}`");
+            auths_builder.add_basic_auth(pattern, username, password);
+        }
+        if let Some(token) = groups.bearer_tokens.get(k) {
+            log::debug!("auth: env vars specify bearer token for URL glob `{pattern}`");
+            // The label lets a publish auth failure name the
+            // `SYSAND_CRED_<LABEL>` variable to fix.
+            auths_builder.add_bearer_auth(pattern, token, k);
+        }
+    }
+    Ok(auths_builder.build()?)
+}
+
+/// The CLI's own credential resolution: [`env_auth_policy`] composed with
+/// the lazily read OS credential store that `sysand auth login` writes.
+/// Used by `run_cli` and by the language bindings, so a binding
+/// authenticates exactly as the CLI does.
+///
+/// Opening the store only resolves a lock file path; no keychain access
+/// happens until a request actually needs a stored credential. An
+/// unavailable store is a warning, not an error. With
+/// `use_credential_store == false` the store is never opened and only
+/// `SYSAND_CRED_*` credentials are used — a policy that can never prompt.
+pub fn standard_auth_policy(use_credential_store: bool) -> Result<CliAuthPolicy> {
+    let env_auth_policy = env_auth_policy()?;
+    if !use_credential_store {
+        return Ok(CliAuthPolicy::without_store(env_auth_policy));
+    }
+    Ok(match credential_store::open_cli_credential_store() {
+        Ok(store) => CliAuthPolicy::new(env_auth_policy, store),
+        Err(err) => {
+            log::warn!(
+                "credential store unavailable: {err};\n\
+                 continuing with `SYSAND_CRED_*` credentials only"
+            );
+            CliAuthPolicy::without_store(env_auth_policy)
+        }
+    })
+}
+
 pub fn run_cli(args: cli::Args) -> Result<()> {
     sysand_core::style::set_style_config(crate::style::CONFIG);
 
@@ -239,38 +294,7 @@ pub fn run_cli(args: cli::Args) -> Result<()> {
         command => command,
     };
 
-    // Validation guarantees every group has a pattern and at least one
-    // complete scheme, so iterating the patterns covers every group.
-    let groups = cred_env::validated_env_groups()?;
-    let mut auths_builder = StandardHTTPAuthenticationBuilder::new();
-    for (k, pattern) in &groups.patterns {
-        if let (Some(username), Some(password)) =
-            (groups.basic_users.get(k), groups.basic_passwords.get(k))
-        {
-            log::debug!("auth: env vars specify HTTP basic for URL glob `{pattern}`");
-            auths_builder.add_basic_auth(pattern, username, password);
-        }
-        if let Some(token) = groups.bearer_tokens.get(k) {
-            log::debug!("auth: env vars specify bearer token for URL glob `{pattern}`");
-            // The label lets a publish auth failure name the
-            // `SYSAND_CRED_<LABEL>` variable to fix.
-            auths_builder.add_bearer_auth(pattern, token, k);
-        }
-    }
-    let env_auth_policy = auths_builder.build()?;
-    // Compose the eager env policy with the lazily read OS keyring store.
-    // Opening the store only resolves a lock file path; no keychain access
-    // happens until a request actually needs a stored credential.
-    let auth_policy = Arc::new(match credential_store::open_cli_credential_store() {
-        Ok(store) => CliAuthPolicy::new(env_auth_policy, store),
-        Err(err) => {
-            log::warn!(
-                "credential store unavailable: {err};\n\
-                 continuing with `SYSAND_CRED_*` credentials only"
-            );
-            CliAuthPolicy::without_store(env_auth_policy)
-        }
-    });
+    let auth_policy = Arc::new(standard_auth_policy(true)?);
 
     match command {
         Command::Init {


### PR DESCRIPTION
This MR gives the Python bindings the three things every index-facing call needs and that `sysand.info` was missing: a way to say which indexes to use, a way to authenticate, and exceptions a caller can catch by kind. `info` is the first user; the same objects are meant to be reused by every later function that reaches an index.

- `sysand.Resolution` mirrors the CLI's `--index` / `--default-index` / `--no-index` / `--include-std` and whether configuration files are read.
- `sysand.AuthPolicy` selects credentials: none, the CLI's own resolution from `SYSAND_CRED_*` and the credential store, or an explicit bearer token or basic pair for a URL glob.
- `sysand.info(uri, *, resolution=..., auth=...)` accepts both. The old `index_urls=` keyword still works and means the same thing.
- Eight exception classes under `SysandError`: `ResolutionError`, `NotFoundError`, `SolveError`, `AuthError`, `IndexProtocolError`, `SyncError`, plus the existing `ProjectError` and `EnvError`. `info` raises the first four that apply instead of a bare `RuntimeError`.
- The CLI crate exports `env_auth_policy()` and `standard_auth_policy(use_credential_store)`, extracted unchanged from `run_cli`, so the bindings authenticate exactly as the CLI does.

No core crate code changes.

## Why

`info` was the only binding that talked to an index, and it did so unauthenticated (the `// FIXME: Add Python support for authentication` in `do_info_py`) with the indexes named by a bare list of URLs. That has three problems for a tool driving sysand from Python:

- It cannot use a private index at all.
- It cannot read the user's `sysand` configuration, so "the indexes the CLI would use" is not expressible.
- Every failure is `RuntimeError` with a message. A caller cannot tell "no such project" from "401" from "the index is broken" without parsing text, and the text for a 401 did not say which credential was tried.

Rather than add `index_urls` and `auth` parameters to each function as it gains index access, this MR introduces the two configuration objects once, defines the exception vocabulary once, and wires `info` to them as the proof.

## What changed

### `AuthPolicy` (`_auth.py`, `lib.rs::AuthSpec` / `build_auth_policy`)

A pure configuration object built through static constructors:

| constructor | meaning |
|---|---|
| `AuthPolicy.none()` | no credentials; a 401/403 raises `AuthError`. This is the default for every call. |
| `AuthPolicy.from_env(keyring=True)` | the CLI's own resolution: validated `SYSAND_CRED_<LABEL>` groups, composed with the OS credential store that `sysand auth login` writes. `keyring=False` skips the store, giving a policy that can never prompt. |
| `AuthPolicy.bearer(url_glob, token, label="python")` | one bearer token for URLs matching the glob |
| `AuthPolicy.basic(url_glob, username, password)` | one basic pair for URLs matching the glob |

Two deliberate choices:

- **Secrets never appear in `repr`.** Both constructors that take a secret print `<redacted>` in its place. `test_auth_policy_repr_hides_secrets` checks every variant.
- **Nothing happens at construction.** `from_env()` does not read the environment or open the credential store; the Rust side builds the real policy per call, inside `py.detach`. Opening the OS store can raise a keychain prompt on some platforms, so a library call only does that when the caller asked for `from_env()` with the default `keyring=True`. A malformed `SYSAND_CRED_*` group is therefore reported by the call that uses the policy, as `AuthError`, before any request is made (`test_from_env_rejects_malformed_groups`).

On the Rust side every variant becomes the CLI's own policy type (`CliAuthPolicy`, via `without_store` for the non-keyring variants), so the resolver stack is monomorphised once and `none()` is simply an empty credential map.

### `Resolution` (`_auth.py`, `lib.rs::ResolutionSpec` / `index_locations`)

Keyword-only fields `index`, `default_index`, `no_index`, `include_std`, `use_config`. `no_index` combined with either list is a `ValueError`, as the CLI rejects the equivalent flags.

`index_locations` reproduces the CLI's merge: with `use_config=True` (the default) the configuration files are loaded from the working directory and merged with the explicit lists through the same `Config::index_urls` the CLI calls, with the built-in default index as the fallback. Only the files are read. The CLI's environment overrides (`SYSAND_INDEX`, `SYSAND_DEFAULT_INDEX`, `SYSAND_CONFIG_FILE`, `SYSAND_NO_CONFIG`) are deliberately not consulted, because a library should not change behaviour based on the caller's shell. Without a `Resolution` at all, or with `no_index=True`, no index is consulted, which is what `info` did before when `index_urls` was omitted.

`include_std` is accepted and stored but not read by anything yet. It is part of the CLI's resolution options and belongs on this object; the field carries an `#[expect(dead_code)]` so the day something reads it the attribute has to go.

### `info` (`_info.py`, `lib.rs::do_info_py`)

`info(uri, *, index_urls=None, resolution=None, auth=None)`. Passing both `index_urls` and `resolution` is a `ValueError`. `index_urls` is translated to `Resolution(default_index=index_urls, use_config=False)`, which with an empty configuration yields exactly the given URLs in order, so existing callers see the same indexes as before. `test_basic.py::test_index_info`, which uses `index_urls`, is unchanged and still passes.

### Typed exceptions (`_errors.py`, `lib.rs::info_error_to_pyerr`)

All subclass `SysandError`, hence `RuntimeError`, and carry `wrote`. The hierarchy: `NotFoundError` is a `ResolutionError`; the rest are direct children.

| class | when |
|---|---|
| `NotFoundError` | no configured source knows the project |
| `AuthError` | an index answered 401 or 403, or `from_env()` found a malformed `SYSAND_CRED_*` group |
| `IndexProtocolError` | an index answered, but not with what the protocol requires (bad discovery document, `versions.json`, digest, JSON shape) |
| `ResolutionError` | any other resolution failure, including connection-level errors, which are not the index's fault |
| `SolveError` | dependency resolution found no solution; has `conflicts`, `report`, `kind` |
| `SyncError` | an installation failed part-way; has `partial` |

`info_error_to_pyerr` matches the resolver's error variants rather than walking `source()`, because the `transparent` wrappers in between collapse the source chain. The resolver's error type is known statically, so the match is exhaustive where it matters and falls back to `ResolutionError`.

`AuthError` messages carry a hint after the HTTP line, computed by `auth_hint` from the policy that was in force: which `AuthPolicy` constructor to pass when there was none, the glob that was tried for an explicit credential, or the `SYSAND_CRED_<LABEL>` variable (found, not matched, or ambiguous) for `from_env`. The hint never contains a secret; `test_info_auth_matrix` asserts the wrong token is absent from every message.

**For reviewers, the one behaviour change:** an `info` failure used to be `RuntimeError(message)`. It is now one of the typed classes above with the same message (plus the hint for `AuthError`). All of them are `RuntimeError` subclasses, so `except RuntimeError` continues to work. A malformed IRI is still `ValueError`.

`SolveError` and `SyncError` are defined here but nothing raises them yet. They are in this MR so the exception vocabulary is complete in one place and later functions do not each add a class; their attributes (`conflicts`, `report`, `kind`, `partial`) are fixed now so callers can be written against them.

### CLI crate (`sysand/src/lib.rs`)

The block of `run_cli` that built the credential policy is extracted into two public functions:

- `env_auth_policy()`: the eager part, every validated `SYSAND_CRED_*` group composed into one `StandardHTTPAuthentication`.
- `standard_auth_policy(use_credential_store)`: the above composed with the lazily opened OS credential store; an unavailable store is a warning, as before, and `false` skips the store entirely.

`run_cli` now calls `standard_auth_policy(true)`. Its behaviour is unchanged; the body moved and gained the `use_credential_store` switch that `AuthPolicy.from_env(keyring=False)` needs.

### Tests (`tests/test_auth.py`)

Seven tests against the mock index:

- `repr` hides secrets for every constructor; `Resolution` defaults and its `ValueError`/`TypeError` cases.
- The hierarchy: each class is a `SysandError` and `RuntimeError`, has `wrote == False` by default, `NotFoundError` is a `ResolutionError`, and `SolveError`/`SyncError` carry their attributes.
- `info` through `Resolution` and through `index_urls` agree; passing both raises.
- An absent project raises `NotFoundError` naming the IRI.
- The auth matrix with the index requiring a bearer token: no policy, `none()`, a wrong bearer, a basic pair (all `AuthError`, with the glob in the message and the secret absent); the right bearer succeeds and the request log shows the unauthenticated first attempt followed by the retry; `from_env()` with and without the store succeeds from `SYSAND_CRED_TEST*`; a wrong env token names the variable, not the token.
- A `SYSAND_CRED_TEST` glob with no credential raises `AuthError` from the call, before any request.

The suite's autouse fixture already clears `SYSAND_*` and points the credential store at the debug-only absent seam, so `from_env()` with `keyring=True` never touches a developer's keyring here.
