### PR TITLE
feat(py): `lock()` with the resolved set and structured solve failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4120,6 +4120,7 @@ dependencies = [
 name = "sysand-py"
 version = "0.2.1"
 dependencies = [
+ "anyhow",
  "camino",
  "camino-tempfile",
  "fluent-uri",

--- a/bindings/py/Cargo.toml
+++ b/bindings/py/Cargo.toml
@@ -23,6 +23,7 @@ kpar-ppmd = ["sysand-core/kpar-ppmd", "sysand/kpar-ppmd"]
 [dependencies]
 sysand-core = { path = "../../core", features = ["python", "filesystem", "networking"] }
 sysand = { path = "../../sysand" }
+anyhow = "1.0.102"
 camino.workspace = true
 fluent-uri.workspace = true
 pyo3 = { version = "0.29.0", default-features = false, features = ["macros"] }

--- a/bindings/py/python/sysand/__init__.py
+++ b/bindings/py/python/sysand/__init__.py
@@ -18,6 +18,9 @@ from ._model import (
     EnvProjectChecksumSrc,
     Discovery,
     VersionListing,
+    LockedProject,
+    LockResult,
+    ProvidedProject,
 )
 
 from ._errors import (
@@ -40,6 +43,8 @@ from ._auth import (
 from ._info import info_path, info
 
 from ._versions import versions
+
+from ._lock import lock
 
 from . import env
 
@@ -100,6 +105,9 @@ __all__ = [
     "EnvProjectChecksumSrc",
     "Discovery",
     "VersionListing",
+    "LockedProject",
+    "LockResult",
+    "ProvidedProject",
     ## Errors
     "SysandError",
     "ProjectError",
@@ -126,6 +134,8 @@ __all__ = [
     "info",
     ## versions
     "versions",
+    ## lock
+    "lock",
     ## Init
     "init",
     ## Build

--- a/bindings/py/python/sysand/_errors.py
+++ b/bindings/py/python/sysand/_errors.py
@@ -44,7 +44,9 @@ class SolveError(SysandError):
             conflict with a ``"kind"`` key (``"Constraint"``, ``"NoVersions"``,
             ``"NotFound"``) and the variant's fields.
         report: the human-readable report, identical to the CLI's output.
-        kind: ``"no_solution"`` or ``"retrieval"``.
+        kind: ``"no_solution"`` (the constraints contradict each other),
+            ``"retrieval"`` (a project or version could not be obtained) or
+            ``"choosing_version"``.
     """
 
     conflicts: typing.List[typing.Dict[str, typing.Any]]

--- a/bindings/py/python/sysand/_lock.py
+++ b/bindings/py/python/sysand/_lock.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+from __future__ import annotations
+
+import typing
+from pathlib import Path
+
+import sysand._sysand_core as sysand_rs  # type: ignore
+
+from ._auth import AuthPolicy, Resolution
+from ._model import LockResult, ProvidedProject
+
+
+def lock(
+    path: str | Path = ".",
+    *,
+    resolution: Resolution | None = None,
+    auth: AuthPolicy | None = None,
+    provided: typing.Sequence[ProvidedProject] | None = None,
+    write: bool = True,
+) -> LockResult:
+    """Resolve the project's dependencies into a lockfile, as ``sysand lock``
+    does, and return the resolved set.
+
+    ``path`` is where discovery starts, like the CLI's working directory:
+    the enclosing project (``.project.json``) and workspace are found by
+    walking up, and the environment root is the workspace root, else the
+    project root. The lockfile belongs to the project root.
+
+    With ``write=True`` (the default, matching the CLI) ``sysand-lock.toml``
+    is written at the project root; the returned ``text`` is exactly what
+    was written. With ``write=False`` nothing is written and ``text`` is
+    what would have been — call it first, show the user the delta, then
+    lock again with ``write=True``.
+
+    ``resolution`` defaults to :class:`Resolution` ``()`` (the CLI's
+    semantics); ``auth`` defaults to :meth:`AuthPolicy.none`. ``provided``
+    projects are treated as already present, like the standard libraries.
+
+    Raises:
+        SolveError: no compatible set of versions exists. ``conflicts`` names
+            every participant (which pin excludes what), ``report`` is the
+            CLI's own text, ``wrote`` is ``False``.
+        ProjectError: ``path`` is not inside a project, the project is
+            malformed, or (with ``wrote=True``) the lockfile could not be
+            written after a successful solve.
+        AuthError, IndexProtocolError, ResolutionError: an index could not be
+            used.
+    """
+    if resolution is None:
+        resolution = Resolution()
+    text, projects = sysand_rs.do_lock_py(
+        str(path),
+        resolution._spec(),
+        auth._spec() if auth is not None else None,
+        list(provided or ()),
+        write,
+    )
+    return LockResult(projects=projects, text=text)
+
+
+__all__ = ["lock"]

--- a/bindings/py/python/sysand/_model.py
+++ b/bindings/py/python/sysand/_model.py
@@ -104,6 +104,32 @@ class VersionListing(typing.TypedDict):
     index cannot publish such entries, but other sources can."""
 
 
+class LockedProject(typing.TypedDict):
+    """One ``[[project]]`` entry of a lockfile, see :func:`sysand.lock`."""
+
+    publisher: typing.Optional[str]
+    name: str
+    version: str
+    identifiers: typing.List[str]
+    exports: typing.List[str]
+    usages: typing.List[str]
+    """The usages this project declares, as lockfile usage strings — names
+    who pins what."""
+    sources: typing.List[str]
+    """Where the project can be obtained from, as the lockfile renders each
+    source (opaque; for diagnostics)."""
+
+
+class LockResult(typing.TypedDict):
+    """Result of :func:`sysand.lock`."""
+
+    projects: typing.List[LockedProject]
+    text: str
+    """The canonical ``sysand-lock.toml`` content that was written, or would
+    have been written with ``write=True``. Byte-exact, so a caller can diff
+    and restore it."""
+
+
 class InterchangeProjectInfo(typing.TypedDict):
     publisher: typing.Optional[str]
     name: str
@@ -167,3 +193,13 @@ __all__ = [
     "Dependencies",
     "CompressionMethod",
 ]
+
+
+class ProvidedProject(typing.TypedDict):
+    """A project satisfied by the host itself, so it is never installed.
+    Accepted by :func:`sysand.lock` and :func:`sysand.sync` (``provided=``);
+    this is how the standard libraries are treated."""
+
+    iri: str
+    info: InterchangeProjectInfo
+    meta: InterchangeProjectMetadata

--- a/bindings/py/src/lib.rs
+++ b/bindings/py/src/lib.rs
@@ -6,12 +6,18 @@ use std::{iter, process::ExitCode, sync::Arc};
 use camino::{Utf8Path, Utf8PathBuf};
 use fluent_uri::Iri;
 use pyo3::{
+    PyTypeInfo as _,
     exceptions::{PyFileExistsError, PyFileNotFoundError, PyIOError, PyRuntimeError, PyValueError},
     prelude::*,
-    types::PyAny,
+    types::{PyAny, PyDict, PyType},
 };
 use semver::{Version, VersionReq};
-use sysand::{CliAuthPolicy, DEFAULT_INDEX_URL, standard_auth_policy};
+use sysand::{
+    CliAuthPolicy, DEFAULT_INDEX_URL,
+    cli::ResolutionOptions,
+    commands::lock::{CliLockError, resolve_lock},
+    get_env, standard_auth_policy,
+};
 use sysand_core::{
     add::do_add_guess,
     auth::{GlobMapResult, StandardHTTPAuthenticationBuilder},
@@ -19,8 +25,10 @@ use sysand_core::{
     commands::{
         env::{EnvError, do_env_local_dir},
         init::do_init_local_file,
+        lock::{DEFAULT_LOCKFILE_NAME, LockError, LockProjectError},
     },
     config::{Config, local_fs::load_configs},
+    context::ProjectContext,
     discover::{discover_project, discover_workspace},
     env::{
         DEFAULT_ENV_NAME, ReadEnvironment as _, WriteEnvironment as _,
@@ -37,6 +45,7 @@ use sysand_core::{
     index_location::IndexLocation,
     info::{InfoError, InfoProjectError, do_info, do_info_project},
     init::InitError,
+    lock::{Lock, Project as LockedProject},
     model::{
         InterchangeProjectChecksumRaw, InterchangeProjectInfoRaw, InterchangeProjectMetadataRaw,
         InterchangeProjectUsage, InterchangeProjectUsageRaw,
@@ -45,19 +54,23 @@ use sysand_core::{
         ProjectRead as _,
         local_kpar::{KparInnerPath, LocalKParProject},
         local_src::{EditInfoError, LocalSrcError, LocalSrcProject},
-        utils::wrapfs,
+        memory::InMemoryProject,
+        utils::{Identifier, wrapfs},
     },
     remove::do_remove_guess,
     resolve::{
         ResolveRead,
         combined::CombinedResolverError,
         net_utils::create_reqwest_client,
+        priority::PriorityError,
         standard::{StandardResolver, standard_resolver},
     },
     root::do_root,
+    solve::pubgrub::SolveConflict,
     sources::{Dependencies, do_sources_local_src_project_no_deps, resolve_dependencies},
     symbols::Language,
     usage::{ConstraintChange, SetConstraintError, do_set_usage_constraint_local},
+    utils::ProvidedProjects,
     utils::format_err,
     versions::do_versions,
 };
@@ -265,8 +278,6 @@ struct ResolutionSpec {
     default_index: Vec<String>,
     #[pyo3(default)]
     no_index: bool,
-    /// Read by `lock`/`sync`, which build the provided-projects set.
-    #[expect(dead_code, reason = "read only by lock and sync, not exposed yet")]
     #[pyo3(default)]
     include_std: bool,
     use_config: bool,
@@ -394,10 +405,22 @@ fn info_error_to_pyerr(
     let message = format_err(&err);
     match &err {
         InfoError::NotFound { .. } => PyNotFoundError::new_err(message),
-        InfoError::Resolution(CombinedResolverError::Index(
+        InfoError::Resolution(inner) => combined_error_to_pyerr(inner, message, auth, policy),
+        _ => PyResolutionError::new_err(message),
+    }
+}
+
+fn combined_error_to_pyerr<F, L, R>(
+    err: &CombinedResolverError<F, L, R, IndexEnvironmentError>,
+    message: String,
+    auth: &AuthSpec,
+    policy: &CliAuthPolicy,
+) -> PyErr {
+    match err {
+        CombinedResolverError::Index(
             IndexEnvironmentError::Discovery(DiscoveryError::Fetch(fetch))
             | IndexEnvironmentError::Fetch(fetch),
-        )) => match fetch {
+        ) => match fetch {
             HttpFetchError::BadHttpStatus { url, status }
                 if matches!(status.as_u16(), 401 | 403) =>
             {
@@ -407,9 +430,7 @@ fn info_error_to_pyerr(
             HttpFetchError::Request { .. } => PyResolutionError::new_err(message),
             _ => PyIndexProtocolError::new_err(message),
         },
-        InfoError::Resolution(CombinedResolverError::Index(_)) => {
-            PyIndexProtocolError::new_err(message)
-        }
+        CombinedResolverError::Index(_) => PyIndexProtocolError::new_err(message),
         _ => PyResolutionError::new_err(message),
     }
 }
@@ -486,6 +507,249 @@ fn do_versions_py(
             listing.ignored,
         ))
     })
+}
+
+/// A project the caller provides itself, as `ProvidedProject` dicts arrive.
+#[derive(FromPyObject)]
+#[pyo3(from_item_all)]
+struct ProvidedSpec {
+    iri: String,
+    info: InterchangeProjectInfoRaw,
+    meta: InterchangeProjectMetadataRaw,
+}
+
+fn provided_projects(specs: Vec<ProvidedSpec>) -> PyResult<ProvidedProjects> {
+    let mut provided = ProvidedProjects::default();
+    for spec in specs {
+        let iri = parse_iri(spec.iri)?;
+        provided
+            .entry(Identifier::from_iri_owned(iri))
+            .or_default()
+            .push(InMemoryProject::from_info_meta(spec.info, spec.meta));
+    }
+    Ok(provided)
+}
+
+/// The CLI's view of where a call runs: the enclosing project and
+/// workspace found from `start` and the environment that belongs to them
+/// (`run_cli`'s own steps). Fails when `start` is not inside a project.
+fn project_context(start: &Utf8Path) -> PyResult<(ProjectContext, Utf8PathBuf)> {
+    let project_error = |e: String| ProjectError::new_err(e);
+    let cwd = wrapfs::canonicalize(start).map_err(|e| project_error(format_err(e)))?;
+    let current_project = discover_project(&cwd).map_err(|e| project_error(format_err(e)))?;
+    let current_workspace = discover_workspace(&cwd).map_err(|e| project_error(format_err(e)))?;
+    let Some(project) = &current_project else {
+        return Err(project_error(format!(
+            "`{cwd}` is not inside a project - neither it nor any of its parent directories \
+             contain a SysML v2 or KerML project"
+        )));
+    };
+    let project_root = project.root_path().to_owned();
+    let env_root = current_workspace
+        .as_ref()
+        .map_or_else(|| project_root.clone(), |w| w.root_path().to_owned());
+    let env = get_env(&env_root).map_err(|e| project_error(format!("{e:#}")))?;
+    Ok((
+        ProjectContext {
+            env,
+            current_workspace,
+            current_project,
+            current_directory: cwd,
+        },
+        project_root,
+    ))
+}
+
+fn resolution_options(spec: &ResolutionSpec) -> ResolutionOptions {
+    ResolutionOptions {
+        index: spec.index.clone(),
+        default_index: spec.default_index.clone(),
+        no_index: spec.no_index,
+        include_std: spec.include_std,
+    }
+}
+
+fn config_for(spec: &ResolutionSpec, project_root: &Utf8Path) -> PyResult<Config> {
+    if spec.use_config {
+        load_configs(project_root).map_err(|e| ProjectError::new_err(format_err(e)))
+    } else {
+        Ok(Config::default())
+    }
+}
+
+/// A failure computed without the GIL, turned into a Python exception once
+/// the thread is attached again (the typed classes take keyword arguments
+/// that `new_err` cannot pass).
+enum Failure {
+    Py(PyErr),
+    Solve {
+        message: String,
+        report: String,
+        kind: &'static str,
+        conflicts: Vec<SolveConflict>,
+    },
+    /// The lockfile write itself failed after a successful solve.
+    Wrote(String),
+}
+
+impl From<PyErr> for Failure {
+    fn from(err: PyErr) -> Self {
+        Self::Py(err)
+    }
+}
+
+fn raise_with_kwargs(
+    class: &Bound<'_, PyType>,
+    message: String,
+    kwargs: &Bound<'_, PyDict>,
+) -> PyErr {
+    match class.call((message,), Some(kwargs)) {
+        Ok(exception) => PyErr::from_value(exception),
+        Err(err) => err,
+    }
+}
+
+fn conflict_to_dict<'py>(
+    py: Python<'py>,
+    conflict: &SolveConflict,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    match conflict {
+        SolveConflict::Constraint {
+            iri,
+            constraint,
+            required_by,
+        } => {
+            dict.set_item("kind", "Constraint")?;
+            dict.set_item("iri", iri)?;
+            dict.set_item("constraint", constraint)?;
+            dict.set_item("required_by", required_by)?;
+        }
+        SolveConflict::NoVersions {
+            iri,
+            constraint,
+            found,
+            required_by,
+        } => {
+            dict.set_item("kind", "NoVersions")?;
+            dict.set_item("iri", iri)?;
+            dict.set_item("constraint", constraint)?;
+            dict.set_item("found", found)?;
+            dict.set_item("required_by", required_by)?;
+        }
+        SolveConflict::NotFound { iri, reason } => {
+            dict.set_item("kind", "NotFound")?;
+            dict.set_item("iri", iri)?;
+            dict.set_item("reason", reason)?;
+        }
+    }
+    Ok(dict)
+}
+
+impl Failure {
+    fn into_pyerr(self, py: Python<'_>) -> PyErr {
+        match self {
+            Self::Py(err) => err,
+            Self::Solve {
+                message,
+                report,
+                kind,
+                conflicts,
+            } => {
+                let kwargs = PyDict::new(py);
+                let conflicts: PyResult<Vec<_>> =
+                    conflicts.iter().map(|c| conflict_to_dict(py, c)).collect();
+                let result = conflicts
+                    .and_then(|conflicts| kwargs.set_item("conflicts", conflicts))
+                    .and_then(|()| kwargs.set_item("report", report))
+                    .and_then(|()| kwargs.set_item("kind", kind));
+                match result {
+                    Ok(()) => raise_with_kwargs(&PySolveError::type_object(py), message, &kwargs),
+                    Err(err) => err,
+                }
+            }
+            Self::Wrote(message) => {
+                let kwargs = PyDict::new(py);
+                match kwargs.set_item("wrote", true) {
+                    Ok(()) => raise_with_kwargs(&ProjectError::type_object(py), message, &kwargs),
+                    Err(err) => err,
+                }
+            }
+        }
+    }
+}
+
+/// Typed failure for `resolve_lock`'s `anyhow::Error`: solver failures
+/// become `SolveError` with their conflicts, unless the solver itself hit a
+/// transport or authentication problem, which is classified like `info`'s.
+fn lock_error_to_failure(err: anyhow::Error, auth: &AuthSpec, policy: &CliAuthPolicy) -> Failure {
+    let message = format!("{err:#}");
+    match err.downcast_ref::<CliLockError<CliAuthPolicy>>() {
+        Some(LockProjectError::LockError(LockError::Solver(solver))) => {
+            if let Some(PriorityError::Lower(inner)) = solver.resolution_error() {
+                return Failure::Py(combined_error_to_pyerr(inner, message, auth, policy));
+            }
+            Failure::Solve {
+                message,
+                report: solver.to_string(),
+                kind: solver.kind(),
+                conflicts: solver.conflicts(),
+            }
+        }
+        Some(_) | None => Failure::Py(ProjectError::new_err(message)),
+    }
+}
+
+/// Returns `(canonical lockfile text, projects)`
+#[pyfunction(name = "do_lock_py")]
+#[pyo3(
+    signature = (path, resolution, auth, provided, write),
+)]
+fn do_lock_py(
+    py: Python,
+    path: String,
+    resolution: ResolutionSpec,
+    auth: Option<AuthSpec>,
+    provided: Vec<ProvidedSpec>,
+    write: bool,
+) -> PyResult<(String, Vec<LockedProject>)> {
+    common_init();
+
+    let provided = provided_projects(provided)?;
+    let outcome: Result<(String, Vec<LockedProject>), Failure> = py.detach(|| {
+        let auth = auth.unwrap_or_default();
+        let (ctx, project_root) = project_context(Utf8Path::new(&path))?;
+        let config = config_for(&resolution, &project_root)?;
+        let client = create_reqwest_client().map_err(|e| PyRuntimeError::new_err(format_err(e)))?;
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(PyErr::from)?,
+        );
+        let auth_policy = build_auth_policy(&auth)?;
+
+        let lock: Lock = resolve_lock(
+            ".",
+            resolution_options(&resolution),
+            &config,
+            &project_root,
+            provided,
+            client,
+            runtime,
+            auth_policy.clone(),
+            &ctx,
+        )
+        .map_err(|e| lock_error_to_failure(e, &auth, &auth_policy))?;
+
+        let text = lock.to_string();
+        if write {
+            wrapfs::write(project_root.join(DEFAULT_LOCKFILE_NAME), &text)
+                .map_err(|e| Failure::Wrote(format_err(e)))?;
+        }
+        Ok((text, lock.projects))
+    });
+    outcome.map_err(|failure| failure.into_pyerr(py))
 }
 
 #[pyfunction(name = "do_root_py")]
@@ -757,11 +1021,13 @@ mod py_errors {
     pyo3::import_exception!(sysand._errors, NotFoundError);
     pyo3::import_exception!(sysand._errors, AuthError);
     pyo3::import_exception!(sysand._errors, IndexProtocolError);
+    pyo3::import_exception!(sysand._errors, SolveError);
 }
 // `sysand_core::commands::env::EnvError` is already in scope under that name.
 use py_errors::{
     AuthError as PyAuthError, EnvError as PyEnvError, IndexProtocolError as PyIndexProtocolError,
     NotFoundError as PyNotFoundError, ProjectError, ResolutionError as PyResolutionError,
+    SolveError as PySolveError,
 };
 
 /// Returns `(matched_resource, found, changed, old_constraint, new_constraint)`.
@@ -938,6 +1204,7 @@ pub fn sysand_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_model_roundtrip_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_info_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_versions_py, m)?)?;
+    m.add_function(wrap_pyfunction!(do_lock_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_root_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_build_py, m)?)?;
     m.add_function(wrap_pyfunction!(do_sources_env_py, m)?)?;

--- a/bindings/py/tests/test_lock.py
+++ b/bindings/py/tests/test_lock.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Sysand contributors <opensource@sensmetry.com>
+
+"""`sysand.lock()` against the mock index."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import sysand
+from mockindex import DEPENDENT, LIBRARY, MockIndex, usage
+
+DEP = "pkg:sysand/mock/dep"
+
+
+def resolution(index: MockIndex) -> sysand.Resolution:
+    return sysand.Resolution(default_index=[index.url], use_config=False)
+
+
+def project_with(tmp_path: Path, usages: list[dict]) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    sysand.init("proj", "acme", "1.0.0", root)
+    manifest = json.loads((root / ".project.json").read_text())
+    manifest["usage"] = usages
+    (root / ".project.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    return root
+
+
+def by_name(result: sysand.LockResult, name: str) -> sysand.LockedProject:
+    [project] = [p for p in result["projects"] if p["name"] == name]
+    return project
+
+
+def test_lock_write_false_leaves_no_lockfile(
+    tmp_path: Path, mock_index: MockIndex
+) -> None:
+    mock_index.publish(DEP, "1.0.0", files={"dep.sysml": b"package Dep;"})
+    root = project_with(tmp_path, [usage(DEP, ">=1.0.0")])
+
+    result = sysand.lock(root, resolution=resolution(mock_index), write=False)
+
+    assert not (root / "sysand-lock.toml").exists()
+    assert "lock_version = " in result["text"]
+    assert {p["name"] for p in result["projects"]} == {"proj", "dep"}
+    dep = by_name(result, "dep")
+    assert dep["version"] == "1.0.0"
+    assert dep["identifiers"] == [DEP]
+    assert dep["publisher"] == "mock"
+    assert any(
+        mock_index.kpar_digest(DEP, "1.0.0").removeprefix("sha256:") in s
+        for s in dep["sources"]
+    )
+    assert by_name(result, "proj")["usages"] == [DEP]
+
+
+def test_lock_writes_exactly_text(tmp_path: Path, mock_index: MockIndex) -> None:
+    mock_index.publish(DEP, "1.0.0")
+    root = project_with(tmp_path, [usage(DEP, ">=1.0.0")])
+    res = resolution(mock_index)
+
+    dry = sysand.lock(root, resolution=res, write=False)
+    written = sysand.lock(root, resolution=res)
+
+    lockfile = root / "sysand-lock.toml"
+    assert lockfile.read_text() == written["text"] == dry["text"]
+    # The lockfile is exactly what the CLI writes.
+    assert lockfile.read_text() == sysand.lock(root, resolution=res)["text"]
+    assert lockfile.read_text() == written["text"]
+
+
+def test_lock_from_a_subdirectory_targets_the_project_root(
+    tmp_path: Path, mock_index: MockIndex
+) -> None:
+    mock_index.publish(DEP, "1.0.0")
+    root = project_with(tmp_path, [usage(DEP, ">=1.0.0")])
+    nested = root / "src" / "deep"
+    nested.mkdir(parents=True)
+
+    sysand.lock(nested, resolution=resolution(mock_index))
+
+    assert (root / "sysand-lock.toml").is_file()
+    assert not (nested / "sysand-lock.toml").exists()
+
+
+def test_lock_conflicts_name_the_dependent(
+    tmp_path: Path, mock_index: MockIndex
+) -> None:
+    mock_index.publish(LIBRARY, "0.10.3")
+    mock_index.publish(LIBRARY, "0.11.0")
+    mock_index.publish(DEPENDENT, "1.0.0", usage=[usage(LIBRARY, "0.10.1")])
+    root = project_with(
+        tmp_path,
+        [usage(DEPENDENT, ">=1.0.0, <2.0.0"), usage(LIBRARY, ">=0.11.0, <0.12.0")],
+    )
+
+    with pytest.raises(sysand.SolveError) as excinfo:
+        sysand.lock(root, resolution=resolution(mock_index))
+    error = excinfo.value
+
+    assert error.wrote is False
+    assert error.kind == "no_solution"
+    assert error.report and error.report in str(error)
+    assert {
+        "kind": "Constraint",
+        "iri": LIBRARY,
+        "constraint": "^0.10.1",
+        "required_by": DEPENDENT,
+    } in error.conflicts
+    assert {
+        "kind": "Constraint",
+        "iri": LIBRARY,
+        "constraint": ">=0.11.0, <0.12.0",
+        "required_by": None,
+    } in error.conflicts
+    assert not (root / "sysand-lock.toml").exists()
+
+
+def test_lock_no_matching_version(tmp_path: Path, mock_index: MockIndex) -> None:
+    mock_index.publish(LIBRARY, "0.10.3")
+    root = project_with(tmp_path, [usage(LIBRARY, ">=0.11.0, <0.12.0")])
+
+    with pytest.raises(sysand.SolveError) as excinfo:
+        sysand.lock(root, resolution=resolution(mock_index), write=False)
+    error = excinfo.value
+
+    assert error.kind == "retrieval"
+    assert error.conflicts == [
+        {
+            "kind": "NoVersions",
+            "iri": LIBRARY,
+            "constraint": ">=0.11.0, <0.12.0",
+            "found": ["0.10.3"],
+            "required_by": None,
+        }
+    ]
+    assert "requested version constraint" in str(error)
+
+
+def test_lock_unknown_project_is_a_not_found_conflict(
+    tmp_path: Path, mock_index: MockIndex
+) -> None:
+    root = project_with(tmp_path, [usage("pkg:sysand/mock/absent")])
+
+    with pytest.raises(sysand.SolveError) as excinfo:
+        sysand.lock(root, resolution=resolution(mock_index), write=False)
+
+    [conflict] = excinfo.value.conflicts
+    assert conflict["kind"] == "NotFound"
+    assert conflict["iri"] == "pkg:sysand/mock/absent"
+
+
+def test_lock_not_in_project(tmp_path: Path, mock_index: MockIndex) -> None:
+    with pytest.raises(sysand.ProjectError) as excinfo:
+        sysand.lock(tmp_path, resolution=resolution(mock_index))
+    assert excinfo.value.wrote is False
+    assert "not inside a project" in str(excinfo.value)
+
+
+def test_lock_provided_project_is_not_fetched(
+    tmp_path: Path, mock_index: MockIndex
+) -> None:
+    root = project_with(tmp_path, [usage(DEP, ">=1.0.0")])
+    provided: sysand.ProvidedProject = {
+        "iri": DEP,
+        "info": {
+            "name": "dep",
+            "publisher": "mock",
+            "description": None,
+            "version": "1.2.0",
+            "license": None,
+            "maintainer": [],
+            "website": None,
+            "topic": [],
+            "usage": [],
+        },
+        "meta": {
+            "index": {},
+            "created": "2026-01-01T00:00:00Z",
+            "metamodel": None,
+            "includes_derived": None,
+            "includes_implied": None,
+            "checksum": None,
+        },
+    }
+
+    result = sysand.lock(
+        root, resolution=resolution(mock_index), provided=[provided], write=False
+    )
+
+    dep = by_name(result, "dep")
+    assert dep["version"] == "1.2.0"
+    assert dep["sources"] == [], "a provided project has nothing to install"
+    assert mock_index.requests("*/versions.json") == []
+
+
+def test_lock_auth(tmp_path: Path, mock_index: MockIndex) -> None:
+    mock_index.publish(DEP, "1.0.0")
+    mock_index.require_bearer("s3cret")
+    root = project_with(tmp_path, [usage(DEP, ">=1.0.0")])
+    res = resolution(mock_index)
+
+    with pytest.raises(sysand.AuthError) as excinfo:
+        sysand.lock(root, resolution=res, write=False)
+    assert excinfo.value.wrote is False
+
+    result = sysand.lock(
+        root,
+        resolution=res,
+        auth=sysand.AuthPolicy.bearer(mock_index.url + "**", "s3cret"),
+        write=False,
+    )
+    assert by_name(result, "dep")["version"] == "1.0.0"

--- a/bindings/py/tests/test_migration_scenarios.py
+++ b/bindings/py/tests/test_migration_scenarios.py
@@ -7,21 +7,40 @@ Each test starts from `baseline` / `make_baseline` (conftest.py): a real
 project whose manifest, lockfile and `.sysand` were produced by the shipped
 CLI against the mock index, with the library pinned to the 0.10 line. The
 tests then move that constraint to the 0.11 line with
-`sysand.set_usage_constraint` and check what happened to the manifest, or
-check what the tool driving the migration can find out about the project
-before it starts.
+`sysand.set_usage_constraint` and check what happened to the manifest,
+resolve the result with `sysand.lock`, or check what the tool driving the
+migration can find out about the project before it starts.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import typing
 
 import pytest
 
 import sysand
 from conftest import Baseline, MakeBaseline
-from mockindex import LEGACY_CONSTRAINT, LIBRARY, TARGET_CONSTRAINT, usage
+from mockindex import (
+    DEPENDENT,
+    LEGACY_CONSTRAINT,
+    LIBRARY,
+    TARGET_CONSTRAINT,
+    MockIndex,
+    usage,
+)
+
+
+def resolution(index: MockIndex) -> sysand.Resolution:
+    return sysand.Resolution(default_index=[index.url], use_config=False)
+
+
+def project_version(projects: typing.Sequence[dict], iri: str) -> str | None:
+    for project in projects:
+        if iri in project["identifiers"]:
+            return project["version"]
+    return None
 
 
 def migrate_constraint(baseline: Baseline) -> None:
@@ -104,3 +123,98 @@ def test_workspace_detection(baseline: Baseline) -> None:
     nested.mkdir(parents=True)
     assert os.path.samefile(sysand.discover(nested)["project_root"], baseline.root)
     assert sysand.discover(workspace)["project_root"] is None
+
+
+# ---------------------------------------------------------------------------
+# Resolving the new constraint
+
+
+def _dependent_baseline(
+    make_baseline: MakeBaseline, mock_index: MockIndex, dependent_constraint: str
+) -> Baseline:
+    """A baseline that also uses a second project, which itself uses the
+    library under ``dependent_constraint``."""
+    mock_index.publish(
+        DEPENDENT,
+        "1.0.0",
+        usage=[usage(LIBRARY, dependent_constraint)],
+        files={"dep.sysml": b"package Dep; // 1.0.0\n"},
+    )
+    return make_baseline(extra_usages=[usage(DEPENDENT, ">=1.0.0, <2.0.0")])
+
+
+def test_dependent_excludes_new_version(
+    make_baseline: MakeBaseline, mock_index: MockIndex
+) -> None:
+    # `"0.10.1"` is caret: `>=0.10.1, <0.11.0`. The baseline resolves; the
+    # migration cannot, and the failure names the dependent as the reason.
+    mock_index.publish(DEPENDENT, "1.0.0", usage=[usage(LIBRARY, "0.10.1")])
+    baseline = make_baseline(extra_usages=[usage(DEPENDENT, "1.0.0")])
+    mock_index.publish(LIBRARY, "0.11.0")
+    res = resolution(mock_index)
+
+    migrate_constraint(baseline)
+    before = baseline.snapshot()
+
+    with pytest.raises(sysand.SolveError) as excinfo:
+        sysand.lock(baseline.root, resolution=res, write=False)
+    error = excinfo.value
+    assert error.wrote is False
+    assert isinstance(error.report, str) and error.report
+    assert any(
+        c["kind"] == "Constraint"
+        and c["required_by"] == DEPENDENT
+        and c["iri"] == LIBRARY
+        for c in error.conflicts
+    ), error.conflicts
+
+    after = baseline.snapshot()
+    assert after["lockfile"] == before["lockfile"]
+    assert after["env.toml"] == before["env.toml"]
+    assert after["installed"] == before["installed"]
+
+
+def test_no_compatible_dependent_release(
+    make_baseline: MakeBaseline, mock_index: MockIndex
+) -> None:
+    baseline = _dependent_baseline(make_baseline, mock_index, "0.10.1")
+    mock_index.publish(LIBRARY, "0.11.0")
+    res = resolution(mock_index)
+
+    migrate_constraint(baseline)
+    before = baseline.snapshot()
+    with pytest.raises(sysand.SolveError) as excinfo:
+        sysand.lock(baseline.root, resolution=res, write=False)
+    assert excinfo.value.wrote is False
+    assert any(
+        c["kind"] == "Constraint" and c["required_by"] == DEPENDENT
+        for c in excinfo.value.conflicts
+    ), excinfo.value.conflicts
+    assert baseline.snapshot() == before
+
+
+def test_new_version_not_published_yet(baseline: Baseline) -> None:
+    index = baseline.index
+    res = resolution(index)
+
+    listing = sysand.versions(LIBRARY, resolution=res)
+    assert listing["versions"] == ["0.10.3"]
+
+    migrate_constraint(baseline)
+    before = baseline.snapshot()
+    with pytest.raises(sysand.SolveError) as excinfo:
+        sysand.lock(baseline.root, resolution=res, write=False)
+    error = excinfo.value
+    assert error.wrote is False
+    [conflict] = [c for c in error.conflicts if c["kind"] == "NoVersions"]
+    assert conflict["iri"] == LIBRARY
+    assert conflict["constraint"] == TARGET_CONSTRAINT
+    assert conflict["found"] == ["0.10.3"]
+    assert baseline.snapshot() == before
+
+    # Once the version appears, the same call resolves; a dry run still
+    # writes nothing.
+    index.publish(LIBRARY, "0.11.0")
+    result = sysand.lock(baseline.root, resolution=res, write=False)
+    assert project_version(result["projects"], LIBRARY) == "0.11.0"
+    assert baseline.snapshot() == before

--- a/core/src/commands/lock_tests.rs
+++ b/core/src/commands/lock_tests.rs
@@ -91,3 +91,108 @@ fn lock_preserves_project_publisher() {
 
     assert_eq!(lock.projects[0].publisher.as_deref(), Some("Acme Labs"));
 }
+
+/// The root wants `library >=0.11.0, <0.12.0`, a dependent it also uses
+/// pins `library "0.10.1"` (caret), and both versions exist: the failure
+/// must name the dependent as the party that excludes the wanted version.
+#[test]
+fn lock_reports_which_dependent_pins_a_conflicting_version() {
+    use crate::{
+        model::InterchangeProjectUsageRaw,
+        project::utils::Identifier,
+        resolve::memory::{AcceptAll, MemoryResolver},
+        solve::pubgrub::SolveConflict,
+    };
+
+    const LIBRARY: &str = "pkg:sysand/mock/library";
+    const DEPENDENT: &str = "pkg:sysand/mock/dependent";
+
+    fn remote(name: &str, version: &str, usage: Vec<(&str, &str)>) -> InMemoryProject {
+        InMemoryProject::from_info_meta(
+            InterchangeProjectInfoRaw {
+                name: name.into(),
+                publisher: None,
+                version: version.into(),
+                description: None,
+                license: None,
+                maintainer: vec![],
+                website: None,
+                topic: vec![],
+                usage: usage
+                    .into_iter()
+                    .map(
+                        |(resource, constraint)| InterchangeProjectUsageRaw::Resource {
+                            resource: resource.into(),
+                            version_constraint: Some(constraint.into()),
+                        },
+                    )
+                    .collect(),
+            },
+            InterchangeProjectMetadataRaw {
+                index: IndexMap::default(),
+                created: "2026-01-01T00:00:00Z".into(),
+                metamodel: None,
+                includes_derived: None,
+                includes_implied: None,
+                checksum: None,
+            },
+        )
+    }
+
+    let mut root = remote(
+        "migrating",
+        "1.0.0",
+        vec![
+            (DEPENDENT, ">=1.0.0, <2.0.0"),
+            (LIBRARY, ">=0.11.0, <0.12.0"),
+        ],
+    );
+    root.nominal_sources = vec![Source::Editable {
+        editable: ".".into(),
+    }];
+    let resolver = MemoryResolver {
+        iri_predicate: AcceptAll {},
+        projects: HashMap::from([
+            (
+                Identifier::from_iri_unchecked_str(DEPENDENT),
+                vec![remote("dependent", "1.0.0", vec![(LIBRARY, "0.10.1")])],
+            ),
+            (
+                Identifier::from_iri_unchecked_str(LIBRARY),
+                vec![
+                    remote("library", "0.10.3", vec![]),
+                    remote("library", "0.11.0", vec![]),
+                ],
+            ),
+        ]),
+    };
+
+    let err = do_lock_projects(
+        [(None, &root)],
+        resolver,
+        &HashMap::new(),
+        &ProjectContext::default(),
+    )
+    .unwrap_err();
+
+    let crate::commands::lock::LockProjectError::LockError(LockError::Solver(err)) = err else {
+        panic!("expected a solver failure, got {err}");
+    };
+    let conflicts = err.conflicts();
+    assert!(
+        conflicts.contains(&SolveConflict::Constraint {
+            iri: LIBRARY.to_owned(),
+            constraint: "^0.10.1".to_owned(),
+            required_by: Some(DEPENDENT.to_owned()),
+        }),
+        "the dependent's pin must be named: {conflicts:?}"
+    );
+    assert!(
+        conflicts.contains(&SolveConflict::Constraint {
+            iri: LIBRARY.to_owned(),
+            constraint: ">=0.11.0, <0.12.0".to_owned(),
+            required_by: None,
+        }),
+        "the root's own constraint must be named: {conflicts:?}"
+    );
+}

--- a/core/src/lock.rs
+++ b/core/src/lock.rs
@@ -12,6 +12,8 @@ use std::{
 };
 
 use fluent_uri::Iri;
+#[cfg(feature = "python")]
+use pyo3::IntoPyObject;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -535,7 +537,12 @@ pub const PROJECT_ENTRIES: &[&str] = &[
 // - `Url`: TBD (maybe URL, maybe URL-encoded publisher+name)
 
 /// Fields that might not be set for every project are `Option`
+///
+/// With the `python` feature a `Project` converts into a dict with these
+/// field names, `usages` as their strings and `sources` as their lockfile
+/// renderings.
 #[derive(Clone, Eq, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "python", derive(IntoPyObject))]
 pub struct Project {
     /// Must match the actual project, i.e. be `None` only when the
     /// project does not declare a publisher
@@ -550,7 +557,23 @@ pub struct Project {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub usages: Vec<Usage>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[cfg_attr(feature = "python", pyo3(into_py_with = sources_to_py))]
     pub sources: Vec<Source>,
+}
+
+#[cfg(feature = "python")]
+// The `Cow<'_, Vec<_>>` signature is dictated by `into_py_with`.
+#[expect(clippy::owned_cow)]
+fn sources_to_py<'py>(
+    sources: std::borrow::Cow<'_, Vec<Source>>,
+    py: pyo3::Python<'py>,
+) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::PyAny>> {
+    use pyo3::IntoPyObjectExt as _;
+    sources
+        .iter()
+        .map(|source| source.to_toml().to_string())
+        .collect::<Vec<_>>()
+        .into_bound_py_any(py)
 }
 
 impl Ord for Project {
@@ -812,6 +835,7 @@ impl Source {
 }
 
 #[derive(Clone, Eq, Debug, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "python", derive(IntoPyObject), pyo3(transparent))]
 pub struct Usage(String);
 
 impl Deref for Usage {

--- a/core/src/solve/pubgrub.rs
+++ b/core/src/solve/pubgrub.rs
@@ -3,7 +3,8 @@
 
 use camino::Utf8PathBuf;
 use pubgrub::{
-    DefaultStringReporter, DependencyConstraints, DependencyProvider, Reporter as _, VersionSet,
+    DefaultStringReporter, DependencyConstraints, DependencyProvider, DerivationTree, External,
+    Reporter as _, VersionSet,
 };
 
 use std::{
@@ -122,7 +123,55 @@ impl Display for DiscreteHashSet {
     }
 }
 
+/// pubgrub's "version" of a project: the position of a candidate in the
+/// list `resolve_candidates` returns for its identifier. The list is
+/// cached per identifier for the whole solve, so a position names the same
+/// candidate every time it is seen. Positions are only ever assigned by
+/// `numbered`; everything that turns a `DiscreteHashSet` back into
+/// candidates goes through that numbering.
 pub type ProjectIndex = usize;
+
+/// Numbers `candidates` the way pubgrub refers to them.
+fn numbered<T>(candidates: &[T]) -> impl Iterator<Item = (ProjectIndex, &T)> {
+    candidates.iter().enumerate()
+}
+
+/// The set of `candidates` that a usage with `constraint` selects: those
+/// whose version matches, or every candidate when there is no constraint.
+fn selected_by<'a>(
+    candidates: impl IntoIterator<Item = (ProjectIndex, &'a semver::Version)>,
+    constraint: Option<&semver::VersionReq>,
+) -> DiscreteHashSet {
+    match constraint {
+        Some(constraint) => DiscreteHashSet::Finite(
+            candidates
+                .into_iter()
+                .filter(|(_, version)| constraint.matches(version))
+                .map(|(index, _)| index)
+                .collect(),
+        ),
+        None => DiscreteHashSet::empty().complement(),
+    }
+}
+
+impl DiscreteHashSet {
+    /// True when the set selects nothing.
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Finite(hash_set) => hash_set.is_empty(),
+            Self::CoFinite(_) => false,
+        }
+    }
+
+    /// True when `self` and `other` select the same candidates out of
+    /// `universe`. Unlike `==`, this does not care whether a set is stored
+    /// as the candidates it contains or as those it excludes.
+    fn selects_same(&self, other: &Self, universe: impl IntoIterator<Item = ProjectIndex>) -> bool {
+        universe
+            .into_iter()
+            .all(|index| self.contains(&index) == other.contains(&index))
+    }
+}
 
 impl VersionSet for DiscreteHashSet {
     type V = ProjectIndex;
@@ -422,41 +471,21 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
                 resource,
                 version_constraint,
             } => {
-                if let Some(constraint) = version_constraint {
-                    let mut valid_candidates = HashSet::new();
-
-                    let mut found_versions = Vec::new();
-                    for (i, candidate_info) in candidates.iter().enumerate() {
-                        found_versions.push(candidate_info.version.clone());
-                        if constraint.matches(&candidate_info.version) {
-                            valid_candidates.insert(i);
-                        }
-                    }
-                    if valid_candidates.is_empty() {
-                        let mut versions = String::new();
-                        // `found_versions` must contain at least one element
-                        write!(versions, "`{}`", found_versions[0]).unwrap();
-                        for v in &found_versions[1..] {
-                            write!(versions, ", `{v}`").unwrap();
-                        }
-                        return Err(InternalSolverError::VersionNotAvailable(format!(
-                            "project `{resource}`\n\
-                            was found, but the requested version constraint `{constraint}`\n\
-                            was not satisfied by any of the found versions:\n\
-                            {versions}"
-                        )));
-                    }
-
-                    deps.push((
-                        DependencyIdentifier::Remote(usage.to_owned()),
-                        DiscreteHashSet::Finite(valid_candidates),
-                    ));
-                } else {
-                    deps.push((
-                        DependencyIdentifier::Remote(usage.to_owned()),
-                        DiscreteHashSet::empty().complement(),
-                    ));
+                let selected = selected_by(
+                    numbered(&candidates).map(|(index, c)| (index, &c.version)),
+                    version_constraint.as_ref(),
+                );
+                if let Some(constraint) = version_constraint
+                    && selected.is_empty()
+                {
+                    return Err(InternalSolverError::VersionNotAvailable {
+                        resource: resource.to_string(),
+                        constraint: constraint.clone(),
+                        found: candidates.iter().map(|c| c.version.clone()).collect(),
+                    });
                 }
+
+                deps.push((DependencyIdentifier::Remote(usage.to_owned()), selected));
             }
             InterchangeProjectUsage::Directory { .. }
             | InterchangeProjectUsage::KparPath { .. } => {
@@ -475,9 +504,69 @@ fn compute_deps<R: ResolveRead + fmt::Debug>(
     Ok(pubgrub::Dependencies::Available(constraints))
 }
 
+/// The versions a `NoVersions` conflict lists: ascending, each once.
+/// Candidates come in resolver order, and two sources offering the same
+/// release put that version in the list twice, so sort (by semver, not
+/// by string) before removing neighbours.
+fn version_strings<'a>(versions: impl IntoIterator<Item = &'a semver::Version>) -> Vec<String> {
+    let mut versions: Vec<&semver::Version> = versions.into_iter().collect();
+    versions.sort_unstable();
+    versions.dedup();
+    versions.into_iter().map(ToString::to_string).collect()
+}
+
+/// Render `found` as `` `v1`, `v2` `` — the shape the CLI has always shown.
+fn format_found_versions(found: &[semver::Version]) -> String {
+    let mut versions = String::new();
+    for (i, v) in found.iter().enumerate() {
+        if i > 0 {
+            versions.push_str(", ");
+        }
+        write!(versions, "`{v}`").unwrap();
+    }
+    versions
+}
+
+/// What the solver learnt about one candidate before it failed: enough to
+/// name versions behind `DiscreteHashSet` indices and to recover the
+/// constraint a dependent put on one of its usages.
+#[derive(Debug, Clone)]
+pub struct CandidateSnapshot {
+    /// The position pubgrub knows this candidate by.
+    pub index: ProjectIndex,
+    pub version: semver::Version,
+    pub usages: Vec<CoalescingUsage>,
+}
+
+/// One machine-readable participant in a failed solve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SolveConflict {
+    /// `iri` is constrained to `constraint` by `required_by` (`None` when
+    /// the requirement comes from the root request).
+    Constraint {
+        iri: String,
+        constraint: String,
+        required_by: Option<String>,
+    },
+    /// `iri` exists but none of `found` satisfies `constraint`. `found` is
+    /// sorted ascending with duplicates removed.
+    NoVersions {
+        iri: String,
+        constraint: String,
+        found: Vec<String>,
+        required_by: Option<String>,
+    },
+    /// `iri` could not be retrieved at all.
+    NotFound { iri: String, reason: String },
+}
+
 #[derive(Debug)]
 pub struct SolverError<R: ResolveRead + fmt::Debug + 'static> {
     pub inner: Box<pubgrub::PubGrubError<ProjectSolver<R>>>,
+    /// Candidates per identifier, captured by `solve()` on failure. pubgrub
+    /// speaks in candidate indices; this is what turns them back into
+    /// versions and constraints.
+    pub candidates: HashMap<Identifier, Vec<CandidateSnapshot>>,
 }
 
 impl<R: ResolveRead + fmt::Debug + 'static> From<Box<pubgrub::PubGrubError<ProjectSolver<R>>>>
@@ -487,7 +576,10 @@ impl<R: ResolveRead + fmt::Debug + 'static> From<Box<pubgrub::PubGrubError<Proje
         if let pubgrub::PubGrubError::NoSolution(ref mut derivation_tree) = *value {
             derivation_tree.collapse_no_versions();
         }
-        Self { inner: value }
+        Self {
+            inner: value,
+            candidates: HashMap::new(),
+        }
     }
 }
 
@@ -496,6 +588,232 @@ impl<R: ResolveRead + fmt::Debug + 'static> From<pubgrub::PubGrubError<ProjectSo
 {
     fn from(value: pubgrub::PubGrubError<ProjectSolver<R>>) -> Self {
         Self::from(Box::new(value))
+    }
+}
+
+/// The version constraint a usage puts on its resource, `*` when none (or
+/// when the usage is not a `Resource` usage).
+fn constraint_of(usage: &CoalescingUsage) -> String {
+    match usage.usage().usage() {
+        InterchangeProjectUsage::Resource {
+            version_constraint: Some(constraint),
+            ..
+        } => constraint.to_string(),
+        _ => "*".to_owned(),
+    }
+}
+
+/// The identifier a solver package stands for; `None` for the root request.
+fn id_of(package: &DependencyIdentifier) -> Option<&CoalescingUsage> {
+    match package {
+        DependencyIdentifier::Requested(_) => None,
+        DependencyIdentifier::Remote(usage) => Some(usage),
+    }
+}
+
+impl<R: ResolveRead + fmt::Debug + 'static> SolverError<R> {
+    /// Which way the solve failed: `no_solution` (the constraints
+    /// contradict each other), `retrieval` (a project or version could not
+    /// be obtained), or `choosing_version`.
+    pub fn kind(&self) -> &'static str {
+        match self.inner.as_ref() {
+            pubgrub::PubGrubError::NoSolution(_) => "no_solution",
+            pubgrub::PubGrubError::ErrorRetrievingDependencies { .. } => "retrieval",
+            pubgrub::PubGrubError::ErrorChoosingVersion { .. }
+            | pubgrub::PubGrubError::ErrorInShouldCancel(_) => "choosing_version",
+        }
+    }
+
+    /// The resolver error behind a retrieval failure, if that is what this
+    /// is: the caller may want to classify a transport or authentication
+    /// problem differently from a genuine solve failure.
+    pub fn resolution_error(&self) -> Option<&R::Error> {
+        match self.inner.as_ref() {
+            pubgrub::PubGrubError::ErrorRetrievingDependencies {
+                source: InternalSolverError::Resolution(err),
+                ..
+            }
+            | pubgrub::PubGrubError::ErrorRetrievingDependencies {
+                source: InternalSolverError::ResolvedError { source: err, .. },
+                ..
+            } => Some(err),
+            _ => None,
+        }
+    }
+
+    /// Flattened, machine-readable view of the failure, in encounter order
+    /// without duplicates. Empty only for transport failures (see
+    /// [`Self::resolution_error`]) and version-choice failures.
+    pub fn conflicts(&self) -> Vec<SolveConflict> {
+        let mut conflicts = Vec::new();
+        match self.inner.as_ref() {
+            pubgrub::PubGrubError::NoSolution(derivation_tree) => {
+                self.walk(derivation_tree, &mut conflicts);
+            }
+            pubgrub::PubGrubError::ErrorRetrievingDependencies {
+                package, source, ..
+            } => {
+                let required_by = id_of(package).map(|u| u.id().to_string());
+                match source {
+                    InternalSolverError::VersionNotAvailable {
+                        resource,
+                        constraint,
+                        found,
+                    } => conflicts.push(SolveConflict::NoVersions {
+                        iri: resource.clone(),
+                        constraint: constraint.to_string(),
+                        found: version_strings(found),
+                        required_by,
+                    }),
+                    InternalSolverError::Resolution(_)
+                    | InternalSolverError::ResolvedError { .. } => {}
+                    InternalSolverError::NotFound(usage, _)
+                    | InternalSolverError::NoValidCandidates(usage)
+                    | InternalSolverError::UnsupportedUsageType { usage, .. }
+                    | InternalSolverError::Unresolvable { usage, .. }
+                    | InternalSolverError::InvalidProject { usage, .. }
+                    | InternalSolverError::MissingVersion { usage }
+                    | InternalSolverError::MissingUsage { usage }
+                    | InternalSolverError::InvalidResolvedVersion { usage, .. }
+                    | InternalSolverError::VersionObtain { usage, .. }
+                    | InternalSolverError::UsageObtain { usage, .. } => {
+                        conflicts.push(SolveConflict::NotFound {
+                            iri: usage.id().to_string(),
+                            reason: format_err(source),
+                        });
+                    }
+                }
+            }
+            pubgrub::PubGrubError::ErrorChoosingVersion { .. }
+            | pubgrub::PubGrubError::ErrorInShouldCancel(_) => {}
+        }
+        conflicts
+    }
+
+    fn walk(
+        &self,
+        tree: &DerivationTree<DependencyIdentifier, DiscreteHashSet, String>,
+        out: &mut Vec<SolveConflict>,
+    ) {
+        match tree {
+            DerivationTree::Derived(derived) => {
+                self.walk(&derived.cause1, out);
+                self.walk(&derived.cause2, out);
+            }
+            DerivationTree::External(external) => {
+                let conflict = match external {
+                    External::NotRoot(..) => None,
+                    External::FromDependencyOf(
+                        dependent,
+                        dependent_set,
+                        dependency,
+                        dependency_set,
+                    ) => {
+                        // pubgrub interns packages by identifier, so the
+                        // `dependency` package may carry another party's usage,
+                        // so only the identifier of it is correct to use here.
+                        // Because `dependency_set` is currently
+                        // `DiscreteHashSet` which does not include version
+                        // constraints in a user-readable form, version
+                        // constraints are instead extracted from the usage list
+                        // of `dependent`.
+                        // FIXME: make `dependency_set` usable directly
+                        id_of(dependency).map(|dependency| {
+                            let iri = dependency.id().to_string();
+                            let (required_by, constraint) = match dependent {
+                                DependencyIdentifier::Requested(usages) => (
+                                    None,
+                                    self.select_usage(
+                                        usages.iter().filter(|u| u.id() == dependency.id()),
+                                        dependency.id(),
+                                        dependency_set,
+                                    ),
+                                ),
+                                DependencyIdentifier::Remote(usage) => (
+                                    Some(usage.id().to_string()),
+                                    self.select_usage(
+                                        self.candidates_in(usage.id(), dependent_set)
+                                            .into_iter()
+                                            .flat_map(|c| c.usages.iter())
+                                            .filter(|u| u.id() == dependency.id()),
+                                        dependency.id(),
+                                        dependency_set,
+                                    ),
+                                ),
+                            };
+                            SolveConflict::Constraint {
+                                iri,
+                                constraint: constraint_of(constraint.unwrap_or(dependency)),
+                                required_by,
+                            }
+                        })
+                    }
+                    External::NoVersions(package, set) => {
+                        id_of(package).map(|usage| SolveConflict::NoVersions {
+                            iri: usage.id().to_string(),
+                            constraint: constraint_of(usage),
+                            found: self.versions_of(usage.id(), set),
+                            required_by: None,
+                        })
+                    }
+                    External::Custom(package, _, reason) => {
+                        id_of(package).map(|usage| SolveConflict::NotFound {
+                            iri: usage.id().to_string(),
+                            reason: reason.clone(),
+                        })
+                    }
+                };
+                if let Some(conflict) = conflict
+                    && !out.contains(&conflict)
+                {
+                    out.push(conflict);
+                }
+            }
+        }
+    }
+
+    /// The candidates of `id` selected by `set`.
+    fn candidates_in(&self, id: &Identifier, set: &DiscreteHashSet) -> Vec<&CandidateSnapshot> {
+        self.candidates
+            .get(id)
+            .into_iter()
+            .flatten()
+            .filter(|candidate| set.contains(&candidate.index))
+            .collect()
+    }
+
+    /// Among several usages of `dependency` declared by one dependent (a
+    /// project may list the same resource twice), the one whose constraint
+    /// selects exactly the candidates in `dependency_set`; otherwise the
+    /// first.
+    fn select_usage<'a>(
+        &self,
+        mut usages: impl Iterator<Item = &'a CoalescingUsage>,
+        dependency: &Identifier,
+        dependency_set: &DiscreteHashSet,
+    ) -> Option<&'a CoalescingUsage> {
+        let first = usages.next()?;
+        let candidates: &[CandidateSnapshot] =
+            self.candidates.get(dependency).map_or(&[], Vec::as_slice);
+        let selects_set = |usage: &CoalescingUsage| match usage.usage().usage() {
+            InterchangeProjectUsage::Resource {
+                version_constraint: Some(constraint),
+                ..
+            } => selected_by(
+                candidates.iter().map(|c| (c.index, &c.version)),
+                Some(constraint),
+            )
+            .selects_same(dependency_set, candidates.iter().map(|c| c.index)),
+            _ => false,
+        };
+        if selects_set(first) {
+            return Some(first);
+        }
+        Some(usages.find(|u| selects_set(u)).unwrap_or(first))
+    }
+
+    fn versions_of(&self, id: &Identifier, set: &DiscreteHashSet) -> Vec<String> {
+        version_strings(self.candidates_in(id, set).into_iter().map(|c| &c.version))
     }
 }
 
@@ -564,9 +882,19 @@ pub enum InternalSolverError<R: ResolveRead> {
         reason: String,
     },
     /// Project is found, but the requested version is not
-    /// Value is the formatted error message
-    #[error("requested version unavailable: {0}")]
-    VersionNotAvailable(String),
+    #[error(
+        "requested version unavailable: project `{resource}`\n\
+         was found, but the requested version constraint `{constraint}`\n\
+         was not satisfied by any of the found versions:\n\
+         {}",
+        format_found_versions(found)
+    )]
+    VersionNotAvailable {
+        resource: String,
+        constraint: semver::VersionReq,
+        /// Every version the resolver offered, in resolver order.
+        found: Vec<semver::Version>,
+    },
     /// Resolution failed due to an invalid usage that is in principle supported
     #[error("usage {usage} is not resolvable: {reason}")]
     Unresolvable {
@@ -664,15 +992,12 @@ impl<R: ResolveRead + fmt::Debug + 'static> DependencyProvider for ProjectSolver
                             usage,
                             &mut self.resolved_candidates.borrow_mut(),
                         )?;
-                        let mut versions_indexes: Vec<(usize, semver::Version)> =
-                            candidate_versions
-                                .into_iter()
-                                .enumerate()
-                                .map(|(idx, el)| (idx, el.version))
+                        let mut versions_indexes: Vec<(ProjectIndex, semver::Version)> =
+                            numbered(&candidate_versions)
+                                .map(|(index, c)| (index, c.version.clone()))
                                 .collect();
-                        // Choose the highest version. We'll assume that version
-                        // order is stable across multiple `resolve_candidates()`
-                        // calls, as DiscreteHashSet does not save actual versions
+                        // Choose the highest version. Positions are stable
+                        // across `resolve_candidates()` calls, see `ProjectIndex`.
                         versions_indexes.sort_unstable_by(|el1, el2| el2.1.cmp(&el1.1));
                         let mut found = None;
                         for (i, v) in &versions_indexes {
@@ -750,7 +1075,30 @@ pub fn solve<R: ResolveRead + fmt::Debug + 'static>(
 
     let version: usize = 0;
 
-    let solution = pubgrub::resolve(&solver, package, version)?;
+    let solution = match pubgrub::resolve(&solver, package, version) {
+        Ok(solution) => solution,
+        Err(err) => {
+            let mut err = SolverError::from(err);
+            err.candidates = solver
+                .resolved_candidates
+                .take()
+                .into_iter()
+                .map(|(id, candidates)| {
+                    (
+                        id,
+                        numbered(&candidates)
+                            .map(|(index, c)| CandidateSnapshot {
+                                index,
+                                version: c.summary.version.clone(),
+                                usages: c.summary.usage.clone(),
+                            })
+                            .collect(),
+                    )
+                })
+                .collect();
+            return Err(err);
+        }
+    };
 
     let mut map = solver.resolved_candidates.take();
 

--- a/core/src/solve/pubgrub_tests.rs
+++ b/core/src/solve/pubgrub_tests.rs
@@ -925,3 +925,160 @@ fn same_project_version_from_different_storages_and_usage_forms_installs_once()
 
     Ok(())
 }
+
+// --- structured failures --------------------------------------------------
+
+use std::assert_matches;
+
+use super::SolveConflict;
+
+fn root_usage(iri: &str, constraint: Option<&str>) -> InterchangeProjectUsage {
+    InterchangeProjectUsage::Resource {
+        resource: Iri::parse(iri).unwrap().into(),
+        version_constraint: constraint.map(|c| semver::VersionReq::parse(c).unwrap()),
+    }
+}
+
+#[test]
+fn conflicts_name_root_pins_that_contradict() {
+    let widget_v1 = trivial_memory_project("widget", "1.0.0", vec![]);
+    let widget_v2 = trivial_memory_project("widget", "2.0.0", vec![]);
+    let resolver = memory_resolver(&[("urn:kpar:widget", &[widget_v1, widget_v2])]);
+
+    let err = super::solve(
+        vec![
+            root_usage("urn:kpar:widget", Some("=1.0.0")),
+            root_usage("urn:kpar:widget", Some("=2.0.0")),
+        ],
+        None,
+        resolver,
+    )
+    .unwrap_err();
+
+    assert_eq!(err.kind(), "no_solution");
+    let conflicts = err.conflicts();
+    for constraint in ["=1.0.0", "=2.0.0"] {
+        assert!(
+            conflicts.contains(&SolveConflict::Constraint {
+                iri: "urn:kpar:widget".to_owned(),
+                constraint: constraint.to_owned(),
+                required_by: None,
+            }),
+            "missing root pin `{constraint}` in {conflicts:?}"
+        );
+    }
+}
+
+#[test]
+fn conflicts_name_the_dependents_that_pin_transitively() {
+    let app_a = trivial_memory_project("app_a", "1.0.0", vec![("urn:kpar:widget", Some("=1.0.0"))]);
+    let app_b = trivial_memory_project("app_b", "1.0.0", vec![("urn:kpar:widget", Some("=2.0.0"))]);
+    let widget_v1 = trivial_memory_project("widget", "1.0.0", vec![]);
+    let widget_v2 = trivial_memory_project("widget", "2.0.0", vec![]);
+    let resolver = memory_resolver(&[
+        ("urn:kpar:app_a", &[app_a]),
+        ("urn:kpar:app_b", &[app_b]),
+        ("urn:kpar:widget", &[widget_v1, widget_v2]),
+    ]);
+
+    let err = super::solve(
+        vec![
+            root_usage("urn:kpar:app_a", None),
+            root_usage("urn:kpar:app_b", None),
+        ],
+        None,
+        resolver,
+    )
+    .unwrap_err();
+
+    assert_eq!(err.kind(), "no_solution");
+    let conflicts = err.conflicts();
+    // The constraint is the *dependent's*, even though pubgrub interns the
+    // `widget` package once (by identifier) with whichever usage came first.
+    for (dependent, constraint) in [("urn:kpar:app_a", "=1.0.0"), ("urn:kpar:app_b", "=2.0.0")] {
+        assert!(
+            conflicts.contains(&SolveConflict::Constraint {
+                iri: "urn:kpar:widget".to_owned(),
+                constraint: constraint.to_owned(),
+                required_by: Some(dependent.to_owned()),
+            }),
+            "missing `{dependent}` pin `{constraint}` in {conflicts:?}"
+        );
+    }
+    assert!(
+        conflicts
+            .iter()
+            .all(|c| !matches!(c, SolveConflict::NotFound { .. })),
+        "{conflicts:?}"
+    );
+}
+
+#[test]
+fn no_matching_version_is_a_retrieval_failure_with_the_found_versions() {
+    let widget_v1 = trivial_memory_project("widget", "1.0.0", vec![]);
+    let widget_v2 = trivial_memory_project("widget", "2.0.0", vec![]);
+    let resolver = memory_resolver(&[("urn:kpar:widget", &[widget_v1, widget_v2])]);
+
+    let err = super::solve(
+        vec![root_usage("urn:kpar:widget", Some(">=3"))],
+        None,
+        resolver,
+    )
+    .unwrap_err();
+
+    assert_eq!(err.kind(), "retrieval");
+    assert_eq!(
+        err.conflicts(),
+        vec![SolveConflict::NoVersions {
+            iri: "urn:kpar:widget".to_owned(),
+            constraint: ">=3".to_owned(),
+            found: vec!["1.0.0".to_owned(), "2.0.0".to_owned()],
+            required_by: None,
+        }]
+    );
+    // The CLI's wording is unchanged.
+    assert_eq!(
+        err.to_string(),
+        "failed to retrieve project(s): requested version unavailable: project `urn:kpar:widget`\n\
+         was found, but the requested version constraint `>=3`\n\
+         was not satisfied by any of the found versions:\n\
+         `1.0.0`, `2.0.0`"
+    );
+}
+
+#[test]
+fn found_versions_are_sorted_by_semver_and_listed_once() {
+    // Resolver order is neither sorted nor free of duplicates: two sources
+    // may offer the same release, and `1.10.0` must sort after `1.9.0`.
+    let widgets: Vec<_> = ["2.0.0", "1.10.0", "1.9.0", "2.0.0"]
+        .into_iter()
+        .map(|v| trivial_memory_project("widget", v, vec![]))
+        .collect();
+    let resolver = memory_resolver(&[("urn:kpar:widget", &widgets)]);
+
+    let err = super::solve(
+        vec![root_usage("urn:kpar:widget", Some(">=3"))],
+        None,
+        resolver,
+    )
+    .unwrap_err();
+
+    assert_matches!(
+        err.conflicts().as_slice(),
+        [SolveConflict::NoVersions { found, .. }] if *found == ["1.9.0", "1.10.0", "2.0.0"]
+    );
+}
+
+#[test]
+fn unknown_project_is_a_not_found_conflict() {
+    let resolver = memory_resolver(&[]);
+
+    let err = super::solve(vec![root_usage("urn:kpar:absent", None)], None, resolver).unwrap_err();
+
+    assert_eq!(err.kind(), "retrieval");
+    assert!(err.resolution_error().is_none());
+    assert_matches!(
+        err.conflicts().as_slice(),
+        [SolveConflict::NotFound { iri, .. }] if iri == "urn:kpar:absent"
+    );
+}

--- a/sysand/src/commands/lock.rs
+++ b/sysand/src/commands/lock.rs
@@ -9,11 +9,17 @@ use camino::Utf8Path;
 
 use sysand_core::{
     auth::HTTPAuthentication,
-    commands::lock::{DEFAULT_LOCKFILE_NAME, LockOutcome, do_lock_local_editable},
+    commands::lock::{
+        DEFAULT_LOCKFILE_NAME, EditableLocalSrcProject, LockOutcome, LockProjectError,
+        do_lock_local_editable,
+    },
     config::Config,
     context::ProjectContext,
-    project::{memory::InMemoryProject, utils::wrapfs},
+    project::{
+        any::AnyProject, memory::InMemoryProject, reference::ProjectReference, utils::wrapfs,
+    },
     resolve::{
+        ResolveRead,
         memory::{AcceptAll, MemoryResolver},
         priority::PriorityResolver,
         standard::{StandardResolver, standard_resolver},
@@ -25,22 +31,48 @@ use typed_path::Utf8UnixPath;
 
 use crate::{DEFAULT_INDEX_URL, cli::ResolutionOptions, get_overrides};
 
-/// Generate a lockfile for `current_project`.
-pub fn command_lock<P: AsRef<Utf8UnixPath>, Policy: HTTPAuthentication, R: AsRef<Utf8Path>>(
+/// The resolver [`create_resolver`] builds: overrides, then provided
+/// projects, then the standard file/env/index stack. Named so that callers
+/// (the language bindings) can match the errors it produces.
+pub type CliResolver<Policy> = PriorityResolver<
+    PriorityResolver<
+        MemoryResolver<AcceptAll, ProjectReference<AnyProject<Policy>>>,
+        MemoryResolver<AcceptAll, InMemoryProject>,
+    >,
+    StandardResolver<Policy>,
+>;
+
+/// The error `resolve_lock`/`command_lock` fail with when the lock itself
+/// fails (as opposed to configuration or context errors); reachable from
+/// the returned `anyhow::Error` through `downcast_ref`.
+pub type CliLockError<Policy> = LockProjectError<
+    EditableLocalSrcProject,
+    <CliResolver<Policy> as ResolveRead>::ProjectStorage,
+    CliResolver<Policy>,
+>;
+
+/// Solve for a lockfile without writing it.
+///
+/// `extra_provided` are projects the caller itself provides (satisfied
+/// without installing), merged with the standard libraries unless
+/// `include_std` is set. The returned lock is canonical.
+pub fn resolve_lock<P: AsRef<Utf8UnixPath>, Policy: HTTPAuthentication, R: AsRef<Utf8Path>>(
     path: P,
     resolution_opts: ResolutionOptions,
     config: &Config,
     project_root: R,
+    extra_provided: ProvidedProjects,
     client: reqwest_middleware::ClientWithMiddleware,
     runtime: Arc<tokio::runtime::Runtime>,
     auth_policy: Arc<Policy>,
     ctx: &ProjectContext,
 ) -> Result<sysand_core::lock::Lock> {
-    let provided_iris = if resolution_opts.include_std {
+    let mut provided_iris = if resolution_opts.include_std {
         HashMap::default()
     } else {
         known_std_libs()
     };
+    provided_iris.extend(extra_provided);
     let wrapped_resolver = create_resolver(
         resolution_opts,
         config,
@@ -75,7 +107,31 @@ pub fn command_lock<P: AsRef<Utf8UnixPath>, Policy: HTTPAuthentication, R: AsRef
         ctx,
     )?;
 
-    let canonical = lock.canonicalize();
+    Ok(lock.canonicalize())
+}
+
+/// Generate a lockfile for `current_project` and write it.
+pub fn command_lock<P: AsRef<Utf8UnixPath>, Policy: HTTPAuthentication, R: AsRef<Utf8Path>>(
+    path: P,
+    resolution_opts: ResolutionOptions,
+    config: &Config,
+    project_root: R,
+    client: reqwest_middleware::ClientWithMiddleware,
+    runtime: Arc<tokio::runtime::Runtime>,
+    auth_policy: Arc<Policy>,
+    ctx: &ProjectContext,
+) -> Result<sysand_core::lock::Lock> {
+    let canonical = resolve_lock(
+        &path,
+        resolution_opts,
+        config,
+        project_root,
+        ProvidedProjects::default(),
+        client,
+        runtime,
+        auth_policy,
+        ctx,
+    )?;
     wrapfs::write(
         Utf8Path::new(path.as_ref().as_str()).join(DEFAULT_LOCKFILE_NAME),
         canonical.to_string(),


### PR DESCRIPTION
This MR adds `sysand.lock(path, *, resolution=None, auth=None, provided=None, write=True)`. It runs the same resolution as `sysand lock`, returns the resolved set together with the canonical lockfile text, and can do so without writing anything. When the solve fails it raises `SolveError` carrying a machine-readable list of the constraints that clashed, in addition to the CLI's report text.

- core (solver): `SolverError` now keeps the candidates the solver had resolved when it failed and offers `conflicts()`, `kind()` and `resolution_error()`. `Display` is unchanged; it remains the human report. `InternalSolverError::VersionNotAvailable` becomes a struct variant holding the resource, constraint and found versions; its message is reproduced verbatim.
- sysand (CLI crate): `command_lock` is split into `resolve_lock` (solve, no write, with caller-provided projects) plus the write. The new `CliResolver` and `CliLockError` type aliases name the resolver stack the CLI builds and the error it fails with, so the bindings can match on them. CLI behaviour is unchanged.
- py: `sysand.lock` returns a `LockResult` with `projects` (one `LockedProject` per lockfile entry) and `text`. Failures raise `SolveError` with `.conflicts`, `.report` and `.kind`, or the typed resolution errors `info` already raises when the solver hit a transport or authentication problem.
- tests: solver conflict shapes in core, `sysand.lock` against the mock index, and three new end-to-end scenarios in `test_migration_scenarios.py`.

## Why

A tool that changes a usage constraint and re-locks has to be able to show the user what will move before anything is written, and when the solve fails it has to say which pin excludes the wanted version. Neither is possible through the CLI: `sysand lock` writes on success and prints a pubgrub derivation tree on failure. That tree is rendered as prose. Recovering "dependent X pins library to `^0.10.1`" from it means parsing English.

The solver already knows every participant of a failure. This MR exposes that knowledge as data, keeps the human report byte-for-byte as it was, and gives Python the same solve the CLI runs, with a `write=False` switch.

## What changed

### Structured solver failures (`core/src/solve/pubgrub.rs`)

`SolverError` gains a `candidates` map, filled by `solve()` on failure from the candidates it had resolved so far. pubgrub speaks in candidate indices (`DiscreteHashSet`), and this map is what turns an index back into a version and a dependent's usage back into its constraint.

On top of it:

- `Display` is untouched: it is still the human report, and `to_string()` is how the bindings obtain it. The CLI prints exactly what it printed before (asserted verbatim in `pubgrub_tests.rs` for the no-matching-version case).
- `kind()` is `"no_solution"` (the constraints contradict each other), `"retrieval"` (a project or version could not be obtained) or `"choosing_version"`.
- `resolution_error()` returns the resolver's own error when a retrieval failure was caused by resolution rather than by the solve. Callers use it to tell a 401 from a genuine conflict.
- `conflicts()` flattens the failure into `SolveConflict` values, in encounter order without duplicates:
  - `Constraint { iri, constraint, required_by }`: `iri` is constrained to `constraint` by `required_by`, `None` when the requirement is the root's own.
  - `NoVersions { iri, constraint, found, required_by }`: `iri` exists but none of `found` satisfies `constraint`.
  - `NotFound { iri, reason }`: `iri` could not be retrieved at all.

  For `NoSolution` the derivation tree is walked and each `External` node becomes one conflict. For `ErrorRetrievingDependencies` the single cause becomes a `NoVersions` or `NotFound`. Transport failures and version-choice failures produce an empty list; the former are what `resolution_error()` is for.

**For reviewers, the one subtle part:** pubgrub interns packages by identifier. When two dependents use the same library, the `dependency` package in a `FromDependencyOf` edge carries whichever usage the solver saw first, so reading the constraint off that package would attribute the wrong pin. `conflicts()` therefore recovers the constraint from the dependent's side: the root request's usages for `Requested`, or the usages of the dependent's candidates selected by `dependent_set` for `Remote`. When a dependent lists the same resource more than once, `select_usage` picks the usage whose constraint selects exactly the candidates in `dependency_set`, falling back to the first. `conflicts_name_the_dependents_that_pin_transitively` is the test for this.

`InternalSolverError::VersionNotAvailable(String)` becomes `VersionNotAvailable { resource, constraint, found }`. The `#[error]` attribute renders the same four-line message the string used to hold, with `format_found_versions` producing the `` `v1`, `v2` `` list; `no_matching_version_is_a_retrieval_failure_with_the_found_versions` asserts the exact text.

### `resolve_lock` (`sysand/src/commands/lock.rs`)

`command_lock` did three things: build the provided set, solve, write. The first two move into `resolve_lock`, which additionally takes `extra_provided: ProvidedProjects` merged into the standard-library set (or into an empty set with `include_std`). `command_lock` calls it with an empty `extra_provided` and writes, so the CLI path is the same code as before.

`CliResolver<Policy>` spells out the resolver `create_resolver` builds (overrides, then provided projects, then the standard file/env/index stack), and `CliLockError<Policy>` is the `LockProjectError` instantiation that `resolve_lock` fails with, reachable from the returned `anyhow::Error` by `downcast_ref`. Both aliases exist only so the bindings can name these types; nothing in the CLI uses them.

### `sysand.lock` (`_lock.py`, `_model.py`, `lib.rs::do_lock_py`)

```python
result = sysand.lock(project_dir, resolution=sysand.Resolution(...), write=False)
result["projects"]   # [{"publisher", "name", "version", "identifiers", "exports", "usages", "sources"}, ...]
result["text"]       # the canonical sysand-lock.toml, byte-exact
```

- `path` is where discovery starts, like the CLI's working directory: the enclosing project and workspace are found by walking up, the environment root is the workspace root or else the project root, and the lockfile belongs to the project root. Calling from a nested directory writes the lockfile at the project root, not in the nested directory. This mirrors the steps `run_cli` performs before `command_lock`, so the resolution matches the CLI's.
- `write=True` (the default, as in the CLI) writes `sysand-lock.toml` at the project root, and `text` is exactly what was written. `write=False` writes nothing; `text` is what would have been written. The intended sequence is a dry run, a diff shown to the user, then a second call with `write=True`.
- `resolution` defaults to `Resolution()`, the CLI's configuration plus default index, as `versions` does. `auth` defaults to `AuthPolicy.none()`.
- `provided` is a sequence of `ProvidedProject` dicts (`iri`, `info`, `meta`). They are treated as already present, the way the standard libraries are: the solver sees them, they are never fetched, and they appear in `projects` with empty `sources`.

`LockedProject` fields are the lockfile's: `usages` are the lockfile usage strings (this is what names who pins what), `sources` are the lockfile renderings of each source, kept opaque and meant for diagnostics.

### Error mapping (`lib.rs`)

The solve runs with the GIL released. Typed exceptions with keyword arguments cannot be built without it, so failures are collected in a `Failure` enum and turned into exceptions once the thread is attached again:

- A solver failure becomes `SolveError(message, conflicts=..., report=..., kind=...)`. Each `SolveConflict` becomes a dict with a `"kind"` key and the variant's fields.
- If the solver failed because the resolver failed (`resolution_error()` is `Some`), the error is classified the way `info` classifies it: `AuthError` with the credential hint on 401/403, `IndexProtocolError` for malformed index answers, `ResolutionError` otherwise. `info_error_to_pyerr` is refactored to share this classification through a new `combined_error_to_pyerr`; `info`'s behaviour is unchanged.
- Not inside a project, unreadable configuration, or any other `resolve_lock` failure: `ProjectError` with `wrote == False`.
- The lockfile write itself failing after a successful solve: `ProjectError` with `wrote == True`.

`SolveError` itself already existed in `_errors.py` with these keyword arguments; this MR is the first to raise it. Its docstring is extended to list `"choosing_version"` among the kinds, since the Rust side can produce it.

### Tests

Core (`pubgrub_tests.rs`, `lock_tests.rs`):

- Two root pins that contradict each other are both reported with `required_by == None`.
- Two dependents pinning the same library to different exact versions are each reported with their own constraint, and no `NotFound` appears.
- A constraint no version satisfies is a `"retrieval"` failure with one `NoVersions` conflict listing the found versions, and the CLI's message is unchanged, asserted verbatim.
- An unknown project is a `NotFound` conflict with `resolution_error()` empty.
- Through `do_lock_projects` with an in-memory resolver: a root wanting `library >=0.11.0, <0.12.0` while a dependent it also uses pins `library "0.10.1"` (caret). Both the dependent's `^0.10.1` and the root's own constraint are named.

Python (`tests/test_lock.py`, nine tests against the mock index, every call with an explicit `resolution=`):

- `write=False` leaves no lockfile and returns the resolved set, including the dependency's publisher, identifiers, a source carrying the archive digest, and the root's usages.
- `write=True` writes exactly `text`, and a dry run and a real run produce the same text.
- Locking from a nested directory writes the lockfile at the project root.
- A conflict names the dependent: `kind == "no_solution"`, `report` is contained in `str(error)`, both the dependent's `^0.10.1` and the root's `>=0.11.0, <0.12.0` are in `conflicts`, no lockfile is written.
- No matching version: `kind == "retrieval"`, exactly one `NoVersions` conflict with `found == ["0.10.3"]`.
- An absent project is a `NotFound` conflict.
- Outside a project: `ProjectError` with `wrote == False`.
- A `provided` project resolves at the provided version, has no sources, and the index is never asked for it.
- With the index requiring a bearer token: `AuthError` with `wrote == False`, then success with `AuthPolicy.bearer`.

### Tests (`tests/test_migration_scenarios.py`)

Three scenarios, continuing the suite from the `baseline` fixture. Each moves the library constraint to the 0.11 line with `set_usage_constraint`, then calls `sysand.lock(..., write=False)` and checks that the failure is attributable and that nothing on disk changed (`baseline.snapshot()` before and after).

- `test_dependent_excludes_new_version`: a second project used by the root pins the library to `"0.10.1"` (caret, `<0.11.0`). The baseline resolves; the migrated manifest does not, and `conflicts` contains a `Constraint` on the library with `required_by` equal to the dependent. Lockfile, `env.toml` and installed set are untouched.
- `test_no_compatible_dependent_release`: the same shape built through a `_dependent_baseline` helper that publishes the dependent with a configurable constraint on the library, so later scenarios can reuse it.
- `test_new_version_not_published_yet`: before 0.11.0 exists, `versions` lists only 0.10.3 and `lock` fails with one `NoVersions` conflict naming the library, the target constraint and `found == ["0.10.3"]`. Once 0.11.0 is published the same dry-run call resolves to it and still writes nothing.

The module docstring is updated to mention `lock`, and two small helpers are added: `resolution(index)` builds the `Resolution` for the mock index, `project_version(projects, iri)` picks a version out of a `LockResult`.
