### PR TITLE
fix(ci): switch from EOL Debian 11 to RockyLinux 8 for old glibc

### DIFF
--- a/.github/workflows/installation-script.yml
+++ b/.github/workflows/installation-script.yml
@@ -193,18 +193,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # No glibc; also proves the script runs under busybox sh. Checkout
-          # works because the runner ships a musl build of node for Alpine.
+          # No glibc; also proves the script runs under busybox sh. The
+          # runner ships a musl build of node for Alpine, so actions/checkout
+          # runs; neither image has git, so checkout falls back to a tarball
+          # download that needs tar, hence installing deps before checkout.
           - image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
             setup: apk add curl python3 tar
-          # glibc 2.31, older than the gnu build's 2.35 requirement.
-          - image: debian:11@sha256:f313b4bd62667092a59b3a664d7d3ab8b5e65f41675f48e81455a15dc5abe792
-            setup: apt-get update && apt-get install -y curl python3
+          # glibc 2.28, older than the gnu build's 2.35 requirement.
+          - image: rockylinux/rockylinux:8-minimal@sha256:6d2ede107b4f005a638728711dae05d5fbbfd8abd521cecf5ab61196b361c965
+            setup: microdnf install -y tar gzip python3
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-
       - name: Install dependencies
         run: ${{ matrix.setup }}
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Run installer against fake musl release
         run: |


### PR DESCRIPTION
Fixes #534.