### PR TITLE
feat(py): `versions()` - authenticated version listing

### DIFF
--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -17,6 +17,7 @@ from ._model import (
     EnvProjectChecksumKpar,
     EnvProjectChecksumSrc,
     Discovery,
+    VersionListing,
 )
 
 from ._errors import (
@@ -37,6 +38,8 @@ from ._auth import (
 )
 
 from ._info import info_path, info
+
+from ._versions import versions
 
 from . import env
 
@@ -96,6 +99,7 @@ __all__ = [
     "EnvProjectChecksumKpar",
     "EnvProjectChecksumSrc",
     "Discovery",
+    "VersionListing",
     ## Errors
     "SysandError",
     "ProjectError",
@@ -120,6 +124,8 @@ __all__ = [
     ## info
     "info_path",
     "info",
+    ## versions
+    "versions",
     ## Init
     "init",
     ## Build

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -92,6 +92,18 @@ class Discovery(typing.TypedDict):
     ``.workspace.json``), or ``None``."""
 
 
+class VersionListing(typing.TypedDict):
+    """Result of :func:`sysand.versions`."""
+
+    iri: str
+    versions: typing.List[str]
+    """Distinct semver versions, highest first. Over an index these are the
+    *available* versions: yanked and removed entries are never listed."""
+    ignored: typing.List[str]
+    """Version strings that are not valid semver, in encounter order. An
+    index cannot publish such entries, but other sources can."""
+
+
 class InterchangeProjectInfo(typing.TypedDict):
     publisher: typing.Optional[str]
     name: str

--- a/bindings/py/python/sysand/_versions.py
+++ b/bindings/py/python/sysand/_versions.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+import sysand._sysand_core as sysand_rs  # type: ignore
+
+from ._auth import AuthPolicy, Resolution
+from ._model import VersionListing
+
+
+def versions(
+    iri: str,
+    *,
+    resolution: Resolution | None = None,
+    auth: AuthPolicy | None = None,
+) -> VersionListing:
+    """List the published versions of the project ``iri``.
+
+    The sibling of :func:`info`: the same resolution, but every candidate's
+    version is collected instead of keeping the best one. Over an index this
+    costs one ``versions.json`` request per index.
+
+    ``resolution`` defaults to :class:`Resolution` ``()``, i.e. the CLI's
+    behaviour: configuration files plus the default index. Pass an explicit
+    :class:`Resolution` to control which indexes are consulted. ``auth``
+    defaults to :meth:`AuthPolicy.none`.
+
+    Raises:
+        NotFoundError: no configured source knows ``iri``.
+        AuthError: an index refused the request (HTTP 401/403).
+        IndexProtocolError: an index answered with something malformed.
+        ResolutionError: any other resolution failure.
+    """
+    if resolution is None:
+        resolution = Resolution()
+    iri_out, found, ignored = sysand_rs.do_versions_py(
+        iri, resolution._spec(), auth._spec() if auth is not None else None
+    )
+    return VersionListing(iri=iri_out, versions=list(found), ignored=list(ignored))
+
+
+__all__ = ["versions"]

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -59,6 +59,7 @@ use sysand_core::{
     symbols::Language,
     usage::{ConstraintChange, SetConstraintError, do_set_usage_constraint_local},
     utils::format_err,
+    versions::do_versions,
 };
 use typed_path::Utf8UnixPathBuf;
 
@@ -413,6 +414,32 @@ fn info_error_to_pyerr(
     }
 }
 
+/// The resolver stack every index-reaching call uses: HTTP client, a
+/// current-thread runtime, the configured indexes and the authentication
+/// policy. Must run inside `py.detach` (the stack is `!Send`).
+fn standard_resolver_for(
+    resolution: Option<&ResolutionSpec>,
+    auth: &AuthSpec,
+    project_root: Option<&Utf8Path>,
+) -> PyResult<(StandardResolver<CliAuthPolicy>, Arc<CliAuthPolicy>)> {
+    let client = create_reqwest_client().map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
+    let runtime = Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?,
+    );
+    let index_urls = index_locations(resolution, project_root)?;
+    let auth_policy = build_auth_policy(auth)?;
+    let resolver = standard_resolver(None, Some(client), index_urls, runtime, auth_policy.clone())
+        .map_err(|err| PyValueError::new_err(format_err(err)))?;
+    Ok((resolver, auth_policy))
+}
+
+fn parse_iri(iri: String) -> PyResult<Iri<String>> {
+    Iri::parse(iri)
+        .map_err(|(e, input)| PyValueError::new_err(format!("invalid IRI `{input}`: {e}")))
+}
+
 #[pyfunction(name = "do_info_py")]
 #[pyo3(
     signature = (uri, resolution, auth),
@@ -427,25 +454,37 @@ fn do_info_py(
 
     py.detach(|| {
         let auth = auth.unwrap_or_default();
-        let client = create_reqwest_client().map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
-
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()?,
-        );
-
         // Without a `Resolution` no index is consulted
-        let index_urls = index_locations(resolution.as_ref(), None)?;
-        let auth_policy = build_auth_policy(&auth)?;
+        let (resolver, auth_policy) = standard_resolver_for(resolution.as_ref(), &auth, None)?;
+        let uri = parse_iri(uri)?;
+        do_info(&uri, &resolver).map_err(|e| info_error_to_pyerr(e, &auth, &auth_policy))
+    })
+}
 
-        let combined_resolver =
-            standard_resolver(None, Some(client), index_urls, runtime, auth_policy.clone())
-                .map_err(|err| PyValueError::new_err(format_err(err)))?;
+/// `(iri, versions highest first, ignored non-semver strings)`.
+#[pyfunction(name = "do_versions_py")]
+#[pyo3(
+    signature = (iri, resolution, auth),
+)]
+fn do_versions_py(
+    py: Python,
+    iri: String,
+    resolution: Option<ResolutionSpec>,
+    auth: Option<AuthSpec>,
+) -> PyResult<(String, Vec<String>, Vec<String>)> {
+    common_init();
 
-        let uri = Iri::parse(uri)
-            .map_err(|(e, input)| PyValueError::new_err(format!("invalid IRI `{input}`: {e}")))?;
-        do_info(&uri, &combined_resolver).map_err(|e| info_error_to_pyerr(e, &auth, &auth_policy))
+    py.detach(|| {
+        let auth = auth.unwrap_or_default();
+        let (resolver, auth_policy) = standard_resolver_for(resolution.as_ref(), &auth, None)?;
+        let iri = parse_iri(iri)?;
+        let listing = do_versions(&iri, &resolver)
+            .map_err(|e| info_error_to_pyerr(e, &auth, &auth_policy))?;
+        Ok((
+            listing.iri,
+            listing.versions.iter().map(Version::to_string).collect(),
+            listing.ignored,
+        ))
     })
 }
 
@@ -898,6 +937,7 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_info_py_path, m)?)?;
     m.add_function(wrap_pyfunction!(do_model_roundtrip_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_info_py, m)?)?;
+    m.add_function(wrap_pyfunction!(do_versions_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_root_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_build_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_sources_env_py, m)?)?;

--- a/bindings/py/tests/mockindex.py
+++ b/bindings/py/tests/mockindex.py
@@ -249,6 +249,12 @@ class MockIndex:
         """Make the next request for ``path`` fail with ``status``."""
         self._fail_next[path] = status
 
+    def override(
+        self, path: str, body: bytes, content_type: str = "application/json"
+    ) -> None:
+        """Serve ``body`` for ``path`` from now on, whatever was published."""
+        self._files[path] = (body, content_type)
+
     # -- observation --------------------------------------------------------
 
     def requests(self, path_glob: str = "*") -> list[str]:

--- a/bindings/py/tests/test_versions.py
+++ b/bindings/py/tests/test_versions.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+"""`sysand.versions()` against the mock index.
+
+Every call here passes an explicit `resolution=`: the default `Resolution()`
+means the CLI's configuration files plus the public default index, which no
+test may touch."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import sysand
+from mockindex import LIBRARY, MockIndex
+
+IRI = "urn:kpar:versions_probe"
+
+
+def resolution(index: MockIndex) -> sysand.Resolution:
+    return sysand.Resolution(default_index=[index.url], use_config=False)
+
+
+def test_versions_lists_highest_first_with_one_request(mock_index: MockIndex) -> None:
+    mock_index.publish(IRI, "0.10.3")
+    mock_index.publish(IRI, "1.0.0")
+    mock_index.publish(IRI, "0.11.0")
+
+    listing = sysand.versions(IRI, resolution=resolution(mock_index))
+
+    assert listing == {
+        "iri": IRI,
+        "versions": ["1.0.0", "0.11.0", "0.10.3"],
+        "ignored": [],
+    }
+    assert mock_index.requests("*/versions.json") == [MockIndex.versions_path(IRI)]
+    # The listing is answered from `versions.json` alone.
+    assert mock_index.requests("*/.project.json") == []
+    assert mock_index.requests("*/.meta.json") == []
+    assert mock_index.requests("*/project.kpar") == []
+
+
+def test_versions_of_a_purl(mock_index: MockIndex) -> None:
+    mock_index.publish(LIBRARY, "0.10.3")
+
+    listing = sysand.versions(LIBRARY, resolution=resolution(mock_index))
+
+    assert listing["iri"] == LIBRARY
+    assert listing["versions"] == ["0.10.3"]
+
+
+def test_versions_not_found(mock_index: MockIndex) -> None:
+    mock_index.publish(IRI, "1.0.0")
+
+    with pytest.raises(sysand.NotFoundError) as excinfo:
+        sysand.versions("urn:kpar:absent", resolution=resolution(mock_index))
+    assert excinfo.value.wrote is False
+
+    with pytest.raises(sysand.NotFoundError):
+        sysand.versions(IRI, resolution=sysand.Resolution(no_index=True))
+    assert mock_index.requests("*/versions.json") == [
+        MockIndex.versions_path("urn:kpar:absent")
+    ]
+
+
+def test_versions_auth(mock_index: MockIndex, monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_index.publish(IRI, "1.0.0")
+    mock_index.require_bearer("s3cret")
+    res = resolution(mock_index)
+    glob = mock_index.url + "**"
+
+    with pytest.raises(sysand.AuthError):
+        sysand.versions(IRI, resolution=res)
+
+    listing = sysand.versions(
+        IRI, resolution=res, auth=sysand.AuthPolicy.bearer(glob, "s3cret")
+    )
+    assert listing["versions"] == ["1.0.0"]
+
+    monkeypatch.setenv("SYSAND_CRED_TEST", glob)
+    monkeypatch.setenv("SYSAND_CRED_TEST_BEARER_TOKEN", "s3cret")
+    listing = sysand.versions(
+        IRI, resolution=res, auth=sysand.AuthPolicy.from_env(keyring=False)
+    )
+    assert listing["versions"] == ["1.0.0"]
+
+
+def test_versions_index_protocol_error(mock_index: MockIndex) -> None:
+    mock_index.publish(IRI, "1.0.0")
+    path = MockIndex.versions_path(IRI)
+    good = json.loads(
+        json.dumps(
+            {
+                "versions": [
+                    {
+                        "version": v,
+                        "usage": [],
+                        "kpar_size": mock_index.kpar_size(IRI, "1.0.0"),
+                        "kpar_digest": mock_index.kpar_digest(IRI, "1.0.0"),
+                    }
+                    for v in ("1.0.0", "2.0.0")
+                ]
+            }
+        )
+    )
+    # Valid JSON that violates the protocol: ascending order.
+    mock_index.override(path, json.dumps(good).encode())
+    with pytest.raises(sysand.IndexProtocolError) as excinfo:
+        sysand.versions(IRI, resolution=resolution(mock_index))
+    assert excinfo.value.wrote is False
+
+    mock_index.override(path, b"{not json")
+    with pytest.raises(sysand.IndexProtocolError):
+        sysand.versions(IRI, resolution=resolution(mock_index))

--- a/core/src/commands/mod.rs
+++ b/core/src/commands/mod.rs
@@ -22,3 +22,4 @@ pub mod root;
 pub mod sources;
 pub mod sync;
 pub mod usage;
+pub mod versions;

--- a/core/src/commands/versions.rs
+++ b/core/src/commands/versions.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+//! List every version a resolver can offer for a project.
+
+use fluent_uri::Iri;
+use semver::Version;
+
+use crate::{
+    info::InfoError,
+    project::ProjectRead as _,
+    resolve::{ResolutionInfo, ResolutionOutcome, ResolveRead},
+    utils::format_err,
+};
+
+/// The versions a resolver offers for one project.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionListing {
+    /// The IRI that was looked up.
+    pub iri: String,
+    /// Distinct semver-valid versions, highest first. Over an index these
+    /// are the *available* versions: yanked and removed entries are never
+    /// enumerated.
+    pub versions: Vec<Version>,
+    /// Version strings that are not valid semver, in encounter order. Kept
+    /// for diagnostics rather than dropped silently; an index cannot publish
+    /// such entries, but other sources can.
+    pub ignored: Vec<String>,
+}
+
+/// List the versions of `iri` known to `resolver`.
+///
+/// The sibling of [`crate::info::do_info`]: the same resolution, but every
+/// candidate's version is collected instead of keeping the best one. Over an
+/// index this costs the per-project `versions.json` request only — each
+/// candidate answers `version()` from the advertised entry.
+///
+/// Candidates that fail to load, or report no version, are skipped with a
+/// log line, as `do_info` skips them. If every candidate was skipped the
+/// result is [`InfoError::NoSemanticVersionsFound`] with an empty list; if
+/// only non-semver versions were found the listing is `Ok` with an empty
+/// `versions` and a full `ignored`, so the caller can report them.
+#[expect(clippy::result_large_err)]
+pub fn do_versions<R: ResolveRead>(
+    iri: &Iri<String>,
+    resolver: &R,
+) -> Result<VersionListing, InfoError<R::Error>> {
+    let resolve = ResolutionInfo::iri(iri.to_owned());
+    let outcome = resolver.resolve_read(&resolve)?;
+
+    let resolved = match outcome {
+        ResolutionOutcome::Resolved(resolved) => resolved,
+        ResolutionOutcome::UnsupportedUsageType { reason } => {
+            return Err(InfoError::UnsupportedUsage {
+                usage: resolve,
+                reason,
+            });
+        }
+        ResolutionOutcome::NotFound { reason } => {
+            return Err(InfoError::NotFound {
+                usage: resolve,
+                reason,
+            });
+        }
+        ResolutionOutcome::Unresolvable { reason } => {
+            return Err(InfoError::NoResolve {
+                usage: resolve,
+                reason,
+            });
+        }
+    };
+
+    let mut versions: Vec<Version> = Vec::new();
+    let mut ignored: Vec<String> = Vec::new();
+    let mut seen_any = false;
+
+    for candidate in resolved {
+        let project = match candidate {
+            Ok(project) => project,
+            Err(e) => {
+                // As in `do_info`: the candidate list is every possibility,
+                // and some are expected not to work.
+                log::debug!("skipping candidate project: {}", format_err(e));
+                continue;
+            }
+        };
+        match project.version() {
+            Ok(Some(version)) => {
+                seen_any = true;
+                match Version::parse(&version) {
+                    Ok(parsed) => versions.push(parsed),
+                    Err(_) => ignored.push(version),
+                }
+            }
+            Ok(None) => {
+                log::warn!("ignoring a candidate of `{iri}` that declares no version");
+            }
+            Err(err) => {
+                log::warn!("ignoring a project because: {}", format_err(err));
+            }
+        }
+    }
+
+    if !seen_any {
+        return Err(InfoError::NoSemanticVersionsFound(Vec::new()));
+    }
+
+    // Reverse sort
+    versions.sort_unstable_by(|a, b| b.cmp(a));
+    versions.dedup();
+
+    Ok(VersionListing {
+        iri: iri.to_string(),
+        versions,
+        ignored,
+    })
+}
+
+#[cfg(test)]
+#[path = "./versions_tests.rs"]
+mod tests;

--- a/core/src/commands/versions_tests.rs
+++ b/core/src/commands/versions_tests.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+use std::{assert_matches, collections::HashMap};
+
+use fluent_uri::Iri;
+use indexmap::IndexMap;
+use semver::Version;
+
+use super::{VersionListing, do_versions};
+use crate::{
+    info::InfoError,
+    model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
+    project::{memory::InMemoryProject, utils::Identifier},
+    resolve::memory::{AcceptAll, MemoryResolver},
+};
+
+const IRI: &str = "urn:kpar:listed";
+
+fn project(version: &str) -> InMemoryProject {
+    InMemoryProject {
+        info: Some(InterchangeProjectInfoRaw {
+            name: "listed".to_owned(),
+            publisher: None,
+            description: None,
+            version: version.to_owned(),
+            license: None,
+            maintainer: vec![],
+            website: None,
+            topic: vec![],
+            usage: vec![],
+        }),
+        meta: Some(InterchangeProjectMetadataRaw {
+            index: IndexMap::new(),
+            created: "2026-01-01T00:00:00Z".to_owned(),
+            metamodel: None,
+            includes_derived: None,
+            includes_implied: None,
+            checksum: None,
+        }),
+        files: HashMap::new(),
+        nominal_sources: vec![],
+    }
+}
+
+fn resolver(candidates: Vec<InMemoryProject>) -> MemoryResolver<AcceptAll, InMemoryProject> {
+    MemoryResolver::from_iter([(Identifier::from_iri_unchecked_str(IRI), candidates)])
+}
+
+fn iri() -> Iri<String> {
+    Iri::parse(IRI).unwrap().into()
+}
+
+fn v(s: &str) -> Version {
+    Version::parse(s).unwrap()
+}
+
+#[test]
+fn lists_distinct_semver_versions_highest_first_and_keeps_the_rest() {
+    let resolver = resolver(vec![
+        project("0.10.3"),
+        project("nightly"),
+        project("1.2.3"),
+        project("0.10.3"),
+    ]);
+
+    let listing = do_versions(&iri(), &resolver).unwrap();
+
+    assert_eq!(
+        listing,
+        VersionListing {
+            iri: IRI.to_owned(),
+            versions: vec![v("1.2.3"), v("0.10.3")],
+            ignored: vec!["nightly".to_owned()],
+        }
+    );
+}
+
+#[test]
+fn only_non_semver_versions_is_not_an_error() {
+    let resolver = resolver(vec![project("nightly"), project("latest")]);
+
+    let listing = do_versions(&iri(), &resolver).unwrap();
+
+    assert!(listing.versions.is_empty());
+    assert_eq!(listing.ignored, vec!["nightly", "latest"]);
+}
+
+#[test]
+fn candidates_without_a_version_are_skipped() {
+    let resolver = resolver(vec![InMemoryProject::default(), project("1.0.0")]);
+
+    let listing = do_versions(&iri(), &resolver).unwrap();
+
+    assert_eq!(listing.versions, vec![v("1.0.0")]);
+    assert!(listing.ignored.is_empty());
+}
+
+#[test]
+fn nothing_usable_is_no_semantic_versions_found() {
+    let resolver = resolver(vec![InMemoryProject::default()]);
+
+    assert_matches!(
+        do_versions(&iri(), &resolver).unwrap_err(),
+        InfoError::NoSemanticVersionsFound(found) if found.is_empty()
+    );
+}
+
+#[test]
+fn unknown_iri_is_not_found() {
+    let resolver = resolver(vec![project("1.0.0")]);
+    let other: Iri<String> = Iri::parse("urn:kpar:other").unwrap().into();
+
+    assert_matches!(
+        do_versions(&other, &resolver).unwrap_err(),
+        InfoError::NotFound { .. }
+    );
+}

--- a/core/src/project/index_entry.rs
+++ b/core/src/project/index_entry.rs
@@ -11,9 +11,10 @@
 //!
 //! - Advertised-tier reads ([`ProjectReadAsync::version_async`],
 //!   [`ProjectReadAsync::usage_async`]) returning fields from
-//!   [`crate::env::index::AdvertisedVersion`] without I/O. Before the archive
-//!   is verified, [`ProjectReadAsync::checksum_canonical_hex_async`] also
-//!   returns the advertised digest directly.
+//!   [`crate::env::index::AdvertisedVersion`] without I/O.
+//!   `checksum_canonical_hex_async` is *not* among them: it is the canonical
+//!   project digest, computed from the fetched info and metadata, so it goes
+//!   through the lazy fetch below.
 //! - Lazily-fetched reads
 //!   ([`ProjectReadAsync::get_project_async`]/`get_info_async`/`get_meta_async`)
 //!   guarded by `fetched_info_meta`'s `OnceCell`.
@@ -52,9 +53,7 @@ pub struct IndexEntryProject<Policy> {
     /// type name tracks the transport.
     pub(crate) archive: ReqwestIndexKparDownloadedProject<Policy>,
     /// Single source of truth for protocol-advertised per-version metadata.
-    /// `version_async` and `usage_async` return these fields without I/O;
-    /// `checksum_canonical_hex_async` does the same until the archive has been
-    /// verified.
+    /// `version_async` and `usage_async` return these fields without I/O.
     pub(crate) advertised: AdvertisedVersion,
     pub(crate) project_json_url: reqwest::Url,
     pub(crate) meta_json_url: reqwest::Url,

--- a/core/src/resolve/combined.rs
+++ b/core/src/resolve/combined.rs
@@ -156,18 +156,7 @@ impl<
                 if let Some(r) = iter.next() {
                     let next = match r {
                         Ok(project) => {
-                            let cached = match project.checksum_canonical_hex() {
-                                Ok(opt) => {
-                                    opt.and_then(|checksum| self.locals.shift_remove(&checksum))
-                                }
-                                Err(err) => {
-                                    log::debug!(
-                                        "remote-project checksum_canonical_hex failed; skipping local-cache match: {}",
-                                        format_err(err)
-                                    );
-                                    None
-                                }
-                            };
+                            let cached = self.take_cached_local(&project, "remote");
 
                             let p = if let Some(local_project) = cached {
                                 CombinedProjectStorage::CachedRemoteProject(CachedProject::new(
@@ -191,18 +180,7 @@ impl<
                 if let Some(r) = iter.next() {
                     let next = match r {
                         Ok(project) => {
-                            let cached = match project.checksum_canonical_hex() {
-                                Ok(opt) => {
-                                    opt.and_then(|checksum| self.locals.shift_remove(&checksum))
-                                }
-                                Err(err) => {
-                                    log::debug!(
-                                        "index-project checksum_canonical_hex failed; skipping local-cache match: {}",
-                                        format_err(err)
-                                    );
-                                    None
-                                }
-                            };
+                            let cached = self.take_cached_local(&project, "index");
 
                             let p = if let Some(local_project) = cached {
                                 CombinedProjectStorage::CachedIndexProject(CachedProject::new(
@@ -223,6 +201,42 @@ impl<
                 }
             }
         }
+    }
+}
+
+impl<
+    FileResolver: ResolveRead,
+    LocalResolver: ResolveRead,
+    RemoteResolver: ResolveRead,
+    IndexResolver: ResolveRead,
+> CombinedIterator<FileResolver, LocalResolver, RemoteResolver, IndexResolver>
+{
+    /// The locally cached copy of `project`, if one is waiting to be matched.
+    ///
+    /// Matching needs the candidate's canonical checksum, which for a
+    /// remote or index candidate means fetching its `.project.json` and
+    /// `.meta.json`. With nothing left to match there is nothing to gain
+    /// from that, so the probe is skipped — a version listing over an index
+    /// then costs one `versions.json` request, not two more per version.
+    fn take_cached_local<P: ProjectRead>(
+        &mut self,
+        project: &P,
+        kind: &str,
+    ) -> Option<LocalResolver::ProjectStorage> {
+        if self.locals.is_empty() {
+            return None;
+        }
+        let checksum = match project.checksum_canonical_hex() {
+            Ok(checksum) => checksum?,
+            Err(err) => {
+                log::debug!(
+                    "{kind}-project checksum_canonical_hex failed; skipping local-cache match: {}",
+                    format_err(err)
+                );
+                return None;
+            }
+        };
+        self.locals.shift_remove(&checksum)
     }
 }
 

--- a/core/src/resolve/combined_tests.rs
+++ b/core/src/resolve/combined_tests.rs
@@ -2,15 +2,21 @@
 // SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
 
 use std::assert_matches;
+use std::cell::Cell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
+use camino::Utf8Path;
 use fluent_uri::Iri;
 use indexmap::IndexMap;
+use typed_path::Utf8UnixPath;
 
 use crate::{
+    context::ProjectContext,
     info::{InfoError, do_info},
+    lock::Source,
     model::{InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw},
-    project::{memory::InMemoryProject, utils::Identifier},
+    project::{ProjectChecksum, ProjectRead, memory::InMemoryProject, utils::Identifier},
     resolve::{
         ResolutionInfo, ResolutionOutcome, ResolveRead,
         combined::{CombinedResolver, NO_RESOLVER},
@@ -267,9 +273,7 @@ fn unsupported_iri() {
         index_resolver: NO_RESOLVER,
     };
 
-    let Ok(crate::resolve::ResolutionOutcome::UnsupportedUsageType { .. }) =
-        resolve(&resolver, example_uri)
-    else {
+    let Ok(ResolutionOutcome::UnsupportedUsageType { .. }) = resolve(&resolver, example_uri) else {
         panic!()
     };
 }
@@ -285,8 +289,7 @@ fn unresolved_iri() {
         index_resolver: empty_any_resolver(),
     };
 
-    let Ok(crate::resolve::ResolutionOutcome::NotFound { .. }) = resolve(&resolver, example_uri)
-    else {
+    let Ok(ResolutionOutcome::NotFound { .. }) = resolve(&resolver, example_uri) else {
         panic!()
     };
 }
@@ -391,4 +394,131 @@ fn no_semantic_versions_error() {
     let info_meta = do_info(&example_uri, &resolver);
 
     assert_matches!(info_meta, Err(InfoError::NoSemanticVersionsFound(_)));
+}
+
+/// An in-memory project that counts how often its info/meta are read, so a
+/// test can assert that a candidate was *not* inspected.
+#[derive(Clone, Debug)]
+struct CountingProject {
+    inner: InMemoryProject,
+    reads: Rc<Cell<usize>>,
+}
+
+impl ProjectRead for CountingProject {
+    type Error = <InMemoryProject as ProjectRead>::Error;
+
+    fn get_project(
+        &self,
+    ) -> Result<
+        (
+            Option<InterchangeProjectInfoRaw>,
+            Option<InterchangeProjectMetadataRaw>,
+        ),
+        Self::Error,
+    > {
+        self.reads.set(self.reads.get() + 1);
+        self.inner.get_project()
+    }
+
+    type SourceReader<'a>
+        = <InMemoryProject as ProjectRead>::SourceReader<'a>
+    where
+        Self: 'a;
+
+    fn read_source<P: AsRef<Utf8UnixPath>>(
+        &self,
+        path: P,
+    ) -> Result<Self::SourceReader<'_>, Self::Error> {
+        self.inner.read_source(path)
+    }
+
+    fn sources(&self, ctx: &ProjectContext) -> Result<Vec<Source>, Self::Error> {
+        self.inner.sources(ctx)
+    }
+
+    fn checksum_canonical_variant(&self) -> Result<ProjectChecksum, Self::Error> {
+        self.inner.checksum_canonical_variant()
+    }
+
+    fn project_root(&self) -> Option<&Utf8Path> {
+        self.inner.project_root()
+    }
+}
+
+fn counting_index_resolver(
+    uri: &str,
+    versions: &[&str],
+) -> (
+    Option<MemoryResolver<AcceptAll, CountingProject>>,
+    Rc<Cell<usize>>,
+) {
+    let reads = Rc::new(Cell::new(0));
+    let projects = versions
+        .iter()
+        .map(|v| CountingProject {
+            inner: minimal_project("counted", v),
+            reads: reads.clone(),
+        })
+        .collect();
+    let mut map = HashMap::new();
+    map.insert(Identifier::from_iri_unchecked_str(uri), projects);
+    (
+        Some(MemoryResolver {
+            iri_predicate: AcceptAll {},
+            projects: map,
+        }),
+        reads,
+    )
+}
+
+#[test]
+fn index_candidates_are_not_probed_when_nothing_local_can_match() {
+    let uri = "urn:kpar:counted";
+    let (index, reads) = counting_index_resolver(uri, &["1.0.0", "2.0.0"]);
+    let resolver = CombinedResolver {
+        file_resolver: NO_RESOLVER,
+        local_resolver: empty_any_resolver(),
+        remote_resolver: NO_RESOLVER,
+        index_resolver: index,
+    };
+
+    let outcome = resolver
+        .resolve_read(&ResolutionInfo::iri(Iri::parse(uri).unwrap().into()))
+        .unwrap();
+    let ResolutionOutcome::Resolved(candidates) = outcome else {
+        panic!("expected the IRI to resolve");
+    };
+    assert_eq!(candidates.count(), 2);
+    assert_eq!(
+        reads.get(),
+        0,
+        "enumerating candidates must not read their info/meta when no local project awaits a match"
+    );
+}
+
+#[test]
+fn index_candidates_are_probed_when_a_local_copy_may_match() {
+    let uri = "urn:kpar:counted";
+    let (index, reads) = counting_index_resolver(uri, &["1.0.0"]);
+    let resolver = CombinedResolver {
+        file_resolver: NO_RESOLVER,
+        local_resolver: single_project_any_resolver(uri, minimal_project("counted", "1.0.0")),
+        remote_resolver: NO_RESOLVER,
+        index_resolver: index,
+    };
+
+    let outcome = resolver
+        .resolve_read(&ResolutionInfo::iri(Iri::parse(uri).unwrap().into()))
+        .unwrap();
+    let ResolutionOutcome::Resolved(candidates) = outcome else {
+        panic!("expected the IRI to resolve");
+    };
+    assert_eq!(candidates.count(), 1);
+    // One checksum probe: `checksum_canonical_hex` reads the info and the
+    // metadata separately, and each goes through `get_project`.
+    assert_eq!(
+        reads.get(),
+        2,
+        "the one candidate must be probed exactly once to match the waiting local copy"
+    );
 }

--- a/sysand/tests/cli_env.rs
+++ b/sysand/tests/cli_env.rs
@@ -215,7 +215,7 @@ fn env_install_from_http_kpar() -> Result<(), Box<dyn std::error::Error>> {
     let git_mock = server
         .mock("GET", "/test_lib.kpar/info/refs?service=git-upload-pack")
         .with_status(404)
-        .expect(2) // TODO: Reduce this to 1 after caching
+        .expect(1)
         .create();
 
     let project_mock = server

--- a/sysand/tests/cli_info.rs
+++ b/sysand/tests/cli_info.rs
@@ -210,16 +210,16 @@ fn info_basic_http_url_noauth() -> Result<(), Box<dyn Error>> {
     let git_mock = server
         .mock("GET", "/info/refs?service=git-upload-pack")
         .with_status(404)
-        .expect(2) // TODO: Reduce this to 1
+        .expect(1)
         .create();
 
     let kpar_range_probe = server.mock("HEAD", "/").with_status(404).expect(0).create();
 
-    // Two calls expected: the resolver tries the URL as a kpar via two
-    // candidate paths (chained through any-resolver). Each path re-issues
-    // the GET on 404 because the failed-download attempt is not recorded.
+    // One call expected: the resolver tries the URL as a kpar once while
+    // resolving it. It is not tried again for the local-cache match, since
+    // with nothing installed there is nothing the candidate could match.
     // Pin the count; further reductions would be a resolver-level change.
-    let kpar_download_try = server.mock("GET", "/").with_status(404).expect(2).create();
+    let kpar_download_try = server.mock("GET", "/").with_status(404).expect(1).create();
 
     let info_mock_head = server
         .mock("HEAD", "/.project.json")
@@ -234,7 +234,7 @@ fn info_basic_http_url_noauth() -> Result<(), Box<dyn Error>> {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let meta_mock_head = server
@@ -250,7 +250,7 @@ fn info_basic_http_url_noauth() -> Result<(), Box<dyn Error>> {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let (_, _, out) = run_sysand(["info", "--iri", &server.url()], None)?;
@@ -281,7 +281,7 @@ fn info_basic_http_url_irrelevant_auth() -> Result<(), Box<dyn Error>> {
     let git_mock = server
         .mock("GET", "/info/refs?service=git-upload-pack")
         .with_status(404)
-        .expect(2) // TODO: Reduce this to 1
+        .expect(1)
         .create();
 
     let kpar_range_probe = server.mock("HEAD", "/").with_status(404).expect(0).create();
@@ -290,7 +290,7 @@ fn info_basic_http_url_irrelevant_auth() -> Result<(), Box<dyn Error>> {
         .mock("GET", "/")
         .with_status(404)
         // See the matching comment in `info_basic_http_url_noauth`.
-        .expect(2)
+        .expect(1)
         .create();
 
     let info_mock_head = server
@@ -306,7 +306,7 @@ fn info_basic_http_url_irrelevant_auth() -> Result<(), Box<dyn Error>> {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let meta_mock_head = server
@@ -322,7 +322,7 @@ fn info_basic_http_url_irrelevant_auth() -> Result<(), Box<dyn Error>> {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let (_, _, out) = run_sysand_with(
@@ -362,7 +362,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         .mock("GET", "/info/refs?service=git-upload-pack")
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
-        .expect(2) // TODO: Reduce this to 1
+        .expect(1)
         .create();
 
     // let kpar_range_probe = server
@@ -377,7 +377,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
         // See the matching comment in `info_basic_http_url_noauth`.
-        .expect(2)
+        .expect(1)
         .create();
 
     let kpar_download_try_auth = server
@@ -387,7 +387,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
             Matcher::Exact("Basic dXNlcl8xMjM0OnBhc3NfNDMyMQ==".to_owned()),
         )
         .with_status(404)
-        .expect(2)
+        .expect(1)
         .create();
 
     let info_mock_head = server
@@ -417,7 +417,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let info_mock_auth = server
@@ -429,7 +429,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let meta_mock_head = server
@@ -459,7 +459,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_header("content-type", "application/json")
         .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let meta_mock_auth = server
@@ -471,7 +471,7 @@ fn info_basic_http_url_auth() -> Result<(), Box<dyn Error>> {
         )
         .with_header("content-type", "application/json")
         .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let (_, _, out) = run_sysand_with(
@@ -517,7 +517,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         .mock("GET", "/info/refs?service=git-upload-pack")
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
-        .expect(2) // TODO: Reduce this to 1
+        .expect(1)
         .create();
 
     // let kpar_range_probe = server
@@ -532,7 +532,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_status(404)
         // See the matching comment in `info_basic_http_url_noauth`.
-        .expect(2)
+        .expect(1)
         .create();
 
     let kpar_download_try_auth = server
@@ -542,7 +542,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
             Matcher::Exact("Bearer this_is_a_token".to_owned()),
         )
         .with_status(404)
-        .expect(2)
+        .expect(1)
         .create();
 
     let info_mock_head = server
@@ -572,7 +572,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let info_mock_auth = server
@@ -584,7 +584,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"name":"info_basic_http_url","version":"1.2.3"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let meta_mock_head = server
@@ -614,7 +614,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         .match_header("authorization", Matcher::Missing)
         .with_header("content-type", "application/json")
         .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let meta_mock_auth = server
@@ -626,7 +626,7 @@ fn info_bearer_http_url_auth() -> Result<(), Box<dyn Error>> {
         )
         .with_header("content-type", "application/json")
         .with_body(r#"{"index":{},"created":"0000-00-00T00:00:00.123456789Z"}"#)
-        .expect(3) // TODO: Reduce this to 1
+        .expect(2) // TODO: Reduce this to 1
         .create();
 
     let (_, _, out) = run_sysand_with(

--- a/sysand/tests/cli_lock.rs
+++ b/sysand/tests/cli_lock.rs
@@ -253,7 +253,7 @@ fn lock_basic_http_deps() -> Result<(), Box<dyn std::error::Error>> {
     let c_url = mock_project(
         &mut server,
         &mut project_mocks,
-        [1, 8, 1, 6],
+        [1, 7, 1, 5],
         "c",
         "lock_basic_http_deps_c",
         "1.0.0",
@@ -263,7 +263,7 @@ fn lock_basic_http_deps() -> Result<(), Box<dyn std::error::Error>> {
     let a_url = mock_project(
         &mut server,
         &mut project_mocks,
-        [1, 8, 1, 6],
+        [1, 7, 1, 5],
         "a",
         "lock_basic_http_deps_a",
         "1.0.0",
@@ -272,7 +272,7 @@ fn lock_basic_http_deps() -> Result<(), Box<dyn std::error::Error>> {
     let b_url = mock_project(
         &mut server,
         &mut project_mocks,
-        [1, 8, 1, 6],
+        [1, 7, 1, 5],
         "b",
         "lock_basic_http_deps_b",
         "1.0.0",
@@ -831,7 +831,7 @@ fn lock_fail_unsatisfiable() -> Result<(), Box<dyn std::error::Error>> {
     let a_url = mock_project(
         &mut server,
         &mut project_mocks,
-        [1, 4, 1, 2],
+        [1, 3, 1, 1],
         "a",
         "lock_basic_http_deps_a",
         "1.0.0",


### PR DESCRIPTION
# feat(py): `versions()`, authenticated version listing

This MR adds `sysand.versions(iri, *, resolution=None, auth=None)`, which lists every version a resolver can offer for a project, highest first. It is the sibling of `sysand.info`: the same resolution over the same indexes with the same `Resolution` and `AuthPolicy` objects, but every candidate's version is collected instead of keeping the best one.

- New core function `sysand_core::versions::do_versions` returning a `VersionListing { iri, versions, ignored }`. Nothing in the CLI calls it yet; the Python binding is its first user.
- `sysand.versions` returns a `VersionListing` typed dict with `versions` as strings, highest first, and `ignored` for version strings that are not valid semver. Errors are the typed classes `info` already raises: `NotFoundError`, `AuthError`, `IndexProtocolError`, `ResolutionError`.
- The combined resolver no longer probes remote and index candidates for their checksum when there is no locally cached project to match against. Over an index, a listing costs one `versions.json` request instead of two more requests per version.
- A stale doc comment in `core/src/project/index_entry.rs` is corrected. Code there is unchanged.
- `do_info_py` and the new `do_versions_py` share a `standard_resolver_for` helper; the body of `do_info_py` moved into it unchanged.

## Why

A tool driving sysand from Python has to answer "which versions of this project exist?" before it can decide whether a constraint change is even possible. `info` cannot answer that: it resolves to one project, the highest version that matches, and a caller that wants the full list would have to re-implement the index protocol. The CLI has no command for it either.

The list has to come through the resolver rather than from a direct `versions.json` fetch so that it sees exactly what `lock` will see: the same index merge, the same authentication, the same treatment of yanked and removed entries, and the same non-index sources when a `Resolution` names them.

## What changed

### `do_versions` (`core/src/commands/versions.rs`)

Resolves `iri` exactly as `do_info` does, then iterates every candidate and collects `project.version()` instead of picking the best one. Over an index each candidate answers `version()` from the entry advertised in `versions.json`, so no per-version fetch is needed.

Semantics, each covered by a unit test in `versions_tests.rs`:

- `versions` is sorted highest first with duplicates removed (the same version offered by two sources is listed once).
- Strings that are not valid semver go to `ignored`, in encounter order. An index cannot publish such entries (ingest validation rejects them), but a `dir` or `src` source can, and dropping them silently would hide a misconfigured project.
- A candidate that fails to load or declares no version is skipped with a log line, as `do_info` skips them.
- If every candidate was skipped the result is `InfoError::NoSemanticVersionsFound` with an empty list. If candidates were found but none had a semver version, the result is `Ok` with an empty `versions` and a full `ignored`, so the caller can report what it saw.
- `NotFound`, `UnsupportedUsage` and `NoResolve` map to the same `InfoError` variants as in `do_info`, so the Python error mapping written for `info` applies without change.

The error type is `InfoError<R::Error>`, shared with `do_info`, rather than a new one: the failure modes are identical and the Python side already maps every variant.

### Combined resolver: skip the checksum probe when nothing can match (`core/src/resolve/combined.rs`)

`CombinedIterator` matches each remote or index candidate against locally cached copies by canonical checksum. For an index candidate that checksum is computed from `.project.json` and `.meta.json`, which means two fetches per candidate, for every version in the listing. When the local set is empty the result of the lookup is always "no match", so the probe is pure cost.

The two duplicated match blocks (one for remote, one for index candidates) are replaced by `take_cached_local`, which returns `None` up front when `locals` is empty and otherwise does what the two blocks did. Two new tests in `combined_tests.rs` use a `CountingProject` wrapper to assert that candidates are not read when there is nothing local to match, and are read when a local copy is waiting.

**For reviewers:** the results are identical by construction: with an empty local set the old code always ended in `shift_remove` on an empty map. What changes is the number of requests, and it differs by candidate kind:

- Index candidates answer `version()` from `versions.json`, so the saving only shows up for callers that need nothing but `version()` or `usage()`. `do_info` is not one of them: it calls `get_project()` on every candidate to pick the best, so `sysand info <iri>` and `sysand.info` over an index make the same requests as before (checked against the mock index, three versions published, six `.project.json`/`.meta.json` fetches before and after).
- Remote candidates (a project given by URL) have no cached listing to answer from. Their checksum probe re-resolved the URL: one more `info/refs?service=git-upload-pack` probe, one more `GET` of the URL as a kpar, and one more `GET` each of `.project.json` and `.meta.json`. With nothing local to match, that round is gone for every URL-based project in `info`, `lock`, `sync` and `env install`. The CLI tests in `sysand/tests/cli_env.rs`, `cli_info.rs` and `cli_lock.rs` pin these counts and are lowered by one per URL-based candidate; most of the old values carried a `TODO: Reduce this to 1` comment, and the git probe ones are now at that target. Behaviour and output are unchanged; only the mock expectations move.

The `checksum_canonical_hex failed; skipping local-cache match` debug line is no longer logged when the local set is empty, since the probe that could fail is not made.

### `index_entry.rs` doc fix

The module and field docs said `checksum_canonical_hex_async` returns the advertised digest without I/O until the archive is verified. It does not, and did not before this MR: the canonical project digest is computed from the fetched info and metadata, which is exactly why the probe above was expensive. The advertised `kpar_digest` is returned by `checksum_canonical_variant_async`, whose docs were already correct. Only the comments change.

### `sysand.versions` (`_versions.py`, `_model.py`, `lib.rs::do_versions_py`)

```python
sysand.versions("pkg:sysand/acme/lib", resolution=sysand.Resolution(...), auth=sysand.AuthPolicy.bearer(...))
# -> {"iri": "pkg:sysand/acme/lib", "versions": ["1.2.0", "1.1.0"], "ignored": []}
```

`VersionListing` is a typed dict with `iri`, `versions` (strings, highest first) and `ignored`. The Rust side returns a plain tuple of strings and the Python side builds the dict, as the other bindings do.

**For reviewers, one deliberate difference from `info`:** when `resolution` is omitted, `versions` uses `Resolution()`, meaning the CLI's configuration files plus the default index, whereas `info` with no `Resolution` consults no index at all. `info` kept that behaviour for compatibility with its original `index_urls=None` meaning; a version listing with no index to ask is useless, so `versions` defaults to what the CLI would use. There is no `index_urls` keyword on `versions` because it is new and has no callers to keep working.

Error mapping reuses `info_error_to_pyerr`: `NotFoundError` when no source knows the IRI (including `Resolution(no_index=True)` with nothing local), `AuthError` with the same credential hint on 401/403, `IndexProtocolError` when `versions.json` is malformed or violates the protocol, `ResolutionError` for everything else, including the "candidates found but none has a version" case.

`do_info_py` is refactored to share `standard_resolver_for` (HTTP client, current-thread runtime, index merge, auth policy) and `parse_iri` with `do_versions_py`. Its behaviour is unchanged and `test_auth.py` still passes untouched.

### Mock index: `override(path, body)` (`tests/mockindex.py`)

Serves an arbitrary body for a path regardless of what was published. Used to feed the resolver a `versions.json` that is valid JSON but breaks the protocol, and one that is not JSON at all.

### Tests (`tests/test_versions.py`)

Five tests against the mock index. Every call passes an explicit `resolution=` because the default would touch the public index.

- Three published versions come back highest first, and the request log shows exactly one `versions.json` request and no `.project.json`, `.meta.json` or `project.kpar` requests. This is the end-to-end check of the combined-resolver change.
- A `pkg:sysand/...` IRI works through the PURL path layout.
- An absent IRI raises `NotFoundError` with `wrote == False`, as does `Resolution(no_index=True)`; the log shows the index was asked only for the absent one.
- With the index requiring a bearer token: no policy raises `AuthError`; `AuthPolicy.bearer` and `AuthPolicy.from_env(keyring=False)` from `SYSAND_CRED_TEST*` both succeed.
- A `versions.json` in ascending order (valid JSON, invalid protocol) and a non-JSON body both raise `IndexProtocolError` with `wrote == False`.
